### PR TITLE
feat(cli,webui): Add `logs`, `events`, `responses`, `list` commands to `execution`

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -913,6 +913,15 @@
             }
           },
           {
+            "name": "show_run_id",
+            "in": "query",
+            "description": "Include the run ID in text output",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "cursor",
             "in": "query",
             "description": "Cursor for pagination (`DateTime`, opaque)",

--- a/src/args.rs
+++ b/src/args.rs
@@ -379,8 +379,129 @@ impl FromStr for FunctionFqnOrShort {
     }
 }
 
+/// Minimum log level for `execution logs`.
+/// One of: `trace`, `debug`, `info`, `warn`, `error`, `off`.
+#[derive(Debug, Clone, Copy, strum::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum LogLevelArg {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    /// Disable structured log output. Use with `--show-streams`.
+    Off,
+}
+
+/// Log stream type for `execution logs`.
+/// One of: `stdout`, `stderr`.
+#[derive(Debug, Clone, Copy, strum::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum LogStreamTypeArg {
+    Stdout,
+    Stderr,
+}
+
 #[derive(Debug, clap::Subcommand)]
 pub(crate) enum Execution {
+    /// List recent executions.
+    List {
+        /// Address of the obelisk server.
+        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        api_url: String,
+        /// Filter by function FFQN prefix.
+        /// Accepts any prefix of a fully-qualified function name, e.g.:
+        ///   `namespace:pkg/ifc.fn`, `namespace:pkg/ifc`, `namespace:pkg/`, `namespace:`
+        /// Short `.../ifc.fn` form is not supported.
+        #[arg(long, value_name = "FFQN_PREFIX")]
+        ffqn: Option<String>,
+        /// Include child (derived) executions spawned by workflows.
+        /// By default only top-level executions are shown.
+        #[arg(long)]
+        show_derived: bool,
+        /// Hide finished executions.
+        #[arg(long)]
+        hide_finished: bool,
+        /// Number of executions to return.
+        #[arg(long, default_value = "20")]
+        limit: u16,
+        /// Output as JSON instead of human-readable text.
+        #[arg(short, long)]
+        json: bool,
+    },
+    /// Fetch structured logs for an execution.
+    Logs {
+        /// Address of the obelisk server.
+        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        api_url: String,
+        /// Execution ID to fetch logs for.
+        #[arg(value_name = "EXECUTION_ID")]
+        execution_id: ExecutionId,
+        /// Include logs from child (derived) executions.
+        #[arg(long)]
+        show_derived: bool,
+        /// Minimum log level: trace, debug, info, warn, error, off.
+        /// `off` disables structured log output entirely (use with --show-streams).
+        #[arg(long, value_name = "LEVEL", default_value = "debug")]
+        level: LogLevelArg,
+        /// Include stdout/stderr stream output.
+        #[arg(long)]
+        show_streams: bool,
+        /// Filter stream output by type (stdout, stderr). Repeatable. Only with --show-streams.
+        #[arg(long, value_name = "TYPE", requires = "show_streams")]
+        stream_type: Vec<LogStreamTypeArg>,
+        /// Show the run ID in each log line.
+        #[arg(long)]
+        show_run_id: bool,
+        /// Only show entries created after this timestamp (RFC3339, e.g. 2026-04-14T10:00:00Z).
+        #[arg(long, value_name = "TIMESTAMP")]
+        after: Option<String>,
+        /// Poll for new log entries until the execution finishes.
+        #[arg(long)]
+        follow: bool,
+        /// Number of log entries to return per request (default: 20, max: 200).
+        #[arg(long, default_value = "20")]
+        limit: u16,
+        /// Output as JSON instead of human-readable text.
+        #[arg(short, long)]
+        json: bool,
+    },
+    /// Show the execution event log (history).
+    Events {
+        /// Address of the obelisk server.
+        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        api_url: String,
+        /// Execution ID.
+        #[arg(value_name = "EXECUTION_ID")]
+        execution_id: ExecutionId,
+        /// Start from this event version (inclusive).
+        #[arg(long, value_name = "VERSION")]
+        from: Option<u32>,
+        /// Number of events to return.
+        #[arg(long, default_value = "20")]
+        limit: u16,
+        /// Output as JSON instead of human-readable text.
+        #[arg(short, long)]
+        json: bool,
+    },
+    /// Show join-set responses for an execution (child results, delay completions).
+    Responses {
+        /// Address of the obelisk server.
+        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        api_url: String,
+        /// Execution ID.
+        #[arg(value_name = "EXECUTION_ID")]
+        execution_id: ExecutionId,
+        /// Start from this response cursor (inclusive).
+        #[arg(long, value_name = "CURSOR")]
+        from: Option<u32>,
+        /// Number of responses to return.
+        #[arg(long, default_value = "20")]
+        limit: u16,
+        /// Output as JSON instead of human-readable text.
+        #[arg(short, long)]
+        json: bool,
+    },
     /// Submit a new execution and optionally follow its status stream until it finishes.
     Submit {
         /// Address of the obelisk server

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -34,6 +34,55 @@ use tracing::instrument;
 impl args::Execution {
     pub(crate) async fn run(self) -> Result<(), anyhow::Error> {
         match self {
+            args::Execution::List {
+                api_url,
+                ffqn,
+                show_derived,
+                hide_finished,
+                limit,
+                json,
+            } => execution_list(&api_url, ffqn, show_derived, hide_finished, limit, json).await,
+            args::Execution::Logs {
+                api_url,
+                execution_id,
+                show_derived,
+                level,
+                show_streams,
+                stream_type,
+                show_run_id,
+                after,
+                follow,
+                limit,
+                json,
+            } => {
+                let opts = LogsOpts::from_args(
+                    level,
+                    show_streams,
+                    &stream_type,
+                    show_derived,
+                    show_run_id,
+                    limit,
+                )?;
+                if follow {
+                    follow_logs(&api_url, &execution_id, &opts, after, json).await
+                } else {
+                    execution_logs_cmd(&api_url, execution_id, &opts, after, json).await
+                }
+            }
+            args::Execution::Events {
+                api_url,
+                execution_id,
+                from,
+                limit,
+                json,
+            } => execution_events_cmd(&api_url, execution_id, from, limit, json).await,
+            args::Execution::Responses {
+                api_url,
+                execution_id,
+                from,
+                limit,
+                json,
+            } => execution_responses_cmd(&api_url, execution_id, from, limit, json).await,
             args::Execution::Submit {
                 api_url,
                 execution_id,
@@ -453,6 +502,306 @@ async fn poll_get_status_stream(
         }
     }
     Ok(())
+}
+
+/// Send a GET request and forward the response body to stdout.
+async fn send_and_print(req: reqwest::RequestBuilder) -> anyhow::Result<()> {
+    let resp = req.send().await.context("failed to send request")?;
+    let status = resp.status();
+    if status.is_success() {
+        let body = resp.text().await.context("failed to read response body")?;
+        // Ensure output ends with a newline even when the server omits it (e.g. JSON).
+        if body.ends_with('\n') {
+            print!("{body}");
+        } else {
+            println!("{body}");
+        }
+        Ok(())
+    } else {
+        let body = resp.text().await.unwrap_or_default();
+        Err(anyhow::anyhow!("server returned {status}: {body}"))
+    }
+}
+
+async fn execution_list(
+    api_url: &str,
+    ffqn: Option<String>,
+    show_derived: bool,
+    hide_finished: bool,
+    limit: u16,
+    json: bool,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let accept = if json {
+        "application/json"
+    } else {
+        "text/plain"
+    };
+    let mut req = client
+        .get(format!("{api_url}/v1/executions"))
+        .header(ACCEPT, accept)
+        .query(&[("length", limit.to_string())]);
+    if let Some(ffqn) = ffqn {
+        req = req.query(&[("ffqn_prefix", ffqn)]);
+    }
+    if show_derived {
+        req = req.query(&[("show_derived", "true")]);
+    }
+    if hide_finished {
+        req = req.query(&[("hide_finished", "true")]);
+    }
+    send_and_print(req).await
+}
+
+/// Resolved log filter parameters shared between the one-shot and follow paths.
+/// `json` is intentionally excluded — it controls output format, not the query filter.
+struct LogsOpts {
+    /// Empty slice means `show_logs=false` (level was `off`).
+    levels: &'static [&'static str],
+    show_streams: bool,
+    stream_type_strs: Vec<&'static str>,
+    show_derived: bool,
+    show_run_id: bool,
+    limit: u16,
+}
+
+impl LogsOpts {
+    fn from_args(
+        level: args::LogLevelArg,
+        show_streams: bool,
+        stream_types: &[args::LogStreamTypeArg],
+        show_derived: bool,
+        show_run_id: bool,
+        limit: u16,
+    ) -> anyhow::Result<Self> {
+        use args::LogLevelArg;
+        let levels: &'static [&'static str] = match level {
+            LogLevelArg::Off => &[],
+            LogLevelArg::Trace => &["trace", "debug", "info", "warn", "error"],
+            LogLevelArg::Debug => &["debug", "info", "warn", "error"],
+            LogLevelArg::Info => &["info", "warn", "error"],
+            LogLevelArg::Warn => &["warn", "error"],
+            LogLevelArg::Error => &["error"],
+        };
+        if levels.is_empty() && !show_streams {
+            anyhow::bail!("either `--level` must not be `off`, or `--show-streams` must be set");
+        }
+        let stream_type_strs = stream_types
+            .iter()
+            .map(|st| match st {
+                args::LogStreamTypeArg::Stdout => "stdout",
+                args::LogStreamTypeArg::Stderr => "stderr",
+            })
+            .collect();
+        Ok(Self {
+            levels,
+            show_streams,
+            stream_type_strs,
+            show_derived,
+            show_run_id,
+            limit,
+        })
+    }
+
+    fn apply_to_request(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let show_logs = !self.levels.is_empty();
+        req = req.query(&[("show_logs", if show_logs { "true" } else { "false" })]);
+        if show_logs {
+            for level_str in self.levels {
+                req = req.query(&[("level", *level_str)]);
+            }
+        }
+        req = req.query(&[(
+            "show_streams",
+            if self.show_streams { "true" } else { "false" },
+        )]);
+        if self.show_streams {
+            for st in &self.stream_type_strs {
+                req = req.query(&[("stream_type", *st)]);
+            }
+        }
+        if self.show_derived {
+            req = req.query(&[("show_derived", "true")]);
+        }
+        if self.show_run_id {
+            req = req.query(&[("show_run_id", "true")]);
+        }
+        req
+    }
+}
+
+async fn execution_logs_cmd(
+    api_url: &str,
+    execution_id: ExecutionId,
+    opts: &LogsOpts,
+    after: Option<String>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let accept = if json {
+        "application/json"
+    } else {
+        "text/plain"
+    };
+    let mut req = reqwest::Client::new()
+        .get(format!("{api_url}/v1/executions/{execution_id}/logs"))
+        .header(ACCEPT, accept)
+        .query(&[("length", opts.limit.to_string())]);
+    req = opts.apply_to_request(req);
+    if let Some(after) = after {
+        req = req
+            .query(&[("cursor", after.as_str())])
+            .query(&[("including_cursor", "false")])
+            .query(&[("direction", "newer")]);
+    }
+    send_and_print(req).await
+}
+
+async fn follow_logs(
+    api_url: &str,
+    execution_id: &ExecutionId,
+    opts: &LogsOpts,
+    initial_after: Option<String>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let logs_url = format!("{api_url}/v1/executions/{execution_id}/logs");
+    let status_url = format!("{api_url}/v1/executions/{execution_id}/status");
+    let accept = if json {
+        "application/json"
+    } else {
+        "text/plain"
+    };
+    let mut cursor: Option<String> = initial_after;
+
+    loop {
+        let mut req = client.get(&logs_url).header(ACCEPT, accept).query(&[
+            ("length", opts.limit.to_string()),
+            ("direction", "newer".into()),
+        ]);
+        req = opts.apply_to_request(req);
+        if let Some(ref c) = cursor {
+            req = req
+                .query(&[("cursor", c.as_str())])
+                .query(&[("including_cursor", "false")]);
+        }
+
+        let resp = req.send().await.context("failed to send logs request")?;
+        let resp_status = resp.status();
+        if !resp_status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow::anyhow!("server returned {resp_status}: {body}"));
+        }
+
+        let body = resp.text().await.context("failed to read logs response")?;
+        let has_items = body.lines().any(|l| !l.is_empty());
+
+        if has_items {
+            if json {
+                // Parse only to extract cursor and emit JSONL; no text rendering.
+                let items: Vec<serde_json::Value> =
+                    serde_json::from_str(&body).context("failed to parse logs JSON")?;
+                for item in &items {
+                    println!(
+                        "{}",
+                        serde_json::to_string(item).context("failed to serialize log item")?
+                    );
+                }
+                if let Some(c) = items.last().and_then(|v| v["cursor"].as_str()) {
+                    cursor = Some(c.to_string());
+                }
+            } else {
+                // Forward server-rendered text directly; cursor is the timestamp
+                // at the start of the last non-empty line (always 30 chars wide).
+                print!("{body}");
+                cursor = body
+                    .lines()
+                    .rev()
+                    .find(|l| !l.is_empty())
+                    .and_then(|l| l.get(..30))
+                    .map(str::to_string);
+            }
+        }
+
+        // Check if the execution has finished.
+        let finished = {
+            let resp = client
+                .get(&status_url)
+                .header(ACCEPT, "application/json")
+                .send()
+                .await
+                .context("failed to get execution status")?;
+            let st = resp.status();
+            if !st.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                return Err(anyhow::anyhow!("status check returned {st}: {body}"));
+            }
+            let status_json: serde_json::Value = resp
+                .json()
+                .await
+                .context("failed to parse status response")?;
+            status_json["pending_state"]["status"].as_str() == Some("finished")
+        };
+
+        if finished && !has_items {
+            break;
+        }
+
+        if !has_items {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    Ok(())
+}
+
+async fn execution_events_cmd(
+    api_url: &str,
+    execution_id: ExecutionId,
+    from: Option<u32>,
+    limit: u16,
+    json: bool,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let accept = if json {
+        "application/json"
+    } else {
+        "text/plain"
+    };
+    let mut req = client
+        .get(format!("{api_url}/v1/executions/{execution_id}/events"))
+        .header(ACCEPT, accept)
+        .query(&[("length", limit.to_string())]);
+    if let Some(from) = from {
+        req = req
+            .query(&[("version", from.to_string())])
+            .query(&[("including_cursor", "true")]);
+    }
+    send_and_print(req).await
+}
+
+async fn execution_responses_cmd(
+    api_url: &str,
+    execution_id: ExecutionId,
+    from: Option<u32>,
+    limit: u16,
+    json: bool,
+) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let accept = if json {
+        "application/json"
+    } else {
+        "text/plain"
+    };
+    let mut req = client
+        .get(format!("{api_url}/v1/executions/{execution_id}/responses"))
+        .header(ACCEPT, accept)
+        .query(&[("length", limit.to_string())]);
+    if let Some(from) = from {
+        req = req
+            .query(&[("cursor", from.to_string())])
+            .query(&[("including_cursor", "true")]);
+    }
+    send_and_print(req).await
 }
 
 impl CancelCommand {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -751,6 +751,9 @@ mod logs {
         /// Include logs from all derived executions
         #[serde(default)]
         show_derived: bool,
+        /// Include the run ID in text output
+        #[serde(default)]
+        show_run_id: bool,
 
         // pagination
         /// Cursor for pagination (`DateTime`, opaque)
@@ -871,19 +874,26 @@ mod logs {
         }
     }
 
-    #[derive(serde::Serialize, derive_more::Display, ToSchema)]
+    #[derive(serde::Serialize, ToSchema)]
     #[serde(rename_all = "snake_case")]
     pub(crate) enum LogLevelSer {
-        #[display("TRACE")]
         Trace,
-        #[display("DEBUG")]
         Debug,
-        #[display("INFO")]
         Info,
-        #[display("WARN")]
         Warn,
-        #[display("ERROR")]
         Error,
+    }
+
+    impl Display for LogLevelSer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.pad(match self {
+                Self::Trace => "TRACE",
+                Self::Debug => "DEBUG",
+                Self::Info => "INFO",
+                Self::Warn => "WARN",
+                Self::Error => "ERROR",
+            })
+        }
     }
 
     impl From<LogLevel> for LogLevelSer {
@@ -898,13 +908,20 @@ mod logs {
         }
     }
 
