### PR TITLE
refactor(workflow-js): Remove `error:"cancelled"` from `js.joinNext()`

### DIFF
--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -66,22 +66,19 @@
 //! ## Check Execution Status
 //! ```js
 //! const status = obelisk.getStatus(execId);
-//! // status.type = "pending" | "locked" | "blockedByJoinSet" | "finished"
-//! // If finished: status.finished = "ok" | "err" | "executionFailure"
+//! // status = "pending" | "locked" | "blockedByJoinSet" | "finished"
+//! // If finished: status.finishedStatus = "ok" | "err" | "executionFailure"
 //! ```
 //!
 //! ## Get Execution Result
 //! ```js
 //! // Blocking - waits until execution completes
 //! const result = obelisk.get(execId);
-//! // result = { ok: value } or { err: value }
+//! // result = { ok/err: value }
 //!
-//! // Non-blocking - returns immediately or throws if not finished
-//! try {
-//!     const result = obelisk.tryGet(execId);
-//! } catch (e) {
-//!     // "not finished yet" or "not found"
-//! }
+//! // Non-blocking - returns immediately
+//! const result = obelisk.tryGet(execId);
+//! // result = `{ pending: true }` or `{ ok/err: value }`
 //! ```
 //!
 //! ## Environment Variables

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -931,20 +931,7 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
                     ResponseId::DelayId(delay_id) => {
                         result_obj.set(js_string!("type"), js_string!("delay"), false, ctx)?;
                         result_obj.set(js_string!("id"), js_string!(delay_id.id), false, ctx)?;
-                        match result {
-                            Ok(()) => {
-                                result_obj.set(js_string!("ok"), true, false, ctx)?;
-                            }
-                            Err(()) => {
-                                result_obj.set(js_string!("ok"), false, false, ctx)?;
-                                result_obj.set(
-                                    js_string!("error"),
-                                    js_string!("cancelled"),
-                                    false,
-                                    ctx,
-                                )?;
-                            }
-                        }
+                        result_obj.set(js_string!("ok"), result.is_ok(), false, ctx)?;
                     }
                 }
 


### PR DESCRIPTION
Delays can error only on cancellation and this is captured with
`{ok: false}`
