### PR TITLE
refactor(exec): Set temp file permissions on file creation

### DIFF
--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-04-15@sha256:90cd81c87f9017480ba5ef0e025abb862f9bc101a57b8ba285572df02282adac
+oci://docker.io/getobelisk/workflow-js-runtime:2026-04-29@sha256:e4711a513fa927408548ee2bbd3c828d46ca27945245224c52bfaade081a8d66

--- a/crates/testing/test-programs/fibo/workflow-outer/wit/impl.wit
+++ b/crates/testing/test-programs/fibo/workflow-outer/wit/impl.wit
@@ -4,7 +4,7 @@ world any {
     export testing:fibo-workflow-outer/workflow;
 
     import obelisk:log/log@1.0.0;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
 
     import testing:fibo-workflow/workflow;
     import testing:fibo-workflow-obelisk-ext/workflow;

--- a/crates/testing/test-programs/fibo/workflow/wit/impl.wit
+++ b/crates/testing/test-programs/fibo/workflow/wit/impl.wit
@@ -4,7 +4,7 @@ world any {
     export testing:fibo-workflow/workflow;
 
     import obelisk:log/log@1.0.0;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
 
     import testing:fibo/fibo;
     import testing:fibo-obelisk-ext/fibo;

--- a/crates/testing/test-programs/http/workflow/wit/impl.wit
+++ b/crates/testing/test-programs/http/workflow/wit/impl.wit
@@ -5,6 +5,6 @@ world any {
 
     import testing:http/http-get;
     import testing:http-obelisk-ext/http-get;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import obelisk:log/log@1.0.0;
 }

--- a/crates/testing/test-programs/sleep/workflow/wit/impl.wit
+++ b/crates/testing/test-programs/sleep/workflow/wit/impl.wit
@@ -2,7 +2,7 @@ package any:any;
 
 world any {
     export testing:sleep-workflow/workflow;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
 
     import testing:sleep/sleep;
     import testing:sleep-obelisk-ext/sleep;

--- a/crates/testing/test-programs/stub/workflow/wit/impl.wit
+++ b/crates/testing/test-programs/stub/workflow/wit/impl.wit
@@ -5,6 +5,6 @@ world any {
     import testing:stub-activity-obelisk-ext/activity;  // for submitting the execution
     import testing:stub-activity-obelisk-stub/activity; // for submitting the execution result
     import testing:stub-activity/activity;              // for direct call
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import obelisk:log/log@1.0.0;
 }

--- a/crates/utils/src/snapshots/obeli_sk_utils__wasm_tools__tests__exports_imports@test_programs_fibo_workflow_component.wasm_imports.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wasm_tools__tests__exports_imports@test_programs_fibo_workflow_component.wasm_imports.snap
@@ -3,8 +3,8 @@ source: crates/utils/src/wasm_tools.rs
 expression: imports
 ---
 {
-  "obelisk:workflow/workflow-support@5.0.0.execution-id-generate": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.execution-id-generate",
+  "obelisk:workflow/workflow-support@5.1.0.execution-id-generate": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.execution-id-generate",
     "parameter_types": [
       {
         "type_wrapper": "option<record { frames: list<record { module: string, func-name: string, symbols: list<record { func-name: option<string>, file: option<string>, line: option<u32>, col: option<u32> }> }> }>",
@@ -21,8 +21,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.get-result-json": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.get-result-json",
+  "obelisk:workflow/workflow-support@5.1.0.get-result-json": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.get-result-json",
     "parameter_types": [
       {
         "type_wrapper": "record { id: string }",
@@ -39,8 +39,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.join-next": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.join-next",
+  "obelisk:workflow/workflow-support@5.1.0.join-next": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.join-next",
     "parameter_types": [
       {
         "type_wrapper": "borrow",
@@ -57,8 +57,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.join-set-create": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.join-set-create",
+  "obelisk:workflow/workflow-support@5.1.0.join-set-create": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.join-set-create",
     "parameter_types": [],
     "return_type": {
       "non_extendable": {
@@ -69,8 +69,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.schedule-json": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.schedule-json",
+  "obelisk:workflow/workflow-support@5.1.0.schedule-json": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.schedule-json",
     "parameter_types": [
       {
         "type_wrapper": "record { id: string }",
@@ -112,8 +112,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.submit-json": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.submit-json",
+  "obelisk:workflow/workflow-support@5.1.0.submit-json": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.submit-json",
     "parameter_types": [
       {
         "type_wrapper": "borrow",

--- a/crates/utils/src/snapshots/obeli_sk_utils__wasm_tools__tests__exports_imports@test_programs_http_get_workflow_component.wasm_imports.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wasm_tools__tests__exports_imports@test_programs_http_get_workflow_component.wasm_imports.snap
@@ -21,8 +21,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.join-set-create": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.join-set-create",
+  "obelisk:workflow/workflow-support@5.1.0.join-set-create": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.join-set-create",
     "parameter_types": [],
     "return_type": {
       "non_extendable": {

--- a/crates/utils/src/snapshots/obeli_sk_utils__wasm_tools__tests__params@test_programs_fibo_workflow_component.wasm_imports.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wasm_tools__tests__params@test_programs_fibo_workflow_component.wasm_imports.snap
@@ -3,8 +3,8 @@ source: crates/utils/src/wasm_tools.rs
 expression: imports
 ---
 {
-  "obelisk:workflow/workflow-support@5.0.0.execution-id-generate": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.execution-id-generate",
+  "obelisk:workflow/workflow-support@5.1.0.execution-id-generate": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.execution-id-generate",
     "parameter_types": [
       {
         "type_wrapper": "option<record { frames: list<record { module: string, func-name: string, symbols: list<record { func-name: option<string>, file: option<string>, line: option<u32>, col: option<u32> }> }> }>",
@@ -21,8 +21,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.get-result-json": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.get-result-json",
+  "obelisk:workflow/workflow-support@5.1.0.get-result-json": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.get-result-json",
     "parameter_types": [
       {
         "type_wrapper": "record { id: string }",
@@ -39,8 +39,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.join-next": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.join-next",
+  "obelisk:workflow/workflow-support@5.1.0.join-next": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.join-next",
     "parameter_types": [
       {
         "type_wrapper": "borrow",
@@ -57,8 +57,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.join-set-create": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.join-set-create",
+  "obelisk:workflow/workflow-support@5.1.0.join-set-create": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.join-set-create",
     "parameter_types": [],
     "return_type": {
       "non_extendable": {
@@ -69,8 +69,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.schedule-json": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.schedule-json",
+  "obelisk:workflow/workflow-support@5.1.0.schedule-json": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.schedule-json",
     "parameter_types": [
       {
         "type_wrapper": "record { id: string }",
@@ -112,8 +112,8 @@ expression: imports
     "extension": null,
     "submittable": false
   },
-  "obelisk:workflow/workflow-support@5.0.0.submit-json": {
-    "ffqn": "obelisk:workflow/workflow-support@5.0.0.submit-json",
+  "obelisk:workflow/workflow-support@5.1.0.submit-json": {
+    "ffqn": "obelisk:workflow/workflow-support@5.1.0.submit-json",
     "parameter_types": [
       {
         "type_wrapper": "borrow",

--- a/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_fibo_workflow_component.wasm_wit.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_fibo_workflow_component.wasm_wit.snap
@@ -9,7 +9,7 @@ world root {
     import obelisk:types/execution@4.2.0;
     import obelisk:types/backtrace@4.2.0;
     import obelisk:types/join-set@4.2.0;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import testing:fibo/fibo;
     import testing:fibo-obelisk-ext/fibo;
 
@@ -198,7 +198,7 @@ package obelisk:types@4.2.0 {
 }
 
 
-package obelisk:workflow@5.0.0 {
+package obelisk:workflow@5.1.0 {
     interface workflow-support {
         use obelisk:types/join-set@4.2.0.{join-set};
         use obelisk:types/execution@4.2.0.{function, submit-config, execution-id};

--- a/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_http_get_workflow_component.wasm_wit.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_http_get_workflow_component.wasm_wit.snap
@@ -10,7 +10,7 @@ world root {
     import obelisk:types/execution@4.2.0;
     import obelisk:types/join-set@4.2.0;
     import testing:http-obelisk-ext/http-get;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import obelisk:log/log@1.0.0;
 
     export testing:http-workflow/workflow;
@@ -205,7 +205,7 @@ package obelisk:types@4.2.0 {
 }
 
 
-package obelisk:workflow@5.0.0 {
+package obelisk:workflow@5.1.0 {
     interface workflow-support {
         use obelisk:types/join-set@4.2.0.{join-set};
 

--- a/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_sleep_workflow_component.wasm_wit.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_sleep_workflow_component.wasm_wit.snap
@@ -8,7 +8,7 @@ world root {
     import obelisk:types/time@4.2.0;
     import obelisk:types/execution@4.2.0;
     import obelisk:types/join-set@4.2.0;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import testing:sleep/sleep;
     import testing:sleep-obelisk-ext/sleep;
     import testing:sleep-obelisk-schedule/sleep;
@@ -206,7 +206,7 @@ package obelisk:types@4.2.0 {
 }
 
 
-package obelisk:workflow@5.0.0 {
+package obelisk:workflow@5.1.0 {
     interface workflow-support {
         use obelisk:types/join-set@4.2.0.{join-set};
         use obelisk:types/time@4.2.0.{schedule-at};

--- a/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_stub_workflow_component.wasm_wit.snap
+++ b/crates/utils/src/snapshots/obeli_sk_utils__wit__tests__wit_should_contain_extensions@test_programs_stub_workflow_component.wasm_wit.snap
@@ -11,7 +11,7 @@ world root {
     import testing:stub-activity-obelisk-ext/activity;
     import testing:stub-activity-obelisk-stub/activity;
     import testing:stub-activity/activity;
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import obelisk:log/log@1.0.0;
 
     export testing:stub-workflow/workflow;
@@ -206,7 +206,7 @@ package obelisk:types@4.2.0 {
 }
 
 
-package obelisk:workflow@5.0.0 {
+package obelisk:workflow@5.1.0 {
     interface workflow-support {
         use obelisk:types/join-set@4.2.0.{join-set};
         use obelisk:types/time@4.2.0.{schedule-at};

--- a/crates/utils/src/wit.rs
+++ b/crates/utils/src/wit.rs
@@ -43,11 +43,11 @@ pub const WIT_OBELISK_TYPES_PACKAGE: [&str; 3] = [
     WIT_OBELISK_TYPES_PACKAGE_CONTENT,
 ];
 pub const WIT_OBELISK_WORKFLOW_PACKAGE: [&str; 3] = [
-    "obelisk_workflow@5.0.0",
-    "obelisk_workflow@5.0.0.wit",
+    "obelisk_workflow@5.1.0",
+    "obelisk_workflow@5.1.0.wit",
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
-        "/wit/obelisk_workflow@5.0.0/obelisk_workflow@5.0.0.wit"
+        "/wit/obelisk_workflow@5.1.0/obelisk_workflow@5.1.0.wit"
     )),
 ];
 

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -218,18 +218,24 @@ impl Worker for ActivityExecWorker {
             }
             ExecProgram::Inline(script) => {
                 // Write script to temp file preserving shebang.
-                let mut tmp = tempfile::Builder::new()
-                    .prefix("obelisk-exec-")
-                    .tempfile()
-                    .map_err(|e| {
-                        WorkerError::FatalError(
-                            FatalError::CannotInstantiate {
-                                reason: "failed to create temp file for inline script".to_string(),
-                                detail: Some(e.to_string()),
-                            },
-                            version.clone(),
-                        )
-                    })?;
+                let mut builder = tempfile::Builder::new();
+                builder.prefix("obelisk-exec-");
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    // Apply 0o755 permissions to the builder
+                    builder.permissions(std::fs::Permissions::from_mode(0o755));
+                }
+
+                let mut tmp = builder.tempfile().map_err(|e| {
+                    WorkerError::FatalError(
+                        FatalError::CannotInstantiate {
+                            reason: "failed to create temp file for inline script".to_string(),
+                            detail: Some(e.to_string()),
+                        },
+                        version.clone(),
+                    )
+                })?;
                 use std::io::Write;
                 tmp.write_all(script.as_bytes()).map_err(|e| {
                     WorkerError::FatalError(
@@ -240,21 +246,6 @@ impl Worker for ActivityExecWorker {
                         version.clone(),
                     )
                 })?;
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    tmp.as_file()
-                        .set_permissions(std::fs::Permissions::from_mode(0o755))
-                        .map_err(|e| {
-                            WorkerError::FatalError(
-                                FatalError::CannotInstantiate {
-                                    reason: "failed to make temp file executable".to_string(),
-                                    detail: Some(e.to_string()),
-                                },
-                                version.clone(),
-                            )
-                        })?;
-                }
                 let temp_path = tmp.into_temp_path(); // Close the file handle.
                 let cmd = tokio::process::Command::new(&temp_path);
                 _temp_file_guard = Some(temp_path);

--- a/crates/wasm-workers/src/registry.rs
+++ b/crates/wasm-workers/src/registry.rs
@@ -246,7 +246,10 @@ impl ComponentConfigRegistry {
                 // log + workflow support + types
                 matches!(
                     import.ffqn.ifc_fqn.pkg_fqn_name().to_string().as_str(),
-                    "obelisk:log@1.0.0" | "obelisk:workflow@5.0.0" | "obelisk:types@4.2.0"
+                    "obelisk:log@1.0.0"
+                        | "obelisk:workflow@5.0.0"
+                        | "obelisk:workflow@5.1.0"
+                        | "obelisk:types@4.2.0"
                 )
             }
             ComponentType::WebhookEndpoint => {

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -2618,15 +2618,25 @@ pub(crate) struct OneOffDelayRequest {
 impl OneOffDelayRequest {
     pub(crate) async fn apply(
         schedule_at: HistoryEventScheduleAt,
+        name: Option<String>,
         expires_at_if_new: DateTime<Utc>,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         event_history: &mut EventHistory,
         db_connection: &mut CachingDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<Result<DateTime<Utc>, ()>, WorkflowFunctionError> {
+        let suffix = name.as_deref().unwrap_or("sleep");
         let join_set_id = event_history
-            .next_join_set_one_off_named("sleep")
-            .expect("no illegal chars in sleep");
+            .next_join_set_one_off_named(suffix)
+            .map_err(|err| WorkflowFunctionError::ImportedFunctionCallError {
+                // Only `sleep-named-bt` passes the name
+                ffqn: FunctionFqn::new_static(
+                    "obelisk:workflow/workflow-support@5.0.0",
+                    "sleep-named-bt",
+                ),
+                reason: "invalid sleep join set name".into(),
+                detail: Some(err.to_string()),
+            })?;
         let delay_id = DelayId::new(&db_connection.execution_id, &join_set_id);
 
         let ChildReturnValue::OneOffDelay {

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -2631,7 +2631,7 @@ impl OneOffDelayRequest {
             .map_err(|err| WorkflowFunctionError::ImportedFunctionCallError {
                 // Only `sleep-named-bt` passes the name
                 ffqn: FunctionFqn::new_static(
-                    "obelisk:workflow/workflow-support@5.0.0",
+                    "obelisk:workflow/workflow-support@5.1.0",
                     "sleep-named-bt",
                 ),
                 reason: "invalid sleep join set name".into(),

--- a/crates/wasm-workers/src/workflow/host_exports.rs
+++ b/crates/wasm-workers/src/workflow/host_exports.rs
@@ -43,7 +43,7 @@ pub(crate) mod latest {
         path: "host-wit-workflow/",
         inline: "package any:any;
         world bindings {
-            import obelisk:workflow/workflow-support@5.0.0;
+            import obelisk:workflow/workflow-support@5.1.0;
             }",
         world: "any:any/bindings",
         with: {

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -930,6 +930,7 @@ impl WorkflowCtx {
     async fn persist_sleep(
         &mut self,
         schedule_at: HistoryEventScheduleAt,
+        name: Option<String>,
         wasm_backtrace: Option<storage::WasmBacktrace>,
     ) -> Result<Result<DateTime<Utc>, ()>, WorkflowFunctionError> {
         let expires_at_if_new = schedule_at
@@ -945,6 +946,7 @@ impl WorkflowCtx {
             })?;
         OneOffDelayRequest::apply(
             schedule_at,
+            name,
             expires_at_if_new,
             wasm_backtrace,
             &mut self.event_history,
@@ -1627,6 +1629,26 @@ impl WorkflowCtx {
 
         inst_workflow_support
             .func_wrap_async(
+                "sleep-named-bt",
+                move |mut caller: wasmtime::StoreContextMut<'_, WorkflowCtx>,
+                      (schedule_at, name, wit_backtrace): (
+                    ScheduleAtTypes,
+                    Option<String>,
+                    Option<typesTypes::backtrace::WasmBacktrace>,
+                )| {
+                    let schedule_at = HistoryEventScheduleAt::from(schedule_at);
+                    Box::new(async move {
+                        let (host, backtrace) =
+                            Self::get_host_maybe_capture_backtrace(&mut caller, wit_backtrace);
+                        let expires_at = host.sleep_named(schedule_at, name, backtrace).await?;
+                        Ok((expires_at,))
+                    })
+                },
+            )
+            .map_err(|err| WasmFileError::linking_error("linking function sleep-named-bt", err))?;
+
+        inst_workflow_support
+            .func_wrap_async(
                 "join-set-create-bt",
                 move |mut caller: wasmtime::StoreContextMut<'_, WorkflowCtx>,
                       (wit_backtrace,): (Option<typesTypes::backtrace::WasmBacktrace>,)| {
@@ -2082,10 +2104,22 @@ pub(crate) mod workflow_support {
             wasm_backtrace: Option<storage::WasmBacktrace>,
         ) -> wasmtime::Result<Result<host_exports::latest::obelisk::types::time::Datetime, ()>>
         {
+            self.sleep_named(schedule_at, None, wasm_backtrace).await
+        }
+
+        pub(crate) async fn sleep_named(
+            &mut self,
+            schedule_at: HistoryEventScheduleAt,
+            name: Option<String>,
+            wasm_backtrace: Option<storage::WasmBacktrace>,
+        ) -> wasmtime::Result<Result<host_exports::latest::obelisk::types::time::Datetime, ()>>
+        {
             Ok(
-                match self.persist_sleep(schedule_at, wasm_backtrace).await
-                .map_err(wasmtime::Error::new)? // Wraps `WorkflowFunctionError` with anyhow to be unwrapped by workflow_worker
-                 {
+                match self
+                    .persist_sleep(schedule_at, name, wasm_backtrace)
+                    .await
+                    .map_err(wasmtime::Error::new)?
+                {
                     Ok(expires_at) => Ok(
                         host_exports::latest::obelisk::types::time::Datetime::try_from(expires_at)?,
                     ),
@@ -2931,7 +2965,8 @@ pub(crate) mod tests {
                     WorkflowStep::Sleep { millis } => workflow_ctx
                         .persist_sleep(
                             HistoryEventScheduleAt::In(Duration::from_millis(u64::from(*millis))),
-                            None,
+                            None, // custom name
+                            None, // backtrace
                         )
                         .await
                         .map(|_| ()),

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -849,7 +849,7 @@ impl WasiView for WorkflowCtx {
     }
 }
 
-const IFC_FQN_WORKFLOW_SUPPORT: &str = "obelisk:workflow/workflow-support@5.0.0";
+const IFC_FQN_WORKFLOW_SUPPORT: &str = "obelisk:workflow/workflow-support@5.1.0";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReplayKind {

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -70,6 +70,7 @@
 //! const wakeUp = obelisk.sleep({ seconds: 30 });  // Date
 //! const wakeUp = obelisk.sleep({ minutes: 5 });   // Date
 //! const wakeUp = obelisk.sleep({ milliseconds: 500 }); // Date
+//! const namedWakeUp = obelisk.sleep({ seconds: 30 }, "retry-timeout"); // Date
 //! console.log(wakeUp.toISOString()); // e.g. "2024-01-01T00:00:00.500Z"
 //! ```
 //!
@@ -119,7 +120,7 @@ use crate::generated::obelisk::workflow::workflow_support::{
     JoinNextTryError, SubmitConfig, call_json, execution_id_generate, get_result_json_bt,
     join_next_bt, join_next_try_bt, join_set_close_bt, join_set_create_bt,
     join_set_create_named_bt, random_string_bt, random_u64_bt, random_u64_inclusive_bt,
-    schedule_json, sleep_bt, stub_json, submit_delay_bt, submit_json_bt,
+    schedule_json, sleep_named_bt, stub_json, submit_delay_bt, submit_json_bt,
 };
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::helpers::{new_object, parse_ffqn};
@@ -473,11 +474,21 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         context,
     )?;
 
-    // obelisk.sleep(schedule)
+    // obelisk.sleep(schedule, [name])
     let sleep_fn = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let schedule = parse_schedule_at(args.get_or_undefined(0), ctx)?;
+        let name = match args.get(1) {
+            Some(arg) if !arg.is_null() && !arg.is_undefined() => Some(
+                arg.as_string()
+                    .ok_or_else(|| {
+                        JsNativeError::typ().with_message("sleep name must be a string")
+                    })?
+                    .to_std_string_escaped(),
+            ),
+            _ => None,
+        };
         let backtrace = capture_backtrace(ctx);
-        match sleep_bt(schedule, Some(&backtrace)) {
+        match sleep_named_bt(schedule, name.as_deref(), Some(&backtrace)) {
             Ok(dt) => {
                 let ms = (dt.seconds as f64) * 1000.0 + (dt.nanoseconds as f64) / 1_000_000.0;
                 let date = JsDate::new(ctx);
@@ -766,13 +777,14 @@ fn setup_math_random(context: &mut Context) -> JsResult<()> {
     Ok(())
 }
 
-/// Override `Date.now()` to return the current Obelisk clock time via `sleep_bt(0)`.
+/// Override `Date.now()` to return the current Obelisk clock time via
+/// `sleep_named_bt(0, None)`.
 ///
 /// Returns milliseconds since Unix epoch as f64 (matching the JS spec).
 fn setup_date_now(context: &mut Context) -> JsResult<()> {
     let date_now_fn = NativeFunction::from_fn_ptr(|_this, _args, ctx| {
         let backtrace = capture_backtrace(ctx);
-        let dt = sleep_bt(ScheduleAt::Now, Some(&backtrace))
+        let dt = sleep_named_bt(ScheduleAt::Now, None, Some(&backtrace))
             .map_err(|()| JsNativeError::error().with_message("sleep failed"))?;
         let ms = (dt.seconds as f64) * 1000.0 + (dt.nanoseconds as f64) / 1_000_000.0;
         Ok(JsValue::from(ms))

--- a/crates/workflow-js-runtime/wit/world.wit
+++ b/crates/workflow-js-runtime/wit/world.wit
@@ -3,6 +3,6 @@ package any:any;
 world any {
     export obelisk-workflow:workflow-js-runtime/execute;
 
-    import obelisk:workflow/workflow-support@5.0.0;
+    import obelisk:workflow/workflow-support@5.1.0;
     import obelisk:log/log@1.0.0;
 }

--- a/wit/obelisk_workflow@5.0.0/obelisk_workflow@5.0.0.wit
+++ b/wit/obelisk_workflow@5.0.0/obelisk_workflow@5.0.0.wit
@@ -163,7 +163,12 @@ interface workflow-support {
 
     /// Like `sleep` but records the call site backtrace.
     @since(version = 5.0.0)
+    @deprecated(version = 5.0.0)
     sleep-bt: func(schedule-at: schedule-at, backtrace: option<wasm-backtrace>) -> result<datetime>;
+
+    /// Like `sleep` but records the call site backtrace and optionally names the one-off join set.
+    @since(version = 5.0.0)
+    sleep-named-bt: func(schedule-at: schedule-at, name: option<string>, backtrace: option<wasm-backtrace>) -> result<datetime>;
 
     /// Like `join-set-create` but records the call site backtrace.
     @since(version = 5.0.0)

--- a/wit/obelisk_workflow@5.1.0/obelisk_workflow@5.1.0.wit
+++ b/wit/obelisk_workflow@5.1.0/obelisk_workflow@5.1.0.wit
@@ -1,4 +1,4 @@
-package obelisk:workflow@5.0.0;
+package obelisk:workflow@5.1.0;
 
 @since(version = 4.0.0)
 interface workflow-support {
@@ -167,7 +167,7 @@ interface workflow-support {
     sleep-bt: func(schedule-at: schedule-at, backtrace: option<wasm-backtrace>) -> result<datetime>;
 
     /// Like `sleep` but records the call site backtrace and optionally names the one-off join set.
-    @since(version = 5.0.0)
+    @since(version = 5.1.0)
     sleep-named-bt: func(schedule-at: schedule-at, name: option<string>, backtrace: option<wasm-backtrace>) -> result<datetime>;
 
     /// Like `join-set-create` but records the call site backtrace.

--- a/wit/obelisk_workflow@latest
+++ b/wit/obelisk_workflow@latest
@@ -1,1 +1,1 @@
-obelisk_workflow@5.0.0/
+obelisk_workflow@5.1.0


### PR DESCRIPTION
- **feat(wit,workflow_js): Add `sleep-named-bt`, allowing to pass name to `sleep`**
- **refactor(wit): Bump `workflow-support` to 5.1.0**
- **chore: Push JS workflow runtime**
- **refactor(exec): Set temp file permissions on file creation**
