### PR TITLE
Make names optional for inline, JS and exec components

### DIFF
--- a/assets/toml/deployment-canonical.json
+++ b/assets/toml/deployment-canonical.json
@@ -13,7 +13,7 @@
     "activities_external": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ActivityExternalComponentConfigToml"
+        "$ref": "#/$defs/ActivityExternalComponentConfigCanonical"
       }
     },
     "activities_js": {
@@ -25,7 +25,7 @@
     "activities_stub": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ActivityStubComponentConfigToml"
+        "$ref": "#/$defs/ActivityStubComponentConfigCanonical"
       }
     },
     "activities_wasm": {
@@ -173,13 +173,13 @@
         "max_output_bytes"
       ]
     },
-    "ActivityExternalComponentConfigToml": {
+    "ActivityExternalComponentConfigCanonical": {
       "anyOf": [
         {
           "$ref": "#/$defs/ActivityExternalFileConfigToml"
         },
         {
-          "$ref": "#/$defs/ActivityStubInlineConfigToml"
+          "$ref": "#/$defs/ActivityStubExtInlineConfigCanonical"
         }
       ]
     },
@@ -293,33 +293,17 @@
         "allowed_hosts"
       ]
     },
-    "ActivityStubComponentConfigToml": {
+    "ActivityStubComponentConfigCanonical": {
       "anyOf": [
         {
           "$ref": "#/$defs/ActivityStubFileConfigToml"
         },
         {
-          "$ref": "#/$defs/ActivityStubInlineConfigToml"
+          "$ref": "#/$defs/ActivityStubExtInlineConfigCanonical"
         }
       ]
     },
-    "ActivityStubFileConfigToml": {
-      "type": "object",
-      "properties": {
-        "location": {
-          "type": "string"
-        },
-        "name": {
-          "$ref": "#/$defs/ConfigName"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "location"
-      ]
-    },
-    "ActivityStubInlineConfigToml": {
+    "ActivityStubExtInlineConfigCanonical": {
       "type": "object",
       "properties": {
         "ffqn": {
@@ -350,6 +334,22 @@
       "required": [
         "name",
         "ffqn"
+      ]
+    },
+    "ActivityStubFileConfigToml": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "$ref": "#/$defs/ConfigName"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "location"
       ]
     },
     "ActivityWasmComponentConfigToml": {

--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -206,7 +206,7 @@
           "$ref": "#/$defs/ActivityExternalFileConfigToml"
         },
         {
-          "$ref": "#/$defs/ActivityStubInlineConfigToml"
+          "$ref": "#/$defs/ActivityStubExtInlineConfigToml"
         }
       ]
     },
@@ -353,34 +353,27 @@
           "$ref": "#/$defs/ActivityStubFileConfigToml"
         },
         {
-          "$ref": "#/$defs/ActivityStubInlineConfigToml"
+          "$ref": "#/$defs/ActivityStubExtInlineConfigToml"
         }
       ]
     },
