### PR TITLE
fix: Fix replaying of unfinished executions

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - report: junit-default.xml
             script: "scripts/test.sh"
+          - report: junit-js-local.xml
+            script: "scripts/test-js-local.sh"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,6 +3285,7 @@ dependencies = [
 name = "obelisk"
 version = "0.37.6"
 dependencies = [
+ "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3362,8 +3363,10 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
+ "webhook-js-runtime-builder",
  "wit-component 0.245.1",
  "wit-parser 0.245.1",
+ "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
+activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -124,9 +127,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = []
-"webhook-js-local" = []
-"workflow-js-local" = []
+"activity-js-local" = ["dep:activity-js-runtime-builder"]
+"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
+"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
 default = ["otlp"]
 
 [lints]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -81,6 +81,16 @@ impl ExecutionLog {
     }
 
     #[must_use]
+    pub fn get_create_request(&self) -> CreateRequest {
+        assert_matches!(self.events.first().cloned(), Some(ExecutionEvent {
+            event:ExecutionRequest::Created{
+                ffqn,params,parent,scheduled_at,component_id,deployment_id,metadata,scheduled_by},
+                created_at, .. }) => CreateRequest { created_at, execution_id:
+                    self.execution_id.clone(), ffqn, params, parent, scheduled_at,
+                    component_id, deployment_id, metadata, scheduled_by })
+    }
+
+    #[must_use]
     pub fn ffqn(&self) -> &FunctionFqn {
         assert_matches!(self.events.first(), Some(ExecutionEvent {
             event: ExecutionRequest::Created { ffqn, .. },
@@ -1464,8 +1474,8 @@ pub trait DbConnection: DbExecutor {
         outcome: Result<(), ()>, // Successfully finished - `Ok(())` or cancelled - `Err(())`
     ) -> Result<AppendDelayResponseOutcome, DbErrorWrite>;
 
-    /// Append a batch of events to an existing execution log, and append a response to a parent execution.
-    /// The batch cannot contain [`ExecutionRequest::Created`].
+    /// Append a batch of events to an existing execution log.
+    /// The batch must not contain [`ExecutionRequest::Created`].
     async fn append_batch(
         &self,
         current_time: DateTime<Utc>, // not persisted, can be used for unblocking `subscribe_to_pending`
@@ -1475,7 +1485,7 @@ pub trait DbConnection: DbExecutor {
     ) -> Result<AppendBatchResponse, DbErrorWrite>;
 
     /// Append one or more events to the parent execution log, and create zero or more child execution logs.
-    /// The batch cannot contain [`ExecutionRequest::Created`].
+    /// The batch must not contain [`ExecutionRequest::Created`].
     async fn append_batch_create_new_execution(
         &self,
         current_time: DateTime<Utc>, // not persisted, can be used for unblocking `subscribe_to_pending`
@@ -1746,12 +1756,12 @@ pub async fn stub_execution(
 pub async fn cancel_delay(
     db_connection: &dyn DbConnection,
     delay_id: DelayId,
-    created_at: DateTime<Utc>,
+    cancelled_at: DateTime<Utc>,
 ) -> Result<CancelOutcome, DbErrorWrite> {
     let (parent_execution_id, join_set_id) = delay_id.split_to_parts();
     db_connection
         .append_delay_response(
-            created_at,
+            cancelled_at,
             parent_execution_id,
             join_set_id,
             delay_id,

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -102,7 +102,7 @@ impl CancelRegistry {
     }
 
     /// It is the responsibility of the caller to check that the execution belongs to an activity!
-    pub async fn cancel(
+    pub async fn cancel_activity(
         &self,
         db_connection: &dyn DbConnection,
         execution_id: &ExecutionId,

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -1,23 +1,41 @@
 use super::workflow_worker::JoinNextBlockingStrategy;
+use crate::activity::cancel_registry::CancelRegistry;
 use chrono::{DateTime, Utc};
 use concepts::{
     ComponentId, ExecutionId,
+    prefixed_ulid::DelayId,
     storage::{
         self, AppendBatchResponse, AppendEventsToExecution, AppendRequest,
-        AppendResponseToExecution, BacktraceInfo, CreateRequest, DbConnection, DbErrorRead,
-        DbErrorReadWithTimeout, DbErrorWrite, ExecutionEvent, ResponseCursor, ResponseWithCursor,
-        TimeoutOutcome, Version,
+        AppendResponseToExecution, BacktraceInfo, CancelOutcome, CreateRequest, DbConnection,
+        DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite, ExecutionEvent, ResponseCursor,
+        ResponseWithCursor, TimeoutOutcome, Version,
     },
 };
 use std::pin::Pin;
 use tracing::{debug, instrument, warn};
 
 pub(crate) struct CachingDbConnection {
-    pub(crate) db_connection: Box<dyn DbConnection>,
+    db_connection: Box<dyn DbConnection>,
     pub(crate) execution_id: ExecutionId,
     pub(crate) caching_buffer: Option<CachingBuffer>,
     pub(crate) version: Version,
 }
+impl CachingDbConnection {
+    pub(crate) fn new(
+        db_connection: Box<dyn DbConnection>,
+        execution_id: ExecutionId,
+        caching_buffer: Option<CachingBuffer>,
+        version: Version,
+    ) -> CachingDbConnection {
+        CachingDbConnection {
+            db_connection,
+            execution_id,
+            caching_buffer,
+            version,
+        }
+    }
+}
+
 pub(crate) enum CacheableDbEvent {
     SubmitChildExecution {
         request: AppendRequest,
@@ -412,6 +430,27 @@ impl CachingDbConnection {
             debug!("Flushing the non-blocking event cache finished");
         }
         Ok(())
+    }
+
+    pub(crate) async fn cancel_activity(
+        &mut self,
+        cancel_registry: &CancelRegistry,
+        execution_id: &ExecutionId,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<CancelOutcome, DbErrorWrite> {
+        self.flush_non_blocking_event_cache(cancelled_at).await?;
+        cancel_registry
+            .cancel_activity(self.db_connection.as_ref(), execution_id, cancelled_at)
+            .await
+    }
+
+    pub(crate) async fn cancel_delay(
+        &mut self,
+        delay_id: DelayId,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<CancelOutcome, DbErrorWrite> {
+        self.flush_non_blocking_event_cache(cancelled_at).await?;
+        storage::cancel_delay(self.db_connection.as_ref(), delay_id, cancelled_at).await
     }
 }
 

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -104,10 +104,13 @@ pub(crate) enum ApplyError {
     ConstraintViolation(StrVariant),
     #[error("executor closing")]
     ExecutorClosing,
+    #[error("replay finished")]
+    ReplayFinished,
 }
 
 #[expect(clippy::struct_field_names)]
 pub(crate) struct EventHistory {
+    replaying_unfinished_execution: bool,
     deployment_id: DeploymentId,
     join_next_blocking_strategy: JoinNextBlockingStrategy,
     // Contains requests (events produced by the workflow)
@@ -134,7 +137,10 @@ pub(crate) struct EventHistory {
 enum FindMatchingResponse {
     Found(ChildReturnValue),
     NotFound,
-    FoundRequestButNotResponse,
+    FoundRequestButNotResponse {
+        join_next_idx: usize,
+        join_next_version: Version,
+    },
 }
 
 impl EventHistory {
@@ -151,8 +157,10 @@ impl EventHistory {
         lock_extension: Option<Duration>,
         subscription_interruption: Option<Duration>,
         worker_span: Span,
+        replaying_unfinished_execution: bool,
     ) -> EventHistory {
         EventHistory {
+            replaying_unfinished_execution,
             deployment_id,
             index_child_exe_to_processed_response_idx: HashMap::default(),
             index_child_exe_to_ffqn: HashMap::default(),
@@ -428,11 +436,9 @@ impl EventHistory {
                 }
             }
             info!("Giving up on waiting for response");
-            Err(ApplyError::InterruptDbUpdated)
-        } else {
-            debug!(join_set_id = %join_next_variant.join_set_id(),  "Interrupting on {join_next_variant:?}");
-            Err(ApplyError::InterruptDbUpdated)
         }
+        debug!(join_set_id = %join_next_variant.join_set_id(),  "Interrupting on {join_next_variant:?}");
+        Err(ApplyError::InterruptDbUpdated)
     }
 
     // Transforms `join_set_close_inner` error to `WorkflowFunctionError` so
@@ -477,10 +483,9 @@ impl EventHistory {
             if let ResponseId::ChildExecutionId(child_execution_id_derived) = response_id
                 && component_type.is_activity()
             {
-                let res = self
-                    .cancel_registry
-                    .cancel(
-                        db_connection.db_connection.as_ref(),
+                let res = db_connection
+                    .cancel_activity(
+                        &self.cancel_registry,
                         &ExecutionId::Derived(child_execution_id_derived.clone()),
                         called_at,
                     )
@@ -490,12 +495,9 @@ impl EventHistory {
                 }
             } else if let ResponseId::DelayId(delay_id) = response_id {
                 debug!("Cancelling {delay_id}");
-                let res = storage::cancel_delay(
-                    db_connection.db_connection.as_ref(),
-                    delay_id.clone(),
-                    called_at,
-                )
-                .await;
+                let res = db_connection
+                    .cancel_delay(delay_id.clone(), called_at)
+                    .await;
                 if let Err(err) = res {
                     // This means that the watcher expired the delay in the mean time.
                     trace!("Ignoring failure to cancel {delay_id} - {err:?}");
@@ -564,9 +566,16 @@ impl EventHistory {
                     assert_eq!(idx, 0, "NotFound must be returned on the first key");
                     return Ok(None);
                 }
-                FindMatchingResponse::FoundRequestButNotResponse => {
+                FindMatchingResponse::FoundRequestButNotResponse {
+                    join_next_idx,
+                    join_next_version,
+                } => {
+                    // JoinNext is still unprocessed. This is the only exception when replay is considered finished.
+                    if join_next_idx == self.event_history.len() - 1 {
+                        return Err(ApplyError::ReplayFinished);
+                    }
                     unreachable!(
-                        "FoundRequestButNotResponse in find_matching_atomic - {event_call:?}"
+                        "bug in executor: FoundRequestButNotResponse in find_matching_atomic - {event_call:?}, {join_next_idx}, {join_next_version}"
                     );
                 }
                 FindMatchingResponse::Found(found) => {
@@ -579,13 +588,13 @@ impl EventHistory {
         unreachable!()
     }
 
-    fn first_unprocessed_request(&self) -> Option<(usize, &HistoryEvent, &Version)> {
+    fn first_unprocessed_request(&self) -> Option<(usize, &HistoryEvent, Version)> {
         self.event_history
             .iter()
             .enumerate()
             .find_map(|(idx, (event, status, version))| {
                 if *status == Unprocessed {
-                    Some((idx, event, version))
+                    Some((idx, event, version.clone()))
                 } else {
                     None
                 }
@@ -599,6 +608,7 @@ impl EventHistory {
         })
     }
 
+    // Only called from `process_event_by_key`
     fn mark_next_unprocessed_response(
         &'_ mut self,
         parent_event_idx: usize, // needs to be marked as Processed as well if found
@@ -668,15 +678,30 @@ impl EventHistory {
         }
     }
 
+    // Only entry point to marking events as processed.
     fn process_event_by_key(
         &mut self,
         key: &DeterministicKey,
     ) -> Result<FindMatchingResponse, ApplyError> {
-        let Some((found_idx, found_request_event, _version)) = self.first_unprocessed_request()
+        let resp = self.process_event_by_key_inner(key)?;
+        if self.replaying_unfinished_execution && !self.has_unprocessed_requests() {
+            return Err(ApplyError::ReplayFinished);
+        }
+        Ok(resp)
+    }
+
+    fn process_event_by_key_inner(
+        &mut self,
+        key: &DeterministicKey,
+    ) -> Result<FindMatchingResponse, ApplyError> {
+        let Some((found_idx, found_request_event, found_version)) =
+            self.first_unprocessed_request()
         else {
             return Ok(FindMatchingResponse::NotFound);
         };
-        trace!("Finding match for {key:?}, [{found_idx}] {found_request_event:?}");
+        trace!(
+            "Finding match for {key:?}, [{found_idx}, v{found_version}] {found_request_event:?}"
+        );
         match (key, found_request_event) {
             (
                 DeterministicKey::CreateJoinSet { join_set_id },
@@ -860,7 +885,10 @@ impl EventHistory {
                             ChildReturnValue::JoinNextRequestingFfqn(Err(function_mismatch)),
                         ))
                     }
-                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse), // no progress, still at JoinNext
+                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse {
+                        join_next_idx: found_idx,
+                        join_next_version: found_version,
+                    }),
                 }
             }
 
@@ -887,7 +915,10 @@ impl EventHistory {
                             result,
                         }))
                     }
-                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse), // no progress, still at JoinNext
+                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse {
+                        join_next_idx: found_idx,
+                        join_next_version: found_version,
+                    }),
                     Some(JoinSetResponseEnriched::ChildExecutionFinished { .. }) => unreachable!(
                         "DeterministicKey::JoinNextDelay is emitted only on one-shot join sets"
                     ),
@@ -935,7 +966,10 @@ impl EventHistory {
                             (ResponseId::DelayId(delay_id.clone()), result),
                         ))))
                     }
-                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse), // no progress, still at JoinNext
+                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse {
+                        join_next_idx: found_idx,
+                        join_next_version: found_version,
+                    }),
                 }
             }
 
@@ -3776,12 +3810,12 @@ mod tests {
             .unwrap();
 
         let exec_log = db_connection.get(&execution_id).await.unwrap();
-        let caching_db_connection = CachingDbConnection {
+        let caching_db_connection = CachingDbConnection::new(
             db_connection,
             execution_id,
-            caching_buffer: CachingBuffer::new(join_next_blocking_strategy),
-            version: exec_log.next_version.clone(),
-        };
+            CachingBuffer::new(join_next_blocking_strategy),
+            exec_log.next_version.clone(),
+        );
         let cancel_registry = CancelRegistry::new();
         let event_history = EventHistory::new(
             DEPLOYMENT_ID_DUMMY,
@@ -3802,6 +3836,7 @@ mod tests {
             None, // lock_extension
             None, // subscription_interruption
             info_span!("worker-test"),
+            false, // replaying_unfinished_execution
         );
 
         (event_history, caching_db_connection)

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -75,11 +75,14 @@ pub(crate) enum WorkflowFunctionError {
     LockExpired,
     #[error("executor closing")]
     ExecutorClosing,
+    #[error("replay finished")]
+    ReplayFinished,
 }
 
 #[derive(Debug)]
 pub(crate) enum WorkerPartialResult {
     FatalError(FatalError, Version),
+    ReplayFinished,
     // retriable:
     InterruptDbUpdated,
     LockExpired,
@@ -116,6 +119,7 @@ impl WorkflowFunctionError {
             }
             WorkflowFunctionError::LockExpired => WorkerPartialResult::LockExpired,
             WorkflowFunctionError::ExecutorClosing => WorkerPartialResult::ExecutorClosing,
+            WorkflowFunctionError::ReplayFinished => WorkerPartialResult::ReplayFinished,
         }
     }
 }
@@ -132,6 +136,7 @@ impl From<ApplyError> for WorkflowFunctionError {
                 WorkflowFunctionError::ConstraintViolation(reason)
             }
             ApplyError::ExecutorClosing => WorkflowFunctionError::ExecutorClosing,
+            ApplyError::ReplayFinished => WorkflowFunctionError::ReplayFinished,
         }
     }
 }
@@ -146,7 +151,7 @@ pub(crate) struct WorkflowCtx {
     pub(crate) resource_table: wasmtime::component::ResourceTable,
     backtrace_persist: bool,
     wasi_ctx: WasiCtx,
-    is_replaying_finished: bool,
+    is_replay: bool, // Used for lowering logs to trace
 }
 
 #[derive(derive_more::Debug)]
@@ -846,6 +851,12 @@ impl WasiView for WorkflowCtx {
 
 const IFC_FQN_WORKFLOW_SUPPORT: &str = "obelisk:workflow/workflow-support@5.0.0";
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReplayKind {
+    Finished,
+    Unfinished,
+}
+
 impl WorkflowCtx {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -865,7 +876,7 @@ impl WorkflowCtx {
         lock_extension: Option<Duration>,
         subscription_interruption: Option<Duration>,
         logs_storage_config: Option<LogStrageConfig>,
-        is_replaying_finished: bool,
+        is_replay: Option<ReplayKind>,
     ) -> Self {
         let mut wasi_ctx_builder = WasiCtxBuilder::new();
         wasi_ctx_builder.allow_tcp(false);
@@ -888,6 +899,7 @@ impl WorkflowCtx {
                 lock_extension,
                 subscription_interruption,
                 worker_span.clone(),
+                is_replay == Some(ReplayKind::Unfinished),
             ),
             rng: StdRng::seed_from_u64(seed),
             clock_fn,
@@ -900,7 +912,7 @@ impl WorkflowCtx {
             resource_table: wasmtime::component::ResourceTable::default(),
             backtrace_persist,
             wasi_ctx: wasi_ctx_builder.build(),
-            is_replaying_finished,
+            is_replay: is_replay.is_some(),
         }
     }
 
@@ -2662,7 +2674,7 @@ pub(crate) mod workflow_support {
 }
 
 fn trace_on_replay(ctx: &mut WorkflowCtx, level: LogLevel, message: String) {
-    if ctx.event_history.has_unprocessed_requests() || ctx.is_replaying_finished {
+    if ctx.event_history.has_unprocessed_requests() || ctx.is_replay {
         ctx.component_logger
             .log(LogLevel::Trace, format!("(replay) {message}"));
     } else {
@@ -2781,7 +2793,9 @@ pub(crate) mod tests {
                 WorkerPartialResult::DbError(db_err) => {
                     Err(executor::worker::WorkerError::DbError(db_err))
                 }
-                WorkerPartialResult::LockExpired | WorkerPartialResult::ExecutorClosing => {
+                WorkerPartialResult::LockExpired
+                | WorkerPartialResult::ExecutorClosing
+                | WorkerPartialResult::ReplayFinished => {
                     unreachable!()
                 }
             }
@@ -2879,12 +2893,12 @@ pub(crate) mod tests {
             info!("Starting");
             let seed = ctx.execution_id.random_seed();
             let join_next_blocking_strategy = JoinNextBlockingStrategy::Interrupt; // Cannot Await: when moving time forward both worker and timers watcher would race.
-            let caching_db_connection = CachingDbConnection {
-                db_connection: self.db_pool.connection().await.unwrap(),
-                execution_id: ctx.execution_id.clone(),
-                caching_buffer: CachingBuffer::new(join_next_blocking_strategy),
-                version: ctx.version,
-            };
+            let caching_db_connection = CachingDbConnection::new(
+                self.db_pool.connection().await.unwrap(),
+                ctx.execution_id.clone(),
+                CachingBuffer::new(join_next_blocking_strategy),
+                ctx.version,
+            );
 
             let cancel_registry = CancelRegistry::new();
             let mut workflow_ctx = WorkflowCtx::new(
@@ -2909,7 +2923,7 @@ pub(crate) mod tests {
                 Some(Duration::from_secs(1)), // lock extension
                 None,                         // subscription_interruption
                 None,                         // logs_storage_config,
-                false,                        // is_finished
+                None,                         // is_replay
             );
             for step in &self.steps {
                 info!("Processing step {step:?}");

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -8,6 +8,7 @@ use super::workflow_worker::{ReplayError, WorkflowConfig, WorkflowWorker, Workfl
 use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::LogStrageConfig;
 use crate::workflow::deadline_tracker::{DeadlineTrackerFactory, DeadlineTrackerFactoryForReplay};
+use crate::workflow::workflow_ctx::ReplayKind;
 use async_trait::async_trait;
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
 use concepts::storage::{DbConnection, DbPool, Locked};
@@ -369,7 +370,6 @@ impl WorkflowJsWorker {
             .get(&execution_id)
             .await
             .map_err(concepts::storage::DbErrorWrite::from)?;
-        let is_finished = log.is_finished();
 
         // Transform the stored params to the workflow-js-runtime format
         let _original_ffqn = log.ffqn().clone();
@@ -407,6 +407,11 @@ impl WorkflowJsWorker {
         )
         .expect("types checked at compile time");
         let (_executor_close_sender, executor_close_watcher) = tokio::sync::watch::channel(false); // TODO: consider using current exec's watcher
+        let replay_kind = if log.is_finished() {
+            ReplayKind::Finished
+        } else {
+            ReplayKind::Unfinished
+        };
         let ctx = WorkerContext {
             execution_id,
             metadata: ExecutionMetadata::empty(),
@@ -444,11 +449,7 @@ impl WorkflowJsWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        worker
-            .run_internal(ctx, is_finished)
-            .await
-            .map(|_| ())
-            .map_err(ReplayError::from)
+        worker.replay_internal(ctx, Some(replay_kind)).await
     }
 }
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -5,7 +5,7 @@ use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::LogStrageConfig;
 use crate::workflow::caching_db_connection::{CachingBuffer, CachingDbConnection};
 use crate::workflow::deadline_tracker::{DeadlineTrackerFactoryForReplay, EpochCallbackError};
-use crate::workflow::workflow_ctx::{ImportedFnCall, WorkerPartialResult};
+use crate::workflow::workflow_ctx::{ImportedFnCall, ReplayKind, WorkerPartialResult};
 use crate::{RunnableComponent, WasmFileError};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -20,6 +20,7 @@ use concepts::{FunctionRegistry, SupportedFunctionReturnValue};
 use db_mem::inmemory_dao::InMemoryPool;
 use executor::worker::{FatalError, WorkerContext, WorkerResult, WorkerResultOk};
 use executor::worker::{Worker, WorkerError};
+use itertools::Either;
 use std::future;
 use std::ops::Deref;
 use std::time::Duration;
@@ -380,6 +381,7 @@ enum WorkerResultRefactored {
     DbError(DbErrorWrite),
     LockExpired(WorkflowCtx),
     ExecutorClosing(WorkflowCtx),
+    ReplayFinished,
 }
 
 type CallFuncResult = Result<(SupportedFunctionReturnValue, WorkflowCtx), RunError>;
@@ -426,11 +428,13 @@ enum PrepareFuncOk {
     },
 }
 
+pub(crate) struct ReplayFinished;
+
 impl WorkflowWorker {
     async fn prepare_func(
         &self,
         ctx: WorkerContext,
-        is_replaying_finished: bool,
+        is_replay: Option<ReplayKind>,
     ) -> Result<PrepareFuncOk, WorkflowError> {
         assert_eq!(self.config.component_id, ctx.locked_event.component_id);
 
@@ -450,12 +454,12 @@ impl WorkflowWorker {
 
         let version_at_start = ctx.version.clone();
         let seed = ctx.execution_id.random_seed();
-        let db_connection = CachingDbConnection {
-            db_connection: self.db_pool.connection().await.unwrap(),
-            execution_id: ctx.execution_id.clone(),
-            caching_buffer: CachingBuffer::new(self.config.join_next_blocking_strategy),
-            version: ctx.version,
-        };
+        let db_connection = CachingDbConnection::new(
+            self.db_pool.connection().await.unwrap(),
+            ctx.execution_id.clone(),
+            CachingBuffer::new(self.config.join_next_blocking_strategy),
+            ctx.version,
+        );
         let workflow_ctx = WorkflowCtx::new(
             self.deployment_id,
             db_connection,
@@ -473,7 +477,7 @@ impl WorkflowWorker {
             self.config.lock_extension,
             self.config.subscription_interruption,
             self.logs_storage_config.clone(),
-            is_replaying_finished,
+            is_replay,
         );
 
         let mut store = Store::new(&self.engine, workflow_ctx);
@@ -636,7 +640,7 @@ impl WorkflowWorker {
         worker_span: &Span,
         execution_deadline: DateTime<Utc>,
         assigned_fuel: Option<u64>,
-    ) -> Result<WorkerResultOk, WorkflowError> {
+    ) -> Result<Either<WorkerResultOk, ReplayFinished>, WorkflowError> {
         // call_func
         let elapsed = now_tokio_instant(); // Not using `clock_fn` here is ok, value is only used for log reporting.
         let res = Self::call_func(store, func, component_func, params, assigned_fuel).await;
@@ -647,14 +651,17 @@ impl WorkflowWorker {
         match worker_result_refactored {
             WorkerResultRefactored::Ok(retval, mut workflow_ctx) => {
                 match Self::close_join_sets(&mut workflow_ctx).await {
-                    Ok(CloseJoinSetOk::Ok) => Ok(WorkerResultOk::RunFinished {
-                        retval,
-                        version: workflow_ctx.db_connection.version.clone(),
-                        http_client_traces: None,
-                    }),
-                    Ok(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher) => {
-                        Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
+                    Ok(Either::Left(CloseJoinSetOk::Ok)) => {
+                        Ok(Either::Left(WorkerResultOk::RunFinished {
+                            retval,
+                            version: workflow_ctx.db_connection.version.clone(),
+                            http_client_traces: None,
+                        }))
                     }
+                    Ok(Either::Left(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher)) => {
+                        Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher))
+                    }
+                    Ok(Either::Right(ReplayFinished)) => Ok(Either::Right(ReplayFinished)),
                     Err(closing_err) => {
                         debug!("Error while closing join sets {closing_err:?}");
                         Err(closing_err)
@@ -663,12 +670,12 @@ impl WorkflowWorker {
             }
             WorkerResultRefactored::DbUpdatedByWorkerOrWatcher => {
                 // Made some progress.
-                Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
+                Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher))
             }
             WorkerResultRefactored::FatalError(err, mut workflow_ctx) => {
                 // Even on fatal error we try to cancel activities and wait for workflows.
                 match Self::close_join_sets(&mut workflow_ctx).await {
-                    Ok(CloseJoinSetOk::Ok | CloseJoinSetOk::DbUpdatedByWorkerOrWatcher) => {
+                    Ok(_) => {
                         // Propagate the original error
                         Err(WorkflowError::FatalError(
                             err,
@@ -708,6 +715,7 @@ impl WorkflowWorker {
                     workflow_ctx.db_connection.version.clone(),
                 ))
             }
+            WorkerResultRefactored::ReplayFinished => Ok(Either::Right(ReplayFinished)),
         }
     }
 
@@ -774,6 +782,7 @@ impl WorkflowWorker {
                         // logged in epoch callback
                         WorkerResultRefactored::ExecutorClosing(workflow_ctx)
                     }
+                    WorkerPartialResult::ReplayFinished => WorkerResultRefactored::ReplayFinished,
                 }
             }
             Err(RunError::ResultParsingError(err, mut workflow_ctx)) => {
@@ -792,10 +801,12 @@ impl WorkflowWorker {
 
     async fn close_join_sets(
         workflow_ctx: &mut WorkflowCtx,
-    ) -> Result<CloseJoinSetOk, WorkflowError> {
+    ) -> Result<Either<CloseJoinSetOk, ReplayFinished>, WorkflowError> {
         match workflow_ctx.join_sets_close_on_finish().await {
-            Ok(()) => Ok(CloseJoinSetOk::Ok),
-            Err(ApplyError::InterruptDbUpdated) => Ok(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher),
+            Ok(()) => Ok(Either::Left(CloseJoinSetOk::Ok)),
+            Err(ApplyError::InterruptDbUpdated) => {
+                Ok(Either::Left(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher))
+            }
 
             Err(ApplyError::DbError(db_error)) => Err(WorkflowError::DbError(db_error)),
             Err(ApplyError::NondeterminismDetected(detail)) => Err(WorkflowError::FatalError(
@@ -809,14 +820,40 @@ impl WorkflowWorker {
             Err(ApplyError::ExecutorClosing) => Err(WorkflowError::ExecutorClosing(
                 workflow_ctx.db_connection.version.clone(),
             )),
+            Err(ApplyError::ReplayFinished) => Ok(Either::Right(ReplayFinished)),
+        }
+    }
+
+    pub(crate) async fn replay_internal(
+        &self,
+        ctx: WorkerContext,
+        is_replay: Option<ReplayKind>,
+    ) -> Result<(), ReplayError> {
+        match self.run_internal(ctx, is_replay).await {
+            Ok(Either::Left(WorkerResultOk::RunFinished { .. })) => {
+                debug!("Replay finished returning a value");
+                Ok(())
+            }
+            Ok(Either::Right(ReplayFinished)) => {
+                debug!("Replay concluded, execution is in progress");
+                Ok(())
+            }
+            Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher)) => {
+                debug!("Replay concluded asking for interrupt"); // Response did not arrive yet.
+                Ok(())
+            }
+            Err(err) => {
+                debug!("Replay failed: {err:?}");
+                Err(ReplayError::from(err))
+            }
         }
     }
 
     pub(crate) async fn run_internal(
         &self,
         ctx: WorkerContext,
-        is_replaying_finished: bool,
-    ) -> Result<WorkerResultOk, WorkflowError> {
+        is_replay: Option<ReplayKind>,
+    ) -> Result<Either<WorkerResultOk, ReplayFinished>, WorkflowError> {
         ctx.worker_span.in_scope(|| info!("Execution run started"));
         if !ctx.can_be_retried {
             warn!(
@@ -825,7 +862,7 @@ impl WorkflowWorker {
         }
         let worker_span = ctx.worker_span.clone();
         let execution_deadline = ctx.locked_event.lock_expires_at;
-        match self.prepare_func(ctx, is_replaying_finished).await? {
+        match self.prepare_func(ctx, is_replay).await? {
             PrepareFuncOk::Finished {
                 store,
                 func,
@@ -844,7 +881,7 @@ impl WorkflowWorker {
                 .await
             }
             PrepareFuncOk::DbUpdatedByWorkerOrWatcher => {
-                Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
+                Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher))
             }
         }
     }
@@ -862,8 +899,7 @@ impl WorkflowWorker {
         execution_id: ExecutionId,
         logs_storage_config: Option<LogStrageConfig>,
     ) -> Result<(), ReplayError> {
-        let clock_fn = ConstClock(DateTime::from_timestamp_nanos(0));
-
+        let clock_fn = ConstClock(DateTime::UNIX_EPOCH);
         let config = WorkflowConfig {
             join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
             backtrace_persist: false,
@@ -878,10 +914,16 @@ impl WorkflowWorker {
             .get(&execution_id)
             .await
             .map_err(DbErrorWrite::from)?;
-        let is_finished = log.is_finished();
-        let (_executor_close_sender, executor_close_watcher) = tokio::sync::watch::channel(false); // TODO: consider using current exec's watcher
+        let replay_kind = if log.is_finished() {
+            ReplayKind::Finished
+        } else {
+            ReplayKind::Unfinished
+        };
+        // TODO: consider using current exec's watcher for faster cancellation
+        let (_executor_close_sender, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let db_pool = Arc::new(InMemoryPool::new());
         let ctx = WorkerContext {
-            execution_id,
+            execution_id: execution_id.clone(),
             metadata: ExecutionMetadata::empty(),
             ffqn: log.ffqn().clone(),
             params: log.params().clone(),
@@ -909,7 +951,7 @@ impl WorkflowWorker {
             clock_fn.clone_box(),
         )?;
         let linked = compiled.link(fn_registry)?;
-        let db_pool = Arc::new(InMemoryPool::new());
+
         let worker = linked.into_worker(
             deployment_id,
             db_pool,
@@ -917,11 +959,7 @@ impl WorkflowWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        worker
-            .run_internal(ctx, is_finished)
-            .await
-            .map(|_| ())
-            .map_err(ReplayError::from)
+        worker.replay_internal(ctx, Some(replay_kind)).await
     }
 }
 
@@ -978,11 +1016,12 @@ impl Worker for WorkflowWorker {
     async fn run(&self, ctx: WorkerContext) -> WorkerResult {
         match self
             .run_internal(
-                ctx, false, // not replaying a finished execution.
+                ctx, None, //is_replay
             )
             .await
         {
-            Ok(ok) => WorkerResult::Ok(ok),
+            Ok(Either::Left(ok)) => WorkerResult::Ok(ok),
+            Ok(Either::Right(_)) => unreachable!("replay was not requested"),
             Err(workflow_err) => WorkerResult::Err(WorkerError::from(workflow_err)),
         }
     }
@@ -1072,6 +1111,7 @@ pub(crate) mod tests {
     use test_db_macro::expand_enum_database;
     use test_utils::ExecutionLogSanitized;
     use test_utils::sim_clock::SimClock;
+    use tokio::sync::mpsc;
     use tracing::debug;
     use tracing::info_span;
     use val_json::{
@@ -1126,37 +1166,62 @@ pub(crate) mod tests {
         fn_registry: &Arc<dyn FunctionRegistry>,
         cancel_registry: CancelRegistry,
     ) -> Arc<WorkflowWorker> {
+        compile_workflow_worker_runnable(
+            wasm_path,
+            db_pool,
+            clock_fn,
+            join_next_blocking_strategy,
+            fn_registry,
+            cancel_registry,
+        )
+        .await
+        .0
+    }
+
+    pub(crate) async fn compile_workflow_worker_runnable(
+        wasm_path: &str,
+        db_pool: Arc<dyn DbPool>,
+        clock_fn: Box<dyn ClockFn>,
+        join_next_blocking_strategy: JoinNextBlockingStrategy,
+        fn_registry: &Arc<dyn FunctionRegistry>,
+        cancel_registry: CancelRegistry,
+    ) -> (Arc<WorkflowWorker>, RunnableComponent) {
         let workflow_engine =
             Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
         let (runnable_component, component_id) =
             compile_workflow_with_engine(wasm_path, &workflow_engine).await;
-        Arc::new(
-            WorkflowWorkerCompiled::new_with_config(
-                runnable_component,
-                WorkflowConfig {
-                    component_id,
-                    join_next_blocking_strategy,
-                    backtrace_persist: false,
-                    stub_wasi: false,
-                    fuel: None,
-                    lock_extension: None,
-                    subscription_interruption: None,
-                },
-                workflow_engine,
-                clock_fn.clone_box(),
-            )
-            .unwrap()
-            .link(fn_registry.clone())
-            .unwrap()
-            .into_worker(
-                DEPLOYMENT_ID_DUMMY,
-                db_pool,
-                Arc::new(DeadlineTrackerFactoryTokio::new(Duration::ZERO, clock_fn)),
-                cancel_registry,
-                None, // logs_storage_config
+        (
+            Arc::new(
+                WorkflowWorkerCompiled::new_with_config(
+                    runnable_component.clone(),
+                    WorkflowConfig {
+                        component_id,
+                        join_next_blocking_strategy,
+                        backtrace_persist: false,
+                        stub_wasi: false,
+                        fuel: None,
+                        lock_extension: None,
+                        subscription_interruption: None,
+                    },
+                    workflow_engine,
+                    clock_fn.clone_box(),
+                )
+                .unwrap()
+                .link(fn_registry.clone())
+                .unwrap()
+                .into_worker(
+                    DEPLOYMENT_ID_DUMMY,
+                    db_pool,
+                    Arc::new(DeadlineTrackerFactoryTokio::new(Duration::ZERO, clock_fn)),
+                    cancel_registry,
+                    None, // logs_storage_config
+                ),
             ),
+            runnable_component,
         )
     }
+
+    const LOCK_EXPIRY_WORKFLOW: Duration = Duration::from_secs(1);
 
     async fn new_workflow_exec_task(
         db_pool: Arc<dyn DbPool>,
@@ -1179,7 +1244,7 @@ pub(crate) mod tests {
         info!("Instantiated worker");
         let exec_config = ExecConfig {
             batch_size: 1,
-            lock_expiry: Duration::from_secs(3),
+            lock_expiry: LOCK_EXPIRY_WORKFLOW,
             tick_sleep: TICK_SLEEP,
             component_id: worker.config.component_id.clone(),
             task_limiter: None,
@@ -1330,7 +1395,7 @@ pub(crate) mod tests {
         assert_eq!(1, executed_workflows.len());
 
         let res = db_connection
-            .wait_for_finished_result(&execution_id, None)
+            .get_finished_result(&execution_id)
             .await
             .unwrap();
         let res = assert_matches!(res, SupportedFunctionReturnValue::Ok(Some(val)) => val);
@@ -3527,5 +3592,180 @@ pub(crate) mod tests {
         let result =
             assert_matches!(result, SupportedFunctionReturnValue::ExecutionError(err) => err);
         assert_matches!(result.kind, ExecutionFailureKind::Cancelled);
+    }
+
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn fibo_workflow_each_stage_replay(db: Database) {
+        let sim_clock = SimClock::epoch();
+        let (_guard, db_pool, db_close) = db.set_up().await;
+        fibo_workflow_each_stage_replay_inner(db_pool.clone(), sim_clock).await;
+        db_close.close().await;
+    }
+
+    async fn fibo_workflow_each_stage_replay_inner(db_pool: Arc<dyn DbPool>, sim_clock: SimClock) {
+        const INPUT_ITERATIONS: u32 = 1;
+        test_utils::set_up();
+
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+
+        let (workflow_runnable, workflow_component_id) = compile_workflow_with_engine(
+            test_programs_fibo_workflow_builder::TEST_PROGRAMS_FIBO_WORKFLOW,
+            &workflow_engine,
+        )
+        .await;
+        let fn_registry = TestingFnRegistry::new_from_components(vec![
+            compile_activity(test_programs_fibo_activity_builder::TEST_PROGRAMS_FIBO_ACTIVITY)
+                .await,
+            (workflow_runnable.clone(), workflow_component_id),
+        ]);
+        let cancel_registry = CancelRegistry::new();
+        let workflow_exec = new_workflow_fibo(
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            JoinNextBlockingStrategy::Interrupt,
+            &fn_registry,
+            cancel_registry,
+            LockingStrategy::ByComponentDigest,
+        )
+        .await;
+        // Create an execution.
+        let execution_id = ExecutionId::generate();
+        let created_at = sim_clock.now();
+        let db_connection = db_pool.connection_test().await.unwrap();
+
+        db_connection
+            .create(CreateRequest {
+                created_at,
+                execution_id: execution_id.clone(),
+                ffqn: FIBOA_WORKFLOW_FFQN,
+                params: Params::from_json_values_test(vec![
+                    json!(FIBO_10_INPUT),
+                    json!(INPUT_ITERATIONS),
+                ]),
+                parent: None,
+                metadata: concepts::ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: workflow_exec.config.component_id.clone(),
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+            })
+            .await
+            .unwrap();
+
+        let (log_sender, _log_storage_recv) = mpsc::channel(100);
+        // Replay just after creating
+        WorkflowWorker::replay(
+            DeploymentId::generate(),
+            workflow_exec.config.component_id.clone(),
+            workflow_runnable.wasmtime_component.clone(),
+            &workflow_runnable.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        info!("Should end as BlockedByJoinSet");
+
+        let executed_workflows = workflow_exec
+            .tick_test(sim_clock.now(), RunId::generate())
+            .await;
+
+        assert_eq!(1, executed_workflows.wait_for_tasks().await.len());
+
+        // Replay before activity has finished
+        WorkflowWorker::replay(
+            DeploymentId::generate(),
+            workflow_exec.config.component_id.clone(),
+            workflow_runnable.wasmtime_component.clone(),
+            &workflow_runnable.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        info!("Execution should call the activity and finish");
+
+        let activity_exec = new_activity_fibo(
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            TokioSleep,
+            LockingStrategy::ByComponentDigest,
+        )
+        .await;
+        let executed_activities = activity_exec
+            .tick_test_await(sim_clock.now(), RunId::generate())
+            .await;
+        assert_eq!(1, executed_activities.len());
+
+        // Replay after activity has finished but before the response was processed
+        WorkflowWorker::replay(
+            DeploymentId::generate(),
+            workflow_exec.config.component_id.clone(),
+            workflow_runnable.wasmtime_component.clone(),
+            &workflow_runnable.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        sim_clock.move_time_forward(LOCK_EXPIRY_WORKFLOW); // another lock will be appended when the current one expires
+
+        let executed_workflows = workflow_exec
+            .tick_test_await(sim_clock.now(), RunId::generate())
+            .await;
+
+        assert_eq!(1, executed_workflows.len());
+
+        let res = db_connection
+            .get_finished_result(&execution_id)
+            .await
+            .unwrap();
+        let res = assert_matches!(res, SupportedFunctionReturnValue::Ok(Some(val)) => val);
+
+        let fibo = assert_matches!(res,
+            WastValWithType {value: WastVal::U64(val), r#type: TypeWrapper::U64 } => val);
+        assert_eq!(FIBO_10_OUTPUT, fibo);
+
+        // Replay after workflow was finished
+        WorkflowWorker::replay(
+            DeploymentId::generate(),
+            workflow_exec.config.component_id.clone(),
+            workflow_runnable.wasmtime_component.clone(),
+            &workflow_runnable.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+        )
+        .await
+        .unwrap();
     }
 }

--- a/obelisk-testing-js-local.toml
+++ b/obelisk-testing-js-local.toml
@@ -83,6 +83,7 @@ ffqn = "testing:integration/workflow-call-stub.call-stub"
 params = [
   { name = "id", type = "u64" },
 ]
+return_type = "result<string, string>"
 
 [[activity_stub]]
 name = "test_inline_stub"
@@ -99,6 +100,7 @@ name = "workflow_busy_sleep"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/busy-sleep.js"
 ffqn = "testing:integration/workflow-busy.busy"
 params = []
+return_type = "result<string, string>"
 
 [[activity_js]]
 name = "activity_busy_sleep"

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -719,7 +719,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                     ));
                 }
                 self.cancel_registry
-                    .cancel(conn.as_ref(), &execution_id, executed_at)
+                    .cancel_activity(conn.as_ref(), &execution_id, executed_at)
                     .await
                     .to_status()?
             }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -550,7 +550,7 @@ async fn execution_cancel(
     let executed_at = Now.now();
     let outcome = state
         .cancel_registry
-        .cancel(conn.as_ref(), &execution_id, executed_at)
+        .cancel_activity(conn.as_ref(), &execution_id, executed_at)
         .await
         .map_err(|e| ErrorWrapper(e, accept))?;
     Ok(HttpResponse::from_cancel_outcome(outcome, accept).into_response())


### PR DESCRIPTION
Replay of unfinished execution was failing because it is using
an empty in-memory db. `event_history` could push events past replay
and attempt to insert new events, causing execution `NotFound` errors.

The fix is to raise `ReplayFinished` when all events in `EventHistry` are processed,
and also when the only unprocessed event is `JoinNext` - waiting for next response.
