### PR TITLE
ci: Fix YAML quoting in check-test matrix

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -72,12 +72,12 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: junit-report
-          path: target/nextest/${{ github.job }}/junit-${{ matrix.report }}.xml
+          path: target/nextest/${{ github.job }}/${{ matrix.report }}
 
       - name: Report results in GitHub UI
         uses: dorny/test-reporter@b082adf0eced0765477756c2a610396589b8c637
         if: always()
         with:
           name: Rust tests
-          path: target/nextest/${{ github.job }}/junit-${{ matrix.report }}.xml
+          path: target/nextest/${{ github.job }}/${{ matrix.report }}
           reporter: java-junit


### PR DESCRIPTION
The second matrix entry in `check-test.yml` had unescaped inner double quotes in the `additional` field, causing a YAML parse error and immediate workflow failure.

Escaped the inner quotes so the value is parsed correctly as:
```
-F activity-js-local -F workflow-js-local --config junit.path="junit-js-local.xml"
```

Fixes the failing run: https://github.com/obeli-sk/obelisk/actions/runs/22174833634