### PR TITLE
chore: release v0.15.1

### DIFF
--- a/.github/workflows/release-3-upload-artifacts.yml
+++ b/.github/workflows/release-3-upload-artifacts.yml
@@ -29,9 +29,43 @@ defaults:
     shell: bash -xe {0}
 
 jobs:
+  create-github-release:
+    runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }} # Use the ref if provided, otherwise defaults to the current branch/commit
+
+      - id: git-info
+        run: |
+          git fetch --tags
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+          echo "tag=$(git tag --contains HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -d '{
+              "tag_name": "'$TAG'",
+              "target_commitish": "'$SHA'",
+              "name": "obelisk-'$TAG'",
+              "body": "",
+              "draft": false,
+              "prerelease": false
+            }' \
+            https://api.github.com/repos/obeli-sk/obelisk/releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.git-info.outputs.tag }}
+          SHA: ${{ steps.git-info.outputs.sha }}
+
   upload-assets:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    needs: create-github-release
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release-5-verify-download-sh.yml
+++ b/.github/workflows/release-5-verify-download-sh.yml
@@ -1,4 +1,4 @@
-name: release-5-verify-install-sh
+name: release-5-verify-download-sh
 
 on:
   workflow_dispatch:
@@ -51,7 +51,7 @@ jobs:
           VERSION=${TAG#v}
           mkdir temp
           cd temp
-          curl -L --tlsv1.2 -sSf https://raw.githubusercontent.com/obeli-sk/obelisk/main/install.sh | bash
+          curl -L --tlsv1.2 -sSf https://raw.githubusercontent.com/obeli-sk/obelisk/main/download.sh | bash
           ./obelisk --version | grep $VERSION
           ./obelisk server generate-config
           ./obelisk server verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/obeli-sk/obelisk/compare/v0.15.0...v0.15.1)
