### PR TITLE
feat(grpc,webapi): Extend replay response with next events and return value

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1032,7 +1032,14 @@
         ],
         "responses": {
           "200": {
-            "description": "Execution replayed"
+            "description": "Execution replayed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplayResponseSer"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not found"
@@ -1886,6 +1893,33 @@
           "wit_type": {
             "type": "string",
             "description": "WIT type representation"
+          }
+        }
+      },
+      "ReplayResponseSer": {
+        "type": "object",
+        "description": "Result of replaying a workflow execution",
+        "required": [
+          "next_events"
+        ],
+        "properties": {
+          "next_events": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "Events that the workflow would produce next"
+          },
+          "return_value": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RetVal",
+                "description": "If the workflow completed during replay, contains the return value"
+              }
+            ]
           }
         }
       },

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -593,168 +593,254 @@ impl From<SupportedFunctionReturnValue> for grpc_gen::SupportedFunctionResult {
 
 pub fn from_execution_event_to_grpc(event: ExecutionEvent) -> grpc_gen::ExecutionEvent {
     grpc_gen::ExecutionEvent {
-            created_at: Some(prost_wkt_types::Timestamp::from(event.created_at)),
-            version: event.version.0,
-            backtrace_id: event.backtrace_id.map(|v|v.0),
-            event: Some(match event.event {
-                ExecutionRequest::Created {
-                    ffqn,
-                    params,
-                    parent: _,
-                    scheduled_at,
-                    component_id,
-                    deployment_id,
-                    metadata: _,
-                    scheduled_by,
-                } => grpc_gen::execution_event::Event::Created(grpc_gen::execution_event::Created {
-                    params: Some(to_any(
-                        params,
-                        format!("urn:obelisk:json:params:{ffqn}"),
-                    ).expect("Params must be JSON-serializable")),
-                    function_name: Some(grpc_gen::FunctionName::from(ffqn)),
-                    scheduled_at: Some(prost_wkt_types::Timestamp::from(scheduled_at)),
-                    component_id: Some(component_id.into()),
-                    deployment_id: Some(deployment_id.into()),
-                    scheduled_by: scheduled_by.map(|id| grpc_gen::ExecutionId { id: id.to_string() }),
-                }),
-                ExecutionRequest::Locked(Locked{
-                    component_id,
-                    deployment_id,
-                    executor_id: _,
-                    run_id,
-                    lock_expires_at,
-                    retry_config: _,
-                }) => grpc_gen::execution_event::Event::Locked(grpc_gen::execution_event::Locked {
-                    component_id: Some(component_id.into()),
-                    deployment_id: Some(deployment_id.into()),
-                    run_id: run_id.to_string(),
-                    lock_expires_at: Some(prost_wkt_types::Timestamp::from(lock_expires_at)),
-                }),
-                ExecutionRequest::Unlocked { backoff_expires_at, reason } => {
-                    grpc_gen::execution_event::Event::Unlocked(grpc_gen::execution_event::Unlocked {
-                        backoff_expires_at: Some(prost_wkt_types::Timestamp::from(backoff_expires_at)),
-                        reason: reason.to_string(),
-                    })
-                },
-                ExecutionRequest::TemporarilyFailed {
-                    backoff_expires_at,
-                    reason,
-                    detail,
-                    http_client_traces
-                } => grpc_gen::execution_event::Event::TemporarilyFailed(grpc_gen::execution_event::TemporarilyFailed {
+        created_at: Some(prost_wkt_types::Timestamp::from(event.created_at)),
+        version: event.version.0,
+        backtrace_id: event.backtrace_id.map(|v| v.0),
+        event: Some(match event.event {
+            ExecutionRequest::Created {
+                ffqn,
+                params,
+                parent: _,
+                scheduled_at,
+                component_id,
+                deployment_id,
+                metadata: _,
+                scheduled_by,
+            } => grpc_gen::execution_event::Event::Created(grpc_gen::execution_event::Created {
+                params: Some(
+                    to_any(params, format!("urn:obelisk:json:params:{ffqn}"))
+                        .expect("Params must be JSON-serializable"),
+                ),
+                function_name: Some(grpc_gen::FunctionName::from(ffqn)),
+                scheduled_at: Some(prost_wkt_types::Timestamp::from(scheduled_at)),
+                component_id: Some(component_id.into()),
+                deployment_id: Some(deployment_id.into()),
+                scheduled_by: scheduled_by.map(|id| grpc_gen::ExecutionId { id: id.to_string() }),
+            }),
+            ExecutionRequest::Locked(Locked {
+                component_id,
+                deployment_id,
+                executor_id: _,
+                run_id,
+                lock_expires_at,
+                retry_config: _,
+            }) => grpc_gen::execution_event::Event::Locked(grpc_gen::execution_event::Locked {
+                component_id: Some(component_id.into()),
+                deployment_id: Some(deployment_id.into()),
+                run_id: run_id.to_string(),
+                lock_expires_at: Some(prost_wkt_types::Timestamp::from(lock_expires_at)),
+            }),
+            ExecutionRequest::Unlocked {
+                backoff_expires_at,
+                reason,
+            } => grpc_gen::execution_event::Event::Unlocked(grpc_gen::execution_event::Unlocked {
+                backoff_expires_at: Some(prost_wkt_types::Timestamp::from(backoff_expires_at)),
+                reason: reason.to_string(),
+            }),
+            ExecutionRequest::TemporarilyFailed {
+                backoff_expires_at,
+                reason,
+                detail,
+                http_client_traces,
+            } => grpc_gen::execution_event::Event::TemporarilyFailed(
+                grpc_gen::execution_event::TemporarilyFailed {
                     reason: reason.to_string(),
                     detail,
                     backoff_expires_at: Some(prost_wkt_types::Timestamp::from(backoff_expires_at)),
-                    http_client_traces: http_client_traces.unwrap_or_default().into_iter().map(grpc_gen::HttpClientTrace::from).collect(),
-                }),
-                ExecutionRequest::TemporarilyTimedOut { backoff_expires_at, http_client_traces } => {
-                    grpc_gen::execution_event::Event::TemporarilyTimedOut(grpc_gen::execution_event::TemporarilyTimedOut {
-                        backoff_expires_at: Some(prost_wkt_types::Timestamp::from(backoff_expires_at)),
-                        http_client_traces: http_client_traces
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(grpc_gen::HttpClientTrace::from)
-                            .collect(),
-                    })
+                    http_client_traces: http_client_traces
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(grpc_gen::HttpClientTrace::from)
+                        .collect(),
                 },
-                ExecutionRequest::Finished { retval: result, http_client_traces } => grpc_gen::execution_event::Event::Finished(grpc_gen::execution_event::Finished {
-                    value: Some(
-                        grpc_gen::SupportedFunctionResult::from(result)
-                    ),
-                    http_client_traces: http_client_traces.unwrap_or_default().into_iter().map(grpc_gen::HttpClientTrace::from).collect(),
+            ),
+            ExecutionRequest::TemporarilyTimedOut {
+                backoff_expires_at,
+                http_client_traces,
+            } => grpc_gen::execution_event::Event::TemporarilyTimedOut(
+                grpc_gen::execution_event::TemporarilyTimedOut {
+                    backoff_expires_at: Some(prost_wkt_types::Timestamp::from(backoff_expires_at)),
+                    http_client_traces: http_client_traces
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(grpc_gen::HttpClientTrace::from)
+                        .collect(),
+                },
+            ),
+            ExecutionRequest::Finished {
+                retval: result,
+                http_client_traces,
+            } => grpc_gen::execution_event::Event::Finished(grpc_gen::execution_event::Finished {
+                value: Some(grpc_gen::SupportedFunctionResult::from(result)),
+                http_client_traces: http_client_traces
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(grpc_gen::HttpClientTrace::from)
+                    .collect(),
+            }),
+            ExecutionRequest::Paused => {
+                grpc_gen::execution_event::Event::Paused(grpc_gen::execution_event::Paused {})
+            }
+            ExecutionRequest::Unpaused => {
+                grpc_gen::execution_event::Event::Unpaused(grpc_gen::execution_event::Unpaused {})
+            }
+            ExecutionRequest::HistoryEvent { event } => {
+                grpc_gen::execution_event::Event::HistoryVariant(history_event_to_grpc(event))
+            }
+        }),
+    }
+}
 
-                }),
-                ExecutionRequest::Paused  => {
-                    grpc_gen::execution_event::Event::Paused(grpc_gen::execution_event::Paused{})
-                },
-                ExecutionRequest::Unpaused => grpc_gen::execution_event::Event::Unpaused(grpc_gen::execution_event::Unpaused{}),
-                ExecutionRequest::HistoryEvent { event } => grpc_gen::execution_event::Event::HistoryVariant(grpc_gen::execution_event::HistoryEvent {
-                    event: Some(match event {
-                        HistoryEvent::Persist { value, kind } => history_event::Event::Persist(history_event::Persist {
-                            data: Some(prost_wkt_types::Any {
-                                type_url: "unknown".to_string(),
-                                value,
-                            }),
-                            kind: Some(history_event::persist::PersistKind { variant: Some(match kind {
-                                PersistKind::RandomU64 { .. } =>
+pub fn history_event_to_grpc(event: HistoryEvent) -> grpc_gen::execution_event::HistoryEvent {
+    grpc_gen::execution_event::HistoryEvent {
+        event: Some(match event {
+            HistoryEvent::Persist { value, kind } => {
+                history_event::Event::Persist(history_event::Persist {
+                    data: Some(prost_wkt_types::Any {
+                        type_url: "unknown".to_string(),
+                        value,
+                    }),
+                    kind: Some(history_event::persist::PersistKind {
+                        variant: Some(match kind {
+                            PersistKind::RandomU64 { .. } => {
                                 history_event::persist::persist_kind::Variant::RandomU64(
-                                    history_event::persist::persist_kind::RandomU64 {  }),
-                                PersistKind::RandomString { .. } =>
+                                    history_event::persist::persist_kind::RandomU64 {},
+                                )
+                            }
+                            PersistKind::RandomString { .. } => {
                                 history_event::persist::persist_kind::Variant::RandomString(
-                                    history_event::persist::persist_kind::RandomString {  }),
-                                PersistKind::ExecutionId =>
+                                    history_event::persist::persist_kind::RandomString {},
+                                )
+                            }
+                            PersistKind::ExecutionId => {
                                 history_event::persist::persist_kind::Variant::ExecutionId(
-                                    history_event::persist::persist_kind::ExecutionId {  }),
-                            }) })
-                        }),
-                        HistoryEvent::JoinSetCreate { join_set_id } =>
-                            history_event::Event::JoinSetCreated(history_event::JoinSetCreated {
-                                join_set_id: Some(join_set_id.into()),
-                            }),
-                        HistoryEvent::JoinSetRequest { join_set_id, request } => history_event::Event::JoinSetRequest(history_event::JoinSetRequest {
-                            join_set_id: Some(join_set_id.into()),
-                            join_set_request: match request {
-                                JoinSetRequest::DelayRequest { delay_id, expires_at, .. } => {
-                                    Some(history_event::join_set_request::JoinSetRequest::DelayRequest(
-                                        history_event::join_set_request::DelayRequest {
-                                            delay_id: Some(delay_id.into()),
-                                            expires_at: Some(prost_wkt_types::Timestamp::from(expires_at)),
-                                        }
-                                    ))
-                                }
-                                JoinSetRequest::ChildExecutionRequest { child_execution_id, params: _, target_ffqn: _, result } => {
-                                    Some(history_event::join_set_request::JoinSetRequest::ChildExecutionRequest(
-                                        history_event::join_set_request::ChildExecutionRequest {
-                                            child_execution_id: Some(grpc_gen::ExecutionId { id: child_execution_id.to_string() }),
-                                            success: result.is_ok(),
-                                        }
-                                    ))
-                                }
-                            },
-                        }),
-                        HistoryEvent::JoinNext { join_set_id, run_expires_at, closing, requested_ffqn:_ } => history_event::Event::JoinNext(history_event::JoinNext {
-                            join_set_id: Some(join_set_id.into()),
-                            run_expires_at: Some(prost_wkt_types::Timestamp::from(run_expires_at)),
-                            closing,
-                        }),
-                        HistoryEvent::JoinNextTooMany { join_set_id, requested_ffqn } => history_event::Event::JoinNextTooMany(history_event::JoinNextTooMany {
-                            join_set_id: Some(join_set_id.into()),
-                            function: requested_ffqn.map(Into::into)
-                        }),
-                        HistoryEvent::JoinNextTry { join_set_id, outcome } => {
-                            let outcome = match outcome {
-                                concepts::storage::JoinNextTryOutcome::Found => history_event::join_next_try::Outcome::Found,
-                                concepts::storage::JoinNextTryOutcome::Pending => history_event::join_next_try::Outcome::Pending,
-                                concepts::storage::JoinNextTryOutcome::AllProcessed => history_event::join_next_try::Outcome::AllProcessed,
-                            };
-                            history_event::Event::JoinNextTry(history_event::JoinNextTry {
-                                join_set_id: Some(join_set_id.into()),
-                                outcome: outcome.into(),
-                            })
-                        }
-                        HistoryEvent::Schedule { execution_id, schedule_at: scheduled_at, result } => history_event::Event::Schedule(history_event::Schedule {
-                            execution_id: Some(grpc_gen::ExecutionId { id: execution_id.to_string() }),
-                            scheduled_at: Some(history_event::schedule::ScheduledAt {
-                                variant: match scheduled_at {
-                                    HistoryEventScheduleAt::Now => Some(history_event::schedule::scheduled_at::Variant::Now(history_event::schedule::scheduled_at::Now {})),
-                                    HistoryEventScheduleAt::At( at) => Some(history_event::schedule::scheduled_at::Variant::At(history_event::schedule::scheduled_at::At {
-                                        at: Some(prost_wkt_types::Timestamp::from(at)),
-                                    })),
-                                    HistoryEventScheduleAt::In (r#in ) => Some(history_event::schedule::scheduled_at::Variant::In(history_event::schedule::scheduled_at::In {
-                                        r#in: prost_wkt_types::Duration::try_from(r#in).ok(),
-                                    })),
-                                },
-                            }),
-                            success: result.is_ok(),
-                        }),
-                        HistoryEvent::Stub { target_execution_id, result, .. } => history_event::Event::Stub(history_event::Stub {
-                            execution_id: Some(ExecutionId::Derived(target_execution_id).into()),
-                            success: result.is_ok()
+                                    history_event::persist::persist_kind::ExecutionId {},
+                                )
+                            }
                         }),
                     }),
-                }),
+                })
+            }
+            HistoryEvent::JoinSetCreate { join_set_id } => {
+                history_event::Event::JoinSetCreated(history_event::JoinSetCreated {
+                    join_set_id: Some(join_set_id.into()),
+                })
+            }
+            HistoryEvent::JoinSetRequest {
+                join_set_id,
+                request,
+            } => history_event::Event::JoinSetRequest(history_event::JoinSetRequest {
+                join_set_id: Some(join_set_id.into()),
+                join_set_request: match request {
+                    JoinSetRequest::DelayRequest {
+                        delay_id,
+                        expires_at,
+                        ..
+                    } => Some(
+                        history_event::join_set_request::JoinSetRequest::DelayRequest(
+                            history_event::join_set_request::DelayRequest {
+                                delay_id: Some(delay_id.into()),
+                                expires_at: Some(prost_wkt_types::Timestamp::from(expires_at)),
+                            },
+                        ),
+                    ),
+                    JoinSetRequest::ChildExecutionRequest {
+                        child_execution_id,
+                        params: _,
+                        target_ffqn: _,
+                        result,
+                    } => Some(
+                        history_event::join_set_request::JoinSetRequest::ChildExecutionRequest(
+                            history_event::join_set_request::ChildExecutionRequest {
+                                child_execution_id: Some(grpc_gen::ExecutionId {
+                                    id: child_execution_id.to_string(),
+                                }),
+                                success: result.is_ok(),
+                            },
+                        ),
+                    ),
+                },
             }),
-        }
+            HistoryEvent::JoinNext {
+                join_set_id,
+                run_expires_at,
+                closing,
+                requested_ffqn: _,
+            } => history_event::Event::JoinNext(history_event::JoinNext {
+                join_set_id: Some(join_set_id.into()),
+                run_expires_at: Some(prost_wkt_types::Timestamp::from(run_expires_at)),
+                closing,
+            }),
+            HistoryEvent::JoinNextTooMany {
+                join_set_id,
+                requested_ffqn,
+            } => history_event::Event::JoinNextTooMany(history_event::JoinNextTooMany {
+                join_set_id: Some(join_set_id.into()),
+                function: requested_ffqn.map(Into::into),
+            }),
+            HistoryEvent::JoinNextTry {
+                join_set_id,
+                outcome,
+            } => {
+                let outcome = match outcome {
+                    concepts::storage::JoinNextTryOutcome::Found => {
+                        history_event::join_next_try::Outcome::Found
+                    }
+                    concepts::storage::JoinNextTryOutcome::Pending => {
+                        history_event::join_next_try::Outcome::Pending
+                    }
+                    concepts::storage::JoinNextTryOutcome::AllProcessed => {
+                        history_event::join_next_try::Outcome::AllProcessed
+                    }
+                };
+                history_event::Event::JoinNextTry(history_event::JoinNextTry {
+                    join_set_id: Some(join_set_id.into()),
+                    outcome: outcome.into(),
+                })
+            }
+            HistoryEvent::Schedule {
+                execution_id,
+                schedule_at: scheduled_at,
+                result,
+            } => history_event::Event::Schedule(history_event::Schedule {
+                execution_id: Some(grpc_gen::ExecutionId {
+                    id: execution_id.to_string(),
+                }),
+                scheduled_at: Some(history_event::schedule::ScheduledAt {
+                    variant: match scheduled_at {
+                        HistoryEventScheduleAt::Now => {
+                            Some(history_event::schedule::scheduled_at::Variant::Now(
+                                history_event::schedule::scheduled_at::Now {},
+                            ))
+                        }
+                        HistoryEventScheduleAt::At(at) => {
+                            Some(history_event::schedule::scheduled_at::Variant::At(
+                                history_event::schedule::scheduled_at::At {
+                                    at: Some(prost_wkt_types::Timestamp::from(at)),
+                                },
+                            ))
+                        }
+                        HistoryEventScheduleAt::In(r#in) => {
+                            Some(history_event::schedule::scheduled_at::Variant::In(
+                                history_event::schedule::scheduled_at::In {
+                                    r#in: prost_wkt_types::Duration::try_from(r#in).ok(),
+                                },
+                            ))
+                        }
+                    },
+                }),
+                success: result.is_ok(),
+            }),
+            HistoryEvent::Stub {
+                target_execution_id,
+                result,
+                ..
+            } => history_event::Event::Stub(history_event::Stub {
+                execution_id: Some(ExecutionId::Derived(target_execution_id).into()),
+                success: result.is_ok(),
+            }),
+        }),
+    }
 }
 
 pub mod response {

--- a/crates/wasm-workers/Cargo.toml
+++ b/crates/wasm-workers/Cargo.toml
@@ -51,7 +51,7 @@ wit-component.workspace = true
 wit-parser.workspace = true
 
 [features]
-test = []
+test = ["concepts/test", "executor/test"]
 
 [dev-dependencies]
 activity-js-runtime-builder.workspace = true

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -578,8 +578,11 @@ impl EventHistory {
                     join_next_idx,
                     join_next_version,
                 } => {
-                    // JoinNext is still unprocessed. This can only happen on replay if there is no progress.
-                    assert_eq!(last_key_idx, join_next_idx);
+                    // JoinNext is still unprocessed. This can only happen on the last key (the JoinNext key).
+                    assert_eq!(
+                        last_key_idx, idx,
+                        "FoundRequestButNotResponse must be returned on the last key"
+                    );
                     return Ok(FindMatchingResponse::FoundRequestButNotResponse {
                         join_next_idx,
                         join_next_version,

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -497,7 +497,8 @@ impl EventHistory {
                         &ExecutionId::Derived(child_execution_id_derived.clone()),
                         called_at,
                     )
-                    .await;
+                    .await
+                    .map(|_| ()); // CancelOutcome is not inspected, this would interfere with replay preview.
                 if let Err(err) = res {
                     debug!("Ignoring failure to cancel {child_execution_id_derived} - {err:?}");
                 }
@@ -505,7 +506,8 @@ impl EventHistory {
                 debug!("Cancelling {delay_id}");
                 let res = db_connection
                     .cancel_delay(delay_id.clone(), called_at)
-                    .await;
+                    .await
+                    .map(|_| ()); // CancelOutcome is not inspected, this would interfere with replay preview.
                 if let Err(err) = res {
                     // This means that the watcher expired the delay in the mean time.
                     trace!("Ignoring failure to cancel {delay_id} - {err:?}");

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -104,8 +104,8 @@ pub(crate) enum ApplyError {
     ConstraintViolation(StrVariant),
     #[error("executor closing")]
     ExecutorClosing,
-    #[error("replay finished")]
-    ReplayFinished,
+    #[error("replay waiting for response")]
+    ReplayWaitingForResponse, // Same state as `InterruptDbUpdated`, but db might not have been updated.
 }
 
 #[expect(clippy::struct_field_names)]
@@ -277,9 +277,16 @@ impl EventHistory {
             self.extend_lock(db_connection, called_at).await?;
         }
 
-        if let Some(resp) = self.find_matching_atomic(&event_call)? {
-            trace!("found_atomic: {resp:?}");
-            return Ok(resp);
+        match self.find_matching_atomic(&event_call)? {
+            FindMatchingResponse::Found(resp) => {
+                trace!("found_atomic: {resp:?}");
+                return Ok(resp);
+            }
+            FindMatchingResponse::NotFound => {} // continue
+            FindMatchingResponse::FoundRequestButNotResponse { .. } => {
+                assert!(self.replaying_unfinished_execution);
+                return Err(ApplyError::ReplayWaitingForResponse);
+            }
         }
 
         match event_call {
@@ -291,9 +298,10 @@ impl EventHistory {
                     .await?;
                 self.event_history.push((event, Unprocessed, version));
                 trace!("find_matching_atomic must mark the non-blocking event as Processed");
-                let non_blocking_resp = self
-                    .find_matching_atomic(&EventCall::NonBlocking(cloned_non_blocking))?
-                    .expect("just stored the event as Unprocessed, it must be found");
+                let non_blocking_resp = assert_matches!(
+                    self
+                    .find_matching_atomic(&EventCall::NonBlocking(cloned_non_blocking))?,
+                    FindMatchingResponse::Found(resp) => resp, "just stored the event as Unprocessed, it must be found");
                 Ok(non_blocking_resp)
             }
             EventCall::Blocking(event_call) => {
@@ -555,7 +563,7 @@ impl EventHistory {
     fn find_matching_atomic(
         &mut self,
         event_call: &EventCall,
-    ) -> Result<Option<ChildReturnValue>, ApplyError> {
+    ) -> Result<FindMatchingResponse, ApplyError> {
         let keys = event_call.as_keys();
         assert!(!keys.is_empty());
         let last_key_idx = keys.len() - 1;
@@ -564,23 +572,22 @@ impl EventHistory {
             match resp {
                 FindMatchingResponse::NotFound => {
                     assert_eq!(idx, 0, "NotFound must be returned on the first key");
-                    return Ok(None);
+                    return Ok(FindMatchingResponse::NotFound);
                 }
                 FindMatchingResponse::FoundRequestButNotResponse {
                     join_next_idx,
                     join_next_version,
                 } => {
-                    // JoinNext is still unprocessed. This is the only exception when replay is considered finished.
-                    if join_next_idx == self.event_history.len() - 1 {
-                        return Err(ApplyError::ReplayFinished);
-                    }
-                    unreachable!(
-                        "bug in executor: FoundRequestButNotResponse in find_matching_atomic - {event_call:?}, {join_next_idx}, {join_next_version}"
-                    );
+                    // JoinNext is still unprocessed. This can only happen on replay if there is no progress.
+                    assert_eq!(last_key_idx, join_next_idx);
+                    return Ok(FindMatchingResponse::FoundRequestButNotResponse {
+                        join_next_idx,
+                        join_next_version,
+                    });
                 }
                 FindMatchingResponse::Found(found) => {
                     if idx == last_key_idx {
-                        return Ok(Some(found));
+                        return Ok(FindMatchingResponse::Found(found));
                     }
                 }
             }
@@ -680,17 +687,6 @@ impl EventHistory {
 
     // Only entry point to marking events as processed.
     fn process_event_by_key(
-        &mut self,
-        key: &DeterministicKey,
-    ) -> Result<FindMatchingResponse, ApplyError> {
-        let resp = self.process_event_by_key_inner(key)?;
-        if self.replaying_unfinished_execution && !self.has_unprocessed_requests() {
-            return Err(ApplyError::ReplayFinished);
-        }
-        Ok(resp)
-    }
-
-    fn process_event_by_key_inner(
         &mut self,
         key: &DeterministicKey,
     ) -> Result<FindMatchingResponse, ApplyError> {

--- a/crates/wasm-workers/src/workflow/mod.rs
+++ b/crates/wasm-workers/src/workflow/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod caching_db_connection;
 pub mod deadline_tracker;
 pub(crate) mod event_history;
 pub mod host_exports;
+pub(crate) mod replay_db_proxy;
 pub(crate) mod wasi;
 pub(crate) mod workflow_ctx;
 pub mod workflow_js_worker;

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -1,0 +1,315 @@
+//! A database proxy for replay that captures all appended `HistoryEvent`s in memory
+//! instead of persisting them. This allows `replay_internal` to collect the events
+//! that the workflow would produce next.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use concepts::component_id::ComponentDigest;
+use concepts::prefixed_ulid::{DelayId, ExecutorId, RunId};
+use concepts::storage::{
+    AppendBatchResponse, AppendEventsToExecution, AppendRequest, AppendResponse,
+    AppendResponseToExecution, BacktraceInfo, CreateRequest, DbConnection, DbErrorGeneric,
+    DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite, DbExecutor, DbPool, ExecutionEvent,
+    ExecutionLog, ExecutionRequest, ExecutionWithState, ExpiredTimer, HistoryEvent,
+    LockPendingResponse, LogInfoAppendRow, ResponseCursor, ResponseWithCursor, TimeoutOutcome,
+    Version,
+};
+use concepts::{
+    ComponentId, ComponentRetryConfig, ExecutionId, FunctionFqn, JoinSetId,
+    SupportedFunctionReturnValue,
+};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+/// Shared buffer that accumulates `HistoryEvent`s during replay.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ReplayEventCollector {
+    events: Arc<Mutex<Vec<HistoryEvent>>>,
+}
+
+impl ReplayEventCollector {
+    pub(crate) fn new() -> Self {
+        Self {
+            events: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Extract collected events, consuming the buffer.
+    pub(crate) fn take_events(&self) -> Vec<HistoryEvent> {
+        std::mem::take(&mut *self.events.lock().unwrap())
+    }
+}
+
+/// A `DbPool` that returns `ReplayDbConnection` instances.
+pub(crate) struct ReplayDbPool {
+    collector: ReplayEventCollector,
+    starting_version: Version,
+}
+
+impl ReplayDbPool {
+    pub(crate) fn new(collector: ReplayEventCollector, starting_version: Version) -> Self {
+        Self {
+            collector,
+            starting_version,
+        }
+    }
+}
+
+#[async_trait]
+impl DbPool for ReplayDbPool {
+    async fn db_exec_conn(&self) -> Result<Box<dyn DbExecutor>, DbErrorGeneric> {
+        Ok(Box::new(ReplayDbConnection {
+            collector: self.collector.clone(),
+            version: self.starting_version.clone(),
+        }))
+    }
+
+    async fn connection(&self) -> Result<Box<dyn DbConnection>, DbErrorGeneric> {
+        Ok(Box::new(ReplayDbConnection {
+            collector: self.collector.clone(),
+            version: self.starting_version.clone(),
+        }))
+    }
+
+    async fn external_api_conn(
+        &self,
+    ) -> Result<Box<dyn concepts::storage::DbExternalApi>, DbErrorGeneric> {
+        unimplemented!("ReplayDbPool does not support external_api_conn")
+    }
+
+    #[cfg(feature = "test")]
+    async fn connection_test(
+        &self,
+    ) -> Result<Box<dyn concepts::storage::DbConnectionTest>, DbErrorGeneric> {
+        unimplemented!("ReplayDbPool does not support connection_test")
+    }
+}
+
+/// A `DbConnection` that captures history events instead of persisting them.
+struct ReplayDbConnection {
+    collector: ReplayEventCollector,
+    version: Version,
+}
+
+impl ReplayDbConnection {
+    fn collect_events_from_batch(&self, batch: &[AppendRequest]) {
+        let mut events = self.collector.events.lock().unwrap();
+        for req in batch {
+            if let ExecutionRequest::HistoryEvent { event } = &req.event {
+                events.push(event.clone());
+            }
+        }
+    }
+
+    fn next_version(&self, count: usize) -> Version {
+        Version::new(self.version.0 + u32::try_from(count).unwrap())
+    }
+}
+
+#[async_trait]
+impl DbExecutor for ReplayDbConnection {
+    async fn lock_pending_by_ffqns(
+        &self,
+        _batch_size: u32,
+        _pending_at_or_sooner: DateTime<Utc>,
+        _ffqns: Arc<[FunctionFqn]>,
+        _created_at: DateTime<Utc>,
+        _component_id: ComponentId,
+        _deployment_id: concepts::prefixed_ulid::DeploymentId,
+        _executor_id: ExecutorId,
+        _lock_expires_at: DateTime<Utc>,
+        _run_id: RunId,
+        _retry_config: ComponentRetryConfig,
+    ) -> Result<LockPendingResponse, DbErrorWrite> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn lock_pending_by_component_digest(
+        &self,
+        _batch_size: u32,
+        _pending_at_or_sooner: DateTime<Utc>,
+        _component_id: &ComponentId,
+        _deployment_id: concepts::prefixed_ulid::DeploymentId,
+        _created_at: DateTime<Utc>,
+        _executor_id: ExecutorId,
+        _lock_expires_at: DateTime<Utc>,
+        _run_id: RunId,
+        _retry_config: ComponentRetryConfig,
+    ) -> Result<LockPendingResponse, DbErrorWrite> {
+        unimplemented!("not used during replay")
+    }
+
+    #[cfg(feature = "test")]
+    async fn lock_one(
+        &self,
+        _created_at: DateTime<Utc>,
+        _component_id: ComponentId,
+        _deployment_id: concepts::prefixed_ulid::DeploymentId,
+        _execution_id: &ExecutionId,
+        _run_id: RunId,
+        _version: Version,
+        _executor_id: ExecutorId,
+        _lock_expires_at: DateTime<Utc>,
+        _retry_config: ComponentRetryConfig,
+    ) -> Result<concepts::storage::LockedExecution, DbErrorWrite> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn append(
+        &self,
+        _execution_id: ExecutionId,
+        version: Version,
+        req: AppendRequest,
+    ) -> Result<AppendResponse, DbErrorWrite> {
+        if let ExecutionRequest::HistoryEvent { event } = &req.event {
+            self.collector.events.lock().unwrap().push(event.clone());
+        }
+        Ok(Version::new(version.0 + 1))
+    }
+
+    async fn append_batch_respond_to_parent(
+        &self,
+        events: AppendEventsToExecution,
+        _response: AppendResponseToExecution,
+        _current_time: DateTime<Utc>,
+    ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        self.collect_events_from_batch(&events.batch);
+        Ok(self.next_version(events.batch.len()))
+    }
+
+    async fn wait_for_pending_by_ffqn(
+        &self,
+        _pending_at_or_sooner: DateTime<Utc>,
+        _ffqns: Arc<[FunctionFqn]>,
+        _timeout_fut: Pin<Box<dyn Future<Output = ()> + Send>>,
+    ) {
+        // no-op for replay
+    }
+
+    async fn wait_for_pending_by_component_digest(
+        &self,
+        _pending_at_or_sooner: DateTime<Utc>,
+        _component_digest: &ComponentDigest,
+        _timeout_fut: Pin<Box<dyn Future<Output = ()> + Send>>,
+    ) {
+        // no-op for replay
+    }
+
+    async fn get_last_execution_event(
+        &self,
+        _execution_id: &ExecutionId,
+    ) -> Result<ExecutionEvent, DbErrorRead> {
+        unimplemented!("not used during replay")
+    }
+}
+
+#[async_trait]
+impl DbConnection for ReplayDbConnection {
+    async fn get(&self, _execution_id: &ExecutionId) -> Result<ExecutionLog, DbErrorRead> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn append_delay_response(
+        &self,
+        _created_at: DateTime<Utc>,
+        _execution_id: ExecutionId,
+        _join_set_id: JoinSetId,
+        _delay_id: DelayId,
+        _outcome: Result<(), ()>,
+    ) -> Result<concepts::storage::AppendDelayResponseOutcome, DbErrorWrite> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn append_batch(
+        &self,
+        _current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        _execution_id: ExecutionId,
+        version: Version,
+    ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        self.collect_events_from_batch(&batch);
+        Ok(Version::new(
+            version.0 + u32::try_from(batch.len()).unwrap(),
+        ))
+    }
+
+    async fn append_batch_create_new_execution(
+        &self,
+        _current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        _execution_id: ExecutionId,
+        version: Version,
+        _child_req: Vec<CreateRequest>,
+        _backtraces: Vec<BacktraceInfo>,
+    ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        self.collect_events_from_batch(&batch);
+        Ok(Version::new(
+            version.0 + u32::try_from(batch.len()).unwrap(),
+        ))
+    }
+
+    async fn get_execution_event(
+        &self,
+        _execution_id: &ExecutionId,
+        _version: &Version,
+    ) -> Result<ExecutionEvent, DbErrorRead> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn get_pending_state(
+        &self,
+        _execution_id: &ExecutionId,
+    ) -> Result<ExecutionWithState, DbErrorRead> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn get_expired_timers(
+        &self,
+        _at: DateTime<Utc>,
+    ) -> Result<Vec<ExpiredTimer>, DbErrorGeneric> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn create(&self, _req: CreateRequest) -> Result<AppendResponse, DbErrorWrite> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn subscribe_to_next_responses(
+        &self,
+        _execution_id: &ExecutionId,
+        _last_response: ResponseCursor,
+        _timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout> {
+        // During replay, there are no new responses to subscribe to.
+        Err(DbErrorReadWithTimeout::Timeout(TimeoutOutcome::Timeout))
+    }
+
+    async fn wait_for_finished_result(
+        &self,
+        _execution_id: &ExecutionId,
+        _timeout_fut: Option<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>>,
+    ) -> Result<SupportedFunctionReturnValue, DbErrorReadWithTimeout> {
+        unimplemented!("not used during replay")
+    }
+
+    async fn append_backtrace(&self, _append: BacktraceInfo) -> Result<(), DbErrorWrite> {
+        // Silently discard backtraces during replay
+        Ok(())
+    }
+
+    async fn append_backtrace_batch(&self, _batch: Vec<BacktraceInfo>) -> Result<(), DbErrorWrite> {
+        // Silently discard backtraces during replay
+        Ok(())
+    }
+
+    async fn append_log(&self, _row: LogInfoAppendRow) -> Result<(), DbErrorWrite> {
+        // Silently discard logs during replay
+        Ok(())
+    }
+
+    async fn append_log_batch(&self, _batch: &[LogInfoAppendRow]) -> Result<(), DbErrorWrite> {
+        // Silently discard logs during replay
+        Ok(())
+    }
+}

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -78,7 +78,7 @@ impl DbPool for ReplayDbPool {
         unimplemented!("ReplayDbPool does not support external_api_conn")
     }
 
-    #[cfg(feature = "test")]
+    #[cfg(any(test, feature = "test"))]
     async fn connection_test(
         &self,
     ) -> Result<Box<dyn concepts::storage::DbConnectionTest>, DbErrorGeneric> {
@@ -101,10 +101,13 @@ impl ReplayDbConnection {
             }
         }
     }
+}
 
-    fn next_version(&self, count: usize) -> Version {
-        Version::new(self.version.0 + u32::try_from(count).unwrap())
-    }
+fn next_version(curr_version: &Version, batch_size: usize) -> Version {
+    Version::new(
+        curr_version.0
+            + u32::try_from(batch_size).expect("batch size is always just a couple of items"),
+    )
 }
 
 #[async_trait]
@@ -140,7 +143,7 @@ impl DbExecutor for ReplayDbConnection {
         unimplemented!("not used during replay")
     }
 
-    #[cfg(feature = "test")]
+    #[cfg(any(test, feature = "test"))]
     async fn lock_one(
         &self,
         _created_at: DateTime<Utc>,
@@ -175,7 +178,7 @@ impl DbExecutor for ReplayDbConnection {
         _current_time: DateTime<Utc>,
     ) -> Result<AppendBatchResponse, DbErrorWrite> {
         self.collect_events_from_batch(&events.batch);
-        Ok(self.next_version(events.batch.len()))
+        Ok(next_version(&self.version, events.batch.len()))
     }
 
     async fn wait_for_pending_by_ffqn(
@@ -200,7 +203,23 @@ impl DbExecutor for ReplayDbConnection {
         &self,
         _execution_id: &ExecutionId,
     ) -> Result<ExecutionEvent, DbErrorRead> {
-        unimplemented!("not used during replay")
+        // During replay, cancel_activity calls this to check if the child is already finished.
+        // Return a "Cancelled" finished event so cancel_activity returns CancelOutcome::Cancelled.
+        Ok(ExecutionEvent {
+            created_at: DateTime::UNIX_EPOCH,
+            event: ExecutionRequest::Finished {
+                retval: SupportedFunctionReturnValue::ExecutionError(
+                    concepts::FinishedExecutionError {
+                        reason: None,
+                        kind: concepts::ExecutionFailureKind::Cancelled,
+                        detail: None,
+                    },
+                ),
+                http_client_traces: None,
+            },
+            backtrace_id: None,
+            version: Version::new(0),
+        })
     }
 }
 
@@ -216,9 +235,10 @@ impl DbConnection for ReplayDbConnection {
         _execution_id: ExecutionId,
         _join_set_id: JoinSetId,
         _delay_id: DelayId,
-        _outcome: Result<(), ()>,
+        outcome: Result<(), ()>,
     ) -> Result<concepts::storage::AppendDelayResponseOutcome, DbErrorWrite> {
-        unimplemented!("not used during replay")
+        assert!(outcome.is_err(), "replay can only request to cancel delays");
+        Ok(concepts::storage::AppendDelayResponseOutcome::AlreadyCancelled)
     }
 
     async fn append_batch(
@@ -229,9 +249,7 @@ impl DbConnection for ReplayDbConnection {
         version: Version,
     ) -> Result<AppendBatchResponse, DbErrorWrite> {
         self.collect_events_from_batch(&batch);
-        Ok(Version::new(
-            version.0 + u32::try_from(batch.len()).unwrap(),
-        ))
+        Ok(next_version(&version, batch.len()))
     }
 
     async fn append_batch_create_new_execution(
@@ -244,9 +262,7 @@ impl DbConnection for ReplayDbConnection {
         _backtraces: Vec<BacktraceInfo>,
     ) -> Result<AppendBatchResponse, DbErrorWrite> {
         self.collect_events_from_batch(&batch);
-        Ok(Version::new(
-            version.0 + u32::try_from(batch.len()).unwrap(),
-        ))
+        Ok(next_version(&version, batch.len()))
     }
 
     async fn get_execution_event(

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -44,6 +44,7 @@ impl ReplayEventCollector {
 /// A `DbPool` that returns `ReplayDbConnection` instances.
 /// Read operations are passed through to the real database pool.
 pub(crate) struct ReplayDbPool {
+    execution_id: ExecutionId,
     collector: ReplayEventCollector,
     starting_version: Version,
     real_pool: Arc<dyn DbPool>,
@@ -51,11 +52,13 @@ pub(crate) struct ReplayDbPool {
 
 impl ReplayDbPool {
     pub(crate) fn new(
+        execution_id: ExecutionId,
         collector: ReplayEventCollector,
         starting_version: Version,
         real_pool: Arc<dyn DbPool>,
     ) -> Self {
         Self {
+            execution_id,
             collector,
             starting_version,
             real_pool,
@@ -67,6 +70,7 @@ impl ReplayDbPool {
 impl DbPool for ReplayDbPool {
     async fn db_exec_conn(&self) -> Result<Box<dyn DbExecutor>, DbErrorGeneric> {
         Ok(Box::new(ReplayDbConnection {
+            execution_id: self.execution_id.clone(),
             collector: self.collector.clone(),
             version: self.starting_version.clone(),
             real_connection: self.real_pool.connection().await?,
@@ -75,6 +79,7 @@ impl DbPool for ReplayDbPool {
 
     async fn connection(&self) -> Result<Box<dyn DbConnection>, DbErrorGeneric> {
         Ok(Box::new(ReplayDbConnection {
+            execution_id: self.execution_id.clone(),
             collector: self.collector.clone(),
             version: self.starting_version.clone(),
             real_connection: self.real_pool.connection().await?,
@@ -98,6 +103,7 @@ impl DbPool for ReplayDbPool {
 /// A `DbConnection` that captures history events instead of persisting them.
 /// Read operations are delegated to the real database connection.
 struct ReplayDbConnection {
+    execution_id: ExecutionId,
     collector: ReplayEventCollector,
     version: Version,
     real_connection: Box<dyn DbConnection>,
@@ -172,10 +178,11 @@ impl DbExecutor for ReplayDbConnection {
 
     async fn append(
         &self,
-        _execution_id: ExecutionId,
+        execution_id: ExecutionId,
         version: Version,
         req: AppendRequest,
     ) -> Result<AppendResponse, DbErrorWrite> {
+        assert_eq!(self.execution_id, execution_id);
         if let ExecutionRequest::HistoryEvent { event } = &req.event {
             self.collector.events.lock().unwrap().push(event.clone());
         }
@@ -188,6 +195,7 @@ impl DbExecutor for ReplayDbConnection {
         _response: AppendResponseToExecution,
         _current_time: DateTime<Utc>,
     ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        assert_eq!(self.execution_id, events.execution_id);
         self.collect_events_from_batch(&events.batch);
         Ok(next_version(&self.version, events.batch.len()))
     }
@@ -212,10 +220,11 @@ impl DbExecutor for ReplayDbConnection {
 
     async fn get_last_execution_event(
         &self,
-        _execution_id: &ExecutionId,
+        _activity_execution_id: &ExecutionId,
     ) -> Result<ExecutionEvent, DbErrorRead> {
         // During replay, cancel_activity calls this to check if the child is already finished.
         // Return a "Cancelled" finished event so cancel_activity returns CancelOutcome::Cancelled.
+        // `EventHistory::join_set_close` does not care about value of `CancelOutcome`.
         Ok(ExecutionEvent {
             created_at: DateTime::UNIX_EPOCH,
             event: ExecutionRequest::Finished {
@@ -237,17 +246,19 @@ impl DbExecutor for ReplayDbConnection {
 #[async_trait]
 impl DbConnection for ReplayDbConnection {
     async fn get(&self, execution_id: &ExecutionId) -> Result<ExecutionLog, DbErrorRead> {
+        // Allow getting the current state of a stubbed execution
         self.real_connection.get(execution_id).await
     }
 
     async fn append_delay_response(
         &self,
         _created_at: DateTime<Utc>,
-        _execution_id: ExecutionId,
+        execution_id: ExecutionId,
         _join_set_id: JoinSetId,
         _delay_id: DelayId,
         outcome: Result<(), ()>,
     ) -> Result<concepts::storage::AppendDelayResponseOutcome, DbErrorWrite> {
+        assert_eq!(self.execution_id, execution_id);
         assert!(outcome.is_err(), "replay can only request to cancel delays");
         Ok(concepts::storage::AppendDelayResponseOutcome::AlreadyCancelled)
     }
@@ -256,9 +267,10 @@ impl DbConnection for ReplayDbConnection {
         &self,
         _current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
-        _execution_id: ExecutionId,
+        execution_id: ExecutionId,
         version: Version,
     ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        assert_eq!(self.execution_id, execution_id);
         self.collect_events_from_batch(&batch);
         Ok(next_version(&version, batch.len()))
     }
@@ -267,15 +279,17 @@ impl DbConnection for ReplayDbConnection {
         &self,
         _current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
-        _execution_id: ExecutionId,
+        execution_id: ExecutionId,
         version: Version,
         _child_req: Vec<CreateRequest>,
         _backtraces: Vec<BacktraceInfo>,
     ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        assert_eq!(self.execution_id, execution_id);
         self.collect_events_from_batch(&batch);
         Ok(next_version(&version, batch.len()))
     }
 
+    // Needed for stubbed executions
     async fn get_execution_event(
         &self,
         execution_id: &ExecutionId,
@@ -286,6 +300,7 @@ impl DbConnection for ReplayDbConnection {
             .await
     }
 
+    // Needed for stubbed executions
     async fn get_pending_state(
         &self,
         execution_id: &ExecutionId,

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -42,16 +42,23 @@ impl ReplayEventCollector {
 }
 
 /// A `DbPool` that returns `ReplayDbConnection` instances.
+/// Read operations are passed through to the real database pool.
 pub(crate) struct ReplayDbPool {
     collector: ReplayEventCollector,
     starting_version: Version,
+    real_pool: Arc<dyn DbPool>,
 }
 
 impl ReplayDbPool {
-    pub(crate) fn new(collector: ReplayEventCollector, starting_version: Version) -> Self {
+    pub(crate) fn new(
+        collector: ReplayEventCollector,
+        starting_version: Version,
+        real_pool: Arc<dyn DbPool>,
+    ) -> Self {
         Self {
             collector,
             starting_version,
+            real_pool,
         }
     }
 }
@@ -62,6 +69,7 @@ impl DbPool for ReplayDbPool {
         Ok(Box::new(ReplayDbConnection {
             collector: self.collector.clone(),
             version: self.starting_version.clone(),
+            real_connection: self.real_pool.connection().await?,
         }))
     }
 
@@ -69,6 +77,7 @@ impl DbPool for ReplayDbPool {
         Ok(Box::new(ReplayDbConnection {
             collector: self.collector.clone(),
             version: self.starting_version.clone(),
+            real_connection: self.real_pool.connection().await?,
         }))
     }
 
@@ -78,7 +87,7 @@ impl DbPool for ReplayDbPool {
         unimplemented!("ReplayDbPool does not support external_api_conn")
     }
 
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(feature = "test")]
     async fn connection_test(
         &self,
     ) -> Result<Box<dyn concepts::storage::DbConnectionTest>, DbErrorGeneric> {
@@ -87,9 +96,11 @@ impl DbPool for ReplayDbPool {
 }
 
 /// A `DbConnection` that captures history events instead of persisting them.
+/// Read operations are delegated to the real database connection.
 struct ReplayDbConnection {
     collector: ReplayEventCollector,
     version: Version,
+    real_connection: Box<dyn DbConnection>,
 }
 
 impl ReplayDbConnection {
@@ -143,7 +154,7 @@ impl DbExecutor for ReplayDbConnection {
         unimplemented!("not used during replay")
     }
 
-    #[cfg(any(test, feature = "test"))]
+    #[cfg(feature = "test")]
     async fn lock_one(
         &self,
         _created_at: DateTime<Utc>,
@@ -225,8 +236,8 @@ impl DbExecutor for ReplayDbConnection {
 
 #[async_trait]
 impl DbConnection for ReplayDbConnection {
-    async fn get(&self, _execution_id: &ExecutionId) -> Result<ExecutionLog, DbErrorRead> {
-        unimplemented!("not used during replay")
+    async fn get(&self, execution_id: &ExecutionId) -> Result<ExecutionLog, DbErrorRead> {
+        self.real_connection.get(execution_id).await
     }
 
     async fn append_delay_response(
@@ -267,17 +278,19 @@ impl DbConnection for ReplayDbConnection {
 
     async fn get_execution_event(
         &self,
-        _execution_id: &ExecutionId,
-        _version: &Version,
+        execution_id: &ExecutionId,
+        version: &Version,
     ) -> Result<ExecutionEvent, DbErrorRead> {
-        unimplemented!("not used during replay")
+        self.real_connection
+            .get_execution_event(execution_id, version)
+            .await
     }
 
     async fn get_pending_state(
         &self,
-        _execution_id: &ExecutionId,
+        execution_id: &ExecutionId,
     ) -> Result<ExecutionWithState, DbErrorRead> {
-        unimplemented!("not used during replay")
+        self.real_connection.get_pending_state(execution_id).await
     }
 
     async fn get_expired_timers(

--- a/crates/wasm-workers/src/workflow/snapshots/obeli_sk_wasm_workers__workflow__workflow_js_worker__tests__workflow_js_replay_call_stub.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/obeli_sk_wasm_workers__workflow__workflow_js_worker__tests__workflow_js_replay_call_stub.snap
@@ -1,0 +1,40 @@
+---
+source: crates/wasm-workers/src/workflow/workflow_js_worker.rs
+expression: replay.next_events
+---
+[
+  {
+    "type": "join_set_create",
+    "join_set_id": "g:1"
+  },
+  {
+    "type": "join_set_request",
+    "join_set_id": "g:1",
+    "request": {
+      "type": "child_execution_request",
+      "child_execution_id": "E_00000000000000000000000000.g:1_1",
+      "target_ffqn": "testing:stub-activity/activity.foo",
+      "params": [
+        "test-input"
+      ],
+      "result": {
+        "Ok": null
+      }
+    }
+  },
+  {
+    "type": "stub",
+    "target_execution_id": "E_00000000000000000000000000.g:1_1",
+    "retval_hash": "011f9f1089426c4e2d1d6c761441181fba8e690f2baeccde7036a92c7d49d6b0e1",
+    "result": {
+      "Err": "execution_not_found"
+    }
+  },
+  {
+    "type": "join_next",
+    "join_set_id": "g:1",
+    "run_expires_at": "1970-01-01T00:00:00Z",
+    "requested_ffqn": null,
+    "closing": true
+  }
+]

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -75,14 +75,14 @@ pub(crate) enum WorkflowFunctionError {
     LockExpired,
     #[error("executor closing")]
     ExecutorClosing,
-    #[error("replay finished")]
-    ReplayFinished,
+    #[error("replay waiting for response")]
+    ReplayWaitingForResponse,
 }
 
 #[derive(Debug)]
 pub(crate) enum WorkerPartialResult {
     FatalError(FatalError, Version),
-    ReplayFinished,
+    ReplayWaitingForResponse,
     // retriable:
     InterruptDbUpdated,
     LockExpired,
@@ -119,7 +119,9 @@ impl WorkflowFunctionError {
             }
             WorkflowFunctionError::LockExpired => WorkerPartialResult::LockExpired,
             WorkflowFunctionError::ExecutorClosing => WorkerPartialResult::ExecutorClosing,
-            WorkflowFunctionError::ReplayFinished => WorkerPartialResult::ReplayFinished,
+            WorkflowFunctionError::ReplayWaitingForResponse => {
+                WorkerPartialResult::ReplayWaitingForResponse
+            }
         }
     }
 }
@@ -136,7 +138,7 @@ impl From<ApplyError> for WorkflowFunctionError {
                 WorkflowFunctionError::ConstraintViolation(reason)
             }
             ApplyError::ExecutorClosing => WorkflowFunctionError::ExecutorClosing,
-            ApplyError::ReplayFinished => WorkflowFunctionError::ReplayFinished,
+            ApplyError::ReplayWaitingForResponse => WorkflowFunctionError::ReplayWaitingForResponse,
         }
     }
 }
@@ -2829,7 +2831,7 @@ pub(crate) mod tests {
                 }
                 WorkerPartialResult::LockExpired
                 | WorkerPartialResult::ExecutorClosing
-                | WorkerPartialResult::ReplayFinished => {
+                | WorkerPartialResult::ReplayWaitingForResponse => {
                     unreachable!()
                 }
             }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -13,7 +13,7 @@ use crate::workflow::workflow_ctx::ReplayKind;
 use crate::workflow::workflow_worker::ReplayResponse;
 use async_trait::async_trait;
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
-use concepts::storage::{DbConnection, DbPool, Locked};
+use concepts::storage::{DbPool, Locked};
 use concepts::time::{ClockFn, ConstClock};
 use concepts::{
     ComponentId, ComponentRetryConfig, ComponentType, ExecutionFailureKind, ExecutionId,
@@ -358,7 +358,7 @@ impl WorkflowJsWorker {
         exim: &utils::wasm_tools::ExIm,
         engine: Arc<Engine>,
         fn_registry: Arc<dyn FunctionRegistry>,
-        db_conn: &dyn DbConnection,
+        real_db_pool: Arc<dyn DbPool>,
         execution_id: ExecutionId,
         logs_storage_config: Option<LogStrageConfig>,
         js_source: String,
@@ -376,6 +376,10 @@ impl WorkflowJsWorker {
             fuel: None,
         };
 
+        let db_conn = real_db_pool
+            .connection()
+            .await
+            .map_err(concepts::storage::DbErrorWrite::from)?;
         let log = db_conn
             .get(&execution_id)
             .await
@@ -426,6 +430,7 @@ impl WorkflowJsWorker {
         let db_pool = Arc::new(ReplayDbPool::new(
             event_collector.clone(),
             log.next_version.clone(),
+            real_db_pool,
         ));
         let ctx = WorkerContext {
             execution_id,
@@ -1240,7 +1245,7 @@ mod tests {
             &runnable_component.wasm_component.exim,
             workflow_engine,
             fn_registry,
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id,
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -2021,7 +2026,7 @@ mod tests {
             &runnable_component.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -2069,7 +2074,7 @@ mod tests {
             &runnable_component.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -2122,7 +2127,7 @@ mod tests {
             &runnable_component.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -2142,6 +2147,132 @@ mod tests {
         assert!(
             replay3.return_value.is_some(),
             "replay of a finished execution should include the return value"
+        );
+
+        db_close.close().await;
+    }
+
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_replay_call_stub(database: Database) {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+        use insta::assert_json_snapshot;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+
+        let js_source = r#"
+        export default function call_stub() {
+            const js = obelisk.createJoinSet();
+            const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            obelisk.stub(execId, { 'ok': 'hello' });
+            const response = js.joinNext();
+            if (!response.ok) throw 'stub failed';
+            return obelisk.getResult(execId).ok;
+        }"#;
+
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");
+        let sim_clock = SimClock::epoch();
+
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+
+        let (worker, component_id, runnable_component) = compile_js_workflow_worker(
+            js_source,
+            &user_ffqn,
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            fn_registry.clone(),
+            workflow_engine.clone(),
+        )
+        .await;
+
+        let workflow_exec =
+            new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
+
+        let execution_id = ExecutionId::from_parts(0, 0);
+        let created_at = sim_clock.now();
+        let db_connection = db_pool.connection_test().await.unwrap();
+
+        db_connection
+            .create(CreateRequest {
+                created_at,
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: component_id.clone(),
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        // replay on just-created execution
+        let (log_sender, _log_recv) = mpsc::channel(100);
+        let replay = WorkflowJsWorker::replay(
+            DeploymentId::generate(),
+            component_id.clone(),
+            runnable_component.wasmtime_component.clone(),
+            &runnable_component.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_pool.clone(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+            js_source.to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(4, replay.next_events.len());
+        assert_json_snapshot!(replay.next_events);
+
+        // Tick - should end with JoinNext
+        // Tick the execution (which already has JoinSetCreate in the log) to completion.
+        assert_eq!(
+            1,
+            workflow_exec
+                .tick_test_await(sim_clock.now(), RunId::generate())
+                .await
+                .len()
+        );
+        // Replay should return the return value
+        let replay = WorkflowJsWorker::replay(
+            DeploymentId::generate(),
+            component_id.clone(),
+            runnable_component.wasmtime_component.clone(),
+            &runnable_component.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_pool.clone(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+            js_source.to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert!(replay.next_events.is_empty());
+        let retval = replay.return_value.expect("retval should be computed");
+        let retval = assert_matches!(retval, SupportedFunctionReturnValue::Ok(Some(WastValWithType{ r#type: _, value })) => value);
+        assert_eq!(
+            "Result(Ok(Some(String(\"\\\"hello\\\"\"))))",
+            format!("{retval:?}")
         );
 
         db_close.close().await;

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -14,13 +14,13 @@ use async_trait::async_trait;
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
 use concepts::storage::{DbConnection, DbPool, Locked};
 use concepts::time::{ClockFn, ConstClock};
+use crate::workflow::replay_db_proxy::{ReplayDbPool, ReplayEventCollector};
 use concepts::{
     ComponentId, ComponentRetryConfig, ComponentType, ExecutionFailureKind, ExecutionId,
     ExecutionMetadata, FinishedExecutionError, FunctionFqn, FunctionMetadata, FunctionRegistry,
     PackageIfcFns, ParameterType, Params, ResultParsingError, ResultParsingErrorFromVal,
     ReturnTypeExtendable, SupportedFunctionReturnValue,
 };
-use db_mem::inmemory_dao::InMemoryPool;
 use executor::worker::{
     FatalError, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
 };
@@ -422,6 +422,11 @@ impl WorkflowJsWorker {
         } else {
             ReplayKind::Unfinished
         };
+        let event_collector = ReplayEventCollector::new();
+        let db_pool = Arc::new(ReplayDbPool::new(
+            event_collector.clone(),
+            log.next_version.clone(),
+        ));
         let ctx = WorkerContext {
             execution_id,
             metadata: ExecutionMetadata::empty(),
@@ -451,7 +456,6 @@ impl WorkflowJsWorker {
             clock_fn.clone_box(),
         )?;
         let linked = compiled.link(fn_registry)?;
-        let db_pool = Arc::new(InMemoryPool::new());
         let worker = linked.into_worker(
             deployment_id,
             db_pool,
@@ -459,7 +463,9 @@ impl WorkflowJsWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        worker.replay_internal(ctx, replay_kind).await
+        worker
+            .replay_internal(ctx, replay_kind, event_collector)
+            .await
     }
 }
 

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -8,13 +8,13 @@ use super::workflow_worker::{ReplayError, WorkflowConfig, WorkflowWorker, Workfl
 use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::LogStrageConfig;
 use crate::workflow::deadline_tracker::{DeadlineTrackerFactory, DeadlineTrackerFactoryForReplay};
+use crate::workflow::replay_db_proxy::{ReplayDbPool, ReplayEventCollector};
 use crate::workflow::workflow_ctx::ReplayKind;
 use crate::workflow::workflow_worker::ReplayResponse;
 use async_trait::async_trait;
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
 use concepts::storage::{DbConnection, DbPool, Locked};
 use concepts::time::{ClockFn, ConstClock};
-use crate::workflow::replay_db_proxy::{ReplayDbPool, ReplayEventCollector};
 use concepts::{
     ComponentId, ComponentRetryConfig, ComponentType, ExecutionFailureKind, ExecutionId,
     ExecutionMetadata, FinishedExecutionError, FunctionFqn, FunctionMetadata, FunctionRegistry,

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1950,4 +1950,200 @@ mod tests {
 
         db_close.close().await;
     }
+
+    /// Test: replay of a JS workflow that creates a join set and returns.
+    /// Replays at three stages:
+    /// 1. Just after creation (no events in DB) — preview returns `JoinSetCreate` + finished result.
+    /// 2. After `JoinSetCreate` event is manually inserted but execution is not finished — preview returns finished result.
+    /// 3. After the execution is fully done — replay returns finished result, no `next_events`.
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_replay_create_join_set(database: Database) {
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+
+        let js_source = r#"
+        export default function test_replay(params) {
+            const js = obelisk.createJoinSet();
+            return "done-" + js.id();
+        }"#;
+
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "test-replay");
+        let sim_clock = SimClock::epoch();
+
+        let fn_registry: Arc<dyn FunctionRegistry> =
+            TestingFnRegistry::new_from_components(Vec::new());
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+
+        let (worker, component_id, runnable_component) = compile_js_workflow_worker(
+            js_source,
+            &user_ffqn,
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            fn_registry.clone(),
+            workflow_engine.clone(),
+        )
+        .await;
+
+        let workflow_exec =
+            new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
+
+        let execution_id = ExecutionId::generate();
+        let created_at = sim_clock.now();
+        let db_connection = db_pool.connection_test().await.unwrap();
+
+        let params = Params::from_json_values_test(vec![json!(Vec::<String>::new())]);
+        db_connection
+            .create(CreateRequest {
+                created_at,
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params,
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: component_id.clone(),
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        // --- Stage 1: Replay on just-created execution (no events in DB) ---
+        let (log_sender, _log_recv) = mpsc::channel(100);
+        let replay = WorkflowJsWorker::replay(
+            DeploymentId::generate(),
+            component_id.clone(),
+            runnable_component.wasmtime_component.clone(),
+            &runnable_component.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+            js_source.to_string(),
+        )
+        .await
+        .unwrap();
+
+        info!("Stage 1 replay: {replay:?}");
+        assert!(
+            replay.return_value.is_some(),
+            "workflow should complete during preview (non-blocking events only)"
+        );
+        assert!(
+            !replay.next_events.is_empty(),
+            "preview should contain at least the JoinSetCreate event"
+        );
+        assert_matches!(&replay.next_events[0], HistoryEvent::JoinSetCreate { .. });
+
+        // --- Stage 2: Manually insert JoinSetCreate event, execution not finished ---
+        // Extract the JoinSetCreate event from the replay preview and insert it.
+        use concepts::storage::AppendRequest;
+        let join_set_create_event = replay.next_events[0].clone();
+        db_connection
+            .append_batch(
+                sim_clock.now(),
+                vec![AppendRequest {
+                    created_at: sim_clock.now(),
+                    event: ExecutionRequest::HistoryEvent {
+                        event: join_set_create_event.clone(),
+                    },
+                }],
+                execution_id.clone(),
+                Version::new(1),
+            )
+            .await
+            .unwrap();
+
+        let replay2 = WorkflowJsWorker::replay(
+            DeploymentId::generate(),
+            component_id.clone(),
+            runnable_component.wasmtime_component.clone(),
+            &runnable_component.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+            js_source.to_string(),
+        )
+        .await
+        .unwrap();
+
+        info!("Stage 2 replay: {replay2:?}");
+        assert!(
+            replay2.return_value.is_some(),
+            "workflow should complete even with partial event log (JoinSetCreate already present)"
+        );
+        // The JoinSetCreate is already in the log, so it should not appear as a next_event.
+        assert!(
+            !replay2
+                .next_events
+                .iter()
+                .any(|e| matches!(e, HistoryEvent::JoinSetCreate { .. })),
+            "JoinSetCreate should not appear in next_events since it's already in the log"
+        );
+
+        // --- Stage 3: Execute the workflow fully, then replay ---
+        // Tick the execution (which already has JoinSetCreate in the log) to completion.
+        assert_eq!(
+            1,
+            workflow_exec
+                .tick_test_await(sim_clock.now(), RunId::generate())
+                .await
+                .len()
+        );
+
+        let res = db_connection
+            .get_finished_result(&execution_id)
+            .await
+            .unwrap();
+        let ok_val = assert_matches!(&res, SupportedFunctionReturnValue::Ok(Some(val)) => val);
+        let result_str = assert_matches!(&ok_val.value, WastVal::String(s) => s);
+        assert!(
+            result_str.starts_with("done-"),
+            "unexpected result: {result_str}"
+        );
+
+        let replay3 = WorkflowJsWorker::replay(
+            DeploymentId::generate(),
+            component_id.clone(),
+            runnable_component.wasmtime_component.clone(),
+            &runnable_component.wasm_component.exim,
+            workflow_engine.clone(),
+            fn_registry.clone(),
+            db_connection.as_ref(),
+            execution_id.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender: log_sender.clone(),
+            }),
+            js_source.to_string(),
+        )
+        .await
+        .unwrap();
+
+        info!("Stage 3 replay: {replay3:?}");
+        assert!(
+            replay3.next_events.is_empty(),
+            "replay of a finished execution must have no next_events, got {:?}",
+            replay3.next_events
+        );
+        assert!(
+            replay3.return_value.is_some(),
+            "replay of a finished execution should include the return value"
+        );
+
+        db_close.close().await;
+    }
 }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -428,6 +428,7 @@ impl WorkflowJsWorker {
         };
         let event_collector = ReplayEventCollector::new();
         let db_pool = Arc::new(ReplayDbPool::new(
+            execution_id.clone(),
             event_collector.clone(),
             log.next_version.clone(),
             real_db_pool,

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2163,7 +2163,7 @@ mod tests {
         test_utils::set_up();
         let (_guard, db_pool, db_close) = database.set_up().await;
 
-        let js_source = r#"
+        let js_source = r"
         export default function call_stub() {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
@@ -2171,7 +2171,7 @@ mod tests {
             const response = js.joinNext();
             if (!response.ok) throw 'stub failed';
             return obelisk.getResult(execId).ok;
-        }"#;
+        }";
 
         let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");
         let sim_clock = SimClock::epoch();

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -9,6 +9,7 @@ use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::LogStrageConfig;
 use crate::workflow::deadline_tracker::{DeadlineTrackerFactory, DeadlineTrackerFactoryForReplay};
 use crate::workflow::workflow_ctx::ReplayKind;
+use crate::workflow::workflow_worker::ReplayResponse;
 use async_trait::async_trait;
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
 use concepts::storage::{DbConnection, DbPool, Locked};
@@ -361,7 +362,7 @@ impl WorkflowJsWorker {
         execution_id: ExecutionId,
         logs_storage_config: Option<LogStrageConfig>,
         js_source: String,
-    ) -> Result<(), ReplayError> {
+    ) -> Result<ReplayResponse, ReplayError> {
         let clock_fn = ConstClock(chrono::DateTime::from_timestamp_nanos(0));
 
         let config = WorkflowConfig {

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -11,7 +11,7 @@ use crate::{RunnableComponent, WasmFileError};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
-use concepts::storage::{DbConnection, DbErrorWrite, DbPool, HistoryEvent, Locked, Version};
+use concepts::storage::{DbErrorWrite, DbPool, HistoryEvent, Locked, Version};
 use concepts::time::{ClockFn, ConstClock, now_tokio_instant};
 use concepts::{
     ComponentId, ExecutionId, ExecutionMetadata, FunctionFqn, FunctionMetadata, PackageIfcFns,
@@ -907,7 +907,7 @@ impl WorkflowWorker {
         exim: &ExIm,
         engine: Arc<Engine>,
         fn_registry: Arc<dyn FunctionRegistry>,
-        db_conn: &dyn DbConnection,
+        real_db_pool: Arc<dyn DbPool>,
         execution_id: ExecutionId,
         logs_storage_config: Option<LogStrageConfig>,
     ) -> Result<ReplayResponse, ReplayError> {
@@ -922,6 +922,10 @@ impl WorkflowWorker {
             fuel: None,
         };
 
+        let db_conn = real_db_pool
+            .connection()
+            .await
+            .map_err(DbErrorWrite::from)?;
         let log = db_conn
             .get(&execution_id)
             .await
@@ -937,6 +941,7 @@ impl WorkflowWorker {
         let db_pool = Arc::new(ReplayDbPool::new(
             event_collector.clone(),
             log.next_version.clone(),
+            real_db_pool,
         ));
         let ctx = WorkerContext {
             execution_id: execution_id.clone(),
@@ -3726,7 +3731,7 @@ pub(crate) mod tests {
             &workflow_runnable.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -3779,7 +3784,7 @@ pub(crate) mod tests {
             &workflow_runnable.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -3824,7 +3829,7 @@ pub(crate) mod tests {
             &workflow_runnable.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,
@@ -3873,7 +3878,7 @@ pub(crate) mod tests {
             &workflow_runnable.wasm_component.exim,
             workflow_engine.clone(),
             fn_registry.clone(),
-            db_connection.as_ref(),
+            db_pool.clone(),
             execution_id.clone(),
             Some(LogStrageConfig {
                 min_level: concepts::storage::LogLevel::Debug,

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -846,7 +846,8 @@ impl WorkflowWorker {
                 Ok(None)
             }
             Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher)) => {
-                unreachable!("replay request does not end with DbUpdatedByWorkerOrWatcher")
+                debug!("Replay interrupted after writing events");
+                Ok(None)
             }
             Err(err) => {
                 debug!("Replay failed: {err:?}");

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -10,7 +10,7 @@ use crate::{RunnableComponent, WasmFileError};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
-use concepts::storage::{DbConnection, DbErrorWrite, DbPool, Locked, Version};
+use concepts::storage::{DbConnection, DbErrorWrite, DbPool, HistoryEvent, Locked, Version};
 use concepts::time::{ClockFn, ConstClock, now_tokio_instant};
 use concepts::{
     ComponentId, ExecutionId, ExecutionMetadata, FunctionFqn, FunctionMetadata, PackageIfcFns,
@@ -381,7 +381,7 @@ enum WorkerResultRefactored {
     DbError(DbErrorWrite),
     LockExpired(WorkflowCtx),
     ExecutorClosing(WorkflowCtx),
-    ReplayFinished,
+    ReplayWaitingForResponse,
 }
 
 type CallFuncResult = Result<(SupportedFunctionReturnValue, WorkflowCtx), RunError>;
@@ -428,7 +428,7 @@ enum PrepareFuncOk {
     },
 }
 
-pub(crate) struct ReplayFinished;
+struct ReplayWaitingForResponse;
 
 impl WorkflowWorker {
     async fn prepare_func(
@@ -640,7 +640,7 @@ impl WorkflowWorker {
         worker_span: &Span,
         execution_deadline: DateTime<Utc>,
         assigned_fuel: Option<u64>,
-    ) -> Result<Either<WorkerResultOk, ReplayFinished>, WorkflowError> {
+    ) -> Result<Either<WorkerResultOk, ReplayWaitingForResponse>, WorkflowError> {
         // call_func
         let elapsed = now_tokio_instant(); // Not using `clock_fn` here is ok, value is only used for log reporting.
         let res = Self::call_func(store, func, component_func, params, assigned_fuel).await;
@@ -661,7 +661,7 @@ impl WorkflowWorker {
                     Ok(Either::Left(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher)) => {
                         Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher))
                     }
-                    Ok(Either::Right(ReplayFinished)) => Ok(Either::Right(ReplayFinished)),
+                    Ok(Either::Right(replay_response)) => Ok(Either::Right(replay_response)),
                     Err(closing_err) => {
                         debug!("Error while closing join sets {closing_err:?}");
                         Err(closing_err)
@@ -715,7 +715,9 @@ impl WorkflowWorker {
                     workflow_ctx.db_connection.version.clone(),
                 ))
             }
-            WorkerResultRefactored::ReplayFinished => Ok(Either::Right(ReplayFinished)),
+            WorkerResultRefactored::ReplayWaitingForResponse => {
+                Ok(Either::Right(ReplayWaitingForResponse))
+            }
         }
     }
 
@@ -782,7 +784,9 @@ impl WorkflowWorker {
                         // logged in epoch callback
                         WorkerResultRefactored::ExecutorClosing(workflow_ctx)
                     }
-                    WorkerPartialResult::ReplayFinished => WorkerResultRefactored::ReplayFinished,
+                    WorkerPartialResult::ReplayWaitingForResponse => {
+                        WorkerResultRefactored::ReplayWaitingForResponse
+                    }
                 }
             }
             Err(RunError::ResultParsingError(err, mut workflow_ctx)) => {
@@ -801,7 +805,7 @@ impl WorkflowWorker {
 
     async fn close_join_sets(
         workflow_ctx: &mut WorkflowCtx,
-    ) -> Result<Either<CloseJoinSetOk, ReplayFinished>, WorkflowError> {
+    ) -> Result<Either<CloseJoinSetOk, ReplayWaitingForResponse>, WorkflowError> {
         match workflow_ctx.join_sets_close_on_finish().await {
             Ok(()) => Ok(Either::Left(CloseJoinSetOk::Ok)),
             Err(ApplyError::InterruptDbUpdated) => {
@@ -820,7 +824,9 @@ impl WorkflowWorker {
             Err(ApplyError::ExecutorClosing) => Err(WorkflowError::ExecutorClosing(
                 workflow_ctx.db_connection.version.clone(),
             )),
-            Err(ApplyError::ReplayFinished) => Ok(Either::Right(ReplayFinished)),
+            Err(ApplyError::ReplayWaitingForResponse) => {
+                Ok(Either::Right(ReplayWaitingForResponse))
+            }
         }
     }
 
@@ -828,32 +834,36 @@ impl WorkflowWorker {
         &self,
         ctx: WorkerContext,
         is_replay: ReplayKind,
-    ) -> Result<(), ReplayError> {
-        match self.run_internal(ctx, Some(is_replay)).await {
-            Ok(Either::Left(WorkerResultOk::RunFinished { .. })) => {
+    ) -> Result<ReplayResponse, ReplayError> {
+        let return_value = match self.run_internal(ctx, Some(is_replay)).await {
+            Ok(Either::Left(WorkerResultOk::RunFinished { retval, .. })) => {
                 debug!("Replay finished returning a value");
-                Ok(())
+                Ok(Some(retval))
             }
-            Ok(Either::Right(ReplayFinished)) => {
-                debug!("Replay concluded, execution is in progress");
-                Ok(())
+            Ok(Either::Right(ReplayWaitingForResponse)) => {
+                debug!("Replay waiting for response");
+                Ok(None)
             }
             Ok(Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher)) => {
-                debug!("Replay concluded asking for interrupt"); // Response did not arrive yet.
-                Ok(())
+                unreachable!("replay request does not end with DbUpdatedByWorkerOrWatcher")
             }
             Err(err) => {
                 debug!("Replay failed: {err:?}");
                 Err(ReplayError::from(err))
             }
-        }
+        }?;
+        // TODO: Collect `next_events`
+        Ok(ReplayResponse {
+            next_events: vec![], // FIXME
+            return_value,
+        })
     }
 
-    pub(crate) async fn run_internal(
+    async fn run_internal(
         &self,
         ctx: WorkerContext,
         is_replay: Option<ReplayKind>,
-    ) -> Result<Either<WorkerResultOk, ReplayFinished>, WorkflowError> {
+    ) -> Result<Either<WorkerResultOk, ReplayWaitingForResponse>, WorkflowError> {
         ctx.worker_span.in_scope(|| info!("Execution run started"));
         if !ctx.can_be_retried {
             warn!(
@@ -898,7 +908,7 @@ impl WorkflowWorker {
         db_conn: &dyn DbConnection,
         execution_id: ExecutionId,
         logs_storage_config: Option<LogStrageConfig>,
-    ) -> Result<(), ReplayError> {
+    ) -> Result<ReplayResponse, ReplayError> {
         let clock_fn = ConstClock(DateTime::UNIX_EPOCH);
         let config = WorkflowConfig {
             join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
@@ -969,6 +979,15 @@ enum CloseJoinSetOk {
     DbUpdatedByWorkerOrWatcher,
 }
 
+/// Result of replaying a workflow execution.
+#[derive(Debug, Clone, Default)]
+pub struct ReplayResponse {
+    /// Events that the workflow would produce next.
+    pub next_events: Vec<HistoryEvent>,
+    /// If the workflow completed during replay, contains the return value.
+    pub return_value: Option<SupportedFunctionReturnValue>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ReplayError {
     #[error(transparent)]
@@ -1016,12 +1035,12 @@ impl Worker for WorkflowWorker {
     async fn run(&self, ctx: WorkerContext) -> WorkerResult {
         match self
             .run_internal(
-                ctx, None, //is_replay
+                ctx, None, // is_replay
             )
             .await
         {
             Ok(Either::Left(ok)) => WorkerResult::Ok(ok),
-            Ok(Either::Right(_)) => unreachable!("replay was not requested"),
+            Ok(Either::Right(_)) => unreachable!("not replaying"),
             Err(workflow_err) => WorkerResult::Err(WorkerError::from(workflow_err)),
         }
     }
@@ -1079,8 +1098,8 @@ pub(crate) mod tests {
     use chrono::DateTime;
     use concepts::prefixed_ulid::{DEPLOYMENT_ID_DUMMY, ExecutionIdDerived};
     use concepts::storage::{
-        AppendEventsToExecution, AppendResponseToExecution, ExecutionLog, JoinSetResponse, Locked,
-        LockedBy, PendingStateFinishedError,
+        AppendEventsToExecution, AppendResponseToExecution, ExecutionLog, JoinSetRequest,
+        JoinSetResponse, Locked, LockedBy, PendingStateFinishedError,
     };
     use concepts::storage::{AppendRequest, DbConnection, DbPool, ExecutionRequest};
     use concepts::time::TokioSleep;
@@ -1126,6 +1145,9 @@ pub(crate) mod tests {
     pub const FIBOA_WORKFLOW_FFQN: FunctionFqn = FunctionFqn::new_static_tuple(
         test_programs_fibo_workflow_builder::exports::testing::fibo_workflow::workflow::FIBOA,
     ); // fiboa: func(n: u8, iterations: u32) -> u64;
+    pub const FIBOA_CONCURRENT_WORKFLOW_FFQN: FunctionFqn = FunctionFqn::new_static_tuple(
+        test_programs_fibo_workflow_builder::exports::testing::fibo_workflow::workflow::FIBOA_CONCURRENT,
+    ); // fiboa-concurrent: func(n: u8, iterations: u32) -> u64;
     pub const FIBOA_SUBMIT_JSON_WORKFLOW_FFQN: FunctionFqn = FunctionFqn::new_static_tuple(
         test_programs_fibo_workflow_builder::exports::testing::fibo_workflow::workflow::FIBOA_SUBMIT_JSON,
     ); // fiboa-submit-json: func(n: u8) -> u64;
@@ -3615,15 +3637,26 @@ pub(crate) mod tests {
     #[expand_enum_database]
     #[rstest]
     #[tokio::test]
-    async fn fibo_workflow_each_stage_replay(db: Database) {
+    async fn fibo_workflow_each_stage_replay(
+        db: Database,
+        #[values(1, 3)] activity_iterations: u32,
+    ) {
         let sim_clock = SimClock::epoch();
         let (_guard, db_pool, db_close) = db.set_up().await;
-        fibo_workflow_each_stage_replay_inner(db_pool.clone(), sim_clock).await;
+        Box::pin(fibo_workflow_each_stage_replay_inner(
+            activity_iterations,
+            db_pool.clone(),
+            sim_clock,
+        ))
+        .await;
         db_close.close().await;
     }
 
-    async fn fibo_workflow_each_stage_replay_inner(db_pool: Arc<dyn DbPool>, sim_clock: SimClock) {
-        const INPUT_ITERATIONS: u32 = 1;
+    async fn fibo_workflow_each_stage_replay_inner(
+        activity_iterations: u32,
+        db_pool: Arc<dyn DbPool>,
+        sim_clock: SimClock,
+    ) {
         test_utils::set_up();
 
         let workflow_engine =
@@ -3658,10 +3691,10 @@ pub(crate) mod tests {
             .create(CreateRequest {
                 created_at,
                 execution_id: execution_id.clone(),
-                ffqn: FIBOA_WORKFLOW_FFQN,
+                ffqn: FIBOA_CONCURRENT_WORKFLOW_FFQN,
                 params: Params::from_json_values_test(vec![
                     json!(FIBO_10_INPUT),
-                    json!(INPUT_ITERATIONS),
+                    json!(activity_iterations),
                 ]),
                 parent: None,
                 metadata: concepts::ExecutionMetadata::empty(),
@@ -3673,10 +3706,12 @@ pub(crate) mod tests {
             })
             .await
             .unwrap();
+        let activity_iterations = usize::try_from(activity_iterations).unwrap();
 
         let (log_sender, _log_storage_recv) = mpsc::channel(100);
-        // Replay just after creating
-        WorkflowWorker::replay(
+        // Replay just after creating - execution is unfinished with no events,
+        // preview should return the first event(s) the workflow would produce.
+        let replay = WorkflowWorker::replay(
             DeploymentId::generate(),
             workflow_exec.config.component_id.clone(),
             workflow_runnable.wasmtime_component.clone(),
@@ -3692,6 +3727,32 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
+        debug!("Preview after creation: {replay:?}");
+        assert!(
+            replay.return_value.is_none(),
+            "workflow should not have completed yet"
+        );
+        assert_eq!(
+            2 + activity_iterations,
+            replay.next_events.len(),
+            "unexpected next_events: {:?}",
+            replay.next_events
+        );
+        // Verify event types: JoinSetCreate, JoinSetRequest (submit) * activity_iterations, JoinNext (await)
+        assert_matches!(&replay.next_events[0], HistoryEvent::JoinSetCreate { .. });
+        for i in 1..=activity_iterations {
+            assert_matches!(
+                &replay.next_events[i],
+                HistoryEvent::JoinSetRequest {
+                    request: JoinSetRequest::ChildExecutionRequest { .. },
+                    ..
+                }
+            );
+        }
+        assert_matches!(
+            replay.next_events.last().unwrap(),
+            HistoryEvent::JoinNext { .. }
+        );
 
         info!("Should end as BlockedByJoinSet");
 
@@ -3701,8 +3762,9 @@ pub(crate) mod tests {
 
         assert_eq!(1, executed_workflows.wait_for_tasks().await.len());
 
-        // Replay before activity has finished
-        WorkflowWorker::replay(
+        // Replay before activity has finished - workflow is blocked by JoinNext,
+        // no response available, so preview cannot produce new events.
+        let replay = WorkflowWorker::replay(
             DeploymentId::generate(),
             workflow_exec.config.component_id.clone(),
             workflow_runnable.wasmtime_component.clone(),
@@ -3719,8 +3781,17 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        info!("Execution should call the activity and finish");
+        assert!(
+            replay.next_events.is_empty(),
+            "unexpected next_events: {:?}",
+            replay.next_events
+        );
+        assert!(
+            replay.return_value.is_none(),
+            "workflow should not have completed yet"
+        );
 
+        // Run all activities to completion.
         let activity_exec = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
@@ -3728,13 +3799,17 @@ pub(crate) mod tests {
             LockingStrategy::ByComponentDigest,
         )
         .await;
-        let executed_activities = activity_exec
-            .tick_test_await(sim_clock.now(), RunId::generate())
-            .await;
-        assert_eq!(1, executed_activities.len());
+        for _ in 0..activity_iterations {
+            let executed_activities = activity_exec
+                .tick_test_await(sim_clock.now(), RunId::generate())
+                .await;
+            assert_eq!(1, executed_activities.len());
+        }
 
-        // Replay after activity has finished but before the response was processed
-        WorkflowWorker::replay(
+        // Replay after all activities have finished but before the response was processed.
+        // With activity_iterations=1, the workflow completes → return_value is set, no next_events.
+        // With activity_iterations>1, the workflow processes one response and blocks on the next JoinNext.
+        let replay = WorkflowWorker::replay(
             DeploymentId::generate(),
             workflow_exec.config.component_id.clone(),
             workflow_runnable.wasmtime_component.clone(),
@@ -3750,6 +3825,16 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
+        // First JoinNext is already in db. Replay should return n - 1 JoinNext events
+        assert_eq!(
+            activity_iterations - 1,
+            replay.next_events.len(),
+            "unexpected replay response after activities finished: {replay:?}"
+        );
+        assert!(
+            replay.return_value.is_some(),
+            "workflow will complete in the next tick"
+        );
 
         sim_clock.move_time_forward(LOCK_EXPIRY_WORKFLOW); // another lock will be appended when the current one expires
 
@@ -3763,14 +3848,17 @@ pub(crate) mod tests {
             .get_finished_result(&execution_id)
             .await
             .unwrap();
+        // Compare prediction with reality
+        assert_eq!(replay.return_value.unwrap(), res);
+
         let res = assert_matches!(res, SupportedFunctionReturnValue::Ok(Some(val)) => val);
 
         let fibo = assert_matches!(res,
             WastValWithType {value: WastVal::U64(val), r#type: TypeWrapper::U64 } => val);
         assert_eq!(FIBO_10_OUTPUT, fibo);
 
-        // Replay after workflow was finished
-        WorkflowWorker::replay(
+        // Replay after workflow was finished - no next_events, return_value is present.
+        let replay = WorkflowWorker::replay(
             DeploymentId::generate(),
             workflow_exec.config.component_id.clone(),
             workflow_runnable.wasmtime_component.clone(),
@@ -3786,5 +3874,14 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
+        assert!(
+            replay.next_events.is_empty(),
+            "replay of a finished execution must have no next_events, got {:?}",
+            replay.next_events
+        );
+        assert!(
+            replay.return_value.is_some(),
+            "replay of a finished execution should include the return value"
+        );
     }
 }

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -939,6 +939,7 @@ impl WorkflowWorker {
         let (_executor_close_sender, executor_close_watcher) = tokio::sync::watch::channel(false);
         let event_collector = ReplayEventCollector::new();
         let db_pool = Arc::new(ReplayDbPool::new(
+            execution_id.clone(),
             event_collector.clone(),
             log.next_version.clone(),
             real_db_pool,

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -5,6 +5,7 @@ use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::LogStrageConfig;
 use crate::workflow::caching_db_connection::{CachingBuffer, CachingDbConnection};
 use crate::workflow::deadline_tracker::{DeadlineTrackerFactoryForReplay, EpochCallbackError};
+use crate::workflow::replay_db_proxy::{ReplayDbPool, ReplayEventCollector};
 use crate::workflow::workflow_ctx::{ImportedFnCall, ReplayKind, WorkerPartialResult};
 use crate::{RunnableComponent, WasmFileError};
 use async_trait::async_trait;
@@ -17,7 +18,6 @@ use concepts::{
     ResultParsingError, StrVariant, TrapKind,
 };
 use concepts::{FunctionRegistry, SupportedFunctionReturnValue};
-use db_mem::inmemory_dao::InMemoryPool;
 use executor::worker::{FatalError, WorkerContext, WorkerResult, WorkerResultOk};
 use executor::worker::{Worker, WorkerError};
 use itertools::Either;
@@ -834,6 +834,7 @@ impl WorkflowWorker {
         &self,
         ctx: WorkerContext,
         is_replay: ReplayKind,
+        event_collector: ReplayEventCollector,
     ) -> Result<ReplayResponse, ReplayError> {
         let return_value = match self.run_internal(ctx, Some(is_replay)).await {
             Ok(Either::Left(WorkerResultOk::RunFinished { retval, .. })) => {
@@ -852,9 +853,9 @@ impl WorkflowWorker {
                 Err(ReplayError::from(err))
             }
         }?;
-        // TODO: Collect `next_events`
+        let next_events = event_collector.take_events();
         Ok(ReplayResponse {
-            next_events: vec![], // FIXME
+            next_events,
             return_value,
         })
     }
@@ -931,7 +932,11 @@ impl WorkflowWorker {
         };
         // TODO: consider using current exec's watcher for faster cancellation
         let (_executor_close_sender, executor_close_watcher) = tokio::sync::watch::channel(false);
-        let db_pool = Arc::new(InMemoryPool::new());
+        let event_collector = ReplayEventCollector::new();
+        let db_pool = Arc::new(ReplayDbPool::new(
+            event_collector.clone(),
+            log.next_version.clone(),
+        ));
         let ctx = WorkerContext {
             execution_id: execution_id.clone(),
             metadata: ExecutionMetadata::empty(),
@@ -969,7 +974,9 @@ impl WorkflowWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        worker.replay_internal(ctx, replay_kind).await
+        worker
+            .replay_internal(ctx, replay_kind, event_collector)
+            .await
     }
 }
 

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -664,6 +664,8 @@ message ReplayExecutionRequest {
   ExecutionId execution_id = 1;
 }
 message ReplayExecutionResponse {
+  repeated ExecutionEvent.HistoryEvent next_events = 1;
+  optional SupportedFunctionResult return_value = 2;
 }
 
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -797,7 +797,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 &replay_info.runnable_component.wasm_component.exim,
                 self.engines.workflow_engine.clone(),
                 Arc::new(component_registry_ro.clone()),
-                conn.as_ref(),
+                self.db_pool.clone(),
                 execution_id.clone(),
                 logs_storage_config,
                 js_info.js_source.clone(),
@@ -811,7 +811,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 &replay_info.runnable_component.wasm_component.exim,
                 self.engines.workflow_engine.clone(),
                 Arc::new(component_registry_ro.clone()),
-                conn.as_ref(),
+                self.db_pool.clone(),
                 execution_id.clone(),
                 logs_storage_config,
             )
@@ -870,8 +870,6 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                         min_level,
                         log_sender: self.log_forwarder_sender.clone(),
                     });
-            let conn = self.db_pool.connection().await.map_err(map_to_status)?;
-
             let replay_res = if let Some(js_info) = &replay_info.js_workflow_info {
                 WorkflowJsWorker::replay(
                     deployment_id,
@@ -880,7 +878,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                     &replay_info.runnable_component.wasm_component.exim,
                     self.engines.workflow_engine.clone(),
                     Arc::new(component_registry_ro.clone()),
-                    conn.as_ref(),
+                    self.db_pool.clone(),
                     execution_id.clone(),
                     logs_storage_config,
                     js_info.js_source.clone(),
@@ -894,7 +892,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                     &replay_info.runnable_component.wasm_component.exim,
                     self.engines.workflow_engine.clone(),
                     Arc::new(component_registry_ro.clone()),
-                    conn.as_ref(),
+                    self.db_pool.clone(),
                     execution_id.clone(),
                     logs_storage_config,
                 )

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -46,6 +46,7 @@ use grpc::grpc_gen;
 use grpc::grpc_gen::GenerateExecutionIdResponse;
 use grpc::grpc_gen::GetStatusResponse;
 use grpc::grpc_gen::get_status_response::Message;
+use grpc::grpc_mapping;
 use grpc::grpc_mapping::TonicServerOptionExt;
 use grpc::grpc_mapping::TonicServerResultExt;
 use grpc::grpc_mapping::convert_length;
@@ -816,11 +817,20 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             )
             .await
         };
-        if let Err(err) = replay_res {
+        let replay_response = replay_res.map_err(|err| {
             info!("Replay failed: {err:?}");
-            return Err(tonic::Status::internal(format!("replay failed: {err}")));
-        }
-        Ok(tonic::Response::new(grpc_gen::ReplayExecutionResponse {}))
+            tonic::Status::internal(format!("replay failed: {err}"))
+        })?;
+        Ok(tonic::Response::new(grpc_gen::ReplayExecutionResponse {
+            next_events: replay_response
+                .next_events
+                .into_iter()
+                .map(grpc_mapping::history_event_to_grpc)
+                .collect(),
+            return_value: replay_response
+                .return_value
+                .map(grpc_gen::SupportedFunctionResult::from),
+        }))
     }
 
     #[instrument(skip_all, fields(execution_id))]

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1656,7 +1656,7 @@ async fn execution_replay(
             &replay_info.runnable_component.wasm_component.exim,
             state.engines.workflow_engine.clone(),
             Arc::new(component_registry_ro.clone()),
-            conn.as_ref(),
+            state.db_pool.clone(),
             execution_id.clone(),
             logs_storage_config,
             js_info.js_source.clone(),
@@ -1670,7 +1670,7 @@ async fn execution_replay(
             &replay_info.runnable_component.wasm_component.exim,
             state.engines.workflow_engine.clone(),
             Arc::new(component_registry_ro.clone()),
-            conn.as_ref(),
+            state.db_pool.clone(),
             execution_id.clone(),
             logs_storage_config,
         )
@@ -1752,12 +1752,6 @@ async fn execution_upgrade(
                     min_level,
                     log_sender: state.log_forwarder_sender.clone(),
                 });
-        let conn = state
-            .db_pool
-            .connection()
-            .await
-            .map_err(|e| ErrorWrapper(e, accept))?;
-
         let replay_res = if let Some(js_info) = &replay_info.js_workflow_info {
             WorkflowJsWorker::replay(
                 deployment_id,
@@ -1766,7 +1760,7 @@ async fn execution_upgrade(
                 &replay_info.runnable_component.wasm_component.exim,
                 state.engines.workflow_engine.clone(),
                 Arc::new(component_registry_ro.clone()),
-                conn.as_ref(),
+                state.db_pool.clone(),
                 execution_id.clone(),
                 logs_storage_config,
                 js_info.js_source.clone(),
@@ -1780,7 +1774,7 @@ async fn execution_upgrade(
                 &replay_info.runnable_component.wasm_component.exim,
                 state.engines.workflow_engine.clone(),
                 Arc::new(component_registry_ro.clone()),
-                conn.as_ref(),
+                state.db_pool.clone(),
                 execution_id.clone(),
                 logs_storage_config,
             )

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -28,8 +28,9 @@ use concepts::{
     storage::{
         self, BacktraceFilter, CancelOutcome, DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout,
         DbErrorWrite, DbErrorWriteNonRetriable, DbPool, ExecutionEvent, ExecutionListPagination,
-        ExecutionRequest, ExecutionWithState, ListExecutionsFilter, LogInfoAppendRow, Pagination,
-        PendingState, ResponseCursor, ResponseWithCursor, TimeoutOutcome, Version, VersionType,
+        ExecutionRequest, ExecutionWithState, HistoryEvent, ListExecutionsFilter, LogInfoAppendRow,
+        Pagination, PendingState, ResponseCursor, ResponseWithCursor, TimeoutOutcome, Version,
+        VersionType,
     },
     time::{ClockFn as _, Now, Sleep as _},
 };
@@ -118,6 +119,7 @@ pub(crate) struct WebApiState {
         ExecutionResponsesResponse,
         ExecutionStubPayload,
         RetVal,
+        ReplayResponseSer,
         ExecutionSubmitPayload,
         ExecutionUpgradePayload,
         logs::LogEntryRowSer,
@@ -1310,6 +1312,25 @@ impl From<SupportedFunctionReturnValue> for RetVal {
     }
 }
 
+/// Result of replaying a workflow execution
+#[derive(Debug, Serialize, ToSchema)]
+struct ReplayResponseSer {
+    /// Events that the workflow would produce next
+    #[schema(value_type = Vec<Object>)]
+    next_events: Vec<HistoryEvent>,
+    /// If the workflow completed during replay, contains the return value
+    return_value: Option<RetVal>,
+}
+
+impl From<wasm_workers::workflow::workflow_worker::ReplayResponse> for ReplayResponseSer {
+    fn from(value: wasm_workers::workflow::workflow_worker::ReplayResponse) -> Self {
+        Self {
+            next_events: value.next_events,
+            return_value: value.return_value.map(RetVal::from),
+        }
+    }
+}
+
 /// Get execution return value
 #[utoipa::path(
     get,
@@ -1580,7 +1601,7 @@ async fn stream_execution_response_task(
         ("execution_id" = String, Path, description = "Execution ID to replay")
     ),
     responses(
-        (status = 200, description = "Execution replayed"),
+        (status = 200, description = "Execution replayed", body = ReplayResponseSer),
         (status = 404, description = "Not found"),
         (status = 422, description = "Replay failed")
     )
@@ -1655,20 +1676,28 @@ async fn execution_replay(
         )
         .await
     };
-    if let Err(err) = replay_res {
+    let replay_response = replay_res.map_err(|err| {
         info!("Replay failed: {err:?}");
-        return Err(HttpResponse {
+        HttpResponse {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             message: format!("Replay failed: {err}"),
             accept,
-        });
-    }
-    Ok(HttpResponse {
-        status: StatusCode::OK,
-        message: "replayed".to_string(),
-        accept,
-    }
-    .into_response())
+        }
+    })?;
+    let ser = ReplayResponseSer::from(replay_response);
+    Ok(match accept {
+        AcceptHeader::Json => Json(ser).into_response(),
+        AcceptHeader::Text => {
+            let mut output = String::new();
+            for event in &ser.next_events {
+                writeln!(&mut output, "{event}").expect("writing to string");
+            }
+            if let Some(retval) = &ser.return_value {
+                writeln!(&mut output, "return_value: {retval:?}").expect("writing to string");
+            }
+            output.into_response()
+        }
+    })
 }
 
 /// Payload for upgrading an execution to a new component version


### PR DESCRIPTION
- **refactor(workflow): Add `ReplayResponse` to store future events**
- **refactor(workflow): Add `ReplayEventCollector`**
- **refactor(workflow): Implement missing methods in `replay_db_proxy`**
- **test(workflow): Add JS replay test with only join set creation**
- **feat(grpc,webapi): Extend replay response with next events and return value**