-    "ActivityStubFileConfigToml": {
-      "type": "object",
-      "properties": {
-        "location": {
-          "type": "string"
-        },
-        "name": {
-          "$ref": "#/$defs/ConfigName"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "name",
-        "location"
-      ]
-    },
-    "ActivityStubInlineConfigToml": {
+    "ActivityStubExtInlineConfigToml": {
       "type": "object",
       "properties": {
         "ffqn": {
           "type": "string"
         },
         "name": {
-          "$ref": "#/$defs/ConfigName"
+          "description": "Component name. Optional — defaults to `{ifc_name}.{function_name}` from `ffqn`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfigName"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "params": {
           "type": [
@@ -402,8 +395,23 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
         "ffqn"
+      ]
+    },
+    "ActivityStubFileConfigToml": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "name": {
+          "$ref": "#/$defs/ConfigName"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "location"
       ]
     },
     "ActivityWasmComponentConfigToml": {

--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -144,7 +144,16 @@
           "minimum": 0
         },
         "name": {
-          "$ref": "#/$defs/ConfigName"
+          "description": "Component name. Optional when `ffqn` is specified — defaults to `{ifc_name}.{function_name}`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfigName"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "params": {
           "description": "Custom parameters for the exec activity.\nEach entry has a `name` and a WIT `type` (e.g. `string`, `u32`, `list<string>`).",
@@ -187,7 +196,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
         "program",
         "ffqn"
       ]
@@ -299,7 +307,16 @@
           "minimum": 0
         },
         "name": {
-          "$ref": "#/$defs/ConfigName"
+          "description": "Component name. Optional when `ffqn` is specified — defaults to `{ifc_name}.{function_name}`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfigName"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "params": {
           "description": "Custom parameters for the JS function.\nEach entry has a `name` and a WIT `type` (e.g. `string`, `u32`, `list<string>`).\nDefaults to no parameters.",
@@ -326,7 +343,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
         "location",
         "ffqn"
       ]
@@ -1111,7 +1127,16 @@
           "default": "debug"
         },
         "name": {
-          "$ref": "#/$defs/ConfigName"
+          "description": "Component name. Optional when `ffqn` is specified — defaults to `{ifc_name}.{function_name}`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConfigName"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "params": {
           "description": "Custom parameters for the JS workflow function.\nEach entry has a `name` and a WIT `type` (e.g. `string`, `u32`, `list<string>`).\nDefaults to no parameters.",
@@ -1138,7 +1163,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
         "location",
         "ffqn"
       ]

--- a/crates/concepts/src/component_id.rs
+++ b/crates/concepts/src/component_id.rs
@@ -63,7 +63,7 @@ impl ComponentId {
     ) -> Result<Self, InvalidNameError<Self>> {
         Ok(Self {
             component_type,
-            name: check_name(name, "_")?,
+            name: check_name(name, "_.-")?,
             component_digest,
         })
     }

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -155,10 +155,26 @@
 # env_vars = [{name = "MY_SECRET", value = "${HOST_SECRET_VAR}"}] # Values support interpolation.
 
 ### External Activity components configuration - only WIT schema is loaded
+### An external activity declares callable activity functions whose implementation
+### is provided outside this deployment.
+### Two modes are supported: file mode (WASM binary for the WIT schema) and inline mode (no WASM file needed).
+##
+## File mode: load WIT schema from an existing WASM binary.
 # [[activity_external]]
 # name = "name" # Required. Each component must be named.
-# location = "path/to/wasm"
+# location = "path/to/external-activity.wasm"
 # location = "oci://docker.io/repo/image:tag"
+##
+## Inline mode: define the function schema directly in TOML (no WASM file required).
+# [[activity_external]]
+# name = "my-external-activity"              # Optional. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
+# ffqn = "namespace:package/interface.function"
+# params = [{ name = "id", type = "u64" }]
+## WIT return type. Defaults to `result<string, string>`.
+## Must be `result`, `result<T>`, `result<T, string>`, or
+## `result<T, variant { execution-failed, ... }>`.
+# return_type = "result<string, string>"
+## Note: `location` and `ffqn` are mutually exclusive; exactly one must be present.
 
 ### Stub Activity components configuration
 ### A stub activity is a placeholder function that never executes on its own.
@@ -180,7 +196,7 @@
 ##
 ## Inline mode: define the function schema directly in TOML (no WASM file required).
 # [[activity_stub]]
-# name = "my-stub"
+# name = "my-stub"                           # Optional. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
 # ffqn = "namespace:package/interface.function"
 # params = [{ name = "id", type = "u64" }]
 ## WIT return type. Defaults to `result<string, string>`.

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -71,7 +71,7 @@
 
 ### JavaScript Activity components configuration
 # [[activity_js]]
-# name = "name"                              # Required. Component name.
+# name = "name"                              # Optional. Component name. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
 ## Location of the JavaScript source file.
 ## Supports local file paths.
 ## OCI references are NOT supported for JS activities.
@@ -112,7 +112,7 @@
 ### instead of a WASM component. Parameters are passed as JSON-encoded CLI args,
 ### and the result is read from stdout (exit 0 → ok, non-zero → err).
 # [[activity_exec]]
-# name = "name"                              # Required. Component name.
+# name = "name"                              # Optional. Component name. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
 ## Program specification: exactly one of `external`, `inline`, or `include`.
 ## `external`: explicit argv — first element is the executable, rest are fixed arguments.
 # program.external = ["/usr/bin/my-tool", "--flag"]
@@ -218,7 +218,7 @@
 
 ### JavaScript Workflow components configuration
 # [[workflow_js]]
-# name = "name"                              # Required. Component name.
+# name = "name"                              # Optional. Component name. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
 ## Location of the JavaScript source file.
 ## Supports local file paths.
 ## OCI references are NOT supported for JS workflows.

--- a/obelisk-testing-js-local.toml
+++ b/obelisk-testing-js-local.toml
@@ -1,5 +1,4 @@
 [[activity_js]]
-name = "test_add_activity"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/activity/add.js"
 ffqn = "testing:integration/activity.add"
 params = [
@@ -9,7 +8,6 @@ params = [
 max_retries = 0
 
 [[workflow_js]]
-name = "test_add_via_activity_workflow"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/add_via_activity.js"
 ffqn = "testing:integration/workflow-add-via-activity.add-via-activity"
 params = [
@@ -18,7 +16,6 @@ params = [
 ]
 
 [[activity_js]]
-name = "test_read_env_activity"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/activity/read_env.js"
 ffqn = "testing:integration/activity.read-env"
 params = [
@@ -28,7 +25,6 @@ max_retries = 0
 env_vars = [{key = "TEST_ENV_VAR", value = "hello_from_env"}]
 
 [[activity_js]]
-name = "activity_js_fetch_get"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/activity/fetch_get.js"
 ffqn = "testing:js/activity.fetch-get"
 params = [
@@ -42,13 +38,11 @@ pattern = "http://localhost:5005"
 methods = ["GET"]
 
 [[workflow_js]]
-name = "workflow_js_test"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/fetch_components.js"
 ffqn = "testing:js/workflow.fetch-components"
 params = []
 
 [[workflow_js]]
-name = "test_call_activity_workflow"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/call_activity.js"
 ffqn = "testing:integration/workflow-call-activity.call-activity"
 params = [
@@ -77,7 +71,6 @@ routes = [{ methods = ["GET"], route = "/call-activity/:a/:b" }]
 # stub
 
 [[workflow_js]]
-name = "test_call_stub_workflow"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/call_stub.js"
 ffqn = "testing:integration/workflow-call-stub.call-stub"
 params = [
@@ -96,14 +89,12 @@ return_type = "result<string, string>"
 # Busy workflow
 
 [[workflow_js]]
-name = "workflow_busy_sleep"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/busy-sleep.js"
 ffqn = "testing:integration/workflow-busy.busy"
 params = []
 return_type = "result<string, string>"
 
 [[activity_js]]
-name = "activity_busy_sleep"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/activity/sleep.js"
 ffqn = "testing:integration/sleep-activity.sleep"
 params = [
@@ -113,14 +104,12 @@ return_type = "result"
 max_retries = 0
 
 [[workflow_js]]
-name = "workflow_busy_cpu"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/busy-cpu.js"
 ffqn = "testing:integration/workflow-busy-cpu.busy-cpu"
 params = []
 exec.lock_expiry.seconds = 10
 
 [[activity_js]]
-name = "activity_busy_cpu"
 location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/activity/busy-cpu.js"
 ffqn = "testing:integration/activity-busy-cpu.busy-cpu"
 params = []

--- a/obelisk-testing-js-local.toml
+++ b/obelisk-testing-js-local.toml
@@ -79,7 +79,6 @@ params = [
 return_type = "result<string, string>"
 
 [[activity_stub]]
-name = "test_inline_stub"
 ffqn = "testing:integration/stubs.my-stub"
 params = [
   { name = "id", type = "u64" },

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -93,10 +93,10 @@ fn find_component_for_push(
         .copied()
         .with_context(|| format!("component '{name}' not found in deployment TOML"))?;
 
-    let deployment = &deployment.inner;
     match component_type {
         TomlComponentType::ActivityWasm => {
             let cfg = deployment
+                .inner
                 .activities_wasm
                 .iter()
                 .find(|c| c.common.name.to_string() == name)
@@ -114,6 +114,7 @@ fn find_component_for_push(
         }
         TomlComponentType::WebhookEndpointWasm => {
             let cfg = deployment
+                .inner
                 .webhooks
                 .iter()
                 .find(|c| c.common.name.to_string() == name)
@@ -131,6 +132,7 @@ fn find_component_for_push(
         }
         TomlComponentType::WorkflowWasm => {
             let cfg = deployment
+                .inner
                 .workflows
                 .iter()
                 .find(|c| c.common.name.to_string() == name)
@@ -147,10 +149,10 @@ fn find_component_for_push(
             })
         }
         TomlComponentType::ActivityJs => {
-            let cfg = deployment
+            let (cfg, _) = deployment
                 .activities_js
                 .iter()
-                .find(|c| c.name.to_string() == name)
+                .find(|(_, n)| n.to_string() == name)
                 .expect("name is in map so it must be in the list");
             let JsLocationToml::Path(ref path) = cfg.location else {
                 bail!("component '{name}' uses OCI, only local paths are supported for push");
@@ -169,10 +171,10 @@ fn find_component_for_push(
             })
         }
         TomlComponentType::WorkflowJs => {
-            let cfg = deployment
+            let (cfg, _) = deployment
                 .workflows_js
                 .iter()
-                .find(|c| c.name.to_string() == name)
+                .find(|(_, n)| n.to_string() == name)
                 .expect("name is in map so it must be in the list");
             let JsLocationToml::Path(ref path) = cfg.location else {
                 bail!("component '{name}' uses OCI, only local paths are supported for push");
@@ -192,6 +194,7 @@ fn find_component_for_push(
         }
         TomlComponentType::WebhookEndpointJs => {
             let cfg = deployment
+                .inner
                 .webhooks_js
                 .iter()
                 .find(|c| c.name.to_string() == name)
@@ -768,7 +771,10 @@ mod tests {
 
         assert_eq!(parsed.activities_js.len(), 1);
         let act = &parsed.activities_js[0];
-        assert_eq!(act.name.to_string(), "my_js_activity");
+        assert_eq!(
+            act.name.as_ref().expect("name set").to_string(),
+            "my_js_activity"
+        );
         assert_eq!(act.ffqn.to_string(), "my-pkg:my-iface/my-ifc.my-fn");
         assert_eq!(act.return_type.as_deref(), Some("result<string>"));
         assert_eq!(act.params.len(), 1);

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -310,44 +310,43 @@ pub(crate) async fn generate_wit_deps(
     let skipped_oci_component_names: HashSet<String> = if skip_local {
         // When `--external-only` is set, build the set of component names that have an OCI location.
         // Local components will be skipped during WIT extraction.
-        let deployment = &deployment.inner;
         let mut skipped_names: HashSet<String> = HashSet::new();
-        for c in &deployment.activities_wasm {
+        for c in &deployment.inner.activities_wasm {
             if matches!(c.common.location, ComponentLocationToml::Path(_)) {
                 skipped_names.insert(c.common.name.to_string());
             }
         }
-        for c in &deployment.activities_stub {
+        for c in &deployment.inner.activities_stub {
             if let ActivityStubComponentConfigToml::File(f) = c
                 && matches!(f.common.location, ComponentLocationToml::Path(_))
             {
                 skipped_names.insert(f.common.name.to_string());
             }
         }
-        for c in &deployment.activities_external {
+        for c in &deployment.inner.activities_external {
             if let ActivityExternalComponentConfigToml::File(f) = c
                 && matches!(f.common.location, ComponentLocationToml::Path(_))
             {
                 skipped_names.insert(f.common.name.to_string());
             }
         }
-        for c in &deployment.activities_js {
+        for (c, name) in &deployment.activities_js {
             if matches!(c.location, JsLocationToml::Path(_)) {
-                skipped_names.insert(c.name.to_string());
+                skipped_names.insert(name.to_string());
             }
         }
         // Exec activities are always local — skip them from WIT generation.
-        for c in &deployment.activities_exec {
-            skipped_names.insert(c.name.to_string());
+        for (_, name) in &deployment.activities_exec {
+            skipped_names.insert(name.to_string());
         }
-        for c in &deployment.workflows {
+        for c in &deployment.inner.workflows {
             if matches!(c.common.location, ComponentLocationToml::Path(_)) {
                 skipped_names.insert(c.common.name.to_string());
             }
         }
-        for c in &deployment.workflows_js {
+        for (c, name) in &deployment.workflows_js {
             if matches!(c.location, JsLocationToml::Path(_)) {
-                skipped_names.insert(c.name.to_string());
+                skipped_names.insert(name.to_string());
             }
         }
         // webhooks are skipped in any case

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -316,18 +316,18 @@ pub(crate) async fn generate_wit_deps(
                 skipped_names.insert(c.common.name.to_string());
             }
         }
-        for c in &deployment.inner.activities_stub {
+        for (c, name) in &deployment.activities_stub {
             if let ActivityStubComponentConfigToml::File(f) = c
                 && matches!(f.common.location, ComponentLocationToml::Path(_))
             {
-                skipped_names.insert(f.common.name.to_string());
+                skipped_names.insert(name.to_string());
             }
         }
-        for c in &deployment.inner.activities_external {
+        for (c, name) in &deployment.activities_external {
             if let ActivityExternalComponentConfigToml::File(f) = c
                 && matches!(f.common.location, ComponentLocationToml::Path(_))
             {
-                skipped_names.insert(f.common.name.to_string());
+                skipped_names.insert(name.to_string());
             }
         }
         for (c, name) in &deployment.activities_js {

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -8,7 +8,7 @@
 //! The `test_addr!` macro ensures unique addresses at link time.
 
 use crate::config::toml::{
-    ActivityStubComponentConfigToml, ActivityStubInlineConfigToml, ConfigName,
+    ActivityStubComponentConfigCanonical, ActivityStubExtInlineConfigCanonical, ConfigName,
 };
 use crate::{
     command::server::{PrepareDirsParams, RunParams, prepare_dirs, run_internal},
@@ -1662,8 +1662,8 @@ async fn hot_redeploy_registry_impl(server: &TestServer, deploy_client: &TestDep
         .submit_and_hot_redeploy(server, |new_deployment| {
             new_deployment
                 .activities_stub
-                .push(ActivityStubComponentConfigToml::Inline(
-                    ActivityStubInlineConfigToml {
+                .push(ActivityStubComponentConfigCanonical::Inline(
+                    ActivityStubExtInlineConfigCanonical {
                         name: ConfigName::new(concepts::StrVariant::Static("new_hot_stub"))
                             .unwrap(),
                         ffqn: NEW_STUB_FFQN.parse().unwrap(),

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -95,6 +95,8 @@ pub(crate) struct DeploymentTomlValidated {
     pub(crate) inner: DeploymentToml,
     pub(crate) activities_js: Vec<(ActivityJsComponentConfigToml, ConfigName)>,
     pub(crate) activities_exec: Vec<(ActivityExecComponentConfigToml, ConfigName)>,
+    pub(crate) activities_stub: Vec<(ActivityStubComponentConfigToml, ConfigName)>,
+    pub(crate) activities_external: Vec<(ActivityExternalComponentConfigToml, ConfigName)>,
     pub(crate) workflows_js: Vec<(WorkflowJsComponentConfigToml, ConfigName)>,
     pub(crate) component_type_by_name: hashbrown::HashMap<String, crate::args::TomlComponentType>,
 }
@@ -108,9 +110,12 @@ impl DeploymentToml {
         deployment_dir: &std::path::Path,
     ) -> Result<DeploymentTomlValidated, anyhow::Error> {
         self.expand_deployment_dir_prefix(deployment_dir);
-        // Resolve optional names from FFQN and drain the three vectors out of `self`.
+        // Resolve optional names from FFQN and drain vectors out of `self`.
         let activities_js = Self::resolve_names(std::mem::take(&mut self.activities_js))?;
         let activities_exec = Self::resolve_names(std::mem::take(&mut self.activities_exec))?;
+        let activities_stub = Self::resolve_stub_names(std::mem::take(&mut self.activities_stub))?;
+        let activities_external =
+            Self::resolve_external_names(std::mem::take(&mut self.activities_external))?;
         let workflows_js = Self::resolve_names(std::mem::take(&mut self.workflows_js))?;
         // Build the name→type index and check for duplicates.
         let mut component_type_by_name = hashbrown::HashMap::new();
@@ -124,9 +129,10 @@ impl DeploymentToml {
             }
         }
         // Components with resolved names.
+        use crate::args::TomlComponentType;
         for (_, name) in &activities_js {
             if component_type_by_name
-                .insert(name.to_string(), crate::args::TomlComponentType::ActivityJs)
+                .insert(name.to_string(), TomlComponentType::ActivityJs)
                 .is_some()
             {
                 bail!("duplicate component name `{name}` in deployment");
@@ -134,10 +140,23 @@ impl DeploymentToml {
         }
         for (_, name) in &activities_exec {
             if component_type_by_name
-                .insert(
-                    name.to_string(),
-                    crate::args::TomlComponentType::ActivityExec,
-                )
+                .insert(name.to_string(), TomlComponentType::ActivityExec)
+                .is_some()
+            {
+                bail!("duplicate component name `{name}` in deployment");
+            }
+        }
+        for (_, name) in &activities_stub {
+            if component_type_by_name
+                .insert(name.to_string(), TomlComponentType::ActivityStub)
+                .is_some()
+            {
+                bail!("duplicate component name `{name}` in deployment");
+            }
+        }
+        for (_, name) in &activities_external {
+            if component_type_by_name
+                .insert(name.to_string(), TomlComponentType::ActivityExternal)
                 .is_some()
             {
                 bail!("duplicate component name `{name}` in deployment");
@@ -145,7 +164,7 @@ impl DeploymentToml {
         }
         for (_, name) in &workflows_js {
             if component_type_by_name
-                .insert(name.to_string(), crate::args::TomlComponentType::WorkflowJs)
+                .insert(name.to_string(), TomlComponentType::WorkflowJs)
                 .is_some()
             {
                 bail!("duplicate component name `{name}` in deployment");
@@ -155,6 +174,8 @@ impl DeploymentToml {
             inner: self,
             activities_js,
             activities_exec,
+            activities_stub,
+            activities_external,
             workflows_js,
             component_type_by_name,
         })
@@ -190,6 +211,88 @@ impl DeploymentToml {
                     .config_name()
                     .cloned()
                     .unwrap_or_else(|| ConfigName::from_ffqn(c.ffqn()));
+                (c, name)
+            })
+            .collect())
+    }
+
+    /// Resolve names for `ActivityStubComponentConfigToml` enum variants.
+    /// File variants always have an explicit name; Inline variants may derive from FFQN.
+    fn resolve_stub_names(
+        configs: Vec<ActivityStubComponentConfigToml>,
+    ) -> Result<Vec<(ActivityStubComponentConfigToml, ConfigName)>, anyhow::Error> {
+        // Check for clashes among auto-derived inline names.
+        let mut auto_names: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
+        for c in &configs {
+            if let ActivityStubComponentConfigToml::Inline(inline) = c
+                && inline.name.is_none()
+            {
+                let derived = ConfigName::from_ffqn(&inline.ffqn);
+                auto_names
+                    .entry(derived.0.as_ref().to_string())
+                    .or_default()
+                    .push(inline.ffqn.to_string());
+            }
+        }
+        for (name, ffqns) in &auto_names {
+            if ffqns.len() > 1 {
+                bail!(
+                    "multiple components derive the same name `{name}` from their FFQNs: {}. \
+                     Please specify an explicit `name` for each of these components",
+                    ffqns.join(", ")
+                );
+            }
+        }
+        Ok(configs
+            .into_iter()
+            .map(|c| {
+                let name = match &c {
+                    ActivityStubComponentConfigToml::File(f) => f.common.name.clone(),
+                    ActivityStubComponentConfigToml::Inline(i) => i
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| ConfigName::from_ffqn(&i.ffqn)),
+                };
+                (c, name)
+            })
+            .collect())
+    }
+
+    /// Resolve names for `ActivityExternalComponentConfigToml` enum variants.
+    fn resolve_external_names(
+        configs: Vec<ActivityExternalComponentConfigToml>,
+    ) -> Result<Vec<(ActivityExternalComponentConfigToml, ConfigName)>, anyhow::Error> {
+        let mut auto_names: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
+        for c in &configs {
+            if let ActivityExternalComponentConfigToml::Inline(inline) = c
+                && inline.name.is_none()
+            {
+                let derived = ConfigName::from_ffqn(&inline.ffqn);
+                auto_names
+                    .entry(derived.0.as_ref().to_string())
+                    .or_default()
+                    .push(inline.ffqn.to_string());
+            }
+        }
+        for (name, ffqns) in &auto_names {
+            if ffqns.len() > 1 {
+                bail!(
+                    "multiple components derive the same name `{name}` from their FFQNs: {}. \
+                     Please specify an explicit `name` for each of these components",
+                    ffqns.join(", ")
+                );
+            }
+        }
+        Ok(configs
+            .into_iter()
+            .map(|c| {
+                let name = match &c {
+                    ActivityExternalComponentConfigToml::File(f) => f.common.name.clone(),
+                    ActivityExternalComponentConfigToml::Inline(i) => i
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| ConfigName::from_ffqn(&i.ffqn)),
+                };
                 (c, name)
             })
             .collect())
@@ -266,18 +369,9 @@ impl DeploymentToml {
         self.activities_wasm
             .iter()
             .map(|c| (c.common.name.0.as_ref(), TomlComponentType::ActivityWasm))
-            .chain(
-                self.activities_stub
-                    .iter()
-                    .map(|c| (c.name_str(), TomlComponentType::ActivityStub)),
-            )
-            .chain(
-                self.activities_external
-                    .iter()
-                    .map(|c| (c.name_str(), TomlComponentType::ActivityExternal)),
-            )
-            // activities_js, activities_exec, workflows_js are handled separately
-            // via DeploymentTomlValidated's resolved-name fields.
+            // activities_stub, activities_external, activities_js, activities_exec,
+            // workflows_js are handled separately via DeploymentTomlValidated's
+            // resolved-name fields.
             .chain(
                 self.workflows
                     .iter()
@@ -783,6 +877,15 @@ impl HasOptionalNameAndFfqn for WorkflowJsComponentConfigToml {
     }
 }
 
+impl HasOptionalNameAndFfqn for ActivityStubExtInlineConfigToml {
+    fn config_name(&self) -> Option<&ConfigName> {
+        self.name.as_ref()
+    }
+    fn ffqn(&self) -> &FunctionFqn {
+        &self.ffqn
+    }
+}
+
 impl std::fmt::Display for ComponentLocationToml {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1124,8 +1227,10 @@ pub(crate) struct ActivityStubFileConfigToml {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ActivityStubInlineConfigToml {
-    pub(crate) name: ConfigName,
+pub(crate) struct ActivityStubExtInlineConfigToml {
+    /// Component name. Optional — defaults to `{ifc_name}.{function_name}` from `ffqn`.
+    #[serde(default)]
+    pub(crate) name: Option<ConfigName>,
     #[schemars(with = "String")]
     pub(crate) ffqn: FunctionFqn,
     #[serde(default)]
@@ -1138,7 +1243,7 @@ pub(crate) struct ActivityStubInlineConfigToml {
 #[serde(untagged)]
 pub(crate) enum ActivityStubComponentConfigToml {
     File(ActivityStubFileConfigToml),
-    Inline(ActivityStubInlineConfigToml),
+    Inline(ActivityStubExtInlineConfigToml),
 }
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
@@ -1156,7 +1261,33 @@ pub(crate) struct ActivityExternalFileConfigToml {
 #[serde(untagged)]
 pub(crate) enum ActivityExternalComponentConfigToml {
     File(ActivityExternalFileConfigToml),
-    Inline(ActivityStubInlineConfigToml),
+    Inline(ActivityStubExtInlineConfigToml),
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ActivityStubExtInlineConfigCanonical {
+    pub(crate) name: ConfigName,
+    #[schemars(with = "String")]
+    pub(crate) ffqn: FunctionFqn,
+    #[serde(default)]
+    pub(crate) params: Option<Vec<JsParamToml>>,
+    #[serde(default)]
+    pub(crate) return_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(untagged)]
+pub(crate) enum ActivityStubComponentConfigCanonical {
+    File(ActivityStubFileConfigToml),
+    Inline(ActivityStubExtInlineConfigCanonical),
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[serde(untagged)]
+pub(crate) enum ActivityExternalComponentConfigCanonical {
+    File(ActivityExternalFileConfigToml),
+    Inline(ActivityStubExtInlineConfigCanonical),
 }
 #[derive(Debug)]
 pub(crate) struct ActivityStubExtConfigVerified {
@@ -1178,7 +1309,7 @@ pub(crate) enum ActivityStubConfigVerified {
     Inline(ActivityStubExtInlineConfigVerified),
 }
 
-impl ActivityStubComponentConfigToml {
+impl ActivityStubComponentConfigCanonical {
     fn name_str(&self) -> &str {
         match self {
             Self::File(f) => f.common.name.0.as_ref(),
@@ -1285,7 +1416,7 @@ pub(crate) enum ActivityExternalConfigVerified {
     Inline(ActivityStubExtInlineConfigVerified),
 }
 
-impl ActivityExternalComponentConfigToml {
+impl ActivityExternalComponentConfigCanonical {
     fn name_str(&self) -> &str {
         match self {
             Self::File(f) => f.common.name.0.as_ref(),
@@ -2416,8 +2547,8 @@ impl WorkflowJsComponentConfigCanonical {
 #[derive(Debug, Deserialize, Serialize, Default, Clone, schemars::JsonSchema)]
 pub(crate) struct DeploymentCanonical {
     pub(crate) activities_wasm: Vec<ActivityWasmComponentConfigToml>,
-    pub(crate) activities_stub: Vec<ActivityStubComponentConfigToml>,
-    pub(crate) activities_external: Vec<ActivityExternalComponentConfigToml>,
+    pub(crate) activities_stub: Vec<ActivityStubComponentConfigCanonical>,
+    pub(crate) activities_external: Vec<ActivityExternalComponentConfigCanonical>,
     pub(crate) activities_js: Vec<ActivityJsComponentConfigCanonical>,
     pub(crate) activities_exec: Vec<ActivityExecComponentConfigCanonical>,
     pub(crate) workflows: Vec<WorkflowWasmComponentConfigCanonical>,
@@ -2555,10 +2686,48 @@ pub(crate) async fn resolve_local_refs_to_canonical(
         });
     }
 
+    // Build canonical stubs/externals with resolved names filled in.
+    let activities_stub = deployment
+        .activities_stub
+        .iter()
+        .map(|(c, name)| match c {
+            ActivityStubComponentConfigToml::File(f) => {
+                ActivityStubComponentConfigCanonical::File(f.clone())
+            }
+            ActivityStubComponentConfigToml::Inline(i) => {
+                ActivityStubComponentConfigCanonical::Inline(ActivityStubExtInlineConfigCanonical {
+                    name: name.clone(),
+                    ffqn: i.ffqn.clone(),
+                    params: i.params.clone(),
+                    return_type: i.return_type.clone(),
+                })
+            }
+        })
+        .collect();
+    let activities_external = deployment
+        .activities_external
+        .iter()
+        .map(|(c, name)| match c {
+            ActivityExternalComponentConfigToml::File(f) => {
+                ActivityExternalComponentConfigCanonical::File(f.clone())
+            }
+            ActivityExternalComponentConfigToml::Inline(i) => {
+                ActivityExternalComponentConfigCanonical::Inline(
+                    ActivityStubExtInlineConfigCanonical {
+                        name: name.clone(),
+                        ffqn: i.ffqn.clone(),
+                        params: i.params.clone(),
+                        return_type: i.return_type.clone(),
+                    },
+                )
+            }
+        })
+        .collect();
+
     Ok(DeploymentCanonical {
         activities_wasm: deployment_inner.activities_wasm.clone(),
-        activities_stub: deployment_inner.activities_stub.clone(),
-        activities_external: deployment_inner.activities_external.clone(),
+        activities_stub,
+        activities_external,
         activities_js,
         activities_exec,
         workflows,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -60,7 +60,7 @@ const DEFAULT_CODEGEN_CACHE_DIRECTORY_IF_PROJECT_DIRS: &str =
     const_format::formatcp!("{}codegen", CACHE_DIR_PREFIX);
 const DEFAULT_CODEGEN_CACHE_DIRECTORY: &str = "cache/codegen";
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Default, Clone)]
+#[derive(Deserialize, Serialize, JsonSchema, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DeploymentToml {
     #[serde(default, rename = "activity_wasm")]
@@ -86,11 +86,16 @@ pub(crate) struct DeploymentToml {
 }
 
 /// A `DeploymentToml` that has passed name-uniqueness validation.
-/// The `component_type_by_name` map is built during validation and can be
-/// used for O(1) component-type lookup by name.
-#[derive(Debug, Default)]
+///
+/// Components that support auto-derived names (`activity_js`, `activity_exec`,
+/// `workflow_js`) are stored as `(Config, ConfigName)` tuples with the resolved name
+/// pulled out of the `Option`. The remaining component types stay inside `inner`.
+#[derive(Default)]
 pub(crate) struct DeploymentTomlValidated {
     pub(crate) inner: DeploymentToml,
+    pub(crate) activities_js: Vec<(ActivityJsComponentConfigToml, ConfigName)>,
+    pub(crate) activities_exec: Vec<(ActivityExecComponentConfigToml, ConfigName)>,
+    pub(crate) workflows_js: Vec<(WorkflowJsComponentConfigToml, ConfigName)>,
     pub(crate) component_type_by_name: hashbrown::HashMap<String, crate::args::TomlComponentType>,
 }
 
@@ -103,7 +108,13 @@ impl DeploymentToml {
         deployment_dir: &std::path::Path,
     ) -> Result<DeploymentTomlValidated, anyhow::Error> {
         self.expand_deployment_dir_prefix(deployment_dir);
+        // Resolve optional names from FFQN and drain the three vectors out of `self`.
+        let activities_js = Self::resolve_names(std::mem::take(&mut self.activities_js))?;
+        let activities_exec = Self::resolve_names(std::mem::take(&mut self.activities_exec))?;
+        let workflows_js = Self::resolve_names(std::mem::take(&mut self.workflows_js))?;
+        // Build the name→type index and check for duplicates.
         let mut component_type_by_name = hashbrown::HashMap::new();
+        // Components remaining in `inner` (all have mandatory names).
         for (name, component_type) in self.all_component_names_with_types() {
             if component_type_by_name
                 .insert(name.to_string(), component_type)
@@ -112,10 +123,76 @@ impl DeploymentToml {
                 bail!("duplicate component name `{name}` in deployment");
             }
         }
+        // Components with resolved names.
+        for (_, name) in &activities_js {
+            if component_type_by_name
+                .insert(name.to_string(), crate::args::TomlComponentType::ActivityJs)
+                .is_some()
+            {
+                bail!("duplicate component name `{name}` in deployment");
+            }
+        }
+        for (_, name) in &activities_exec {
+            if component_type_by_name
+                .insert(
+                    name.to_string(),
+                    crate::args::TomlComponentType::ActivityExec,
+                )
+                .is_some()
+            {
+                bail!("duplicate component name `{name}` in deployment");
+            }
+        }
+        for (_, name) in &workflows_js {
+            if component_type_by_name
+                .insert(name.to_string(), crate::args::TomlComponentType::WorkflowJs)
+                .is_some()
+            {
+                bail!("duplicate component name `{name}` in deployment");
+            }
+        }
         Ok(DeploymentTomlValidated {
             inner: self,
+            activities_js,
+            activities_exec,
+            workflows_js,
             component_type_by_name,
         })
+    }
+
+    fn resolve_names<T: HasOptionalNameAndFfqn>(
+        configs: Vec<T>,
+    ) -> Result<Vec<(T, ConfigName)>, anyhow::Error> {
+        let mut resolved_names: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
+        for c in &configs {
+            if c.config_name().is_none() {
+                let derived = ConfigName::from_ffqn(c.ffqn());
+                resolved_names
+                    .entry(derived.0.as_ref().to_string())
+                    .or_default()
+                    .push(c.ffqn().to_string());
+            }
+        }
+        for (name, ffqns) in &resolved_names {
+            if ffqns.len() > 1 {
+                bail!(
+                    "multiple components derive the same name `{name}` from their FFQNs: {}. \
+                     Please specify an explicit `name` for each of these components",
+                    ffqns.join(", ")
+                );
+            }
+        }
+
+        Ok(configs
+            .into_iter()
+            .map(|c| {
+                let name = c
+                    .config_name()
+                    .cloned()
+                    .unwrap_or_else(|| ConfigName::from_ffqn(c.ffqn()));
+                (c, name)
+            })
+            .collect())
     }
 
     /// Expand `${DEPLOYMENT_DIR}/` prefixes in all local file paths.
@@ -199,25 +276,12 @@ impl DeploymentToml {
                     .iter()
                     .map(|c| (c.name_str(), TomlComponentType::ActivityExternal)),
             )
-            .chain(
-                self.activities_js
-                    .iter()
-                    .map(|c| (c.name.0.as_ref(), TomlComponentType::ActivityJs)),
-            )
-            .chain(
-                self.activities_exec
-                    .iter()
-                    .map(|c| (c.name.0.as_ref(), TomlComponentType::ActivityExec)),
-            )
+            // activities_js, activities_exec, workflows_js are handled separately
+            // via DeploymentTomlValidated's resolved-name fields.
             .chain(
                 self.workflows
                     .iter()
                     .map(|c| (c.common.name.0.as_ref(), TomlComponentType::WorkflowWasm)),
-            )
-            .chain(
-                self.workflows_js
-                    .iter()
-                    .map(|c| (c.name.0.as_ref(), TomlComponentType::WorkflowJs)),
             )
             .chain(self.webhooks.iter().map(|c| {
                 (
@@ -686,6 +750,39 @@ impl FromStr for ComponentLocationToml {
     }
 }
 
+/// Trait for config structs that have an optional `name` and a required `ffqn`.
+trait HasOptionalNameAndFfqn {
+    fn config_name(&self) -> Option<&ConfigName>;
+    fn ffqn(&self) -> &FunctionFqn;
+}
+
+impl HasOptionalNameAndFfqn for ActivityJsComponentConfigToml {
+    fn config_name(&self) -> Option<&ConfigName> {
+        self.name.as_ref()
+    }
+    fn ffqn(&self) -> &FunctionFqn {
+        &self.ffqn
+    }
+}
+
+impl HasOptionalNameAndFfqn for ActivityExecComponentConfigToml {
+    fn config_name(&self) -> Option<&ConfigName> {
+        self.name.as_ref()
+    }
+    fn ffqn(&self) -> &FunctionFqn {
+        &self.ffqn
+    }
+}
+
+impl HasOptionalNameAndFfqn for WorkflowJsComponentConfigToml {
+    fn config_name(&self) -> Option<&ConfigName> {
+        self.name.as_ref()
+    }
+    fn ffqn(&self) -> &FunctionFqn {
+        &self.ffqn
+    }
+}
+
 impl std::fmt::Display for ComponentLocationToml {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -743,7 +840,7 @@ impl FromStr for JsLocationToml {
 pub struct ConfigName(#[schemars(with = "String")] StrVariant);
 impl ConfigName {
     pub fn new(name: StrVariant) -> Result<Self, InvalidNameError<ConfigName>> {
-        Ok(Self(check_name(name, "_")?))
+        Ok(Self(check_name(name, "_.-")?))
     }
 }
 impl<'de> Deserialize<'de> for ConfigName {
@@ -759,6 +856,17 @@ impl<'de> Deserialize<'de> for ConfigName {
 impl serde::Serialize for ConfigName {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         self.0.serialize(s)
+    }
+}
+
+impl ConfigName {
+    /// Derive a `ConfigName` from a `FunctionFqn` using the short form `{ifc_name}.{function_name}`.
+    pub(crate) fn from_ffqn(ffqn: &FunctionFqn) -> Self {
+        let ifc_name = ffqn.ifc_fqn.ifc_name();
+        let function_name: &str = &ffqn.function_name;
+        // WIT identifiers are kebab-case ([a-z0-9-]), so the derived name
+        // contains only [a-z0-9-.] — always valid for ConfigName.
+        Self(StrVariant::from(format!("{ifc_name}.{function_name}")))
     }
 }
 
@@ -1352,7 +1460,9 @@ impl ActivityWasmComponentConfigToml {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ActivityJsComponentConfigToml {
-    pub(crate) name: ConfigName,
+    /// Component name. Optional when `ffqn` is specified — defaults to `{ifc_name}.{function_name}`.
+    #[serde(default)]
+    pub(crate) name: Option<ConfigName>,
     /// Location of the JavaScript source file.
     /// Supports local file paths and OCI registry references (`oci://...`).
     pub(crate) location: JsLocationToml,
@@ -1516,7 +1626,9 @@ const fn default_max_output_bytes() -> u64 {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ActivityExecComponentConfigToml {
-    pub(crate) name: ConfigName,
+    /// Component name. Optional when `ffqn` is specified — defaults to `{ifc_name}.{function_name}`.
+    #[serde(default)]
+    pub(crate) name: Option<ConfigName>,
     /// Program specification. Exactly one of `external`, `inline`, or `include`.
     pub(crate) program: ExecProgramToml,
     #[schemars(with = "String")]
@@ -1722,7 +1834,9 @@ impl ActivityExecConfigVerified {
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct WorkflowJsComponentConfigToml {
-    pub(crate) name: ConfigName,
+    /// Component name. Optional when `ffqn` is specified — defaults to `{ifc_name}.{function_name}`.
+    #[serde(default)]
+    pub(crate) name: Option<ConfigName>,
     /// Location of the JavaScript source file.
     /// Supports local file paths and OCI registry references (`oci://...`).
     pub(crate) location: JsLocationToml,
@@ -2319,11 +2433,10 @@ pub(crate) struct DeploymentCanonical {
 pub(crate) async fn resolve_local_refs_to_canonical(
     deployment: &DeploymentTomlValidated,
 ) -> anyhow::Result<DeploymentCanonical> {
-    let deployment = &deployment.inner;
     let mut activities_js = Vec::with_capacity(deployment.activities_js.len());
-    for a in &deployment.activities_js {
+    for (a, name) in &deployment.activities_js {
         activities_js.push(ActivityJsComponentConfigCanonical {
-            name: a.name.clone(),
+            name: name.clone(),
             location: resolve_js_to_canonical(&a.location).await?,
             content_digest: a.content_digest.clone(),
             component_digest: a.component_digest.clone(),
@@ -2341,8 +2454,9 @@ pub(crate) async fn resolve_local_refs_to_canonical(
         });
     }
 
-    let mut workflows = Vec::with_capacity(deployment.workflows.len());
-    for w in &deployment.workflows {
+    let deployment_inner = &deployment.inner;
+    let mut workflows = Vec::with_capacity(deployment_inner.workflows.len());
+    for w in &deployment_inner.workflows {
         workflows.push(WorkflowWasmComponentConfigCanonical {
             common: w.common.clone(),
             component_digest: w.component_digest.clone(),
@@ -2357,9 +2471,9 @@ pub(crate) async fn resolve_local_refs_to_canonical(
     }
 
     let mut workflows_js = Vec::with_capacity(deployment.workflows_js.len());
-    for w in &deployment.workflows_js {
+    for (w, name) in &deployment.workflows_js {
         workflows_js.push(WorkflowJsComponentConfigCanonical {
-            name: w.name.clone(),
+            name: name.clone(),
             location: resolve_js_to_canonical(&w.location).await?,
             content_digest: w.content_digest.clone(),
             component_digest: w.component_digest.clone(),
@@ -2374,8 +2488,8 @@ pub(crate) async fn resolve_local_refs_to_canonical(
         });
     }
 
-    let mut webhooks = Vec::with_capacity(deployment.webhooks.len());
-    for w in &deployment.webhooks {
+    let mut webhooks = Vec::with_capacity(deployment_inner.webhooks.len());
+    for w in &deployment_inner.webhooks {
         webhooks.push(webhook::WebhookWasmComponentConfigCanonical {
             common: w.common.clone(),
             http_server: w.http_server.clone(),
@@ -2389,8 +2503,8 @@ pub(crate) async fn resolve_local_refs_to_canonical(
         });
     }
 
-    let mut webhooks_js = Vec::with_capacity(deployment.webhooks_js.len());
-    for w in &deployment.webhooks_js {
+    let mut webhooks_js = Vec::with_capacity(deployment_inner.webhooks_js.len());
+    for w in &deployment_inner.webhooks_js {
         webhooks_js.push(webhook::WebhookJsComponentConfigCanonical {
             name: w.name.clone(),
             location: resolve_js_to_canonical(&w.location).await?,
@@ -2406,7 +2520,7 @@ pub(crate) async fn resolve_local_refs_to_canonical(
     }
 
     let mut activities_exec = Vec::with_capacity(deployment.activities_exec.len());
-    for a in &deployment.activities_exec {
+    for (a, name) in &deployment.activities_exec {
         let program = match &a.program {
             ExecProgramToml::External(argv) => ExecProgramCanonical::External(argv.clone()),
             ExecProgramToml::Inline(script) => ExecProgramCanonical::Inline(script.clone()),
@@ -2422,7 +2536,7 @@ pub(crate) async fn resolve_local_refs_to_canonical(
             }
         };
         activities_exec.push(ActivityExecComponentConfigCanonical {
-            name: a.name.clone(),
+            name: name.clone(),
             program,
             ffqn: a.ffqn.clone(),
             params: a.params.clone(),
@@ -2442,16 +2556,16 @@ pub(crate) async fn resolve_local_refs_to_canonical(
     }
 
     Ok(DeploymentCanonical {
-        activities_wasm: deployment.activities_wasm.clone(),
-        activities_stub: deployment.activities_stub.clone(),
-        activities_external: deployment.activities_external.clone(),
+        activities_wasm: deployment_inner.activities_wasm.clone(),
+        activities_stub: deployment_inner.activities_stub.clone(),
+        activities_external: deployment_inner.activities_external.clone(),
         activities_js,
         activities_exec,
         workflows,
         workflows_js,
         webhooks,
         webhooks_js,
-        crons: deployment.crons.clone(),
+        crons: deployment_inner.crons.clone(),
     })
 }
 


### PR DESCRIPTION
- **refactor(toml): Make name optional for `workflow_js`,`activity_js`,`activity_exec`**
- **refactor(toml): Make names optional for inline stub and external activities**
