### PR TITLE
feat(activity_exec): Stream std streams, only apply limit to stdout

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,7 +79,7 @@ cargo test --package obelisk grpc_server::tests
 
 | Task | Files |
 |------|-------|
-| TOML | `src/config/toml.rs`, `obelisk-help-server.toml`, `obelisk-help-deployment.toml` — update the `obelisk-help-*.toml` files when changing TOML config |
+| TOML | `src/config/toml.rs`, `obelisk-help-server.toml`, `obelisk-help-deployment.toml` — update the `obelisk-help-*.toml` files when changing TOML config, then run `scripts/update-toml-schema.sh` to regenerate JSON schemas |
 | Database schema/queries | `crates/db-sqlite/src/sqlite_dao.rs`, `crates/db-postgres/src/postgres_dao.rs` |
 | Storage traits | `crates/concepts/src/storage.rs` |
 | gRPC API | `proto/obelisk.proto`, `src/server/grpc_server.rs`,`crates/grpc/src/grpc_mapping.rs` |

--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -131,7 +131,7 @@
           "default": "debug"
         },
         "max_output_bytes": {
-          "description": "Maximum bytes collected from stdout to form the response.\nExceeding the limit fails the execution.\nNot used when return_type is result (default), since the response carries no data.",
+          "description": "Maximum bytes collected from stdout to form the response.\nExceeding the limit fails the execution.\nNot used when `return_type` is result (default), since the response carries no data.",
           "type": "integer",
           "format": "uint64",
           "default": 1024,

--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -134,7 +134,7 @@
           "description": "Maximum bytes collected from stdout to form the response.\nExceeding the limit fails the execution.\nNot used when `return_type` is result (default), since the response carries no data.",
           "type": "integer",
           "format": "uint64",
-          "default": 1024,
+          "default": 4096,
           "minimum": 0
         },
         "max_retries": {

--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -131,7 +131,7 @@
           "default": "debug"
         },
         "max_output_bytes": {
-          "description": "Maximum bytes per stream (stdout/stderr). Excess is truncated and execution fails.",
+          "description": "Maximum bytes collected from stdout to form the response.\nExceeding the limit fails the execution.\nNot used when return_type is result (default), since the response carries no data.",
           "type": "integer",
           "format": "uint64",
           "default": 1024,

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -640,6 +640,11 @@ pub struct TypeWrapperTopLevel {
     pub ok: Option<Box<TypeWrapper>>,
     pub err: Option<Box<TypeWrapper>>,
 }
+impl TypeWrapperTopLevel {
+    pub fn is_result_of_units(&self) -> bool {
+        self.ok.is_none() && self.err.is_none()
+    }
+}
 impl From<TypeWrapperTopLevel> for TypeWrapper {
     fn from(value: TypeWrapperTopLevel) -> TypeWrapper {
         TypeWrapper::Result {

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -641,6 +641,7 @@ pub struct TypeWrapperTopLevel {
     pub err: Option<Box<TypeWrapper>>,
 }
 impl TypeWrapperTopLevel {
+    #[must_use]
     pub fn is_result_of_units(&self) -> bool {
         self.ok.is_none() && self.err.is_none()
     }

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -371,9 +371,16 @@ impl Worker for ActivityExecWorker {
                     &ctx,
                 );
                 let (stdout_result, stderr_result) = tokio::join!(stdout_fut, stderr_fut);
-                let (stdout_bytes, stdout_exceeded) = stdout_result?;
+                let (mut stdout_bytes, mut stdout_exceeded) = stdout_result?;
                 let _ = stderr_result?;
                 let exit_code = child.wait().await?.code().unwrap_or(-1);
+                // If the unit type was requested, return empty response.
+                if exit_code == 0 && self.user_return_type.type_wrapper_tl.ok.is_none()
+                    || exit_code != 0 && self.user_return_type.type_wrapper_tl.err.is_none()
+                {
+                    stdout_exceeded = false;
+                    stdout_bytes = Vec::new();
+                }
                 Ok::<_, std::io::Error>((stdout_bytes, stdout_exceeded, exit_code))
             } => {
                 result.map_err(|e| {

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -150,24 +150,43 @@ pub struct ActivityExecWorker {
     user_exports_noext: Vec<FunctionMetadata>,
 }
 
-/// Read up to `limit` bytes from `reader`, returning the bytes read.
-/// If the stream exceeds `limit`, returns the bytes read so far + a flag.
-async fn read_limited(
+/// Read from `reader` in chunks, streaming each chunk to `forwarder`,
+/// while accumulating the full output (up to `capture_limit` bytes).
+/// Capturing can be turned off by setting `capture_limit` to zero.
+async fn read_and_stream(
     reader: &mut (impl tokio::io::AsyncRead + Unpin),
-    limit: u64,
+    capture_limit: u64,
+    forwarder: Option<&StdOutputConfigWithSender>,
+    ctx: &WorkerContext,
 ) -> std::io::Result<(Vec<u8>, bool)> {
-    let mut buf = Vec::with_capacity(limit.min(8192) as usize);
-    let mut limited = reader.take(limit + 1);
-    limited.read_to_end(&mut buf).await?;
-    if buf.len() as u64 > limit {
-        buf.truncate(
-            usize::try_from(limit)
-                .expect("u64 must fit in usize - 32-bit platforms are not supported"),
-        );
-        Ok((buf, true))
-    } else {
-        Ok((buf, false))
+    let mut buf = Vec::with_capacity(capture_limit.min(8192) as usize);
+    let mut chunk = [0u8; 4096];
+    let mut exceeded = false;
+    loop {
+        let n = reader.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        // Forward to log storage.
+        if let Some(fwd) = forwarder {
+            forward_output(fwd, &chunk[..n], ctx);
+        }
+        // Accumulate for result capture unless turned off.
+        if !exceeded && capture_limit > 0 {
+            let space = (capture_limit as usize).saturating_sub(buf.len());
+            if space > 0 {
+                let to_capture = n.min(space);
+                buf.extend_from_slice(&chunk[..to_capture]);
+            }
+            if buf.len() as u64 >= capture_limit && n > space {
+                exceeded = true;
+            }
+        }
     }
+    if capture_limit == 0 {
+        assert!(!exceeded);
+    }
+    Ok((buf, exceeded))
 }
 
 #[async_trait]
@@ -258,30 +277,30 @@ impl Worker for ActivityExecWorker {
         }
         cmd.args(param_args);
 
-        // 4. Clean environment + configured env vars.
+        // Clean environment + configured env vars.
         cmd.env_clear();
         for env_var in self.env_vars.iter() {
             cmd.env(&env_var.key, &env_var.val);
         }
 
-        // 5. Set cwd if configured.
+        // Set cwd if configured.
         if let Some(cwd) = &self.cwd {
             cmd.current_dir(cwd);
         }
 
-        // 6. Process group and kill_on_drop.
+        // Process group and kill_on_drop.
         #[cfg(unix)]
         cmd.process_group(0);
         cmd.kill_on_drop(true);
 
-        // 7. Capture stdout/stderr, optionally pipe stdin.
+        // Capture stdout/stderr, optionally pipe stdin.
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
         if self.stdin_content.is_some() {
             cmd.stdin(std::process::Stdio::piped());
         }
 
-        // 8. Spawn the child process.
+        // Spawn the child process.
         trace!("Spawning {cmd:?}");
         let mut child = cmd.spawn().map_err(|e| {
             WorkerError::FatalError(
@@ -293,7 +312,7 @@ impl Worker for ActivityExecWorker {
             )
         })?;
 
-        // 8b. Write stdin content if configured (e.g. resolved secrets).
+        // Write stdin content if configured (e.g. resolved secrets).
         if let Some(ref stdin_content) = self.stdin_content {
             use tokio::io::AsyncWriteExt;
             let mut child_stdin = child.stdin.take().expect("stdin was piped");
@@ -316,34 +335,46 @@ impl Worker for ActivityExecWorker {
         let mut child_stdout = child.stdout.take().expect("stdout was piped");
         let mut child_stderr = child.stderr.take().expect("stderr was piped");
 
-        // 9. Register cancellation token.
+        // Register cancellation token.
         let cancel_token = self
             .cancel_registry
             .obtain_cancellation_token(ctx.execution_id.clone());
 
-        // 10. Read stdout/stderr concurrently with cancellation support.
-        let max_bytes = self.max_output_bytes;
+        // Skip stdout collection when return_type is `result` (unit ok and err variants).
+        let max_stdout_bytes = if self.user_return_type.type_wrapper_tl.is_result_of_units() {
+            0
+        } else {
+            self.max_output_bytes
+        };
         let result = tokio::select! {
             biased;
             _ = cancel_token => {
                 // Kill the child on cancellation.
                 let _ = child.kill().await;
                 return Err(WorkerError::FatalError(
-                    FatalError::CannotInstantiate {
-                        reason: "execution cancelled".to_string(),
-                        detail: None,
-                    },
+                    FatalError::Cancelled,
                     version,
                 ));
             }
             result = async {
-                let stdout_fut = read_limited(&mut child_stdout, max_bytes);
-                let stderr_fut = read_limited(&mut child_stderr, max_bytes);
+                // Read stdout/stderr concurrently, streaming to log forwarder as chunks arrive.
+                let stdout_fut = read_and_stream(
+                    &mut child_stdout,
+                    max_stdout_bytes,
+                    self.forward_stdout.as_ref(),
+                    &ctx,
+                );
+                let stderr_fut = read_and_stream(
+                    &mut child_stderr,
+                    0, // stderr is only streamed to logs, not captured
+                    self.forward_stderr.as_ref(),
+                    &ctx,
+                );
                 let (stdout_result, stderr_result) = tokio::join!(stdout_fut, stderr_fut);
                 let (stdout_bytes, stdout_exceeded) = stdout_result?;
-                let (stderr_bytes, stderr_exceeded) = stderr_result?;
+                let _ = stderr_result?;
                 let status = child.wait().await?;
-                Ok::<_, std::io::Error>((stdout_bytes, stdout_exceeded, stderr_bytes, stderr_exceeded, status))
+                Ok::<_, std::io::Error>((stdout_bytes, stdout_exceeded, status))
             } => {
                 result.map_err(|e| {
                     WorkerError::FatalError(
@@ -357,9 +388,9 @@ impl Worker for ActivityExecWorker {
             }
         };
 
-        let (stdout_bytes, stdout_exceeded, stderr_bytes, stderr_exceeded, status) = result;
+        let (stdout_bytes, stdout_exceeded, status) = result;
 
-        // 11. Check output size limits.
+        // Check output size limits.
         if stdout_exceeded {
             return Err(WorkerError::FatalError(
                 FatalError::CannotInstantiate {
@@ -372,45 +403,23 @@ impl Worker for ActivityExecWorker {
                 version,
             ));
         }
-        if stderr_exceeded {
-            return Err(WorkerError::FatalError(
-                FatalError::CannotInstantiate {
-                    reason: format!(
-                        "stderr exceeded max_output_bytes limit of {} bytes",
-                        self.max_output_bytes
-                    ),
-                    detail: None,
-                },
-                version,
-            ));
-        }
 
         let stdout_str = String::from_utf8_lossy(&stdout_bytes);
-        let stderr_str = String::from_utf8_lossy(&stderr_bytes);
-
-        // 12. Forward stdout/stderr per config.
-        if let Some(ref config) = self.forward_stdout {
-            forward_output(config, &stdout_str, &ctx);
-        }
-        if let Some(ref config) = self.forward_stderr {
-            forward_output(config, &stderr_str, &ctx);
-        }
 
         debug!(
             exit_code = status.code(),
             stdout_len = stdout_bytes.len(),
-            stderr_len = stderr_bytes.len(),
             "Child process finished"
         );
 
-        // 13. Map exit code + stdout to result.
+        // Map exit code + stdout to result.
         let exit_code = status.code().unwrap_or(-1);
         if exit_code == 0 {
             // Ok path: stdout is the ok-variant JSON.
             let stdout_trimmed = stdout_str.trim();
             if stdout_trimmed.is_empty() {
                 let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    None,
+                    None, // no JSON was sent, this is accepted only for the unit type.
                     &self.user_return_type,
                     version.clone(),
                 )?;
@@ -477,16 +486,18 @@ impl Worker for ActivityExecWorker {
     }
 }
 
-fn forward_output(config: &StdOutputConfigWithSender, output: &str, ctx: &WorkerContext) {
+fn forward_output(config: &StdOutputConfigWithSender, output: &[u8], ctx: &WorkerContext) {
     if output.is_empty() {
         return;
     }
     match config {
         StdOutputConfigWithSender::Stdout => {
-            print!("{output}");
+            use std::io::Write;
+            let _ = std::io::stdout().write_all(output);
         }
         StdOutputConfigWithSender::Stderr => {
-            eprint!("{output}");
+            use std::io::Write;
+            let _ = std::io::stderr().write_all(output);
         }
         StdOutputConfigWithSender::Db {
             sender,
@@ -494,7 +505,7 @@ fn forward_output(config: &StdOutputConfigWithSender, output: &str, ctx: &Worker
         } => {
             let log_entry = concepts::storage::LogEntry::Stream {
                 created_at: chrono::Utc::now(),
-                payload: output.as_bytes().to_vec(),
+                payload: output.to_vec(),
                 stream_type: *forwarding_from,
             };
             let row = LogInfoAppendRow {

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -373,8 +373,8 @@ impl Worker for ActivityExecWorker {
                 let (stdout_result, stderr_result) = tokio::join!(stdout_fut, stderr_fut);
                 let (stdout_bytes, stdout_exceeded) = stdout_result?;
                 let _ = stderr_result?;
-                let status = child.wait().await?;
-                Ok::<_, std::io::Error>((stdout_bytes, stdout_exceeded, status))
+                let exit_code = child.wait().await?.code().unwrap_or(-1);
+                Ok::<_, std::io::Error>((stdout_bytes, stdout_exceeded, exit_code))
             } => {
                 result.map_err(|e| {
                     WorkerError::FatalError(
@@ -388,9 +388,9 @@ impl Worker for ActivityExecWorker {
             }
         };
 
-        let (stdout_bytes, stdout_exceeded, status) = result;
+        let (stdout_bytes, stdout_exceeded, exit_code) = result;
 
-        // Check output size limits.
+        // Check output size limit.
         if stdout_exceeded {
             return Err(WorkerError::FatalError(
                 FatalError::CannotInstantiate {
@@ -404,85 +404,43 @@ impl Worker for ActivityExecWorker {
             ));
         }
 
-        let stdout_str = String::from_utf8_lossy(&stdout_bytes);
-
         debug!(
-            exit_code = status.code(),
+            exit_code,
             stdout_len = stdout_bytes.len(),
             "Child process finished"
         );
-
-        // Map exit code + stdout to result.
-        let exit_code = status.code().unwrap_or(-1);
-        if exit_code == 0 {
-            // Ok path: stdout is the ok-variant JSON.
-            let stdout_trimmed = stdout_str.trim();
-            if stdout_trimmed.is_empty() {
-                let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    None, // no JSON was sent, this is accepted only for the unit type.
-                    &self.user_return_type,
-                    version.clone(),
-                )?;
-                Ok(WorkerResultOk::RunFinished {
-                    retval,
-                    version,
-                    http_client_traces: None,
-                })
-            } else {
-                let ok_val: serde_json::Value = serde_json::from_str(stdout_trimmed)
-                    .map_err(|e| {
-                        WorkerError::FatalError(
-                            FatalError::ResultParsingError(
-                                concepts::ResultParsingError::ResultParsingErrorFromVal(
-                                    concepts::ResultParsingErrorFromVal::TypeCheckError(format!(
-                                        "failed to parse stdout as JSON on exit 0: {e}, stdout: `{stdout_trimmed}`"
-                                    )),
-                                ),
-                            ),
-                            version.clone(),
-                        )
-                    })?;
-                let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    Some(&ok_val),
-                    &self.user_return_type,
-                    version.clone(),
-                )?;
-                Ok(WorkerResultOk::RunFinished {
-                    retval,
-                    version,
-                    http_client_traces: None,
-                })
-            }
+        let stdout = String::from_utf8_lossy(&stdout_bytes);
+        let parsed = if stdout.trim().is_empty() {
+            None
         } else {
-            // Err path: stdout is the err-variant JSON.
-            let stdout_trimmed = stdout_str.trim();
-            if stdout_trimmed.is_empty() {
-                // Empty stdout on non-zero exit → JSON null for err
-                let retval = crate::js_worker_utils::map_js_throw_to_user_err(
-                    "null",
-                    &self.user_return_type,
+            Some(serde_json::from_str::<serde_json::Value>(&stdout).map_err(|e| {
+                WorkerError::FatalError(
+                    FatalError::ResultParsingError(
+                        concepts::ResultParsingError::ResultParsingErrorFromVal(
+                            concepts::ResultParsingErrorFromVal::TypeCheckError(format!(
+                                "failed to parse stdout as JSON on exit {exit_code}: {e}, stdout: `{stdout}`"
+                            )),
+                        ),
+                    ),
                     version.clone(),
-                )?;
-                Ok(WorkerResultOk::RunFinished {
-                    retval,
-                    version,
-                    http_client_traces: None,
-                })
-            } else {
-                // stdout should already be valid JSON; pass it through as-is to map_js_throw_to_user_err
-                // which expects the raw JSON string.
-                let retval = crate::js_worker_utils::map_js_throw_to_user_err(
-                    stdout_trimmed,
-                    &self.user_return_type,
-                    version.clone(),
-                )?;
-                Ok(WorkerResultOk::RunFinished {
-                    retval,
-                    version,
-                    http_client_traces: None,
-                })
-            }
-        }
+                )
+            })?)
+        };
+
+        let retval = if exit_code == 0 {
+            crate::js_worker_utils::map_ok_variant(parsed, &self.user_return_type, version.clone())?
+        } else {
+            crate::js_worker_utils::map_err_variant(
+                parsed,
+                &self.user_return_type,
+                version.clone(),
+            )?
+        };
+        Ok(WorkerResultOk::RunFinished {
+            retval,
+            version,
+            http_client_traces: None,
+        })
     }
 }
 

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -173,7 +173,9 @@ async fn read_and_stream(
         }
         // Accumulate for result capture unless turned off.
         if !exceeded && capture_limit > 0 {
-            let space = (capture_limit as usize).saturating_sub(buf.len());
+            let space = usize::try_from(capture_limit)
+                .expect("32 bit systems are unsupported")
+                .saturating_sub(buf.len());
             if space > 0 {
                 let to_capture = n.min(space);
                 buf.extend_from_slice(&chunk[..to_capture]);

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -163,23 +163,25 @@ impl Worker for ActivityJsWorker {
 
         let (retval, version, http_client_traces) = assert_matches!(inner_worker_ok, WorkerResultOk::RunFinished { retval, version,  http_client_traces }
             => (retval, version,  http_client_traces), "activity_js_runtime runs in ActivityWorker");
+
         match retval {
             SupportedFunctionReturnValue::Ok(Some(WastValWithType {
                 r#type:
                     TypeWrapper::Result {
-                        ok: Some(ok_type),   // String
-                        err: Some(err_type), // err string was not sent
+                        ok: Some(ok_type),
+                        err: Some(err_type),
                     },
                 value: WastVal::Result(Ok(Some(ok_val))), // activity-js-runtime returned {"ok": {"ok": "<json-encoded value>"}}
-            })) if *ok_type == TypeWrapper::String && *err_type == TypeWrapper::String => {
+            })) => {
+                assert!(*ok_type == TypeWrapper::String && *err_type == TypeWrapper::String);
                 let WastVal::String(ok_val) = *ok_val else {
                     unreachable!("ok type is String, so value must be WastVal::String")
                 };
                 let Ok(ok_val) = serde_json::from_str(&ok_val) else {
                     unreachable!("activity-js-runtime always sends JSON-encoded string")
                 };
-                let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                    Some(&ok_val),
+                let retval = crate::js_worker_utils::map_ok_variant(
+                    Some(ok_val),
                     &self.user_return_type,
                     version.clone(),
                 )?;
@@ -196,13 +198,17 @@ impl Worker for ActivityJsWorker {
                         ok: Some(ok_type),
                         err: Some(err_type),
                     },
-                value: WastVal::Result(Err(Some(err_val))), // js runtime returned {"ok":{"err":"some string"}}
-            })) if *ok_type == TypeWrapper::String && *err_type == TypeWrapper::String => {
-                let WastVal::String(thrown) = *err_val else {
+                value: WastVal::Result(Err(Some(err_val))), // js runtime returned {"ok":{"err":"<json-encoded value>"}}
+            })) => {
+                assert!(*ok_type == TypeWrapper::String && *err_type == TypeWrapper::String);
+                let WastVal::String(err_val) = *err_val else {
                     unreachable!("err type is String, so value must be WastVal::String")
                 };
-                let retval = crate::js_worker_utils::map_js_throw_to_user_err(
-                    &thrown,
+                let Ok(err_val) = serde_json::from_str(&err_val) else {
+                    unreachable!("activity-js-runtime always sends JSON-encoded string")
+                };
+                let retval = crate::js_worker_utils::map_err_variant(
+                    Some(err_val),
                     &self.user_return_type,
                     version.clone(),
                 )?;

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -305,16 +305,6 @@ mod tests {
     use tracing::info_span;
     use val_json::wast_val::WastVal;
 
-    fn default_return_type() -> ReturnTypeExtendable {
-        ReturnTypeExtendable {
-            type_wrapper_tl: TypeWrapperTopLevel {
-                ok: Some(Box::new(TypeWrapper::String)),
-                err: Some(Box::new(TypeWrapper::String)),
-            },
-            wit_type: StrVariant::Static("result<string, string>"),
-        }
-    }
-
     struct JsWorkerBuilder {
         js_source: String,
         user_ffqn: FunctionFqn,
@@ -334,7 +324,13 @@ mod tests {
                     name: StrVariant::Static("params"),
                     wit_type: StrVariant::Static("list<string>"),
                 }],
-                user_return_type: default_return_type(),
+                user_return_type: ReturnTypeExtendable {
+                    type_wrapper_tl: TypeWrapperTopLevel {
+                        ok: Some(Box::new(TypeWrapper::String)),
+                        err: Some(Box::new(TypeWrapper::String)),
+                    },
+                    wit_type: StrVariant::Static("result<string, string>"),
+                },
                 allowed_hosts: Vec::new(),
                 logs_storage_config: None,
             }
@@ -684,14 +680,14 @@ mod tests {
             )
             => {
                 assert_eq!(
-                    "failed to type check the return value `{\"count\":42,\"name\":\"test\"}` as type string - invalid type: map, expected value matching \"string\" at line 1 column 1",
+                    "failed to type check the ok variant value `{\"count\":42,\"name\":\"test\"}` as type string - invalid type: map, expected value matching \"string\" at line 1 column 1",
                     reason);
             }
         );
     }
 
     #[tokio::test]
-    async fn throwing_object_should_fail_to_typecheck() {
+    async fn throwing_object_should_fail_to_typecheck_expecting_result_string_string() {
         test_utils::set_up();
         let ffqn = FunctionFqn::new_static("test:pkg/ifc", "throw-object");
         let js_source = r"
@@ -713,9 +709,9 @@ mod tests {
                 _version,
             )
             => {
-                assert!(
-                    reason.contains("failed to type check thrown value"),
-                    "{reason} should mention type check failure"
+                assert_eq!(
+                    r#"failed to type check the err variant value `{"code":42,"message":"error"}` as type string - invalid type: map, expected value matching "string" at line 1 column 1"#,
+                    reason
                 );
             }
         );
@@ -1435,7 +1431,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn typed_throw_err_none_is_fatal() {
+    async fn throwing_anything_on_err_unit_is_ok() {
         test_utils::set_up();
         let ffqn = FunctionFqn::new_static("test:pkg/ifc", "no-err");
         let js_source = r#"
@@ -1458,19 +1454,13 @@ mod tests {
             .await;
         let ctx = make_worker_context(ffqn, &[]);
 
-        let err = worker.run(ctx).await.unwrap_err();
-        let reason = assert_matches!(
-            err,
-            WorkerError::FatalError(
-                FatalError::ResultParsingError(ResultParsingError::ResultParsingErrorFromVal(
-                    ResultParsingErrorFromVal::TypeCheckError(reason),
-                )),
-                _version,
-            ) => reason
-        );
-        assert_eq!(
-            reason,
-            "thrown value type check failed: return type is `result<u32>` (no error type), expected `throw null`, got `\"oops\"`"
+        let worker_ok = worker.run(ctx).await.unwrap();
+        assert_matches!(
+            worker_ok,
+            WorkerResultOk::RunFinished {
+                retval: SupportedFunctionReturnValue::Err(None),
+                ..
+            }
         );
     }
 

--- a/crates/wasm-workers/src/js_worker_utils.rs
+++ b/crates/wasm-workers/src/js_worker_utils.rs
@@ -9,93 +9,76 @@ use concepts::{
     SupportedFunctionReturnValue, storage::Version,
 };
 use executor::worker::{FatalError, WorkerError};
+use val_json::type_wrapper::TypeWrapper;
 
-/// Maps a JSON-encoded JS ok return value to the user-configured ok type.
-pub(crate) fn map_js_ok_to_user_retval(
-    ok_val: Option<&serde_json::Value>,
+pub(crate) fn map_ok_variant(
+    val: Option<serde_json::Value>,
     user_return_type: &ReturnTypeExtendable,
     version: Version,
 ) -> Result<SupportedFunctionReturnValue, WorkerError> {
-    match (&user_return_type.type_wrapper_tl.ok, ok_val) {
-        (Some(configured_ok_type), Some(ok_val)) => {
+    map_variant(
+        val,
+        version,
+        user_return_type.type_wrapper_tl.ok.as_deref(),
+        Ok(()),
+    )
+}
+pub(crate) fn map_err_variant(
+    val: Option<serde_json::Value>,
+    user_return_type: &ReturnTypeExtendable,
+    version: Version,
+) -> Result<SupportedFunctionReturnValue, WorkerError> {
+    map_variant(
+        val,
+        version,
+        user_return_type.type_wrapper_tl.err.as_deref(),
+        Err(()),
+    )
+}
+
+fn map_variant(
+    val: Option<serde_json::Value>,
+    version: Version,
+    expected_type: Option<&TypeWrapper>,
+    variant: Result<(), ()>,
+) -> Result<SupportedFunctionReturnValue, WorkerError> {
+    let supported_func = if variant.is_ok() {
+        SupportedFunctionReturnValue::Ok
+    } else {
+        SupportedFunctionReturnValue::Err
+    };
+
+    match (expected_type, val) {
+        (Some(ty), Some(ok_val)) => {
             let wvt =
-                val_json::wast_val_ser::deserialize_value(ok_val, *configured_ok_type.clone())
+                val_json::wast_val_ser::deserialize_value(&ok_val, ty.clone())
                     .map_err(|err| {
                         WorkerError::FatalError(
                             FatalError::ResultParsingError(
                                 ResultParsingError::ResultParsingErrorFromVal(
                                     ResultParsingErrorFromVal::TypeCheckError(format!(
-                                        "failed to type check the return value `{ok_val}` as type {configured_ok_type} - {err}"
+                                        "failed to type check the {variant} variant value `{ok_val}` as type {ty} - {err}",
+                                        variant = if variant.is_ok() { "ok" } else { "err" }
                                     )),
                                 ),
                             ),
                             version.clone(),
                         )
                     })?;
-            Ok(SupportedFunctionReturnValue::Ok(Some(wvt)))
+            Ok(supported_func(Some(wvt)))
         }
-        (None, _) => Ok(SupportedFunctionReturnValue::Ok(None)), // Convenience: unit type accepts (blocks) any response.
-        (Some(ty), ok_val) => Err(WorkerError::FatalError(
+        (None, _) => Ok(supported_func(None)), // Convenience: unit type accepts (blocks) any response.
+        (Some(ty), val) => Err(WorkerError::FatalError(
             FatalError::ResultParsingError(ResultParsingError::ResultParsingErrorFromVal(
                 ResultParsingErrorFromVal::TypeCheckError(format!(
-                    "return value type check failed, expected value of type {ty}, got {ok_val}",
-                    ok_val = ok_val
-                        .map(|ok_val| format!("`{ok_val}`"))
+                    "failed to type check the {variant} variant `{val} as type {ty}",
+                    variant = if variant.is_ok() { "ok" } else { "err" },
+                    val = val
+                        .map(|val| format!("`{val}`"))
                         .unwrap_or_else(|| "empty response".to_string())
                 )),
             )),
             version,
         )),
-    }
-}
-
-/// Maps a JSON-encoded JS throw to the user-configured err type.
-///
-/// The Boa runtime JSON-encodes all thrown values (consistent with ok values), so
-/// `throw null` → `"null"`, `throw "foo"` → `"\"foo\""`, `throw "my-case"` → `"\"my-case\""`.
-///
-/// * `err: None` (void) — only JSON null is accepted → `Err(None)`; anything else is fatal.
-/// * `err: Some(T)` — the JSON is type-checked and deserialized via `deserialize_value`.
-pub(crate) fn map_js_throw_to_user_err(
-    thrown: &str,
-    user_return_type: &ReturnTypeExtendable,
-    version: Version,
-) -> Result<SupportedFunctionReturnValue, WorkerError> {
-    let thrown_val: serde_json::Value =
-        serde_json::from_str(thrown).unwrap_or(serde_json::Value::Null);
-    match user_return_type.type_wrapper_tl.err.as_deref() {
-        None => {
-            if thrown_val == serde_json::Value::Null {
-                Ok(SupportedFunctionReturnValue::Err(None))
-            } else {
-                let declared_return_type = user_return_type.to_string();
-                Err(WorkerError::FatalError(
-                    FatalError::ResultParsingError(ResultParsingError::ResultParsingErrorFromVal(
-                        ResultParsingErrorFromVal::TypeCheckError(format!(
-                            "thrown value type check failed: return type is `{declared_return_type}` (no error \
-                             type), expected `throw null`, got `{thrown}`"
-                        )),
-                    )),
-                    version,
-                ))
-            }
-        }
-        Some(user_err_type) => {
-            let wvt = val_json::wast_val_ser::deserialize_value(&thrown_val, user_err_type.clone())
-                .map_err(|e| {
-                    WorkerError::FatalError(
-                        FatalError::ResultParsingError(
-                            ResultParsingError::ResultParsingErrorFromVal(
-                                ResultParsingErrorFromVal::TypeCheckError(format!(
-                                    "failed to type check thrown value `{thrown}` as \
-                                     `{user_err_type}`: {e}"
-                                )),
-                            ),
-                        ),
-                        version.clone(),
-                    )
-                })?;
-            Ok(SupportedFunctionReturnValue::Err(Some(wvt)))
-        }
     }
 }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -216,15 +216,18 @@ impl Worker for WorkflowJsWorker {
                                 err: Some(err_type),
                             },
                         value: WastVal::Result(Ok(Some(ok_val))),
-                    })) if *ok_type == TypeWrapper::String && *err_type == TypeWrapper::String => {
+                    })) => {
+                        assert!(
+                            *ok_type == TypeWrapper::String && *err_type == TypeWrapper::String
+                        );
                         let WastVal::String(ok_val) = *ok_val else {
                             unreachable!("ok type is String, so value must be WastVal::String")
                         };
                         let Ok(ok_val) = serde_json::from_str(&ok_val) else {
                             unreachable!("workflow-js-runtime always sends JSON-encoded string")
                         };
-                        let retval = crate::js_worker_utils::map_js_ok_to_user_retval(
-                            Some(&ok_val),
+                        let retval = crate::js_worker_utils::map_ok_variant(
+                            Some(ok_val),
                             &self.user_return_type,
                             version.clone(),
                         )?;
@@ -242,12 +245,18 @@ impl Worker for WorkflowJsWorker {
                                 err: Some(err_type),
                             },
                         value: WastVal::Result(Err(Some(err_val))),
-                    })) if *ok_type == TypeWrapper::String && *err_type == TypeWrapper::String => {
-                        let WastVal::String(thrown) = *err_val else {
+                    })) => {
+                        assert!(
+                            *ok_type == TypeWrapper::String && *err_type == TypeWrapper::String
+                        );
+                        let WastVal::String(err_val) = *err_val else {
                             unreachable!("err type is String, so value must be WastVal::String")
                         };
-                        let retval = crate::js_worker_utils::map_js_throw_to_user_err(
-                            &thrown,
+                        let Ok(err_val) = serde_json::from_str(&err_val) else {
+                            unreachable!("workflow-js-runtime always sends JSON-encoded string")
+                        };
+                        let retval = crate::js_worker_utils::map_err_variant(
+                            Some(err_val),
                             &self.user_return_type,
                             version.clone(),
                         )?;

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -669,7 +669,7 @@ mod tests {
                 _version,
             ) => {
                 assert_eq!(
-                    "failed to type check the return value `{}` as type string - invalid type: map, expected value matching \"string\" at line 1 column 2",
+                    "failed to type check the ok variant value `{}` as type string - invalid type: map, expected value matching \"string\" at line 1 column 2",
                     reason,
                 );
             }

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -147,7 +147,10 @@
 ## Working directory for the child process. Supports `${DEPLOYMENT_DIR}/` prefix interpolation.
 ## Defaults to the server's working directory.
 # cwd = "${DEPLOYMENT_DIR}/workdir"
-## Maximum bytes per stream (stdout/stderr). Excess causes execution to fail. Default: 1024.
+## Maximum bytes collected from stdout to form the response.
+## Exceeding the limit fails the execution.
+## Not used when return_type is result (default), since the response carries no data.
+## Default: 1024.
 # max_output_bytes = 1024
 ## Secrets: resolved from host environment variables at startup and piped to the child's stdin as JSON.
 ## The child receives `{"KEY":"value",...}` on stdin. Use `jq .KEY /dev/stdin` or equivalent to parse.

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -150,8 +150,8 @@
 ## Maximum bytes collected from stdout to form the response.
 ## Exceeding the limit fails the execution.
 ## Not used when return_type is result (default), since the response carries no data.
-## Default: 1024.
-# max_output_bytes = 1024
+## Default: 4096.
+# max_output_bytes = 4096
 ## Secrets: resolved from host environment variables at startup and piped to the child's stdin as JSON.
 ## The child receives `{"KEY":"value",...}` on stdin. Use `jq .KEY /dev/stdin` or equivalent to parse.
 # [activity_exec.secrets]

--- a/obelisk-testing-exec.toml
+++ b/obelisk-testing-exec.toml
@@ -1,0 +1,7 @@
+[[activity_exec]]
+ffqn = "testing:integration/exec-stream.stream-test"
+program.inline = '''#!/usr/bin/env bash
+echo "line1" >&2
+sleep 0.1
+echo "line2" >&2
+'''

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -266,9 +266,8 @@ params = [
 return_type = "result<string, string>"
 
 [[activity_exec]]
-name = "test_exec_add"
-program.external = ["{ws}/crates/testing/test-programs/exec/add.sh"]
 ffqn = "testing:integration/exec-add.add"
+program.external = ["{ws}/crates/testing/test-programs/exec/add.sh"]
 params = [
   {{ name = "a", type = "u32" }},
   {{ name = "b", type = "u32" }},
@@ -276,101 +275,91 @@ params = [
 return_type = "result<u32, string>"
 
 [[activity_exec]]
-name = "test_exec_greet_include"
-program.include = "{ws}/crates/testing/test-programs/exec/greet.sh"
 ffqn = "testing:integration/exec-greet.greet-include"
+program.include = "{ws}/crates/testing/test-programs/exec/greet.sh"
 params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
 
 [[activity_exec]]
-name = "test_exec_greet_external"
-program.external = ["{ws}/crates/testing/test-programs/exec/greet.sh"]
 ffqn = "testing:integration/exec-greet.greet-external"
+program.external = ["{ws}/crates/testing/test-programs/exec/greet.sh"]
 params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
 
 [[activity_exec]]
-name = "test_exec_greet_inline"
+ffqn = "testing:integration/exec-greet.greet-inline"
 program.inline = '''
 #!/usr/bin/env bash
 raw=$(echo $1 | jq -r .)
 echo "\"Hello, $raw!\""
 '''
-ffqn = "testing:integration/exec-greet.greet-inline"
 params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
 
 [[activity_exec]]
-name = "test_exec_read_env"
-program.include = "{ws}/crates/testing/test-programs/exec/read-env.sh"
 ffqn = "testing:integration/exec-env.read-env"
-params = []
+program.include = "{ws}/crates/testing/test-programs/exec/read-env.sh"
 return_type = "result<string, string>"
 env_vars = [{{key = "MY_VAR", value = "hello_from_exec_env"}}]
 
 [[activity_exec]]
-name = "test_exec_error"
+ffqn = "testing:integration/exec-error.fail"
 program.inline = '''#!/usr/bin/env bash
 echo '"something went wrong"'
 exit 1
 '''
-ffqn = "testing:integration/exec-error.fail"
-params = []
 return_type = "result<string, string>"
 
 [[activity_exec]]
-name = "test_exec_record_ok"
+ffqn = "testing:integration/exec-record.make-record"
 program.inline = '''#!/usr/bin/env bash
 printf '{{"name": "Alice", "count": 42}}'
 '''
-ffqn = "testing:integration/exec-record.make-record"
-params = []
 return_type = "result<record {{ name: string, count: u32 }}, string>"
 
 [[activity_exec]]
-name = "test_exec_expose_secrets"
-program.external = ["{ws}/crates/testing/test-programs/exec/expose-secrets.sh"]
 ffqn = "testing:integration/exec-stdin.expose-secrets"
-params = []
+program.external = ["{ws}/crates/testing/test-programs/exec/expose-secrets.sh"]
 return_type = "result<string, string>"
 [activity_exec.secrets]
 env_vars = [{{ name = "MY_SECRET", value = "s3cret_value" }}]
 
 [[activity_exec]]
-name = "test_exec_void_ok"
 program.external = ["true"]
 ffqn = "testing:integration/exec-void.void-ok"
-params = []
 return_type = "result"
 
 [[activity_exec]]
-name = "test_exec_void_err"
 program.external = ["false"]
 ffqn = "testing:integration/exec-void.void-err"
-params = []
-return_type = "result"
 
 [[activity_exec]]
-name = "test_exec_args_passthrough"
+ffqn = "testing:integration/exec-args.echo-args"
 program.inline = '''#!/usr/bin/env bash
 # Receives two u32 params as JSON args: $1 and $2
 printf '{{"a": %s, "b": %s}}' "$1" "$2"
 '''
-ffqn = "testing:integration/exec-args.echo-args"
 params = [
   {{ name = "a", type = "u32" }},
   {{ name = "b", type = "u32" }},
 ]
 return_type = "result<record {{ a: u32, b: u32 }}, string>"
 
+[[activity_exec]]
+ffqn = "testing:integration/exec-stream.stream-test"
+program.inline = '''#!/usr/bin/env bash
+echo "line1" >&2
+sleep 0.1
+echo "line2" >&2
+'''
+
 [[activity_stub]]
-name = "test_inline_stub"
 ffqn = "testing:integration/stubs.my-stub"
 params = [
   {{ name = "id", type = "u64" }},
@@ -2181,5 +2170,42 @@ async fn activity_exec_error_exit() {
     assert_eq!(resp.status().as_u16(), 201);
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body, json!({ "err": "something went wrong" }));
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn activity_exec_stream_logs() {
+    let server = TestServer::start(test_addr!(61)).await;
+    let exec_id = server.generate_execution_id().await;
+
+    let resp = server
+        .submit_follow_with_id(
+            &exec_id,
+            "testing:integration/exec-stream.stream-test",
+            vec![],
+        )
+        .await;
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body, json!({ "ok": null }));
+
+    // Allow log forwarding to flush.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let logs = server.get_logs(&exec_id).await;
+
+    // Filter for stderr stream entries.
+    let stderr_entries: Vec<&Value> = logs
+        .as_array()
+        .expect("logs must be an array")
+        .iter()
+        .filter(|entry| entry["type"] == "stream" && entry["stream_type"] == "stderr")
+        .collect();
+
+    // Streaming must produce at least 2 separate stderr entries (one per echo).
+    assert!(
+        stderr_entries.len() >= 2,
+        "expected at least 2 stderr stream entries, got {}: {stderr_entries:?}",
+        stderr_entries.len(),
+    );
     server.shutdown().await;
 }

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -70,84 +70,91 @@ expression: components
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_add"
+      "name": "exec-add.add"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_greet_include"
+      "name": "exec-greet.greet-include"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_greet_external"
+      "name": "exec-greet.greet-external"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_greet_inline"
+      "name": "exec-greet.greet-inline"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_read_env"
+      "name": "exec-env.read-env"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_error"
+      "name": "exec-error.fail"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_record_ok"
+      "name": "exec-record.make-record"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_expose_secrets"
+      "name": "exec-stdin.expose-secrets"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_void_ok"
+      "name": "exec-void.void-ok"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_void_err"
+      "name": "exec-void.void-err"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity",
-      "name": "test_exec_args_passthrough"
+      "name": "exec-args.echo-args"
+    }
+  },
+  {
+    "component_id": {
+      "component_digest": "sha256:<REDACTED>",
+      "component_type": "activity",
+      "name": "exec-stream.stream-test"
     }
   },
   {
     "component_id": {
       "component_digest": "sha256:<REDACTED>",
       "component_type": "activity_stub",
-      "name": "test_inline_stub"
+      "name": "stubs.my-stub"
     }
   },
   {

--- a/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
@@ -64,6 +64,9 @@ expression: functions
     "ffqn": "testing:integration/exec-args.echo-args"
   },
   {
+    "ffqn": "testing:integration/exec-stream.stream-test"
+  },
+  {
     "ffqn": "testing:integration/stubs.my-stub"
   },
   {

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1800,7 +1800,7 @@ pub(crate) struct ActivityExecComponentConfigToml {
     pub(crate) cwd: Option<String>,
     /// Maximum bytes collected from stdout to form the response.
     /// Exceeding the limit fails the execution.
-    /// Not used when return_type is result (default), since the response carries no data.
+    /// Not used when `return_type` is result (default), since the response carries no data.
     #[serde(default = "default_max_output_bytes")]
     pub(crate) max_output_bytes: u64,
     /// Secrets pushed to stdin. See `ExecSecretsToml`.

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1798,7 +1798,9 @@ pub(crate) struct ActivityExecComponentConfigToml {
     /// Defaults to the server's working directory.
     #[serde(default)]
     pub(crate) cwd: Option<String>,
-    /// Maximum bytes per stream (stdout/stderr). Excess is truncated and execution fails.
+    /// Maximum bytes collected from stdout to form the response.
+    /// Exceeding the limit fails the execution.
+    /// Not used when return_type is result (default), since the response carries no data.
     #[serde(default = "default_max_output_bytes")]
     pub(crate) max_output_bytes: u64,
     /// Secrets pushed to stdin. See `ExecSecretsToml`.

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1756,7 +1756,7 @@ pub(crate) struct ExecSecretsToml {
 }
 
 const fn default_max_output_bytes() -> u64 {
-    1024
+    4096
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]


### PR DESCRIPTION
- **feat(activity_exec): Stream std streams, only apply limit to stdout**
- **refactor(js,exec): Use same logic for ok/err mapping**
- **refactor(exec): Do not fail on `stdout_exceeded` when unit type is requested**
- **test: Fix test messages**
- **style: Fix clippy**
