### PR TITLE
test: Add `$PATH` to exec tests that use `jq`

### DIFF
--- a/assets/toml/deployment.json
+++ b/assets/toml/deployment.json
@@ -783,7 +783,7 @@
       "description": "Program specification for exec activities (TOML input form).",
       "oneOf": [
         {
-          "description": "Explicit argv. The first element is the executable; remaining elements are fixed arguments.\nActivity params are JSON-serialized and appended as trailing args.",
+          "description": "Explicit argv. The first element is the executable; remaining elements are fixed arguments.\nActivity params are JSON-serialized and appended as trailing args.\nDoes not support `${DEPLOYMENT_DIR}/` prefix.",
           "type": "object",
           "properties": {
             "external": {

--- a/crates/testing/test-programs/exec/expose-secrets.sh
+++ b/crates/testing/test-programs/exec/expose-secrets.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+set -exuo pipefail
 
 jq -R . /dev/stdin

--- a/crates/testing/test-programs/exec/greet.sh
+++ b/crates/testing/test-programs/exec/greet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -exuo pipefail
 # $1 is a JSON string e.g. "World" (with quotes). Strip quotes for raw value.
 
 raw=$(echo $1 | jq -r .)

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -114,13 +114,13 @@
 # [[activity_exec]]
 # name = "name"                              # Optional. Component name. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
 ## Program specification: exactly one of `external`, `inline`, or `include`.
-## `external`: explicit argv — first element is the executable, rest are fixed arguments.
+## `external`: explicit argv — first element is the executable, rest are fixed arguments. Does not support `${DEPLOYMENT_DIR}/` prefix.
 # program.external = ["/usr/bin/my-tool", "--flag"]
-## `inline`: script content embedded in the TOML. Written to a temp file at each execution.
+## `inline`: script content embedded in the TOML. Written to a temp file at each execution. Supports `${DEPLOYMENT_DIR}/` prefix.
 # program.inline = '''#!/usr/bin/env bash
 # echo "\"hello\""
 # '''
-## `include`: file path read at deploy time and converted to `inline`, making deployment self-contained.
+## `include`: file path read at deploy time and converted to `inline`, making deployment self-contained. Supports `${DEPLOYMENT_DIR}/` prefix.
 # program.include = "${DEPLOYMENT_DIR}/scripts/my-script.sh"
 # ffqn = "namespace:package/interface.function" # Required. Fully qualified function name.
 ## Custom parameters. If omitted, defaults to no parameters.

--- a/obelisk-testing-exec.toml
+++ b/obelisk-testing-exec.toml
@@ -1,7 +1,41 @@
 [[activity_exec]]
 ffqn = "testing:integration/exec-stream.stream-test"
 program.inline = '''#!/usr/bin/env bash
+set -exuo pipefail
+
 echo "line1" >&2
 sleep 0.1
 echo "line2" >&2
 '''
+
+[[activity_exec]]
+ffqn = "testing:integration/exec-greet.greet-include"
+program.include = "${DEPLOYMENT_DIR}/crates/testing/test-programs/exec/greet.sh"
+params = [
+  { name = "name", type = "string" },
+]
+return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq
+
+[[activity_exec]]
+ffqn = "testing:integration/exec-greet.greet-external"
+program.external = ["crates/testing/test-programs/exec/greet.sh"]
+params = [
+  { name = "name", type = "string" },
+]
+return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq
+
+[[activity_exec]]
+ffqn = "testing:integration/exec-greet.greet-inline"
+program.inline = '''
+#!/usr/bin/env bash
+set -exuo pipefail
+raw=$(echo $1 | jq -r .)
+echo "\"Hello, $raw!\""
+'''
+params = [
+  { name = "name", type = "string" },
+]
+return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -281,6 +281,7 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq
 
 [[activity_exec]]
 ffqn = "testing:integration/exec-greet.greet-external"
@@ -289,11 +290,13 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq
 
 [[activity_exec]]
 ffqn = "testing:integration/exec-greet.greet-inline"
 program.inline = '''
 #!/usr/bin/env bash
+set -exuo pipefail
 raw=$(echo $1 | jq -r .)
 echo "\"Hello, $raw!\""
 '''
@@ -301,6 +304,7 @@ params = [
   {{ name = "name", type = "string" }},
 ]
 return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq
 
 [[activity_exec]]
 ffqn = "testing:integration/exec-env.read-env"
@@ -327,6 +331,7 @@ return_type = "result<record {{ name: string, count: u32 }}, string>"
 ffqn = "testing:integration/exec-stdin.expose-secrets"
 program.external = ["{ws}/crates/testing/test-programs/exec/expose-secrets.sh"]
 return_type = "result<string, string>"
+env_vars = ["PATH"] # for jq
 [activity_exec.secrets]
 env_vars = [{{ name = "MY_SECRET", value = "s3cret_value" }}]
 

--- a/src/config/config_holder.rs
+++ b/src/config/config_holder.rs
@@ -151,27 +151,27 @@ impl ConfigHolder {
 /// Load and validate a deployment TOML file.
 /// `${DEPLOYMENT_DIR}/` prefixes in WASM component paths are expanded to absolute paths.
 pub(crate) async fn load_deployment_toml(
-    path: PathBuf,
+    deployment_toml: PathBuf,
 ) -> Result<DeploymentTomlValidated, anyhow::Error> {
-    let exists = path.try_exists().unwrap_or_default();
+    let exists = deployment_toml.try_exists().unwrap_or_default();
     if !exists {
-        bail!("cannot find deployment file {path:?}");
+        bail!("cannot find deployment file {deployment_toml:?}");
     }
-    info!("Using deployment file {:?}", path);
-    let deployment_dir =
-        canonicalize_parent(&path).with_context(|| format!("cannot resolve parent of {path:?}"))?;
+    info!("Using deployment file {:?}", deployment_toml);
+    let deployment_dir = canonicalize_parent(&deployment_toml)
+        .with_context(|| format!("cannot resolve parent of {deployment_toml:?}"))?;
     let builder = ConfigBuilder::<AsyncState>::default().add_source(
-        File::from(path.as_path())
+        File::from(deployment_toml.as_path())
             .required(true)
             .format(FileFormat::Toml),
     );
     let settings = builder.build().await?;
     let deployment: DeploymentToml = settings
         .try_deserialize()
-        .with_context(|| format!("cannot parse deployment file {path:?}"))?;
+        .with_context(|| format!("cannot parse deployment file {deployment_toml:?}"))?;
     deployment
         .validate(&deployment_dir)
-        .with_context(|| format!("invalid deployment file {path:?}"))
+        .with_context(|| format!("invalid deployment file {deployment_toml:?}"))
 }
 
 fn canonicalize_parent(path: &Path) -> Result<PathBuf, anyhow::Error> {

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1712,6 +1712,7 @@ impl ActivityJsConfigVerified {
 pub(crate) enum ExecProgramToml {
     /// Explicit argv. The first element is the executable; remaining elements are fixed arguments.
     /// Activity params are JSON-serialized and appended as trailing args.
+    /// Does not support `${DEPLOYMENT_DIR}/` prefix.
     #[serde(rename = "external")]
     External(Vec<String>),
     /// Inline script content. Written to a temp file at each execution.

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1721,7 +1721,7 @@ pub(crate) enum ExecProgramToml {
     /// File path to include. Resolved to `inline` at canonicalization time.
     /// Supports `${DEPLOYMENT_DIR}/` prefix.
     #[serde(rename = "include")]
-    Include(String),
+    Include(String), // expanded in `expand_deployment_dir_prefix`
 }
 
 /// Program specification for exec activities (canonical/wire form).


### PR DESCRIPTION
- **test: Add `$PATH` to exec tests that use `jq`**
- **doc(toml): Clarify exec program path expansion**
