### PR TITLE
chore: Bump Rust to 1.85

### DIFF
--- a/.github/workflows/check-build-webui.yml
+++ b/.github/workflows/check-build-webui.yml
@@ -28,9 +28,7 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Populate the nix store
-        run: nix develop --command echo
+        run: nix develop .#web --command echo
 
       - name: Build webui + proxy
-        run: nix develop --command ./scripts/push-webui.sh dummytag
-        env:
-          DRY_RUN: true
+        run: nix develop .#web --command ./scripts/push-webui.sh dry-run

--- a/dev-deps.txt
+++ b/dev-deps.txt
@@ -7,8 +7,7 @@ litecli Version: 1.12.3
 nixpkgs-fmt 1.3.0
 pkg-config 0.29.2
 libprotoc 29.3
-rustc 1.84.1 (e71f9a9a9 2025-01-27)
-tokio-console 0.1.13
+rustc 1.85.1 (4eb161250 2025-03-15)
 wasm-tools 1.228.0
 wasmtime 31.0.0
 wasm-opt version 120

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,7 @@
               [
                 (pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
                 binaryen # wasm-opt
+                protobuf
                 trunk
                 wasm-bindgen-cli
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
             nativeBuildInputs = with pkgs;
               [
                 (pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+                binaryen # wasm-opt
                 trunk
                 wasm-bindgen-cli
               ];

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip2"]
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer", "cargo"]

--- a/scripts/cargo-publish-workspace.sh
+++ b/scripts/cargo-publish-workspace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Publish all packages in the workspace except for those listed in assets/unpublishable-packages.txt.
-
+# Requires Rust nightly ATM, see `flake.nix` for exact version.
 set -exuo pipefail
 cd "$(dirname "$0")/.."
 

--- a/scripts/dev-deps.sh
+++ b/scripts/dev-deps.sh
@@ -19,12 +19,15 @@ echo "pkg-config $(pkg-config --version)" >> dev-deps.txt
 # protobuf
 protoc --version >> dev-deps.txt
 rustc --version >> dev-deps.txt
-tokio-console --version >> dev-deps.txt
 wasm-tools --version >> dev-deps.txt
 wasmtime --version >> dev-deps.txt
-# webui
-wasm-opt --version >> dev-deps.txt # binarien
-trunk --version >> dev-deps.txt
-wasm-bindgen --version >> dev-deps.txt
+
+# web
+nix develop .#web --command wasm-opt --version >> dev-deps.txt # binaryen
+nix develop .#web --command trunk --version >> dev-deps.txt
+nix develop .#web --command wasm-bindgen --version >> dev-deps.txt
+
 # libc
 ldd --version | head -n 1 >> dev-deps.txt
+
+


### PR DESCRIPTION
Use a forked `wasm-bindgen-cli` to work around https://github.com/rustwasm/wasm-bindgen/issues/4446 . Extract `web` devShell.