### PR TITLE
feat(grpc,webapi,cli): Allow creation of paused executions

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1590,6 +1590,10 @@
             "type": "array",
             "items": {},
             "description": "Function parameters as JSON values"
+          },
+          "paused": {
+            "type": "boolean",
+            "description": "If true, create the execution in paused state."
           }
         }
       },

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -356,6 +356,7 @@ mod bench {
                 component_id: ComponentId::dummy_workflow(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -87,7 +87,7 @@ impl ExecutionLog {
                 ffqn,params,parent,scheduled_at,component_id,deployment_id,metadata,scheduled_by},
                 created_at, .. }) => CreateRequest { created_at, execution_id:
                     self.execution_id.clone(), ffqn, params, parent, scheduled_at,
-                    component_id, deployment_id, metadata, scheduled_by })
+                    component_id, deployment_id, metadata, scheduled_by, paused: false })
     }
 
     #[must_use]
@@ -936,6 +936,7 @@ pub struct CreateRequest {
     pub deployment_id: DeploymentId,
     pub metadata: ExecutionMetadata,
     pub scheduled_by: Option<ExecutionId>,
+    pub paused: bool,
 }
 
 impl From<CreateRequest> for ExecutionRequest {
@@ -1533,6 +1534,7 @@ pub trait DbConnection: DbExecutor {
                 deployment_id,
                 metadata,
                 scheduled_by,
+                paused: false,
             })
         } else {
             Err(DbErrorRead::Generic(DbErrorGeneric::Uncategorized {

--- a/crates/db-mem/src/inmemory_dao.rs
+++ b/crates/db-mem/src/inmemory_dao.rs
@@ -834,6 +834,7 @@ impl DbHolder {
         let subscription = self.ffqn_to_pending_subscription.get(&req.ffqn);
         let scheduled_at = req.scheduled_at;
         let created_at = req.created_at;
+        let paused = req.paused;
         let mut journal = ExecutionJournal::new(req);
         let version = journal.version();
         self.index.update(&mut journal);
@@ -842,7 +843,8 @@ impl DbHolder {
             old_val.is_none(),
             "journals cannot contain the new execution"
         );
-        if scheduled_at <= created_at
+        if !paused
+            && scheduled_at <= created_at
             && let Some(subscription) = subscription
         {
             let _ = subscription.try_send(());

--- a/crates/db-mem/src/journal.rs
+++ b/crates/db-mem/src/journal.rs
@@ -35,18 +35,34 @@ impl ExecutionJournal {
         let execution_id = req.execution_id.clone();
         let component_id = req.component_id.clone();
         let deployment_id = req.deployment_id;
+        let paused = req.paused;
 
         let created_at = req.created_at;
-        let event = ExecutionEvent {
+        let created_event = ExecutionEvent {
             event: ExecutionRequest::from(req),
             created_at,
             backtrace_id: None,
             version: Version(0),
         };
+        let mut events = vec![created_event];
+        let pending_state = if paused {
+            events.push(ExecutionEvent {
+                event: ExecutionRequest::Paused,
+                created_at,
+                backtrace_id: None,
+                version: Version(1),
+            });
+            PendingState::Paused(PendingStatePaused::PendingAt(PendingStatePendingAt {
+                scheduled_at: created_at,
+                last_lock: None,
+            }))
+        } else {
+            pending_state
+        };
         Self {
             execution_id,
             pending_state,
-            execution_events: vec![event],
+            execution_events: events,
             responses: Vec::default(),
             response_subscriber: None,
             component_id,
@@ -287,6 +303,7 @@ impl ExecutionJournal {
             deployment_id,
             metadata,
             scheduled_by,
+            paused: false,
         }
     }
 

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -378,6 +378,7 @@ async fn fetch_created_event(
             deployment_id,
             metadata,
             scheduled_by,
+            paused: false,
         })
     } else {
         error!("Row with version=0 must be a `Created` event - {event:?}");
@@ -418,6 +419,7 @@ async fn create_inner(
     let scheduled_at = req.scheduled_at;
     let component_id = req.component_id.clone();
     let deployment_id = req.deployment_id;
+    let paused = req.paused;
 
     let event = ExecutionRequest::from(req);
     let event = Json(event);
@@ -458,7 +460,7 @@ async fn create_inner(
                 intermittent_event_count,
                 is_paused
             ) VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CURRENT_TIMESTAMP, 0, false
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CURRENT_TIMESTAMP, 0, $12
             )",
             &[
                 &execution_id_str,
@@ -472,22 +474,40 @@ async fn create_inner(
                 &component_id.component_type.to_string(),
                 &deployment_id.to_string(),
                 &scheduled_at,
+                &paused,
             ],
         )
         .await?;
 
         AppendNotifier {
-            pending_at: Some(NotifierPendingAt {
-                scheduled_at,
-                ffqn,
-                component_input_digest: component_id.component_digest,
-            }),
+            pending_at: if paused {
+                None
+            } else {
+                Some(NotifierPendingAt {
+                    scheduled_at,
+                    ffqn: ffqn.clone(),
+                    component_input_digest: component_id.component_digest,
+                })
+            },
             execution_finished: None,
             response: None,
         }
     };
 
-    let next_version = Version::new(version.0 + 1);
+    let mut next_version = Version::new(version.0 + 1);
+    if paused {
+        let (v, _) = append(
+            tx,
+            &execution_id,
+            AppendRequest {
+                created_at,
+                event: ExecutionRequest::Paused,
+            },
+            next_version,
+        )
+        .await?;
+        next_version = v;
+    }
     Ok((next_version, pending_at))
 }
 

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -815,6 +815,7 @@ impl SqlitePool {
                 deployment_id,
                 metadata,
                 scheduled_by,
+                paused: false,
             })
         } else {
             error!("Row with version=0 must be a `Created` event - {event:?}");
@@ -855,6 +856,7 @@ impl SqlitePool {
         let scheduled_at = req.scheduled_at;
         let component_id = req.component_id.clone();
         let deployment_id = req.deployment_id;
+        let paused = req.paused;
         let event = ExecutionRequest::from(req);
         let event_ser = serde_json::to_string(&event).map_err(|err| {
             error!("Cannot serialize {event:?} - {err:?}");
@@ -907,7 +909,7 @@ impl SqlitePool {
                     CURRENT_TIMESTAMP,
                     :first_scheduled_at,
                     0,
-                    false
+                    :is_paused
                     )
                 ",
             )?
@@ -923,18 +925,36 @@ impl SqlitePool {
                 ":component_type": component_id.component_type,
                 ":deployment_id": deployment_id.to_string(),
                 ":first_scheduled_at": scheduled_at,
+                ":is_paused": paused,
             })?;
             AppendNotifier {
-                pending_at: Some(NotifierPendingAt {
-                    scheduled_at,
-                    ffqn,
-                    component_input_digest: component_id.component_digest,
-                }),
+                pending_at: if paused {
+                    None
+                } else {
+                    Some(NotifierPendingAt {
+                        scheduled_at,
+                        ffqn: ffqn.clone(),
+                        component_input_digest: component_id.component_digest,
+                    })
+                },
                 execution_finished: None,
                 response: None,
             }
         };
-        let next_version = Version::new(version.0 + 1);
+        let mut next_version = Version::new(version.0 + 1);
+        if paused {
+            // Append the Paused event in the same transaction.
+            let (v, _) = Self::append(
+                tx,
+                &execution_id,
+                AppendRequest {
+                    created_at,
+                    event: ExecutionRequest::Paused,
+                },
+                next_version,
+            )?;
+            next_version = v;
+        }
         Ok((next_version, pending_at))
     }
 
@@ -4691,6 +4711,7 @@ mod tests {
                     component_id: ComponentId::dummy_activity(),
                     deployment_id: DEPLOYMENT_ID_DUMMY,
                     scheduled_by: None,
+                    paused: false,
                 };
                 SqlitePool::create_inner(tx, req)?;
                 SqlitePool::pause_execution(tx, &EXECUTION_ID_DUMMY, created_at)?;

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1130,6 +1130,7 @@ mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1453,6 +1454,7 @@ mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1491,6 +1493,7 @@ mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             };
             let current_time = sim_clock.now();
             let join_set = AppendRequest {
@@ -1710,6 +1713,7 @@ mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/crates/testing/db-tests/tests/deployment_pagination.rs
+++ b/crates/testing/db-tests/tests/deployment_pagination.rs
@@ -64,6 +64,7 @@ async fn create_deployment_with_execution(
             component_id,
             deployment_id,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();

--- a/crates/testing/db-tests/tests/diff-tests.rs
+++ b/crates/testing/db-tests/tests/diff-tests.rs
@@ -51,6 +51,7 @@ async fn diff_proptest_inner(seed: u64) {
         component_id: ComponentId::dummy_activity(),
         deployment_id: DEPLOYMENT_ID_DUMMY,
         scheduled_by: None,
+        paused: false,
     };
     let mut append_requests = vec![];
     while append_requests.is_empty() {
@@ -196,6 +197,7 @@ async fn persist_finished_event(
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -177,6 +177,7 @@ async fn append_after_finish_should_not_be_possible(
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -324,6 +325,7 @@ async fn locking_in_unlock_backoff_should_not_be_possible(
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -483,6 +485,7 @@ async fn lock_and_attept_to_extend(
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -568,6 +571,7 @@ async fn locking_in_timeout_backoff_should_not_be_possible(database: Database) {
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -734,6 +738,7 @@ async fn creating_execution_twice_should_fail(database: Database) {
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -751,6 +756,7 @@ async fn creating_execution_twice_should_fail(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap_err();
@@ -793,6 +799,7 @@ async fn lock_pending_while_expired_lock_should_return_nothing_inner(
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -875,6 +882,7 @@ pub async fn expired_lock_should_be_found(db_connection: &dyn DbConnection, sim_
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -939,6 +947,7 @@ async fn append_batch_respond_to_parent(db_connection: &dyn DbConnectionTest, si
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -983,6 +992,7 @@ async fn append_batch_respond_to_parent(db_connection: &dyn DbConnectionTest, si
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1065,6 +1075,7 @@ async fn append_batch_respond_to_parent(db_connection: &dyn DbConnectionTest, si
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1177,6 +1188,7 @@ async fn lock_pending_should_sort_by_scheduled_at(
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1195,6 +1207,7 @@ async fn lock_pending_should_sort_by_scheduled_at(
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1213,6 +1226,7 @@ async fn lock_pending_should_sort_by_scheduled_at(
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1280,6 +1294,7 @@ async fn test_lock_inner(db_connection: &dyn DbConnection, sim_clock: SimClock) 
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1369,6 +1384,7 @@ async fn get_expired_lock(db_connection: &dyn DbConnection, sim_clock: SimClock)
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1431,6 +1447,7 @@ async fn get_expired_delay(db_connection: &dyn DbConnection, sim_clock: SimClock
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1544,6 +1561,7 @@ async fn get_expired_times_with_execution_that_made_progress(
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1645,6 +1663,7 @@ async fn append_same_delay_id_twice_should_fail(
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1830,6 +1849,7 @@ async fn append_response_with_same_id_twice_should_fail(
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -1922,6 +1942,7 @@ async fn delay_cancellation_should_be_idempotent(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2010,6 +2031,7 @@ async fn pause_and_unpause_should_work(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2090,6 +2112,7 @@ async fn pause_finished_execution_should_fail(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2153,6 +2176,7 @@ async fn pause_and_unpause_locked_execution_should_return_to_locked(database: Da
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2231,6 +2255,7 @@ async fn cannot_lock_paused_execution(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2293,6 +2318,7 @@ async fn pause_with_pending_child_then_response_then_unpause_should_be_pending(d
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2446,6 +2472,7 @@ async fn pause_with_pending_delay_then_response_then_unpause_should_be_pending(d
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2599,6 +2626,7 @@ async fn test_backtrace(database: Database) {
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2735,6 +2763,7 @@ async fn wait_for_finished_result_should_fetch_before_racing_with_timeout(databa
             component_id: component_id.clone(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2798,6 +2827,7 @@ async fn list_responses_empty_should_return_empty_list(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -2883,6 +2913,7 @@ async fn test_list_responses(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -3006,6 +3037,7 @@ async fn test_list_responses_pagination_direction(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -3188,6 +3220,7 @@ async fn test_list_execution_events_pagination_direction(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -3561,6 +3594,7 @@ async fn list_logs_with_show_derived(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -3594,6 +3628,7 @@ async fn list_logs_with_show_derived(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();
@@ -3626,6 +3661,7 @@ async fn list_logs_with_show_derived(database: Database) {
             component_id: ComponentId::dummy_activity(),
             deployment_id: DEPLOYMENT_ID_DUMMY,
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -797,6 +797,7 @@ pub(crate) mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -980,6 +981,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1157,6 +1159,7 @@ pub(crate) mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1375,6 +1378,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1505,6 +1509,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1657,6 +1662,7 @@ pub(crate) mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1800,6 +1806,7 @@ pub(crate) mod tests {
                 component_id,
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1890,6 +1897,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1958,6 +1966,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2031,6 +2040,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/crates/wasm-workers/src/cron/cron_worker.rs
+++ b/crates/wasm-workers/src/cron/cron_worker.rs
@@ -109,6 +109,7 @@ impl Worker for CronWorker {
             deployment_id: self.deployment_id,
             metadata: ExecutionMetadata::empty(),
             scheduled_by: Some(current_execution_id.clone()),
+            paused: false,
         };
 
         // Build the history event for the schedule
@@ -265,6 +266,7 @@ mod tests {
             deployment_id: DEPLOYMENT_ID_DUMMY,
             metadata: ExecutionMetadata::empty(),
             scheduled_by: None,
+            paused: false,
         })
         .await
         .unwrap();

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -781,6 +781,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             component_id: component_id.clone(),
             deployment_id: self.deployment_id,
             scheduled_by: Some(ExecutionId::TopLevel(self.execution_id)),
+            paused: false,
         };
 
         let db_connection = match self.db_pool.connection().await {
@@ -944,6 +945,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             component_id: component_id.clone(),
             deployment_id: self.deployment_id,
             scheduled_by: None,
+            paused: false,
         };
 
         let db_connection = match self.db_pool.connection().await {
@@ -1226,6 +1228,7 @@ impl WebhookEndpointCtx {
             component_id: self.component_id.clone(),
             deployment_id: self.deployment_id,
             scheduled_by: None,
+            paused: false,
         };
         let conn = self.db_pool.connection().await?;
         let version = conn.create(create_request).await?;
@@ -1340,6 +1343,7 @@ impl WebhookEndpointCtx {
                     component_id: child_component_id.clone(),
                     deployment_id: self.deployment_id,
                     scheduled_by: Some(ExecutionId::TopLevel(self.execution_id)),
+                    paused: false,
                 };
                 let db_connection = self.db_pool.connection().await?;
                 let expected_next_version = version.increment();
@@ -1431,6 +1435,7 @@ impl WebhookEndpointCtx {
                 component_id: child_component_id.clone(),
                 deployment_id: self.deployment_id,
                 scheduled_by: None,
+                paused: false,
             };
             let db_connection = self.db_pool.connection().await?;
             let appended = vec![req_join_set_created, req_child_exec, req_join_next];

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -495,14 +495,14 @@ pub async fn server(
                                 break result;
                             }
                             changed = wh_server_state_watcher.changed() => {
+                                conn.as_mut().graceful_shutdown();
                                 if changed.is_ok() {
                                     let new_deployment_id = wh_server_state_watcher.borrow().deployment_id;
                                     debug!(%http_server, "Switching to {new_deployment_id}, gracefully shutting down connection");
                                 } else {
                                     debug!(%http_server, "Deployment watcher dropped, gracefully shutting down connection");
+                                    break conn.as_mut().await;
                                 }
-
-                                conn.as_mut().graceful_shutdown();
                             }
                         }
                     };

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -440,10 +440,7 @@ pub async fn server(
             .accept()
             .await
             .map_err(WebhookServerError::SocketError)?;
-        let stream_id = stream
-            .local_addr()
-            .map(|local_addr| local_addr.port())
-            .unwrap_or_default();
+        let stream_id = format!("{stream:?}");
         let stream = TokioIo::new(stream);
 
         // Each connection must not affect other connections.

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -1206,6 +1206,7 @@ impl EventHistory {
                             component_id: fn_component_id,
                             deployment_id: self.deployment_id,
                             scheduled_by: None,
+                            paused: false,
                         };
                         (Ok(()), params, Some(child_req))
                     }
@@ -1327,6 +1328,7 @@ impl EventHistory {
                             component_id: fn_component_id,
                             deployment_id: self.deployment_id,
                             scheduled_by: Some(db_connection.execution_id.clone()),
+                            paused: false,
                         };
                         (Ok(()), Some(child_req))
                     }
@@ -1713,6 +1715,7 @@ impl EventHistory {
                     component_id: fn_component_id,
                     deployment_id: self.deployment_id,
                     scheduled_by: None,
+                    paused: false,
                 };
                 db_connection
                     .append_batch_create_new_execution(
@@ -3799,6 +3802,7 @@ mod tests {
                 component_id: ComponentId::dummy_activity(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -3207,6 +3207,7 @@ pub(crate) mod tests {
 
                     deployment_id: DEPLOYMENT_ID_DUMMY,
                     scheduled_by: None,
+                    paused: false,
                 })
                 .await
                 .unwrap();
@@ -3406,6 +3407,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -3713,6 +3715,7 @@ pub(crate) mod tests {
 
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1064,6 +1064,7 @@ mod tests {
                 component_id,
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1339,6 +1340,7 @@ mod tests {
                     component_id,
                     deployment_id: DEPLOYMENT_ID_DUMMY,
                     scheduled_by: None,
+                    paused: false,
                 })
                 .await
                 .unwrap();
@@ -1753,6 +1755,7 @@ mod tests {
                 component_id,
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -458,7 +458,7 @@ impl WorkflowJsWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        worker.replay_internal(ctx, Some(replay_kind)).await
+        worker.replay_internal(ctx, replay_kind).await
     }
 }
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -827,9 +827,9 @@ impl WorkflowWorker {
     pub(crate) async fn replay_internal(
         &self,
         ctx: WorkerContext,
-        is_replay: Option<ReplayKind>,
+        is_replay: ReplayKind,
     ) -> Result<(), ReplayError> {
-        match self.run_internal(ctx, is_replay).await {
+        match self.run_internal(ctx, Some(is_replay)).await {
             Ok(Either::Left(WorkerResultOk::RunFinished { .. })) => {
                 debug!("Replay finished returning a value");
                 Ok(())
@@ -959,7 +959,7 @@ impl WorkflowWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        worker.replay_internal(ctx, Some(replay_kind)).await
+        worker.replay_internal(ctx, replay_kind).await
     }
 }
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1336,6 +1336,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1464,6 +1465,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1579,6 +1581,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1645,6 +1648,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1710,6 +1714,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1797,6 +1802,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -1894,6 +1900,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2059,6 +2066,7 @@ pub(crate) mod tests {
                     scheduled_at: sim_clock.now(),
                     component_id: worker.config.component_id.clone(),
                     scheduled_by: None,
+                    paused: false,
                 })
                 .await
                 .unwrap();
@@ -2183,6 +2191,7 @@ pub(crate) mod tests {
                     component_id: worker.config.component_id.clone(),
                     deployment_id: DEPLOYMENT_ID_DUMMY,
                     scheduled_by: None,
+                    paused: false,
                 })
                 .await
                 .unwrap();
@@ -2352,6 +2361,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2460,6 +2470,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2563,6 +2574,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2661,6 +2673,7 @@ pub(crate) mod tests {
                 component_id: worker.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2785,6 +2798,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -2871,6 +2885,7 @@ pub(crate) mod tests {
                 component_id: worker.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -3072,6 +3087,7 @@ pub(crate) mod tests {
                 component_id: worker.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -3274,6 +3290,7 @@ pub(crate) mod tests {
                 component_id: worker.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -3436,6 +3453,7 @@ pub(crate) mod tests {
                 },
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();
@@ -3651,6 +3669,7 @@ pub(crate) mod tests {
                 component_id: workflow_exec.config.component_id.clone(),
                 deployment_id: DEPLOYMENT_ID_DUMMY,
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .unwrap();

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -208,6 +208,9 @@ message SubmitRequest {
     ExecutionId execution_id = 1;
     FunctionName function_name = 2;
     google.protobuf.Any params = 3;
+    // If true, create the execution in paused state so it won't be picked up
+    // by an executor until explicitly unpaused or advanced.
+    bool paused = 4;
 }
 
 message SubmitResponse {

--- a/src/args.rs
+++ b/src/args.rs
@@ -539,6 +539,9 @@ pub(crate) enum Execution {
         /// Do not attempt to reconnect on connection error while following the status stream.
         #[arg(long, requires = "follow")]
         no_reconnect: bool,
+        /// Create the execution in paused state so it won't run until explicitly unpaused or advanced.
+        #[arg(long)]
+        paused: bool,
         /// Output events as JSON in Web API format instead of human-readable text.
         #[arg(short, long)]
         json: bool,

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -95,6 +95,7 @@ impl args::Execution {
                 params,
                 follow,
                 no_reconnect,
+                paused,
                 json,
             } => {
                 let opts = if json {
@@ -108,7 +109,15 @@ impl args::Execution {
                         no_reconnect,
                     }
                 };
-                submit(&api_url, execution_id, ffqn, parse_params(params)?, opts).await
+                submit(
+                    &api_url,
+                    execution_id,
+                    ffqn,
+                    parse_params(params)?,
+                    paused,
+                    opts,
+                )
+                .await
             }
             args::Execution::Stub(args::Stub {
                 api_url,
@@ -191,6 +200,7 @@ pub(crate) async fn submit(
     execution_id: Option<ExecutionId>,
     ffqn: FunctionFqnOrShort,
     params: Vec<serde_json::Value>,
+    paused: bool,
     opts: SubmitOutputOpts,
 ) -> anyhow::Result<()> {
     let channel = to_channel(api_url).await?;
@@ -251,6 +261,7 @@ pub(crate) async fn submit(
                         value: serde_json::Value::Array(params).to_string().into_bytes(),
                     }),
                     function_name: Some(grpc_gen::FunctionName::from(ffqn)),
+                    paused,
                 }))
                 .await?;
             println!("{execution_id}");
@@ -277,6 +288,7 @@ pub(crate) async fn submit(
                     &ExecutionSubmitPayload {
                         ffqn: ffqn.clone(),
                         params: params.clone(),
+                        paused,
                     },
                 );
                 match request.send().await {

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1705,7 +1705,7 @@ async fn hot_redeploy_webhook_js_env_var_impl(
             }];
         })
         .await;
-
+    debug!("Expecting new deployment to answer the next request");
     let resp = server
         .client
         .get(format!("{}/read-env", server.webhook_base_url))

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -254,6 +254,7 @@ pub(crate) async fn submit(
     execution_id: ExecutionId,
     ffqn: FunctionFqn,
     mut params: Vec<serde_json::Value>,
+    paused: bool,
     component_registry_ro: &ComponentConfigRegistryRO,
 ) -> Result<SubmitOutcome, SubmitError> {
     let span = Span::current();
@@ -364,6 +365,7 @@ pub(crate) async fn submit(
             component_id: component_id.clone(),
             deployment_id,
             scheduled_by: None,
+            paused,
         })
         .await;
     match res {
@@ -1592,6 +1594,7 @@ async fn create_missing_cron_seeds(
                 deployment_id,
                 metadata: concepts::ExecutionMetadata::empty(),
                 scheduled_by: None,
+                paused: false,
             })
             .await
             .map_err(|e| {

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -219,6 +219,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             execution_id,
             ffqn,
             params,
+            request.paused,
             &component_registry_ro,
         )
         .await?;

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1367,6 +1367,9 @@ pub(crate) struct ExecutionSubmitPayload {
     pub(crate) ffqn: FunctionFqn,
     /// Function parameters as JSON values
     pub(crate) params: Vec<serde_json::Value>,
+    /// If true, create the execution in paused state.
+    #[serde(default)]
+    pub(crate) paused: bool,
 }
 
 #[derive(Deserialize, Debug, IntoParams)]
@@ -1446,6 +1449,7 @@ async fn execution_submit(
         execution_id.clone(),
         payload.ffqn,
         payload.params,
+        payload.paused,
         &component_registry_ro,
     )
     .await


### PR DESCRIPTION
- **style: Remove optional from `ReplayKind` param in `replay_internal`**
- **tracing: Fix `stream_id`**
- **refactor(webhook): Avoid `select`ing the always-ready closed watcher on shutdown**
- **feat(grpc,webapi,cli): Allow creation of paused executions**