+
+### ⛰️ Features
+
+- *(cli)* Add `--json` parameter to `submit` and `get` - ([e437ef9](https://github.com/obeli-sk/obelisk/commit/e437ef9c1c050dcceec1d71097b63cea0eecf5f2))
+- *(toml)* Add `~` prefix expansion - ([43050f5](https://github.com/obeli-sk/obelisk/commit/43050f57e05e98b6ec4745b4aad46d8de0bb6826))
+- Print join set name in CLI - ([1c9225d](https://github.com/obeli-sk/obelisk/commit/1c9225de47104b0db28d41f7d11ff79447b3e34d))
+
+### 🚜 Refactor
+
+- Add "Server is ready" info message - ([bfa966f](https://github.com/obeli-sk/obelisk/commit/bfa966f1a7a78bd6f8086d5faa6bfd57e9fbb9ed))
+
+
 ## [0.15.0](https://github.com/obeli-sk/obelisk/compare/v0.14.2...v0.15.0)
 
 ### ⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
  "bitflags",
  "libc",
@@ -2593,6 +2593,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,9 +2606,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",
@@ -2913,7 +2919,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum",
+ "strum 0.27.0",
  "thiserror 2.0.8",
  "tracing",
  "tracing-opentelemetry",
@@ -3004,12 +3010,12 @@ dependencies = [
  "test-utils",
  "thiserror 2.0.8",
  "tracing",
- "wasmparser 0.223.1",
+ "wasmparser 0.225.0",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wit-component 0.223.1",
- "wit-parser 0.223.1",
+ "wit-component 0.225.0",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
@@ -3025,7 +3031,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.8",
  "wasmtime",
- "wast 223.0.1",
+ "wast 225.0.0",
 ]
 
 [[package]]
@@ -3123,7 +3129,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "shadow-rs",
- "strum",
+ "strum 0.27.0",
  "tempfile",
  "thiserror 2.0.8",
  "tokio-stream",
@@ -3200,8 +3206,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror 2.0.8",
 ]
 
@@ -3247,32 +3253,48 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.8",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.2.0",
+ "opentelemetry",
+ "reqwest",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 1.2.0",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror 2.0.8",
  "tokio",
  "tonic",
  "tracing",
@@ -3280,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3292,15 +3314,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -3311,7 +3333,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.8",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3919,6 +3941,7 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.2.0",
@@ -4329,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974eb8222c62a8588bc0f02794dd1ba5b60b3ec88b58e050729d0907ed6af610"
+checksum = "6ec14cc798c29f4bf74a6c4299c657c04d4e9fba03875c1f0eec569af03aed89"
 dependencies = [
  "const_format",
  "git2",
@@ -4460,8 +4483,14 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.0",
 ]
 
 [[package]]
@@ -4469,6 +4498,19 @@ name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4585,7 +4627,7 @@ dependencies = [
 name = "test-programs-fibo-activity"
 version = "0.15.0"
 dependencies = [
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -4601,7 +4643,7 @@ version = "0.15.0"
 dependencies = [
  "waki",
  "waki-macros",
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -4615,7 +4657,7 @@ dependencies = [
 name = "test-programs-fibo-workflow"
 version = "0.15.0"
 dependencies = [
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -4631,7 +4673,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "waki",
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -4645,7 +4687,7 @@ dependencies = [
 name = "test-programs-http-get-workflow"
 version = "0.15.0"
 dependencies = [
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -4659,7 +4701,7 @@ dependencies = [
 name = "test-programs-sleep-activity"
 version = "0.15.0"
 dependencies = [
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -4673,7 +4715,7 @@ dependencies = [
 name = "test-programs-sleep-workflow"
 version = "0.15.0"
 dependencies = [
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -5156,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5570,22 +5612,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.223.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0a96fdeaee8fbeb4bd917fb8157d48c0d61c3b1f4ee4c363c8e8d68b2f4fe8"
-dependencies = [
- "leb128",
- "wasmparser 0.223.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab7a13a23790fe91ea4eb7526a1f3131001d874e3e00c2976c48861f2e82920"
 dependencies = [
  "leb128",
  "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
@@ -5617,23 +5659,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.223.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7e37883181704d96b89dbd8f1291be13694c71cd0663aebb94b46d235a377"
-dependencies = [
- "anyhow",
- "indexmap 2.7.0",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "url",
- "wasm-encoder 0.223.1",
- "wasmparser 0.223.1",
-]
-
-[[package]]
-name = "wasm-metadata"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c93c9e49fa2749be3c5ab28ad4be03167294915cd3b2ded3f04f760cef5cfb86"
@@ -5647,6 +5672,23 @@ dependencies = [
  "url",
  "wasm-encoder 0.224.1",
  "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20d0bf2c73c32a5114cf35a5c10ccf9f9aa37a3a2c0114b3e11cbf6faac12"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "url",
+ "wasm-encoder 0.225.0",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
@@ -5701,19 +5743,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.223.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664b980991ed9a8c834eb528a8979ab1109edcf52dc05dd5751e2cc3fb31035d"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.2",
- "indexmap 2.7.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
@@ -5722,6 +5751,19 @@ dependencies = [
  "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -6066,15 +6108,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "223.0.1"
+version = "225.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fce293087c1cd10b4ee82fee235d7a5d131194c6f6d85ed9a8cfc6ba1cd86ab"
+checksum = "c61496027ff707f9fa9e0b22c34ec163eb7adb1070df565e32a9180a76e4300b"
 dependencies = [
  "bumpalo",
- "leb128",
+ "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.223.1",
+ "wasm-encoder 0.225.0",
 ]
 
 [[package]]
@@ -6142,8 +6184,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-logger",
  "web-sys",
- "wit-component 0.223.1",
- "wit-parser 0.223.1",
+ "wit-component 0.225.0",
+ "wit-parser 0.225.0",
  "yew",
  "yew-router",
  "yew_icons",
@@ -6167,7 +6209,7 @@ dependencies = [
  "futures",
  "url",
  "webui-builder",
- "wit-bindgen 0.37.0",
+ "wit-bindgen 0.39.0",
 ]
 
 [[package]]
@@ -6446,12 +6488,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9219694564701fa935754f1552ce299154fc74948d6d148134ce55f3504c8bf1"
+checksum = "e4dd9a372b25d6f35456b0a730d2adabeb0c4878066ba8f8089800349be6ecb5"
 dependencies = [
- "wit-bindgen-rt 0.37.0",
- "wit-bindgen-rust-macro 0.37.0",
+ "wit-bindgen-rt 0.39.0",
+ "wit-bindgen-rust-macro 0.39.0",
 ]
 
 [[package]]
@@ -6467,13 +6509,13 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba105733ba146c94e067793fb46505265ea8720eb14ceae65b10797c7728a65"
+checksum = "f108fa9b77a346372858b30c11ea903680e7e2b9d820b1a5883e9d530bf51c7e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.223.1",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
@@ -6496,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc801b991c56492f87ab3086e786468f75c285a4d73017ab0ebc2fa1aed5d82c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
  "futures",
@@ -6523,18 +6565,18 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257e0d217bc06635837d751447c39e77b9901752e052288ff6fe0fdb17850bc5"
+checksum = "e5ba5b852e976d35dbf6cb745746bf1bd4fc26782bab1e0c615fc71a7d8aac05"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.7.0",
  "prettyplease",
  "syn 2.0.90",
- "wasm-metadata 0.223.1",
- "wit-bindgen-core 0.37.0",
- "wit-component 0.223.1",
+ "wasm-metadata 0.225.0",
+ "wit-bindgen-core 0.39.0",
+ "wit-component 0.225.0",
 ]
 
 [[package]]
@@ -6554,17 +6596,17 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac98caa9302234687b8e67ce7dfcf31ae5238523f166b93c23988fd0d4e0594"
+checksum = "401529c9af9304a20ed99fa01799e467b7d37727126f0c9a958895471268ad7a"
 dependencies = [
  "anyhow",
  "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
- "wit-bindgen-core 0.37.0",
- "wit-bindgen-rust 0.37.0",
+ "wit-bindgen-core 0.39.0",
+ "wit-bindgen-rust 0.39.0",
 ]
 
 [[package]]
@@ -6588,25 +6630,6 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.223.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc2fcc52a79f6f010a89c867e53e06d4227f86c58984add3e37f32b8e7af5f0"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.7.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.223.1",
- "wasm-metadata 0.223.1",
- "wasmparser 0.223.1",
- "wit-parser 0.223.1",
-]
-
-[[package]]
-name = "wit-component"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923637fe647372efbbb654757f8c884ba280924477e1d265eca7e35d4cdcea8b"
@@ -6622,6 +6645,25 @@ dependencies = [
  "wasm-metadata 0.224.1",
  "wasmparser 0.224.1",
  "wit-parser 0.224.1",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2505c917564c1d74774563bbcd3e4f8c216a6508050862fd5f449ee56e3c5125"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.7.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.225.0",
+ "wasm-metadata 0.225.0",
+ "wasmparser 0.225.0",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
@@ -6662,24 +6704,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.223.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263fde17f1fbe55a413f16eb59094bf751795c6da469a05c3d45ea6c77df6b40"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.7.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.223.1",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
@@ -6694,6 +6718,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.224.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebefaa234e47224f10ce60480c5bfdece7497d0f3b87a12b41ff39e5c8377a78"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "db-mem"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "db-tests"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.7.0",
@@ -4625,21 +4625,21 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "wit-bindgen 0.39.0",
 ]
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "waki",
  "waki-macros",
@@ -4648,28 +4648,28 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "wit-bindgen 0.39.0",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "waki",
@@ -4678,56 +4678,56 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "wit-bindgen 0.39.0",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "wit-bindgen 0.39.0",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "wit-bindgen 0.39.0",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6159,7 +6159,7 @@ dependencies = [
 
 [[package]]
 name = "webui"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "webui-builder"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "cargo_metadata",
  "yewprint-css",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "webui-proxy"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.11",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -402,9 +402,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "camino"
@@ -463,7 +463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea13372b49df066d1ae654e5c6e41799c1efd9f6b36794b921e877ea4037977"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.6"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e329294a796e9b22329669c1f433a746983f9e324e07f4ef135be81bb2262de4"
+checksum = "8cf9dc8d4ef88e27a8cb23e85cb116403dedd57f7971964dc4b18ccead548901"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -629,7 +629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "winnow 0.6.20",
+ "winnow 0.7.2",
 ]
 
 [[package]]
@@ -1549,8 +1549,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1746,7 +1758,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903f432be5ba34427eac5e16048ef65604a82061fe93789f2212afc73d8617d6"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
  "gloo-events 0.2.0",
  "gloo-utils 0.2.0",
  "serde",
@@ -2121,9 +2133,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2426,13 +2438,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+checksum = "71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86"
 dependencies = [
  "console",
  "linked-hash-map",
  "once_cell",
+ "pin-project",
  "serde",
  "similar",
 ]
@@ -2699,7 +2712,7 @@ dependencies = [
  "madsim-macros",
  "naive-timer",
  "panic-message",
- "rand",
+ "rand 0.8.5",
  "rand_xoshiro",
  "rustversion",
  "serde",
@@ -2804,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2886,7 +2899,7 @@ dependencies = [
  "derivative",
  "derive_more",
  "fxhash",
- "getrandom",
+ "getrandom 0.2.11",
  "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "insta",
@@ -2894,7 +2907,7 @@ dependencies = [
  "madsim-tokio",
  "obeli-sk-val-json",
  "opentelemetry",
- "rand",
+ "rand 0.8.5",
  "rstest",
  "rusqlite",
  "serde",
@@ -2991,12 +3004,12 @@ dependencies = [
  "test-utils",
  "thiserror 2.0.8",
  "tracing",
- "wasmparser 0.223.0",
+ "wasmparser 0.223.1",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wit-component 0.223.0",
- "wit-parser 0.223.0",
+ "wit-component 0.223.1",
+ "wit-parser 0.223.1",
 ]
 
 [[package]]
@@ -3012,7 +3025,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.8",
  "wasmtime",
- "wast 223.0.0",
+ "wast 223.0.1",
 ]
 
 [[package]]
@@ -3044,7 +3057,7 @@ dependencies = [
  "obeli-sk-executor",
  "obeli-sk-utils",
  "obeli-sk-val-json",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "route-recognizer",
  "rstest",
@@ -3194,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f147e207436277483c23cb8e55ccd039ee1657c6a8d19471a6de187da6973ef8"
+checksum = "0609c917e8f4c44cd9d619a6e4741535d1cc199cfd995ad75580742bf6d624e8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3205,8 +3218,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
- "wit-component 0.219.1",
- "wit-parser 0.219.1",
+ "wit-component 0.224.1",
+ "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -3296,7 +3309,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -3429,7 +3442,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3458,7 +3471,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -3535,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3565,12 +3578,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -3677,8 +3690,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.2.11",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls 0.23.20",
@@ -3720,8 +3733,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3731,7 +3755,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -3740,7 +3774,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3749,7 +3793,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3787,7 +3831,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3798,7 +3842,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
  "libredox",
  "thiserror 2.0.8",
 ]
@@ -3919,7 +3963,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.11",
  "libc",
  "spin",
  "untrusted",
@@ -4200,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -4516,12 +4560,13 @@ checksum = "dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4835,15 +4880,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -4868,15 +4913,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "winnow 0.7.2",
 ]
 
 [[package]]
@@ -4984,7 +5029,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -5242,11 +5287,11 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "1.1.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f294bff79170ed1c5633812aff1e565c35d993a36e757f9bc0accf5eec4e6045"
+checksum = "ab82fc73182c29b02e2926a6df32f2241dbadb5cfc111fd595515b3598f46bb3"
 dependencies = [
- "rand",
+ "rand 0.9.0",
  "serde",
  "web-time",
 ]
@@ -5414,6 +5459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt 0.33.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5516,12 +5570,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.223.0"
+version = "0.223.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e636076193fa68103e937ac951b5f2f587624097017d764b8984d9c0f149464"
+checksum = "7a0a96fdeaee8fbeb4bd917fb8157d48c0d61c3b1f4ee4c363c8e8d68b2f4fe8"
 dependencies = [
  "leb128",
- "wasmparser 0.223.0",
+ "wasmparser 0.223.1",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab7a13a23790fe91ea4eb7526a1f3131001d874e3e00c2976c48861f2e82920"
+dependencies = [
+ "leb128",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
@@ -5553,9 +5617,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.223.0"
+version = "0.223.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c730c3379d3d20e5a0245b0724b924483e853588ca8fba547c1e21f19e7d735"
+checksum = "e2e7e37883181704d96b89dbd8f1291be13694c71cd0663aebb94b46d235a377"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
@@ -5564,8 +5628,25 @@ dependencies = [
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder 0.223.0",
- "wasmparser 0.223.0",
+ "wasm-encoder 0.223.1",
+ "wasmparser 0.223.1",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c93c9e49fa2749be3c5ab28ad4be03167294915cd3b2ded3f04f760cef5cfb86"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "url",
+ "wasm-encoder 0.224.1",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
@@ -5620,15 +5701,27 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.223.0"
+version = "0.223.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a99faceb1a5a84dd6084ec4bfa4b2ab153b5793b43fd8f58b89232634afc35"
+checksum = "664b980991ed9a8c834eb528a8979ab1109edcf52dc05dd5751e2cc3fb31035d"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.2",
  "indexmap 2.7.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.0",
+ "semver",
 ]
 
 [[package]]
@@ -5973,15 +6066,15 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "223.0.0"
+version = "223.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59b2ba8a2ff9f06194b7be9524f92e45e70149f4dacc0d0c7ad92b59ac875e4"
+checksum = "5fce293087c1cd10b4ee82fee235d7a5d131194c6f6d85ed9a8cfc6ba1cd86ab"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.223.0",
+ "wasm-encoder 0.223.1",
 ]
 
 [[package]]
@@ -6039,7 +6132,7 @@ dependencies = [
  "obeli-sk-val-json",
  "prost",
  "prost-wkt-types",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "tonic",
  "tonic-build",
@@ -6049,8 +6142,8 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-logger",
  "web-sys",
- "wit-component 0.223.0",
- "wit-parser 0.223.0",
+ "wit-component 0.223.1",
+ "wit-parser 0.223.1",
  "yew",
  "yew-router",
  "yew_icons",
@@ -6300,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]
@@ -6380,7 +6473,16 @@ checksum = "8ba105733ba146c94e067793fb46505265ea8720eb14ceae65b10797c7728a65"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.223.0",
+ "wit-parser 0.223.1",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -6430,9 +6532,9 @@ dependencies = [
  "indexmap 2.7.0",
  "prettyplease",
  "syn 2.0.90",
- "wasm-metadata 0.223.0",
+ "wasm-metadata 0.223.1",
  "wit-bindgen-core 0.37.0",
- "wit-component 0.223.0",
+ "wit-component 0.223.1",
 ]
 
 [[package]]
@@ -6486,9 +6588,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.223.0"
+version = "0.223.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10ed2aeee4c8ec5715875f62f4a3de3608d6987165c116810d8c2908aa9d93b"
+checksum = "3fc2fcc52a79f6f010a89c867e53e06d4227f86c58984add3e37f32b8e7af5f0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6497,10 +6599,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.223.0",
- "wasm-metadata 0.223.0",
- "wasmparser 0.223.0",
- "wit-parser 0.223.0",
+ "wasm-encoder 0.223.1",
+ "wasm-metadata 0.223.1",
+ "wasmparser 0.223.1",
+ "wit-parser 0.223.1",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923637fe647372efbbb654757f8c884ba280924477e1d265eca7e35d4cdcea8b"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.7.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.224.1",
+ "wasm-metadata 0.224.1",
+ "wasmparser 0.224.1",
+ "wit-parser 0.224.1",
 ]
 
 [[package]]
@@ -6541,9 +6662,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.223.0"
+version = "0.223.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92772f4dcacb804b275981eea1d920b12b377993b53307f1e33d87404e080281"
+checksum = "263fde17f1fbe55a413f16eb59094bf751795c6da469a05c3d45ea6c77df6b40"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -6554,7 +6675,25 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.223.0",
+ "wasmparser 0.223.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.224.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3477d8d0acb530d76beaa8becbdb1e3face08929db275f39934963eb4f716f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
@@ -6744,7 +6883,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -6752,6 +6900,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,12 +167,12 @@ arbitrary = { version = "1.4.1", features = ["derive"] }
 assert_matches = "1.5.0"
 async-channel = "2.3.1"
 async-trait = "0.1"
-bytes = "1.9"
+bytes = "1.10"
 cargo_metadata = "0.19"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.39", features = ["arbitrary", "serde"] }
-clap = { version = "4.5.27", features = ["derive"] }
-config = { version = "0.15.6", default-features = false, features = [
+clap = { version = "4.5.29", features = ["derive"] }
+config = { version = "0.15.8", default-features = false, features = [
     "toml",
     "preserve_order",
     "async",
@@ -198,20 +198,20 @@ hashbrown = { version = "0.15.2", features = ["serde"] }
 hdrhistogram = "7.5.4"
 http = "1.2.0"
 http-body-util = "0.1"
-hyper = "1.5.2"
+hyper = "1.6.0"
 hyper-util = { version = "0.1", features = ["tokio"] }
 indexmap = { version = "2.7", features = ["serde"] }
-insta = { version = "1.42.0", features = ["json"] }
+insta = { version = "1.42.1", features = ["json"] }
 itertools = "0.14"
 lazy_static = "1.5"
 madsim = "0.2.31"
 oci-client = { version = "0.14.0", default-features = false, features = [
     "rustls-tls",
 ] }
-oci-wasm = { version = "0.2.0", default-features = false, features = [ # Dependent on matching oci-client
+oci-wasm = { version = "0.2.1", default-features = false, features = [ # Dependent on matching oci-client
     "rustls-tls",
 ] }
-prost = "0.13.4"
+prost = "0.13.5"
 prost-wkt-types = "0.6"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = [
@@ -226,12 +226,12 @@ rusqlite = { version = "0.33.0", features = [
     "serde_json",
 ] }
 serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.137"
+serde_json = "1.0.138"
 serde_with = "3.12.0"
 sha2 = "0.10.8"
 shadow-rs = "0.37"
 strum = { version = "0.26.3", features = ["derive"] }
-tempfile = "3.14.0"
+tempfile = "3.16.0"
 thiserror = "2.0"
 tokio = { version = "0.2.30", package = "madsim-tokio", features = [
     "fs",
@@ -244,7 +244,7 @@ tokio = { version = "0.2.30", package = "madsim-tokio", features = [
     "tracing",
 ] }
 tokio-stream = "0.1.17"
-toml = { version = "0.8.19", features = ["preserve_order"] }
+toml = { version = "0.8.20", features = ["preserve_order"] }
 tonic = { version = "0.12.3", default-features = false }
 tonic-build = { version = "0.12.3", default-features = false }
 tonic-web = "0.12.3"
@@ -253,7 +253,7 @@ tower-http = { version = "0.6.2", features = ["trace", "cors"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
-ulid = { version = "1.1.4", features = ["serde"] }
+ulid = { version = "1.2.0", features = ["serde"] }
 url = "2.5.4"
 waki = "0.5.1"
 waki-macros = "0.5.1"
@@ -265,7 +265,7 @@ id-arena = "2.2.1"
 implicit-clone = "0.5.0"
 log = "0.4.25"
 semver = "1.0.25"
-tonic-web-wasm-client = "0.6.0"
+tonic-web-wasm-client = "0.6.1"
 wasm-bindgen = "=0.2.100"                                                     # Must be equal to wasm-bindgen-cli in nix. Update Trunk.toml.
 wasm-bindgen-futures = "=0.4.50"                                              # Must match https://github.com/rustwasm/wasm-bindgen/blob/$WASM_BINDGEN_VERSION/crates/futures/Cargo.toml
 web-sys = "=0.3.77"                                                           # Must match https://github.com/rustwasm/wasm-bindgen/blob/$WASM_BINDGEN_VERSION/crates/web-sys/Cargo.toml
@@ -280,10 +280,10 @@ wasmtime = { version = "29.0.1", features = ["memory-protection-keys"] }
 wasmtime-wasi = "29.0.1"
 wasmtime-wasi-http = "29.0.1"
 # wasm-tools
-wast = "223.0.0"
-wit-parser = "0.223.0"
-wasmparser = "0.223.0"
-wit-component = "0.223.0"
+wast = "223.0.1"
+wit-parser = "0.223.1"
+wasmparser = "0.223.1"
+wit-component = "0.223.1"
 
 # testing components
 wit-bindgen = "0.37.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
 authors = ["Project Developers"]
@@ -139,11 +139,11 @@ edition = "2021"
 rust-version = "1.83.0"
 
 [workspace.dependencies]
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.15.0" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.15.1" }
 db-mem = { path = "crates/db-mem" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.15.0" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.15.1" }
 db-tests = { path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.15.0" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.15.1" }
 obelisk-component-builder = { path = "crates/component-builder", features = [
     "genrs",
 ] }
@@ -155,9 +155,9 @@ test-programs-http-get-workflow-builder = { path = "crates/testing/test-programs
 test-programs-sleep-activity-builder = { path = "crates/testing/test-programs/sleep/activity/builder" }
 test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sleep/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.15.0" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.15.0" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.15.0" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.15.1" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.15.1" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.15.1" }
 webui-builder = { path = "crates/webui/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers"
 webui-builder = { path = "crates/webui/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
-axum = { version = "0.8.2", features = ["http2"] }
+axum = { version = "0.8.1", features = ["http2"] }
 directories = "6.0"
 arbitrary = { version = "1.4.1", features = ["derive"] }
 assert_matches = "1.5.0"
@@ -229,8 +229,8 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 serde_with = "3.12.0"
 sha2 = "0.10.8"
-shadow-rs = "0.37"
-strum = { version = "0.26.3", features = ["derive"] }
+shadow-rs = "0.38"
+strum = { version = "0.27.0", features = ["derive"] }
 tempfile = "3.16.0"
 thiserror = "2.0"
 tokio = { version = "0.2.30", package = "madsim-tokio", features = [
@@ -280,20 +280,24 @@ wasmtime = { version = "29.0.1", features = ["memory-protection-keys"] }
 wasmtime-wasi = "29.0.1"
 wasmtime-wasi-http = "29.0.1"
 # wasm-tools
-wast = "223.0.1"
-wit-parser = "0.223.1"
-wasmparser = "0.223.1"
-wit-component = "0.223.1"
+wast = "225.0.0"
+wit-parser = "0.225.0"
+wasmparser = "0.225.0"
+wit-component = "0.225.0"
 
 # testing components
-wit-bindgen = "0.37.0"
+wit-bindgen = "0.39.0"
 
 # otlp
-opentelemetry = "0.27.1"
-opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.27.0", features = ["tls", "tls-roots"] }
-opentelemetry-semantic-conventions = "0.27.0"
-tracing-opentelemetry = "0.28"
+opentelemetry = "0.28.0"
+opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.28.0", features = [
+    "tls",
+    "tls-roots",
+    "grpc-tonic",
+] }
+opentelemetry-semantic-conventions = "0.28.0"
+tracing-opentelemetry = "0.29"
 
 [patch.crates-io]
 getrandom = { git = "https://github.com/madsim-rs/getrandom.git", rev = "e79a7aecbcf8a43a802d30742667b77d75c613bd" } # madsim

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,27 @@
+# After launch
+
+## UI
+hide OneOff join sets
+add request to obtain the stack trace
+HAR like view of child executions https://github.com/monasticacademy/httptap
+
+## build
+Add -snapshot after release or investigate retaining git ref in --version,
+Pass the version to flakes.nix, perhaps use https://crane.dev/API.html e.g. https://github.com/tursodatabase/limbo/blob/main/flake.nix
+
+## CLI
+obelisk client component inspect/wit should accept: path, componentId, oci location
+
+## obelisk generate
+obelisk generate ext for webhook (just -schedule ext)
+obelisk generate config blank -c my.toml
+- blank
+- testing
+- stargazers
+
+obelisk generate workflow ... + host wit files
+obelisk add --oci ...
+
+## SAAS
+configuration needs to have a name for obelisk deploy.
+Investigate warg

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
         .extern_path(".google.protobuf.Duration", "::prost_wkt_types::Duration")
         .extern_path(".google.protobuf.Any", "::prost_wkt_types::Any")
+        .type_attribute(".", "#[derive(serde::Serialize)]") // for CLI only
+        .type_attribute(".", "#[serde(rename_all=\"snake_case\")]") // for CLI only
         .build_server(true)
         .build_client(true)
         .compile_protos(&["proto/obelisk.proto"], &[] as &[&str])?;

--- a/dev-deps.txt
+++ b/dev-deps.txt
@@ -2,17 +2,16 @@ cargo-binstall 1.10.22
 cargo-edit-upgrade 0.13.1
 cargo-expand 1.0.100
 cargo-nextest 0.9.87
-cargo-semver-checks 0.38.0
+cargo-semver-checks 0.39.0
 litecli Version: 1.12.3
-lldb version 19.1.6
 nixpkgs-fmt 1.3.0
 pkg-config 0.29.2
-libprotoc 29.2
+libprotoc 29.3
 rustc 1.84.1 (e71f9a9a9 2025-01-27)
 tokio-console 0.1.13
 wasm-tools 1.224.0
 wasmtime 29.0.1
 wasm-opt version 120
-trunk 0.21.5
+trunk 0.21.7
 wasm-bindgen 0.2.100
 ldd (GNU libc) 2.40

--- a/download.sh
+++ b/download.sh
@@ -4,7 +4,7 @@
 # Usage:
 # curl -L --tlsv1.2 -sSf https://raw.githubusercontent.com/obeli-sk/obelisk/main/download.sh | bash
 
-set -eux
+set -eu
 
 # Set pipefail if it works in a subshell, disregard if unsupported
 (set -o pipefail 2> /dev/null) && set -o pipefail
@@ -26,7 +26,7 @@ if [ "$os" = "Linux" ]; then
     if echo "$ldd_version" | grep -q "musl" || echo "$issue" | grep -q "NixOS"; then
         lib="musl"
         if echo "$issue" | grep -q "NixOS"; then
-            echo "Using musl on NixOS. If you want to use glibc, please use run with `nix profile install github:obeli-sk/obelisk/latest`"
+            echo -e "Downloading musl-based bianry on NixOS. Consider installing with\nnix profile install github:obeli-sk/obelisk/latest"
         fi
     else
         lib="gnu"
@@ -49,4 +49,5 @@ else
 fi
 
 # Download and extract the tarball
+echo "Downloading and extracting $url"
 curl -L --proto '=https' --tlsv1.2 -sSf "$url" | tar -xvzf -

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738410390,
-        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738549608,
-        "narHash": "sha256-GdyT9QEUSx5k/n8kILuNy83vxxdyUfJ8jL5mMpQZWfw=",
+        "lastModified": 1739413688,
+        "narHash": "sha256-57OAXXYhOibG7Rqhhr4ecI1H8mtDJB2uj0T8rbQVGLY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "35c6f8c4352f995ecd53896200769f80a3e8f22d",
+        "rev": "675a6427d505f140dab8c56379afb66d4f55800b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,6 @@
                 cargo-nextest
                 cargo-semver-checks
                 litecli
-                lldb
                 nixd
                 nixpkgs-fmt
                 pkg-config

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -246,7 +246,7 @@ message GetStatusResponse {
         ExecutionSummary summary = 1;
         // Remaining messages
         ExecutionStatus current_status = 2;
-        // Finished status
+        // Finished status, sent only if `send_finished_status` is set.
         FinishedStatus finished_status = 3;
     }
 }

--- a/scripts/dev-deps.sh
+++ b/scripts/dev-deps.sh
@@ -14,7 +14,6 @@ cargo-expand --version >> dev-deps.txt
 cargo nextest --version | head -n 1 >> dev-deps.txt
 cargo semver-checks --version >> dev-deps.txt
 echo "litecli $(litecli --version)" >> dev-deps.txt
-lldb --version >> dev-deps.txt
 echo $(nixpkgs-fmt --version) >> dev-deps.txt
 echo "pkg-config $(pkg-config --version)" >> dev-deps.txt
 # protobuf

--- a/src/args.rs
+++ b/src/args.rs
@@ -120,14 +120,20 @@ pub(crate) enum Execution {
         /// Function in the fully qualified format
         #[arg(value_name = "FUNCTION")]
         ffqn: FunctionFqn,
-        /// Parameters encoded as an JSON array
+        /// Parameters encoded as an JSON
         #[arg(value_name = "PARAMS")]
         params: String,
+        /// Print output as JSON
+        #[arg(long)]
+        json: bool,
     },
     Get {
         /// Follow the stream of events until the execution finishes
         #[arg(short, long)]
         follow: bool,
         execution_id: ExecutionId,
+        /// Print output as JSON
+        #[arg(long)]
+        json: bool,
     },
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -117,9 +117,6 @@ pub(crate) enum Execution {
         /// Follow the stream of events until the execution finishes
         #[arg(short, long)]
         follow: bool,
-        /// Enable full verbosity with `-vv`
-        #[arg(short, long, action = clap::ArgAction::Count)]
-        verbosity: u8,
         /// Function in the fully qualified format
         #[arg(value_name = "FUNCTION")]
         ffqn: FunctionFqn,
@@ -132,8 +129,5 @@ pub(crate) enum Execution {
         #[arg(short, long)]
         follow: bool,
         execution_id: ExecutionId,
-        /// Enable full verbosity with `-vv`
-        #[arg(short, long, action = clap::ArgAction::Count)]
-        verbosity: u8,
     },
 }

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -866,6 +866,7 @@ async fn run_internal(
         )
         .serve_with_shutdown(api_listening_addr, async move {
             info!("Serving gRPC requests at {api_listening_addr}");
+            info!("Server is ready");
             tokio::signal::ctrl_c()
                 .await
                 .expect("failed to listen for SIGINT event");

--- a/src/config/config_holder.rs
+++ b/src/config/config_holder.rs
@@ -1,7 +1,7 @@
 use super::toml::ConfigToml;
 use anyhow::bail;
 use config::{builder::AsyncState, ConfigBuilder, Environment, File, FileFormat};
-use directories::ProjectDirs;
+use directories::{BaseDirs, ProjectDirs};
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
@@ -10,6 +10,7 @@ const EXAMPLE_TOML: &[u8] = include_bytes!("../../obelisk.toml");
 pub(crate) struct ConfigHolder {
     paths: Vec<PathBuf>,
     pub(crate) project_dirs: Option<ProjectDirs>,
+    pub(crate) base_dirs: Option<BaseDirs>,
 }
 
 impl ConfigHolder {
@@ -21,7 +22,11 @@ impl ConfigHolder {
         Ok(())
     }
 
-    pub(crate) fn new(project_dirs: Option<ProjectDirs>, config: Option<PathBuf>) -> Self {
+    pub(crate) fn new(
+        project_dirs: Option<ProjectDirs>,
+        base_dirs: Option<BaseDirs>,
+        config: Option<PathBuf>,
+    ) -> Self {
         let paths = if let Some(config) = config {
             vec![config]
         } else {
@@ -56,6 +61,7 @@ impl ConfigHolder {
         Self {
             paths,
             project_dirs,
+            base_dirs,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use args::{Args, Client, ClientSubcommand, Server, Subcommand};
 use clap::Parser;
 use command::server::{RunParams, VerifyParams};
 use config::config_holder::ConfigHolder;
-use directories::ProjectDirs;
+use directories::{BaseDirs, ProjectDirs};
 use grpc_util::{injector::TracingInjector, to_channel};
 use std::path::PathBuf;
 use tonic::{codec::CompressionEncoding, transport::Channel};
@@ -30,6 +30,7 @@ async fn main() -> Result<(), anyhow::Error> {
         }) => {
             Box::pin(command::server::run(
                 project_dirs(),
+                BaseDirs::new(),
                 config,
                 RunParams {
                     clean_db,
@@ -54,6 +55,7 @@ async fn main() -> Result<(), anyhow::Error> {
         }) => {
             command::server::verify(
                 project_dirs(),
+                BaseDirs::new(),
                 config,
                 VerifyParams {
                     clean_db,

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     ffqn,
                     params,
                     follow,
+                    json: json_output,
                 }) => {
                     // TODO interactive search for ffqn showing param types and result, file name
                     // enter parameters one by one
@@ -116,14 +117,16 @@ async fn main() -> Result<(), anyhow::Error> {
                     let serde_json::Value::Array(params) = params else {
                         bail!("params should be a JSON array");
                     };
-                    command::execution::submit(client, ffqn, params, follow).await
+                    command::execution::submit(client, ffqn, params, follow, json_output).await
                 }
                 ClientSubcommand::Execution(args::Execution::Get {
                     execution_id,
                     follow,
+                    json: json_output,
                 }) => {
                     let client = get_execution_repository_client(api_url).await?;
-                    command::execution::get(client, execution_id, follow).await
+                    let json_output_started = if json_output { Some(false) } else { None };
+                    command::execution::get(client, execution_id, follow, json_output_started).await
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,6 @@ async fn main() -> Result<(), anyhow::Error> {
                     ffqn,
                     params,
                     follow,
-                    verbosity,
                 }) => {
                     // TODO interactive search for ffqn showing param types and result, file name
                     // enter parameters one by one
@@ -117,15 +116,14 @@ async fn main() -> Result<(), anyhow::Error> {
                     let serde_json::Value::Array(params) = params else {
                         bail!("params should be a JSON array");
                     };
-                    command::execution::submit(client, ffqn, params, follow, verbosity.into()).await
+                    command::execution::submit(client, ffqn, params, follow).await
                 }
                 ClientSubcommand::Execution(args::Execution::Get {
                     execution_id,
-                    verbosity,
                     follow,
                 }) => {
                     let client = get_execution_repository_client(api_url).await?;
-                    command::execution::get(client, execution_id, follow, verbosity.into()).await
+                    command::execution::get(client, execution_id, follow).await
                 }
             }
         }


### PR DESCRIPTION
## 🤖 New release
* `obeli-sk-concepts`: 0.15.0 -> 0.15.1
* `obeli-sk-val-json`: 0.15.0 -> 0.15.1
* `obeli-sk-utils`: 0.15.0 -> 0.15.1
* `obelisk-component-builder`: 0.15.0 -> 0.15.1
* `obeli-sk-db-sqlite`: 0.15.0 -> 0.15.1
* `obeli-sk-executor`: 0.15.0 -> 0.15.1
* `obeli-sk-wasm-workers`: 0.15.0 -> 0.15.1
* `obelisk`: 0.15.0 -> 0.15.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `obelisk`
<blockquote>

## [0.15.1](https://github.com/obeli-sk/obelisk/compare/v0.15.0...v0.15.1)

### ⛰️ Features

- *(cli)* Add `--json` parameter to `submit` and `get` - ([e437ef9](https://github.com/obeli-sk/obelisk/commit/e437ef9c1c050dcceec1d71097b63cea0eecf5f2))
- *(toml)* Add `~` prefix expansion - ([43050f5](https://github.com/obeli-sk/obelisk/commit/43050f57e05e98b6ec4745b4aad46d8de0bb6826))
- Print join set name in CLI - ([1c9225d](https://github.com/obeli-sk/obelisk/commit/1c9225de47104b0db28d41f7d11ff79447b3e34d))

### 🚜 Refactor

- Add "Server is ready" info message - ([bfa966f](https://github.com/obeli-sk/obelisk/commit/bfa966f1a7a78bd6f8086d5faa6bfd57e9fbb9ed))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).