-    #[derive(serde::Serialize, derive_more::Display, ToSchema)]
+    #[derive(serde::Serialize, ToSchema)]
     #[serde(rename_all = "snake_case")]
     pub(crate) enum LogStreamTypeSer {
-        #[display("STDOUT")]
         Stdout,
-        #[display("STDERR")]
         Stderr,
+    }
+
+    impl Display for LogStreamTypeSer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.pad(match self {
+                Self::Stdout => "STDOUT",
+                Self::Stderr => "STDERR",
+            })
+        }
     }
 
     impl From<LogStreamType> for LogStreamTypeSer {
@@ -993,8 +1010,8 @@ mod logs {
             }
             AcceptHeader::Text => {
                 let mut output = String::new();
-                struct ExecId<'a>(bool, &'a ExecutionId);
-                impl Display for ExecId<'_> {
+                struct PrefixId<'a>(bool, &'a dyn Display);
+                impl Display for PrefixId<'_> {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                         if self.0 {
                             write!(f, "{} ", self.1)
@@ -1013,10 +1030,10 @@ mod logs {
                             let level = LogLevelSer::from(level);
                             writeln!(
                                 &mut output,
-                                "{exec_id}{run_id} `{created_at}` [{level}] {message}",
-                                exec_id = ExecId(params.show_derived, &log.execution_id),
-                                run_id = log.run_id,
-                                created_at = created_at.to_rfc3339(),
+                                "{created_at} [{level:<6}] {run_id}{exec_id}{message}",
+                                created_at = created_at.format("%Y-%m-%dT%H:%M:%S%.9fZ"),
+                                run_id = PrefixId(params.show_run_id, &log.run_id),
+                                exec_id = PrefixId(params.show_derived, &log.execution_id),
                             )
                             .expect("writing to string");
                         }
@@ -1029,10 +1046,10 @@ mod logs {
                             let payload_utf8 = String::from_utf8_lossy(&payload);
                             writeln!(
                                 &mut output,
-                                "{exec_id}{run_id} `{created_at}` [{stream_type}] {payload_utf8}",
-                                exec_id = ExecId(params.show_derived, &log.execution_id),
-                                run_id = log.run_id,
-                                created_at = created_at.to_rfc3339(),
+                                "{created_at} [{stream_type:<6}] {run_id}{exec_id}{payload_utf8}",
+                                created_at = created_at.format("%Y-%m-%dT%H:%M:%S%.9fZ"),
+                                run_id = PrefixId(params.show_run_id, &log.run_id),
+                                exec_id = PrefixId(params.show_derived, &log.execution_id),
                             )
                             .expect("writing to string");
                         }


### PR DESCRIPTION
This changes format of webapi responses for plaintext logs, adds `show_run_id` query param.
