### PR TITLE
refactor: limit each integration test to at most one insta snapshot

### DIFF
--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -423,6 +423,8 @@ async fn greet_activity_logs() {
         )
         .await;
     assert_eq!(resp.status().as_u16(), 201);
+    // Consume the streamed body to wait for execution to finish.
+    let _: Value = resp.json().await.unwrap();
 
     // Allow log forwarding to flush.
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -446,6 +448,8 @@ async fn greet_activity_status() {
         )
         .await;
     assert_eq!(resp.status().as_u16(), 201);
+    // Consume the streamed body to wait for execution to finish.
+    let _: Value = resp.json().await.unwrap();
 
     let status = server.get_status(&exec_id).await;
     let status = sanitize_json(&status);


### PR DESCRIPTION
Split `submit_greet_activity_and_inspect` into three separate tests (`greet_activity_events`, `greet_activity_logs`, `greet_activity_status`), each with a single snapshot assertion.

Remove the redundant `list_functions` snapshot from `list_components` (already covered by the dedicated `list_functions` test).

Snapshot names are unchanged so existing `.snap` files still match.