### PR TITLE
refactor(js,exec): Make unit type accept any response

### DIFF
--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -409,10 +409,8 @@ impl Worker for ActivityExecWorker {
             // Ok path: stdout is the ok-variant JSON.
             let stdout_trimmed = stdout_str.trim();
             if stdout_trimmed.is_empty() {
-                // Empty stdout → JSON null (for void ok types like `result`)
-                let ok_val = serde_json::Value::Null;
                 let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    &ok_val,
+                    None,
                     &self.user_return_type,
                     version.clone(),
                 )?;
@@ -436,7 +434,7 @@ impl Worker for ActivityExecWorker {
                         )
                     })?;
                 let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    &ok_val,
+                    Some(&ok_val),
                     &self.user_return_type,
                     version.clone(),
                 )?;

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -179,7 +179,7 @@ impl Worker for ActivityJsWorker {
                     unreachable!("activity-js-runtime always sends JSON-encoded string")
                 };
                 let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    &ok_val,
+                    Some(&ok_val),
                     &self.user_return_type,
                     version.clone(),
                 )?;
@@ -293,6 +293,7 @@ mod tests {
     };
     use concepts::{SupportedFunctionReturnValue, TypeWrapperTopLevel};
     use executor::worker::{WorkerContext, WorkerError, WorkerResultOk};
+    use rstest::rstest;
     use serde_json::json;
     use tokio::sync::mpsc;
     use tracing::info_span;
@@ -677,7 +678,7 @@ mod tests {
             )
             => {
                 assert_eq!(
-                    r#"failed to type check the return value `{"count":42,"name":"test"}` as `string`: invalid type: map, expected value matching "string" at line 1 column 1"#,
+                    "failed to type check the return value `{\"count\":42,\"name\":\"test\"}` as type string - invalid type: map, expected value matching \"string\" at line 1 column 1",
                     reason);
             }
         );
@@ -1350,15 +1351,19 @@ mod tests {
         );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn retval_ok_none_should_accept_null() {
+    async fn retval_ok_none_should_accept_anything(
+        #[values("return;", "return null;", "return 1")] return_stmt: &str,
+    ) {
         test_utils::set_up();
         let ffqn = FunctionFqn::new_static("test:pkg/ifc", "ok-none");
-        let js_source = r"
-            export default function ok_none() {
-                return null;
-            }
-        ";
+        let js_source = format!(
+            r"
+            export default function ok_none() {{
+                {return_stmt}
+            }}"
+        );
 
         let return_type = ReturnTypeExtendable {
             type_wrapper_tl: TypeWrapperTopLevel {
@@ -1368,7 +1373,7 @@ mod tests {
             wit_type: StrVariant::Static("result<_, string>"),
         };
 
-        let worker = JsWorkerBuilder::new(js_source, ffqn.clone())
+        let worker = JsWorkerBuilder::new(&js_source, ffqn.clone())
             .with_return_type(return_type)
             .build()
             .await;

--- a/crates/wasm-workers/src/js_worker_utils.rs
+++ b/crates/wasm-workers/src/js_worker_utils.rs
@@ -11,16 +11,13 @@ use concepts::{
 use executor::worker::{FatalError, WorkerError};
 
 /// Maps a JSON-encoded JS ok return value to the user-configured ok type.
-///
-/// * `ok: None` (void) — only JSON null is accepted → `Ok(None)`; anything else is fatal.
-/// * `ok: Some(T)` — the JSON is type-checked and deserialized via `deserialize_value`.
 pub(crate) fn map_js_ok_to_user_retval(
-    ok_val: &serde_json::Value,
+    ok_val: Option<&serde_json::Value>,
     user_return_type: &ReturnTypeExtendable,
     version: Version,
 ) -> Result<SupportedFunctionReturnValue, WorkerError> {
-    match &user_return_type.type_wrapper_tl.ok {
-        Some(configured_ok_type) => {
+    match (&user_return_type.type_wrapper_tl.ok, ok_val) {
+        (Some(configured_ok_type), Some(ok_val)) => {
             let wvt =
                 val_json::wast_val_ser::deserialize_value(ok_val, *configured_ok_type.clone())
                     .map_err(|err| {
@@ -28,8 +25,7 @@ pub(crate) fn map_js_ok_to_user_retval(
                             FatalError::ResultParsingError(
                                 ResultParsingError::ResultParsingErrorFromVal(
                                     ResultParsingErrorFromVal::TypeCheckError(format!(
-                                        "failed to type check the return value `{ok_val}` as \
-                                         `{configured_ok_type}`: {err}"
+                                        "failed to type check the return value `{ok_val}` as type {configured_ok_type} - {err}"
                                     )),
                                 ),
                             ),
@@ -38,20 +34,18 @@ pub(crate) fn map_js_ok_to_user_retval(
                     })?;
             Ok(SupportedFunctionReturnValue::Ok(Some(wvt)))
         }
-        None => {
-            if *ok_val == serde_json::Value::Null {
-                Ok(SupportedFunctionReturnValue::Ok(None))
-            } else {
-                Err(WorkerError::FatalError(
-                    FatalError::ResultParsingError(ResultParsingError::ResultParsingErrorFromVal(
-                        ResultParsingErrorFromVal::TypeCheckError(format!(
-                            "return value type check failed, expected `null`, got `{ok_val}`"
-                        )),
-                    )),
-                    version,
-                ))
-            }
-        }
+        (None, _) => Ok(SupportedFunctionReturnValue::Ok(None)), // Convenience: unit type accepts (blocks) any response.
+        (Some(ty), ok_val) => Err(WorkerError::FatalError(
+            FatalError::ResultParsingError(ResultParsingError::ResultParsingErrorFromVal(
+                ResultParsingErrorFromVal::TypeCheckError(format!(
+                    "return value type check failed, expected value of type {ty}, got {ok_val}",
+                    ok_val = ok_val
+                        .map(|ok_val| format!("`{ok_val}`"))
+                        .unwrap_or_else(|| "empty response".to_string())
+                )),
+            )),
+            version,
+        )),
     }
 }
 

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -224,7 +224,7 @@ impl Worker for WorkflowJsWorker {
                             unreachable!("workflow-js-runtime always sends JSON-encoded string")
                         };
                         let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                            &ok_val,
+                            Some(&ok_val),
                             &self.user_return_type,
                             version.clone(),
                         )?;
@@ -660,9 +660,8 @@ mod tests {
                 _version,
             ) => {
                 assert_eq!(
+                    "failed to type check the return value `{}` as type string - invalid type: map, expected value matching \"string\" at line 1 column 2",
                     reason,
-                    "failed to type check the return value `{}` as `string`: \
-                     invalid type: map, expected value matching \"string\" at line 1 column 2"
                 );
             }
         );


### PR DESCRIPTION
Accept any JS or stdout value when  user sets the retval to `result<_, _>`.
Previously this must have been `null`/`undefined` for JS and an empty
string for stdout.
