### PR TITLE
feat: support ${VAR} interpolation in env_vars values

### DIFF
--- a/obelisk-help.toml
+++ b/obelisk-help.toml
@@ -96,8 +96,8 @@ webui.listening_addr = "127.0.0.1:8080" # Address and port on which the webui wi
 ## Guest std stream forwarding to host: one of "none","stdout","stderr","db". Default is "db".
 # forward_stdout="db" # Persist guest's stdout to the database.
 # forward_stderr="db" # Persist guest's stderr to the database.
-## Environment variables: Set to a specific value or forward from the host. Default is empty.
-# env_vars = ["ENV1", "ENV2=somevalue"]
+## Environment variables: Set to a specific value, use ${VAR} interpolation, or forward from the host. Default is empty.
+# env_vars = ["ENV1", "ENV2=somevalue", "ENV3=${HOST_VAR}", "ENV4=prefix ${HOST_VAR}"]
 ## Preopened directory support
 ## When enabled, `.` will be available to the activity with all permissions.
 ## On host the folder is mapped to `activities.directories.parent_directory`/ExecutionID.
@@ -171,8 +171,8 @@ webui.listening_addr = "127.0.0.1:8080" # Address and port on which the webui wi
 # forward_stdout="stderr" # forwards stdout to host's stderr
 # forward_stderr="stderr" # forwards stderr to host's stderr
 
-## Environment variables: Set to a specific value or forward from the host. Default is empty.
-# env_vars = ["ENV1", "ENV2=somevalue"]
+## Environment variables: Set to a specific value, use ${VAR} interpolation, or forward from the host. Default is empty.
+# env_vars = ["ENV1", "ENV2=somevalue", "ENV3=${HOST_VAR}", "ENV4=prefix ${HOST_VAR}"]
 
 # backtrace.sources = {"frame symbol file path" = "path to the source file", ".../src/lib.rs" = "path to source file"}
 # backtrace.ignore_component_digest = false # If set to true, sha256 digest of the requested component will not be compared to the loaded component's digset.

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1630,7 +1630,10 @@ fn resolve_env_vars(
     env_vars
         .into_iter()
         .map(|EnvVarConfig { key, val }| match val {
-            Some(val) => Ok(EnvVar { key, val }),
+            Some(val) => Ok(EnvVar {
+                key,
+                val: replace_env_vars(&val)?,
+            }),
             None => match std::env::var(&key) {
                 Ok(val) => Ok(EnvVar { key, val }),
                 Err(err) => {


### PR DESCRIPTION
Allow env_vars values to use ${VAR} interpolation from host environment variables, reusing the existing `replace_env_vars` function already used for postgres config.

## Examples

```toml
env_vars = ["ENV1", "ENV2=${FOO}", "ENV3=prefix ${FOO} ${BAR}"]
```

- `ENV1` — forwarded from host (existing behavior, unchanged)
- `ENV2=somevalue` — literal value (existing behavior, unchanged)
- `ENV2=${FOO}` — value interpolated from host's `FOO`
- `ENV3=prefix ${FOO} ${BAR}` — mixed literal and interpolated

## Changes

- **`src/config/toml.rs`**: Apply `replace_env_vars()` to the value in `resolve_env_vars()` when a value is provided
- **`src/config/env_var.rs`**: Add unit tests for `replace_env_vars()`
- **`obelisk-help.toml`**: Update comments to show interpolation examples