### PR TITLE
refactor(cli): Rename `--deployment-empty` to `--empty` in `server run`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -264,12 +264,12 @@ pub(crate) enum Server {
         server_config: Option<PathBuf>,
         /// Path to the deployment TOML file. If provided, the deployment is inserted and activated on startup,
         /// overriding any existing Enqueued or Active deployment in the database.
-        #[arg(short, long, conflicts_with = "deployment_empty")]
+        #[arg(short, long, conflicts_with = "empty")]
         deployment: Option<PathBuf>,
         /// Start with an empty deployment, ignoring any Enqueued or Active deployment in the database.
         /// Useful for recovering from a faulty deployment: start empty, then push a new deployment or switch to existing via gRPC.
         #[arg(long)]
-        deployment_empty: bool,
+        empty: bool,
         /// Do not fail startup when a component's imports/exports fail type checking against the current deployment.
         #[arg(long, short)]
         suppress_type_checking_errors: bool,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -178,7 +178,7 @@ impl Server {
                 clean_codegen_cache,
                 server_config,
                 deployment,
-                deployment_empty,
+                empty: deployment_empty,
                 suppress_type_checking_errors,
             } => {
                 Box::pin(run(


### PR DESCRIPTION
This brings the switch in line with all other commands that use
empty deployment switch.
