### PR TITLE
feat(cli): Show std streams in `execution logs` unless disabled

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -404,17 +404,18 @@ pub(crate) enum LogLevelArg {
     Info,
     Warn,
     Error,
-    /// Disable structured log output. Use with `--show-streams`.
+    /// Disable structured log output.
     Off,
 }
 
 /// Log stream type for `execution logs`.
-/// One of: `stdout`, `stderr`.
+/// One of: `stdout`, `stderr`, `none`.
 #[derive(Debug, Clone, Copy, strum::EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum LogStreamTypeArg {
     Stdout,
     Stderr,
+    None,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -459,15 +460,14 @@ pub(crate) enum Execution {
         #[arg(long)]
         show_derived: bool,
         /// Minimum log level: trace, debug, info, warn, error, off.
-        /// `off` disables structured log output entirely (use with --show-streams).
+        /// `off` disables structured log output entirely.
         #[arg(long, value_name = "LEVEL", default_value = "debug")]
         level: LogLevelArg,
-        /// Include stdout/stderr stream output.
-        #[arg(long)]
-        show_streams: bool,
-        /// Filter stream output by type (stdout, stderr). Repeatable. Only with --show-streams.
-        #[arg(long, value_name = "TYPE", requires = "show_streams")]
-        stream_type: Vec<LogStreamTypeArg>,
+        /// Select which stream output to show: stdout, stderr, none.
+        /// If not specified, both stdout and stderr are shown.
+        /// Use `none` to hide all stream output.
+        #[arg(long, value_name = "TYPE")]
+        stream_type: Option<LogStreamTypeArg>,
         /// Show the run ID in each log line.
         #[arg(long)]
         show_run_id: bool,

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -59,7 +59,6 @@ impl args::Execution {
                 execution_id,
                 show_derived,
                 level,
-                show_streams,
                 stream_type,
                 show_run_id,
                 after,
@@ -67,14 +66,8 @@ impl args::Execution {
                 limit,
                 json,
             } => {
-                let opts = LogsOpts::from_args(
-                    level,
-                    show_streams,
-                    &stream_type,
-                    show_derived,
-                    show_run_id,
-                    limit,
-                )?;
+                let opts =
+                    LogsOpts::from_args(level, stream_type, show_derived, show_run_id, limit)?;
                 if follow {
                     follow_logs(&api_url, &execution_id, &opts, after, json).await
                 } else {
@@ -610,13 +603,29 @@ async fn execution_list(
     send_and_print(req).await
 }
 
+#[derive(Debug, Clone, Copy)]
+enum StreamType {
+    Stdout,
+    Stderr,
+}
+
+impl StreamType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
 /// Resolved log filter parameters shared between the one-shot and follow paths.
 /// `json` is intentionally excluded — it controls output format, not the query filter.
 struct LogsOpts {
     /// Empty slice means `show_logs=false` (level was `off`).
     levels: &'static [&'static str],
-    show_streams: bool,
-    stream_type_strs: Vec<&'static str>,
+    /// Empty means `show_streams=false` (`--stream-type none`).
+    /// Defaults to `[Stdout, Stderr]` when no `--stream-type` is given.
+    stream_types: Vec<StreamType>,
     show_derived: bool,
     show_run_id: bool,
     limit: u16,
@@ -625,8 +634,7 @@ struct LogsOpts {
 impl LogsOpts {
     fn from_args(
         level: args::LogLevelArg,
-        show_streams: bool,
-        stream_types: &[args::LogStreamTypeArg],
+        stream_type_arg: Option<args::LogStreamTypeArg>,
         show_derived: bool,
         show_run_id: bool,
         limit: u16,
@@ -640,20 +648,20 @@ impl LogsOpts {
             LogLevelArg::Warn => &["warn", "error"],
             LogLevelArg::Error => &["error"],
         };
-        if levels.is_empty() && !show_streams {
-            anyhow::bail!("either `--level` must not be `off`, or `--show-streams` must be set");
+        let stream_types = match stream_type_arg {
+            None => vec![StreamType::Stdout, StreamType::Stderr],
+            Some(args::LogStreamTypeArg::Stdout) => vec![StreamType::Stdout],
+            Some(args::LogStreamTypeArg::Stderr) => vec![StreamType::Stderr],
+            Some(args::LogStreamTypeArg::None) => vec![],
+        };
+        if levels.is_empty() && stream_types.is_empty() {
+            anyhow::bail!(
+                "either `--level` must not be `off`, or `--stream-type` must not be `none`"
+            );
         }
-        let stream_type_strs = stream_types
-            .iter()
-            .map(|st| match st {
-                args::LogStreamTypeArg::Stdout => "stdout",
-                args::LogStreamTypeArg::Stderr => "stderr",
-            })
-            .collect();
         Ok(Self {
             levels,
-            show_streams,
-            stream_type_strs,
+            stream_types,
             show_derived,
             show_run_id,
             limit,
@@ -668,14 +676,10 @@ impl LogsOpts {
                 req = req.query(&[("level", *level_str)]);
             }
         }
-        req = req.query(&[(
-            "show_streams",
-            if self.show_streams { "true" } else { "false" },
-        )]);
-        if self.show_streams {
-            for st in &self.stream_type_strs {
-                req = req.query(&[("stream_type", *st)]);
-            }
+        let show_streams = !self.stream_types.is_empty();
+        req = req.query(&[("show_streams", if show_streams { "true" } else { "false" })]);
+        for st in &self.stream_types {
+            req = req.query(&[("stream_type", st.as_str())]);
         }
         if self.show_derived {
             req = req.query(&[("show_derived", "true")]);


### PR DESCRIPTION
Collapse `--show-streams` into `--stream-type` filter, allow specifying `none`.
