### PR TITLE
Fix `cwd` expansion when trailing `/` is missing

### DIFF
--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -88,7 +88,7 @@
           "default": null
         },
         "cwd": {
-          "description": "Working directory for the child process. Supports `${DEPLOYMENT_DIR}/`.\nDefaults to the server's working directory.",
+          "description": "Working directory for the child process. Supports `${DEPLOYMENT_DIR}` expansion.\nDefaults to the server's working directory.",
           "type": [
             "string",
             "null"

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -113,7 +113,6 @@ params = [
   {{ name = "b", type = "u32" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_js]]
 name = "test_greet_activity"
@@ -123,7 +122,6 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_js]]
 name = "test_fetch_denied_activity"
@@ -134,7 +132,6 @@ params = [
   {{ name = "headers", type = "list<tuple<string,string>>" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_js]]
 name = "test_fetch_allowed_activity"
@@ -145,7 +142,6 @@ params = [
   {{ name = "headers", type = "list<tuple<string,string>>" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 [[activity_js.allowed_host]]
 pattern = "http://{ip}:{API_PORT}"
 methods = ["GET"]
@@ -158,7 +154,6 @@ params = [
   {{ name = "key", type = "string" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 env_vars = [{{key = "TEST_ENV_VAR", value = "hello_from_env"}}]
 
 [[activity_js]]
@@ -169,7 +164,6 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<record {{ name: string, count: u32 }}, string>"
-max_retries = 0
 
 [[activity_js]]
 name = "test_throw_variant_activity"
@@ -177,7 +171,6 @@ location = "{ws}/crates/testing/test-programs/js/activity/throw_variant.js"
 ffqn = "testing:integration/activity-throw-variant.throw-variant"
 params = []
 return_type = "result<u32, variant {{ execution-failed, not-found }}>"
-max_retries = 0
 
 [[activity_js]]
 name = "test_throw_null_activity"
@@ -185,7 +178,6 @@ location = "{ws}/crates/testing/test-programs/js/activity/throw_null.js"
 ffqn = "testing:integration/activity-throw-null.throw-null"
 params = []
 return_type = "result<string>"
-max_retries = 0
 
 [[workflow_js]]
 name = "test_add_workflow"
@@ -272,7 +264,6 @@ params = [
   {{ name = "message", type = "string" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_add"
@@ -283,7 +274,6 @@ params = [
   {{ name = "b", type = "u32" }},
 ]
 return_type = "result<u32, string>"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_greet_include"
@@ -293,7 +283,6 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_greet_external"
@@ -303,8 +292,6 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
-
 
 [[activity_exec]]
 name = "test_exec_greet_inline"
@@ -318,7 +305,6 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_read_env"
@@ -326,7 +312,6 @@ program.include = "{ws}/crates/testing/test-programs/exec/read-env.sh"
 ffqn = "testing:integration/exec-env.read-env"
 params = []
 return_type = "result<string, string>"
-max_retries = 0
 env_vars = [{{key = "MY_VAR", value = "hello_from_exec_env"}}]
 
 [[activity_exec]]
@@ -338,7 +323,6 @@ exit 1
 ffqn = "testing:integration/exec-error.fail"
 params = []
 return_type = "result<string, string>"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_record_ok"
@@ -348,7 +332,6 @@ printf '{{"name": "Alice", "count": 42}}'
 ffqn = "testing:integration/exec-record.make-record"
 params = []
 return_type = "result<record {{ name: string, count: u32 }}, string>"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_expose_secrets"
@@ -356,7 +339,6 @@ program.external = ["{ws}/crates/testing/test-programs/exec/expose-secrets.sh"]
 ffqn = "testing:integration/exec-stdin.expose-secrets"
 params = []
 return_type = "result<string, string>"
-max_retries = 0
 [activity_exec.secrets]
 env_vars = [{{ name = "MY_SECRET", value = "s3cret_value" }}]
 
@@ -366,7 +348,6 @@ program.external = ["true"]
 ffqn = "testing:integration/exec-void.void-ok"
 params = []
 return_type = "result"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_void_err"
@@ -374,7 +355,6 @@ program.external = ["false"]
 ffqn = "testing:integration/exec-void.void-err"
 params = []
 return_type = "result"
-max_retries = 0
 
 [[activity_exec]]
 name = "test_exec_args_passthrough"
@@ -388,7 +368,6 @@ params = [
   {{ name = "b", type = "u32" }},
 ]
 return_type = "result<record {{ a: u32, b: u32 }}, string>"
-max_retries = 0
 
 [[activity_stub]]
 name = "test_inline_stub"

--- a/src/command/snapshots/obelisk__command__integration_tests__greet_activity_events.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__greet_activity_events.snap
@@ -17,7 +17,7 @@ expression: events
           "executor_id": "Exr_<REDACTED>",
           "lock_expires_at": "<TIMESTAMP>",
           "retry_config": {
-            "max_retries": 0,
+            "max_retries": 5,
             "retry_exp_backoff": {
               "nanos": 100000000,
               "secs": 0

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -48,7 +48,6 @@ use wasm_workers::{
 };
 use webhook::{HttpServer, WebhookJsComponentConfigToml, WebhookWasmComponentConfigToml};
 
-const DEPLOYMENT_DIR_PREFIX: &str = "${DEPLOYMENT_DIR}/";
 const DEFAULT_SQLITE_DIR_IF_PROJECT_DIRS: &str =
     const_format::formatcp!("{}obelisk-sqlite", DATA_DIR_PREFIX);
 const DEFAULT_SQLITE_DIR: &str = "obelisk-sqlite";
@@ -298,22 +297,28 @@ impl DeploymentToml {
             .collect())
     }
 
-    /// Expand `${DEPLOYMENT_DIR}/` prefixes in all local file paths.
-    fn expand_deployment_dir_prefix(&mut self, dir: &std::path::Path) {
-        let expand_str = |s: &mut String| {
-            if let Some(suffix) = s.strip_prefix(DEPLOYMENT_DIR_PREFIX) {
-                *s = dir.join(suffix).to_string_lossy().into_owned();
+    fn expand_deployment_dir(s: &mut String, is_dir: bool, deployment_dir: &std::path::Path) {
+        if let Some(suffix) = s.strip_prefix("${DEPLOYMENT_DIR}") {
+            // if is_dir, we allow suffix to be empty. Otherwise we expect `/`
+            if is_dir && suffix.is_empty() {
+                *s = deployment_dir.to_string_lossy().into_owned();
+            } else if let Some(suffix) = suffix.strip_prefix("/") {
+                *s = deployment_dir.join(suffix).to_string_lossy().into_owned();
             }
-        };
+        }
+    }
+
+    /// Expand `${DEPLOYMENT_DIR}` prefixes in all local file paths.
+    fn expand_deployment_dir_prefix(&mut self, deployment_dir: &std::path::Path) {
         let expand_loc = |loc: &mut ComponentLocationToml| {
             if let ComponentLocationToml::Path(p) = loc {
-                expand_str(p);
+                Self::expand_deployment_dir(p, false, deployment_dir);
             }
         };
         let expand_backtrace = |bt: &mut ComponentBacktraceConfig| {
             for loc in bt.frame_files_to_sources.values_mut() {
                 let BacktraceSourceLocation::Path(p) = loc;
-                expand_str(p);
+                Self::expand_deployment_dir(p, false, deployment_dir);
             }
         };
         for c in &mut self.activities_wasm {
@@ -331,15 +336,15 @@ impl DeploymentToml {
         }
         for c in &mut self.activities_js {
             if let JsLocationToml::Path(p) = &mut c.location {
-                expand_str(p);
+                Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
         for c in &mut self.activities_exec {
             if let ExecProgramToml::Include(p) = &mut c.program {
-                expand_str(p);
+                Self::expand_deployment_dir(p, false, deployment_dir);
             }
             if let Some(cwd) = &mut c.cwd {
-                expand_str(cwd);
+                Self::expand_deployment_dir(cwd, true, deployment_dir);
             }
         }
         for c in &mut self.workflows {
@@ -348,7 +353,7 @@ impl DeploymentToml {
         }
         for c in &mut self.workflows_js {
             if let JsLocationToml::Path(p) = &mut c.location {
-                expand_str(p);
+                Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
         for c in &mut self.webhooks {
@@ -357,7 +362,7 @@ impl DeploymentToml {
         }
         for c in &mut self.webhooks_js {
             if let JsLocationToml::Path(p) = &mut c.location {
-                expand_str(p);
+                Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
     }
@@ -1789,7 +1794,7 @@ pub(crate) struct ActivityExecComponentConfigToml {
     pub(crate) logs_store_min_level: LogLevelToml,
     #[serde(default)]
     pub(crate) env_vars: Vec<EnvVarConfig>,
-    /// Working directory for the child process. Supports `${DEPLOYMENT_DIR}/`.
+    /// Working directory for the child process. Supports `${DEPLOYMENT_DIR}` expansion.
     /// Defaults to the server's working directory.
     #[serde(default)]
     pub(crate) cwd: Option<String>,
@@ -1818,7 +1823,7 @@ pub(crate) struct ActivityExecComponentConfigCanonical {
     pub(crate) forward_stderr: ComponentStdOutputToml,
     pub(crate) logs_store_min_level: LogLevelToml,
     pub(crate) env_vars: Vec<EnvVarConfig>,
-    pub(crate) cwd: Option<String>,
+    pub(crate) cwd: Option<String>, // Must be resolved.
     pub(crate) max_output_bytes: u64,
     pub(crate) secrets: Option<ExecSecretsToml>,
 }

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -4099,7 +4099,10 @@ name = "my_stub"
         #[test]
         fn fetch_and_verify_activity_exec_secret_fails_when_missing_and_not_ignored() {
             let config = exec_config_with_secret("${MISSING_EXEC_SECRET}");
-            let error = config.fetch_and_verify(false, None).unwrap_err().to_string();
+            let error = config
+                .fetch_and_verify(false, None)
+                .unwrap_err()
+                .to_string();
             assert!(
                 error.contains("failed to resolve exec secrets"),
                 "unexpected error: {error}"

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1892,12 +1892,20 @@ impl ActivityExecComponentConfigCanonical {
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars)?
         };
         let resolved_secrets = if let Some(secrets) = self.secrets {
-            let mut resolved = indexmap::IndexMap::new();
-            for secret in secrets.env_vars {
-                let val = interpolate_env_vars_secret(&secret.value)
-                    .map_err(|e| anyhow!("failed to resolve secret `{}`: {e}", secret.name))?;
-                resolved.insert(secret.name, val);
-            }
+            let resolved = resolve_secret_env_vars(
+                secrets
+                    .env_vars
+                    .into_iter()
+                    .map(|secret| EnvVarConfig::KeyValue {
+                        key: secret.name,
+                        value: secret.value,
+                    })
+                    .collect(),
+                ignore_missing_env_vars,
+            )
+            .map_err(|e| anyhow!("failed to resolve exec secrets: {e}"))?
+            .into_iter()
+            .collect::<indexmap::IndexMap<_, _>>();
             if resolved.is_empty() {
                 None
             } else {
@@ -4056,6 +4064,57 @@ ffqn = "ns:pkg/ifc.fn"
 name = "my_stub"
 "#;
             toml::from_str::<ActivityStubComponentConfigToml>(toml_str).unwrap_err();
+        }
+    }
+
+    mod activity_exec {
+        use super::super::*;
+
+        fn exec_config_with_secret(value: &str) -> ActivityExecComponentConfigCanonical {
+            ActivityExecComponentConfigCanonical {
+                name: ConfigName::new(StrVariant::from("exec-test")).unwrap(),
+                program: ExecProgramCanonical::Inline("#!/usr/bin/env bash\necho null\n".into()),
+                ffqn: "testing:integration/exec-secret.expose".parse().unwrap(),
+                params: vec![],
+                return_type: Some("result<string, string>".into()),
+                component_digest: None,
+                exec: ExecConfigToml::default(),
+                max_retries: default_max_retries(),
+                retry_exp_backoff: default_retry_exp_backoff(),
+                forward_stdout: ComponentStdOutputToml::default(),
+                forward_stderr: ComponentStdOutputToml::default(),
+                logs_store_min_level: LogLevelToml::default(),
+                env_vars: vec![],
+                cwd: None,
+                max_output_bytes: default_max_output_bytes(),
+                secrets: Some(ExecSecretsToml {
+                    env_vars: vec![SecretEnvVarToml {
+                        name: "MY_SECRET".into(),
+                        value: value.into(),
+                    }],
+                }),
+            }
+        }
+
+        #[test]
+        fn fetch_and_verify_activity_exec_secret_fails_when_missing_and_not_ignored() {
+            let config = exec_config_with_secret("${MISSING_EXEC_SECRET}");
+            let error = config.fetch_and_verify(false, None).unwrap_err().to_string();
+            assert!(
+                error.contains("failed to resolve exec secrets"),
+                "unexpected error: {error}"
+            );
+            assert!(
+                error.contains("MISSING_EXEC_SECRET"),
+                "unexpected error: {error}"
+            );
+        }
+
+        #[test]
+        fn fetch_and_verify_activity_exec_secret_is_skipped_when_missing_and_ignored() {
+            let config = exec_config_with_secret("${MISSING_EXEC_SECRET}");
+            let verified = config.fetch_and_verify(true, None).unwrap();
+            assert!(verified.secrets.is_none());
         }
     }
 }


### PR DESCRIPTION
- **refactor(toml): Honor `--missing-env-vars` when verifying exec with secrets**
- **style: Format sources**
- **test: Remove disabled retries from integration tests for slow CI runs**
- **refactor(toml): Fix `cwd` expansion when trailing `/` is missing**
