### PR TITLE
capture writes for execution errors

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1099,8 +1099,15 @@
           "404": {
             "description": "Not found"
           },
-          "422": {
-            "description": "Replay failed"
+          "409": {
+            "description": "Replay failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReplayResponseSer"
+                }
+              }
+            }
           }
         }
       }
@@ -2378,6 +2385,31 @@
                 "type": "string",
                 "enum": [
                   "blocked"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "error",
+              "captured_writes",
+              "type"
+            ],
+            "properties": {
+              "captured_writes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CapturedWriteSer"
+                }
+              },
+              "error": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "replay_failed"
                 ]
               }
             }

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -1088,7 +1088,7 @@ pub enum ParamsParsingError {
         err: TypeConversionError,
     },
     #[error("parameters cannot be deserialized: {0}")]
-    ParamsDeserializationError(serde_json::Error),
+    ParamsDeserializationError(#[source] serde_json::Error),
     #[error("parameter cardinality mismatch, expected: {expected}, specified: {specified}")]
     ParameterCardinalityMismatch { expected: usize, specified: usize },
 }

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1024,6 +1024,7 @@ pub enum CapturedDbWrite {
         current_time: DateTime<Utc>,
     },
     AppendFinished {
+        // TODO: Extract struct AppendFinished
         execution_id: ExecutionId,
         version: Version,
         current_time: DateTime<Utc>,

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -180,3 +180,49 @@ impl From<FatalError> for FinishedExecutionError {
         }
     }
 }
+
+impl From<&FatalError> for FinishedExecutionError {
+    fn from(err: &FatalError) -> Self {
+        let reason_generic = err.to_string(); // Override with err's reason if no information is lost.
+        match err {
+            FatalError::NondeterminismDetected { detail } => FinishedExecutionError {
+                reason: None,
+                kind: ExecutionFailureKind::NondeterminismDetected,
+                detail: Some(detail.clone()),
+            },
+            FatalError::OutOfFuel { reason } => FinishedExecutionError {
+                reason: Some(reason.clone()),
+                kind: ExecutionFailureKind::OutOfFuel,
+                detail: None,
+            },
+            FatalError::ParamsParsingError(err) => FinishedExecutionError {
+                reason: Some(reason_generic),
+                kind: ExecutionFailureKind::Uncategorized,
+                detail: err.detail(),
+            },
+            FatalError::CannotInstantiate { reason, detail } => FinishedExecutionError {
+                reason: Some(reason.clone()),
+                kind: ExecutionFailureKind::Uncategorized,
+                detail: detail.clone(),
+            },
+            FatalError::ResultParsingError(_) | FatalError::ConstraintViolation { reason: _ } => {
+                FinishedExecutionError {
+                    reason: Some(reason_generic),
+                    kind: ExecutionFailureKind::Uncategorized,
+                    detail: None,
+                }
+            }
+            FatalError::ImportedFunctionCallError { detail, .. }
+            | FatalError::WorkflowTrap { detail, .. } => FinishedExecutionError {
+                reason: Some(reason_generic),
+                kind: ExecutionFailureKind::Uncategorized,
+                detail: detail.clone(),
+            },
+            FatalError::Cancelled => FinishedExecutionError {
+                kind: ExecutionFailureKind::Cancelled,
+                reason: None,
+                detail: None,
+            },
+        }
+    }
+}

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -32,11 +32,20 @@ pub enum WorkerResultOk {
     DbUpdatedByWorkerOrWatcher,
     /// The execution run has returned a valid `retval`. Activity with retry budget returning `err` will be retried by the executor.
     #[display("{retval}")]
+    // TODO: Extract
     RunFinished {
         retval: SupportedFunctionReturnValue,
         version: Version,
         http_client_traces: Option<Vec<HttpClientTrace>>,
     },
+}
+
+#[derive(Debug, derive_more::Display)]
+#[display("{retval}")]
+pub struct RunFinished {
+    pub retval: SupportedFunctionReturnValue,
+    pub version: Version,
+    pub http_client_traces: Option<Vec<HttpClientTrace>>,
 }
 
 #[derive(Debug)]

--- a/crates/testing/test-programs/js/workflow/return_wrong_type.js
+++ b/crates/testing/test-programs/js/workflow/return_wrong_type.js
@@ -1,0 +1,3 @@
+export default function return_wrong_type() {
+    return "not-a-number";
+}

--- a/crates/wasm-workers/src/js_worker_utils.rs
+++ b/crates/wasm-workers/src/js_worker_utils.rs
@@ -23,6 +23,20 @@ pub(crate) fn map_ok_variant(
         Ok(()),
     )
 }
+
+pub(crate) fn map_ok_variant_fatal(
+    val: Option<serde_json::Value>,
+    user_return_type: &ReturnTypeExtendable,
+    version: Version,
+) -> Result<SupportedFunctionReturnValue, (FatalError, Version)> {
+    map_variant_fatal(
+        val,
+        version,
+        user_return_type.type_wrapper_tl.ok.as_deref(),
+        Ok(()),
+    )
+}
+
 pub(crate) fn map_err_variant(
     val: Option<serde_json::Value>,
     user_return_type: &ReturnTypeExtendable,
@@ -36,12 +50,35 @@ pub(crate) fn map_err_variant(
     )
 }
 
+pub(crate) fn map_err_variant_fatal(
+    val: Option<serde_json::Value>,
+    user_return_type: &ReturnTypeExtendable,
+    version: Version,
+) -> Result<SupportedFunctionReturnValue, (FatalError, Version)> {
+    map_variant_fatal(
+        val,
+        version,
+        user_return_type.type_wrapper_tl.err.as_deref(),
+        Err(()),
+    )
+}
+
 fn map_variant(
     val: Option<serde_json::Value>,
     version: Version,
     expected_type: Option<&TypeWrapper>,
     variant: Result<(), ()>,
 ) -> Result<SupportedFunctionReturnValue, WorkerError> {
+    map_variant_fatal(val, version, expected_type, variant)
+        .map_err(|(err, version)| WorkerError::FatalError(err, version))
+}
+
+fn map_variant_fatal(
+    val: Option<serde_json::Value>,
+    version: Version,
+    expected_type: Option<&TypeWrapper>,
+    variant: Result<(), ()>,
+) -> Result<SupportedFunctionReturnValue, (FatalError, Version)> {
     let supported_func = if variant.is_ok() {
         SupportedFunctionReturnValue::Ok
     } else {
@@ -53,7 +90,7 @@ fn map_variant(
             let wvt =
                 val_json::wast_val_ser::deserialize_value(&ok_val, ty.clone())
                     .map_err(|err| {
-                        WorkerError::FatalError(
+                        (
                             FatalError::ResultParsingError(
                                 ResultParsingError::ResultParsingErrorFromVal(
                                     ResultParsingErrorFromVal::TypeCheckError(format!(
@@ -68,7 +105,7 @@ fn map_variant(
             Ok(supported_func(Some(wvt)))
         }
         (None, _) => Ok(supported_func(None)), // Convenience: unit type accepts (blocks) any response.
-        (Some(ty), val) => Err(WorkerError::FatalError(
+        (Some(ty), val) => Err((
             FatalError::ResultParsingError(ResultParsingError::ResultParsingErrorFromVal(
                 ResultParsingErrorFromVal::TypeCheckError(format!(
                     "failed to type check the {variant} variant `{val} as type {ty}",

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -327,7 +327,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         &mut self,
         execution_id: ExecutionId,
         req: AppendRequest,
-        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
         _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
@@ -347,7 +347,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         execution_id: ExecutionId,
         req: AppendRequest,
         cancellations: Option<JoinSetCloseCancellations>,
-        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
         _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
@@ -375,7 +375,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
-        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
         _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
@@ -403,7 +403,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
         child_req: Vec<CreateRequest>,
-        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
         _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -24,7 +24,7 @@ use concepts::{
     SupportedFunctionReturnValue,
 };
 use executor::worker::{
-    FatalError, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
+    FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
 };
 use std::sync::Arc;
 use tracing::{debug, info};
@@ -228,7 +228,19 @@ impl Worker for WorkflowJsWorker {
                 version,
                 http_client_traces,
                 &self.user_return_type,
-            ),
+            )
+            .map(
+                |RunFinished {
+                     retval,
+                     version,
+                     http_client_traces,
+                 }| WorkerResultOk::RunFinished {
+                    retval,
+                    version,
+                    http_client_traces,
+                },
+            )
+            .map_err(|(err, version)| WorkerError::FatalError(err, version)),
         }
     }
 }
@@ -240,7 +252,7 @@ fn transform_to_outer_result(
     version: Version,
     http_client_traces: Option<Vec<HttpClientTrace>>,
     user_return_type: &ReturnTypeExtendable,
-) -> WorkerResult {
+) -> Result<RunFinished, (FatalError, Version)> {
     match retval {
         SupportedFunctionReturnValue::Ok(Some(WastValWithType {
             r#type:
@@ -257,12 +269,12 @@ fn transform_to_outer_result(
             let Ok(ok_val) = serde_json::from_str(&ok_val) else {
                 unreachable!("workflow-js-runtime always sends JSON-encoded string")
             };
-            let retval = crate::js_worker_utils::map_ok_variant(
+            let retval = crate::js_worker_utils::map_ok_variant_fatal(
                 Some(ok_val),
                 user_return_type,
                 version.clone(),
             )?;
-            Ok(WorkerResultOk::RunFinished {
+            Ok(RunFinished {
                 retval,
                 version,
                 http_client_traces,
@@ -284,12 +296,12 @@ fn transform_to_outer_result(
             let Ok(err_val) = serde_json::from_str(&err_val) else {
                 unreachable!("workflow-js-runtime always sends JSON-encoded string")
             };
-            let retval = crate::js_worker_utils::map_err_variant(
+            let retval = crate::js_worker_utils::map_err_variant_fatal(
                 Some(err_val),
                 user_return_type,
                 version.clone(),
             )?;
-            Ok(WorkerResultOk::RunFinished {
+            Ok(RunFinished {
                 retval,
                 version,
                 http_client_traces,
@@ -312,7 +324,7 @@ fn transform_to_outer_result(
                         unreachable!("both variants have string payload")
                     };
 
-                    Err(WorkerError::FatalError(
+                    Err((
                         FatalError::ResultParsingError(
                             ResultParsingError::ResultParsingErrorFromVal(
                                 ResultParsingErrorFromVal::TypeCheckError(reason),
@@ -329,7 +341,7 @@ fn transform_to_outer_result(
                             None
                         }
                     });
-                    Err(WorkerError::FatalError(
+                    Err((
                         FatalError::CannotInstantiate {
                             reason: format!("js-runtime-error: {name}"),
                             detail,
@@ -341,7 +353,7 @@ fn transform_to_outer_result(
                     // This variant is returned when a workflow function fails,
                     // e.g., when joinNext returns an error from a child execution.
                     // We propagate this as an ExecutionError.
-                    Ok(WorkerResultOk::RunFinished {
+                    Ok(RunFinished {
                         retval: SupportedFunctionReturnValue::ExecutionError(
                             FinishedExecutionError {
                                 kind: ExecutionFailureKind::Uncategorized,
@@ -357,16 +369,35 @@ fn transform_to_outer_result(
             }
         }
 
-        retval @ SupportedFunctionReturnValue::ExecutionError(_) => {
-            Ok(WorkerResultOk::RunFinished {
-                retval,
-                version,
-                http_client_traces,
-            })
-        }
+        retval @ SupportedFunctionReturnValue::ExecutionError(_) => Ok(RunFinished {
+            retval,
+            version,
+            http_client_traces,
+        }),
 
         other => unreachable!("unexpected SupportedFunctionReturnValue: {other:?}"),
     }
+}
+
+fn transform_to_append_finished(
+    retval: SupportedFunctionReturnValue,
+    version: Version,
+    user_return_type: &ReturnTypeExtendable,
+) -> SupportedFunctionReturnValue {
+    let (retval, version_obtained) =
+        match transform_to_outer_result(retval, version.clone(), None, user_return_type) {
+            Ok(RunFinished {
+                retval, version, ..
+            }) => (retval, version),
+            Err((fatal_error, version)) => {
+                let retval = SupportedFunctionReturnValue::ExecutionError(
+                    FinishedExecutionError::from(fatal_error),
+                );
+                (retval, version)
+            }
+        };
+    assert_eq!(version, version_obtained);
+    retval
 }
 
 impl WorkflowJsWorker {
@@ -427,12 +458,8 @@ impl WorkflowJsWorker {
                         current_time,
                         retval, // workflow-js-runtime WASM result
                     } => {
-                        let Ok(WorkerResultOk::RunFinished {
-                            retval, version, ..
-                        }) = transform_to_outer_result(retval, version, None, user_return_type)
-                        else {
-                            unimplemented!("FIXME")
-                        };
+                        let retval =
+                            transform_to_append_finished(retval, version.clone(), user_return_type);
                         CapturedDbWrite::AppendFinished {
                             execution_id,
                             version,
@@ -519,13 +546,8 @@ impl WorkflowJsWorker {
             ..
         }) = fresh_replay.last_mut()
         {
-            let Ok(WorkerResultOk::RunFinished {
-                retval: retval_transformed,
-                ..
-            }) = transform_to_outer_result(retval.clone(), version.clone(), None, user_return_type)
-            else {
-                unimplemented!("FIXME")
-            };
+            let retval_transformed =
+                transform_to_append_finished(retval.clone(), version.clone(), user_return_type);
             *retval = retval_transformed;
         }
         WorkflowWorker::advance_from_log(

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -381,23 +381,23 @@ fn transform_to_outer_result(
 
 fn transform_to_append_finished(
     retval: SupportedFunctionReturnValue,
-    version: Version,
+    version: &Version,
     user_return_type: &ReturnTypeExtendable,
-) -> SupportedFunctionReturnValue {
-    let (retval, version_obtained) =
+) -> (SupportedFunctionReturnValue, Option<FatalError>) {
+    let (retval, version_obtained, fatal_error) =
         match transform_to_outer_result(retval, version.clone(), None, user_return_type) {
             Ok(RunFinished {
                 retval, version, ..
-            }) => (retval, version),
+            }) => (retval, version, None),
             Err((fatal_error, version)) => {
                 let retval = SupportedFunctionReturnValue::ExecutionError(
-                    FinishedExecutionError::from(fatal_error),
+                    FinishedExecutionError::from(&fatal_error),
                 );
-                (retval, version)
+                (retval, version, Some(fatal_error))
             }
         };
-    assert_eq!(version, version_obtained);
-    retval
+    assert_eq!(*version, version_obtained);
+    (retval, fatal_error)
 }
 
 impl WorkflowJsWorker {
@@ -429,9 +429,10 @@ impl WorkflowJsWorker {
             .get(&execution_id)
             .await
             .map_err(concepts::storage::DbErrorWrite::from)?;
-        let finished_result = log.as_finished_result();
+        let already_finished_result = log.as_finished_result();
         let (ffqn, params) = Self::boa_invocation(log.params(), js_source, None);
-        let captured_writes = WorkflowWorker::capture_replay_writes_from_log(
+
+        let (captured_writes, mut fatal_error) = WorkflowWorker::capture_replay_writes_from_log(
             deployment_id,
             component_id,
             wasmtime_component,
@@ -447,6 +448,7 @@ impl WorkflowJsWorker {
             params,
         )
         .await?;
+        // Remove side effects, unwrapping user retval or fatal error.
         let captured_writes: Vec<_> = captured_writes
             .into_iter()
             .map(|internal_write| {
@@ -458,8 +460,12 @@ impl WorkflowJsWorker {
                         current_time,
                         retval, // workflow-js-runtime WASM result
                     } => {
-                        let retval =
-                            transform_to_append_finished(retval, version.clone(), user_return_type);
+                        let (retval, fatal_error_from_wit) =
+                            transform_to_append_finished(retval, &version, user_return_type);
+                        if fatal_error_from_wit.is_some() {
+                            // TODO: can both fatal errors be present?
+                            fatal_error = fatal_error_from_wit;
+                        }
                         CapturedDbWrite::AppendFinished {
                             execution_id,
                             version,
@@ -471,15 +477,8 @@ impl WorkflowJsWorker {
                 }
             })
             .collect();
-        if !captured_writes.is_empty() {
-            Ok(ReplayResponse::Advanceable(ReplayAdvanceable {
-                captured_writes,
-            }))
-        } else if let Some(result) = finished_result {
-            Ok(ReplayResponse::Finished { result })
-        } else {
-            Ok(ReplayResponse::Blocked)
-        }
+
+        WorkflowWorker::replay_response(captured_writes, fatal_error, already_finished_result)
     }
 
     /// Advance a paused JS workflow by one interrupt boundary.
@@ -522,7 +521,7 @@ impl WorkflowJsWorker {
 
         let old_version = log.next_version.clone();
         let (ffqn, params) = Self::boa_invocation(log.params(), js_source, None);
-        let mut fresh_replay = WorkflowWorker::capture_replay_writes_from_log(
+        let (mut fresh_replay, _fatal_error) = WorkflowWorker::capture_replay_writes_from_log(
             deployment_id,
             component_id,
             wasmtime_component,
@@ -546,8 +545,8 @@ impl WorkflowJsWorker {
             ..
         }) = fresh_replay.last_mut()
         {
-            let retval_transformed =
-                transform_to_append_finished(retval.clone(), version.clone(), user_return_type);
+            let (retval_transformed, _fatal_error_from_wit) =
+                transform_to_append_finished(retval.clone(), version, user_return_type);
             *retval = retval_transformed;
         }
         WorkflowWorker::advance_from_log(

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -441,7 +441,7 @@ pub enum JoinSetCloseError {
     ExecutorClosing(Version),
 }
 impl JoinSetCloseError {
-    fn to_workflow_error(
+    fn into_workflow_error(
         self,
         db_connection: Box<dyn WorkflowDbConnection + 'static>,
     ) -> WorkflowError {
@@ -480,7 +480,7 @@ impl WorkflowWorker {
         log: ExecutionLog,
         ffqn: FunctionFqn,
         params: Params,
-    ) -> Result<Vec<InternalCapturedWrite>, ReplayError> {
+    ) -> Result<(Vec<InternalCapturedWrite>, Option<FatalError>), ReplayError> {
         let replay_kind = if log.is_finished() {
             ReplayKind::Finished
         } else {
@@ -542,14 +542,9 @@ impl WorkflowWorker {
             CancelRegistry::new(),
             logs_storage_config,
         );
-        let captured_writes = worker
+        worker
             .replay_internal(ctx, replay_db_connection, replay_kind)
-            .await?;
-        debug!(
-            "Execution replay completed, captured writes: {}",
-            captured_writes.len(),
-        );
-        Ok(captured_writes)
+            .await
     }
 
     pub(crate) async fn advance_from_log(
@@ -588,7 +583,7 @@ impl WorkflowWorker {
             "Advance written {} captured writes{}",
             requested.captured_writes.len(),
             if outcome.finished.is_some() {
-                " finishing the execution"
+                " finished the execution"
             } else {
                 ""
             }
@@ -836,7 +831,7 @@ impl WorkflowWorker {
                     }
                     Err(closing_err) => {
                         debug!("Error while closing join sets {closing_err:?}");
-                        Err(closing_err.to_workflow_error(workflow_ctx.db_connection))
+                        Err(closing_err.into_workflow_error(workflow_ctx.db_connection))
                     }
                 }
             }
@@ -863,7 +858,7 @@ impl WorkflowWorker {
                         );
                         // This can be a temporary db or limit reached error, schedule a retry
                         // to properly close join sets.
-                        Err(closing_err.to_workflow_error(workflow_ctx.db_connection))
+                        Err(closing_err.into_workflow_error(workflow_ctx.db_connection))
                     }
                 }
             }
@@ -998,20 +993,21 @@ impl WorkflowWorker {
         ctx: WorkerContext,
         replay_db_connection: ReplayWorkflowDbConnection,
         replay_kind: ReplayKind,
-    ) -> Result<Vec<InternalCapturedWrite>, ReplayError> {
-        let (retval, replay_db_connection) = match self
+    ) -> Result<(Vec<InternalCapturedWrite>, Option<FatalError>), ReplayError> {
+        let (retval, replay_db_connection, fatal_error) = match self
             .run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind))
             .await
         {
             Ok((Either::Left(WorkerResultOk::RunFinished { retval, .. }), db)) => {
-                Ok((Some(retval), db))
+                Ok((Some(retval), db, None))
             }
-            Ok((_, db)) => Ok((None, db)), // replay interrupted or db updated (both have writes) or execution is waiting
+            Ok((_, db)) => Ok((None, db, None)), // replay interrupted or db updated (both have writes) or execution is waiting
             Err(WorkflowError::FatalError { err, db_connection }) => {
                 debug!("Replay finished with fatal error: {err:?}");
-                let retval =
-                    SupportedFunctionReturnValue::ExecutionError(FinishedExecutionError::from(err));
-                Ok((Some(retval), db_connection))
+                let retval = SupportedFunctionReturnValue::ExecutionError(
+                    FinishedExecutionError::from(&err),
+                );
+                Ok((Some(retval), db_connection, Some(err)))
             }
             Err(err) => {
                 debug!("Replay failed: {err:?}");
@@ -1040,8 +1036,7 @@ impl WorkflowWorker {
                 retval,
             });
         }
-
-        Ok(replay_db_connection.into_writes())
+        Ok((replay_db_connection.into_writes(), fatal_error))
     }
 
     // Returns the same `db_connection` it was supplied.
@@ -1099,10 +1094,10 @@ impl WorkflowWorker {
             .get(&execution_id)
             .await
             .map_err(DbErrorWrite::from)?;
-        let finished_result = log.as_finished_result();
+        let already_finished_result = log.as_finished_result();
         let ffqn = log.ffqn().clone();
         let params = log.params().clone();
-        let captured_writes = Self::capture_replay_writes_from_log(
+        let (captured_writes, fatal_error) = Self::capture_replay_writes_from_log(
             deployment_id,
             component_id,
             wasmtime_component,
@@ -1118,15 +1113,29 @@ impl WorkflowWorker {
             params,
         )
         .await?;
+        // Remove side effects
         let captured_writes: Vec<_> = captured_writes
             .into_iter()
             .map(|write| write.write)
             .collect();
-        if !captured_writes.is_empty() {
+        Self::replay_response(captured_writes, fatal_error, already_finished_result)
+    }
+
+    pub(crate) fn replay_response(
+        captured_writes: Vec<CapturedDbWrite>,
+        fatal_error: Option<FatalError>,
+        already_finished_result: Option<SupportedFunctionReturnValue>,
+    ) -> Result<ReplayResponse, ReplayError> {
+        if let Some(err) = fatal_error {
+            Err(ReplayError::ReplayFailed {
+                err,
+                captured_writes,
+            })
+        } else if !captured_writes.is_empty() {
             Ok(ReplayResponse::Advanceable(ReplayAdvanceable {
                 captured_writes,
             }))
-        } else if let Some(result) = finished_result {
+        } else if let Some(result) = already_finished_result {
             Ok(ReplayResponse::Finished { result })
         } else {
             Ok(ReplayResponse::Blocked)
@@ -1179,7 +1188,7 @@ impl WorkflowWorker {
         let old_version = log.next_version.clone();
         let ffqn = log.ffqn().clone();
         let params = log.params().clone();
-        let fresh_replay = Self::capture_replay_writes_from_log(
+        let (fresh_replay, _fatal_error) = Self::capture_replay_writes_from_log(
             deployment_id,
             component_id,
             wasmtime_component,
@@ -1217,10 +1226,13 @@ enum CloseJoinSetOk {
 #[derive(Debug, Clone)]
 #[cfg_attr(any(test, feature = "test"), derive(serde::Serialize))]
 pub enum ReplayResponse {
+    /// Execution can be advanced by one or more captured writes.
     Advanceable(ReplayAdvanceable),
+    /// Execution is already finished.
     Finished {
         result: SupportedFunctionReturnValue,
     },
+    /// Replay did not capture any writes and the execution is not finished.
     Blocked,
 }
 
@@ -1338,6 +1350,13 @@ pub enum ReplayError {
     // Transient error
     #[error("executor closing")]
     ExecutorClosing,
+    /// Replay failed.
+    /// `captured_writes` is non-empty iff execution has not finished yet, and therefore can be advanced to an execution error.
+    #[error("fatal error: {err}")]
+    ReplayFailed {
+        err: FatalError,
+        captured_writes: Vec<CapturedDbWrite>,
+    },
 }
 impl From<WorkflowError> for ReplayError {
     fn from(value: WorkflowError) -> Self {

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -23,8 +23,8 @@ use concepts::storage::{
 };
 use concepts::time::{ClockFn, now_tokio_instant};
 use concepts::{
-    ComponentId, ExecutionId, ExecutionMetadata, FunctionFqn, FunctionMetadata, PackageIfcFns,
-    Params, ResultParsingError, StrVariant, TrapKind,
+    ComponentId, ExecutionId, ExecutionMetadata, FinishedExecutionError, FunctionFqn,
+    FunctionMetadata, PackageIfcFns, Params, ResultParsingError, StrVariant, TrapKind,
 };
 use concepts::{FunctionRegistry, SupportedFunctionReturnValue};
 use executor::worker::{FatalError, WorkerContext, WorkerResult, WorkerResultOk};
@@ -395,14 +395,18 @@ enum WorkerResultRefactored {
 
 type CallFuncResult = Result<(SupportedFunctionReturnValue, WorkflowCtx), RunError>;
 
-#[derive(Debug, thiserror::Error)]
-pub enum WorkflowError {
+#[derive(derive_more::Debug, thiserror::Error)]
+enum WorkflowError {
     #[error("limit reached: {reason}")]
     LimitReached { reason: String, version: Version },
     #[error(transparent)]
     DbError(DbErrorWrite),
-    #[error("fatal error: {0}")]
-    FatalError(FatalError, Version),
+    #[error("fatal error: {err}")]
+    FatalError {
+        err: FatalError,
+        #[debug(skip)]
+        db_connection: Box<dyn WorkflowDbConnection>,
+    },
     #[error("lock expired")]
     LockExpired(Version),
     #[error("executor closing")]
@@ -415,14 +419,38 @@ impl From<WorkflowError> for WorkerError {
                 WorkerError::LimitReached { reason, version }
             }
             WorkflowError::DbError(db_err) => WorkerError::DbError(db_err),
-            WorkflowError::FatalError(fatal_error, version) => {
-                WorkerError::FatalError(fatal_error, version)
+            WorkflowError::FatalError { err, db_connection } => {
+                WorkerError::FatalError(err, db_connection.version().clone())
             }
             WorkflowError::LockExpired(version) => WorkerError::TemporaryTimeout {
                 http_client_traces: None,
                 version,
             },
             WorkflowError::ExecutorClosing(version) => WorkerError::ExecutorClosing(version),
+        }
+    }
+}
+
+#[derive(derive_more::Debug, thiserror::Error)]
+pub enum JoinSetCloseError {
+    #[error(transparent)]
+    DbError(DbErrorWrite),
+    #[error("fatal error: {err}")]
+    FatalError { err: FatalError },
+    #[error("executor closing")]
+    ExecutorClosing(Version),
+}
+impl JoinSetCloseError {
+    fn to_workflow_error(
+        self,
+        db_connection: Box<dyn WorkflowDbConnection + 'static>,
+    ) -> WorkflowError {
+        match self {
+            JoinSetCloseError::DbError(db_error_write) => WorkflowError::DbError(db_error_write),
+            JoinSetCloseError::FatalError { err } => {
+                WorkflowError::FatalError { err, db_connection }
+            }
+            JoinSetCloseError::ExecutorClosing(version) => WorkflowError::ExecutorClosing(version),
         }
     }
 }
@@ -531,6 +559,10 @@ impl WorkflowWorker {
         fresh_replay: Vec<InternalCapturedWrite>,
         old_version: Version,
     ) -> Result<AdvanceResponse, AdvanceError> {
+        assert!(
+            !requested.captured_writes.is_empty(),
+            "caller must have checked for NoWrites error"
+        );
         let fresh_public_writes: Vec<_> = fresh_replay
             .iter()
             .map(|write| write.write.clone())
@@ -552,7 +584,15 @@ impl WorkflowWorker {
             return Err(AdvanceError::ReplayMismatch);
         };
 
-        info!("Advance finished with {outcome:?}");
+        info!(
+            "Advance written {} captured writes{}",
+            requested.captured_writes.len(),
+            if outcome.finished.is_some() {
+                " finishing the execution"
+            } else {
+                ""
+            }
+        );
         Ok(outcome)
     }
 
@@ -578,7 +618,6 @@ impl WorkflowWorker {
             }
         };
 
-        let version_at_start = ctx.version.clone();
         let seed = ctx.execution_id.random_seed();
         let workflow_ctx = WorkflowCtx::new(
             self.deployment_id,
@@ -634,32 +673,34 @@ impl WorkflowWorker {
             Ok(instance) => instance,
             Err(err) => {
                 let reason = err.to_string();
-                let version = store.into_data().db_connection.version().clone();
+                let db_connection = store.into_data().db_connection;
+                let version = db_connection.version().clone();
                 if reason.starts_with("maximum concurrent") {
                     return Err(WorkflowError::LimitReached { reason, version });
                 }
-                return Err(WorkflowError::FatalError(
-                    FatalError::CannotInstantiate {
+                return Err(WorkflowError::FatalError {
+                    err: FatalError::CannotInstantiate {
                         reason: format!("cannot instantiate: {err}"),
                         detail: Some(format!("{err:?}")),
                     },
-                    version,
-                ));
+                    db_connection,
+                });
             }
         };
 
         let func = {
             let Some(fn_export_index) = self.exported_ffqn_to_index.get(&ctx.ffqn) else {
-                return Err(WorkflowError::FatalError(
-                    FatalError::CannotInstantiate {
+                let db_connection = store.into_data().db_connection;
+                return Err(WorkflowError::FatalError {
+                    err: FatalError::CannotInstantiate {
                         reason: format!(
                             "function {} not found in exports of {}",
                             ctx.ffqn, self.config.component_id
                         ),
                         detail: None,
                     },
-                    store.into_data().db_connection.version().clone(),
-                ));
+                    db_connection,
+                });
             };
             instance
                 .get_func(&mut store, fn_export_index)
@@ -669,10 +710,11 @@ impl WorkflowWorker {
         let params = match ctx.params.as_vals(component_func.params()) {
             Ok(params) => params,
             Err(err) => {
-                return Err(WorkflowError::FatalError(
-                    FatalError::ParamsParsingError(err),
-                    version_at_start,
-                ));
+                let db_connection = store.into_data().db_connection;
+                return Err(WorkflowError::FatalError {
+                    err: FatalError::ParamsParsingError(err),
+                    db_connection,
+                });
             }
         };
         Ok(PrepareFuncFinished {
@@ -794,7 +836,7 @@ impl WorkflowWorker {
                     }
                     Err(closing_err) => {
                         debug!("Error while closing join sets {closing_err:?}");
-                        Err(closing_err)
+                        Err(closing_err.to_workflow_error(workflow_ctx.db_connection))
                     }
                 }
             }
@@ -810,10 +852,10 @@ impl WorkflowWorker {
                 match Self::close_join_sets(&mut workflow_ctx).await {
                     Ok(_) => {
                         // Propagate the original error
-                        Err(WorkflowError::FatalError(
+                        Err(WorkflowError::FatalError {
                             err,
-                            workflow_ctx.db_connection.version().clone(),
-                        ))
+                            db_connection: workflow_ctx.db_connection,
+                        })
                     }
                     Err(closing_err) => {
                         debug!(
@@ -821,7 +863,7 @@ impl WorkflowWorker {
                         );
                         // This can be a temporary db or limit reached error, schedule a retry
                         // to properly close join sets.
-                        Err(closing_err)
+                        Err(closing_err.to_workflow_error(workflow_ctx.db_connection))
                     }
                 }
             }
@@ -929,23 +971,20 @@ impl WorkflowWorker {
 
     async fn close_join_sets(
         workflow_ctx: &mut WorkflowCtx,
-    ) -> Result<Either<CloseJoinSetOk, ReplayWaitingForResponse>, WorkflowError> {
+    ) -> Result<Either<CloseJoinSetOk, ReplayWaitingForResponse>, JoinSetCloseError> {
         match workflow_ctx.join_sets_close_on_finish().await {
             Ok(()) => Ok(Either::Left(CloseJoinSetOk::Ok)),
             Err(ApplyError::InterruptDbUpdated) => {
                 Ok(Either::Left(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher))
             }
-
-            Err(ApplyError::DbError(db_error)) => Err(WorkflowError::DbError(db_error)),
-            Err(ApplyError::NondeterminismDetected(detail)) => Err(WorkflowError::FatalError(
-                FatalError::NondeterminismDetected { detail },
-                workflow_ctx.db_connection.version().clone(),
-            )),
-            Err(ApplyError::ConstraintViolation(reason)) => Err(WorkflowError::FatalError(
-                FatalError::ConstraintViolation { reason },
-                workflow_ctx.db_connection.version().clone(),
-            )),
-            Err(ApplyError::ExecutorClosing) => Err(WorkflowError::ExecutorClosing(
+            Err(ApplyError::DbError(db_error)) => Err(JoinSetCloseError::DbError(db_error)),
+            Err(ApplyError::NondeterminismDetected(detail)) => Err(JoinSetCloseError::FatalError {
+                err: FatalError::NondeterminismDetected { detail },
+            }),
+            Err(ApplyError::ConstraintViolation(reason)) => Err(JoinSetCloseError::FatalError {
+                err: FatalError::ConstraintViolation { reason },
+            }),
+            Err(ApplyError::ExecutorClosing) => Err(JoinSetCloseError::ExecutorClosing(
                 workflow_ctx.db_connection.version().clone(),
             )),
             Err(ApplyError::ReplayWaitingForResponse) => {
@@ -960,13 +999,25 @@ impl WorkflowWorker {
         replay_db_connection: ReplayWorkflowDbConnection,
         replay_kind: ReplayKind,
     ) -> Result<Vec<InternalCapturedWrite>, ReplayError> {
-        let (return_value, replay_db_connection) = self
+        let (retval, replay_db_connection) = match self
             .run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind))
             .await
-            .map_err(|err| {
+        {
+            Ok((Either::Left(WorkerResultOk::RunFinished { retval, .. }), db)) => {
+                Ok((Some(retval), db))
+            }
+            Ok((_, db)) => Ok((None, db)), // replay interrupted or db updated (both have writes) or execution is waiting
+            Err(WorkflowError::FatalError { err, db_connection }) => {
+                debug!("Replay finished with fatal error: {err:?}");
+                let retval =
+                    SupportedFunctionReturnValue::ExecutionError(FinishedExecutionError::from(err));
+                Ok((Some(retval), db_connection))
+            }
+            Err(err) => {
                 debug!("Replay failed: {err:?}");
-                ReplayError::from(err)
-            })?;
+                Err(ReplayError::from(err))
+            }
+        }?;
 
         let Ok(mut replay_db_connection) = replay_db_connection
             .as_any()
@@ -976,7 +1027,7 @@ impl WorkflowWorker {
         };
 
         if replay_kind == ReplayKind::Unfinished
-            && let Either::Left(WorkerResultOk::RunFinished { retval, .. }) = return_value
+            && let Some(retval) = retval
         {
             debug!("Replay finished returning a value: {retval:?}");
             // Capture the Finished event that the executor would write.
@@ -1287,9 +1338,6 @@ pub enum ReplayError {
     // Transient error
     #[error("executor closing")]
     ExecutorClosing,
-    /// Replay failed
-    #[error("fatal error: {0}")]
-    ReplayFailed(FatalError),
 }
 impl From<WorkflowError> for ReplayError {
     fn from(value: WorkflowError) -> Self {
@@ -1298,9 +1346,9 @@ impl From<WorkflowError> for ReplayError {
                 ReplayError::LimitReached { reason, version }
             }
             WorkflowError::DbError(db_error_write) => ReplayError::DbError(db_error_write),
-            WorkflowError::FatalError(fatal_error, _version) => {
-                ReplayError::ReplayFailed(fatal_error)
-            }
+            WorkflowError::FatalError { .. } => unreachable!(
+                "fatal errors are transformed to SupportedFunctionReturnValue::ExecutionError"
+            ),
             WorkflowError::LockExpired(_version) => ReplayError::LockExpired,
             WorkflowError::ExecutorClosing(_version) => ReplayError::ExecutorClosing,
         }

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -826,10 +826,16 @@ message ReplayExecutionResponse {
   message Blocked {
   }
 
+  message ReplayFailed {
+    string error = 1;
+    repeated CapturedWrite captured_writes = 2;
+  }
+
   oneof outcome {
     Advanceable advanceable = 1;
     Finished finished = 2;
     Blocked blocked = 3;
+    ReplayFailed replay_failed = 4;
   }
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -619,6 +619,9 @@ pub(crate) enum Execution {
         /// Rewrite replayed submitted executions so they are created paused when advance is applied.
         #[arg(long)]
         pause_submitted: bool,
+        /// Advance even if replay failed with an error, persisting the execution error.
+        #[arg(long)]
+        force: bool,
     },
     /// Upgrade a workflow execution to the current component version in the active deployment.
     ///

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -184,7 +184,8 @@ impl args::Execution {
                 json,
                 trim,
                 pause_submitted,
-            } => advance(&api_url, execution_id, json, trim, pause_submitted).await,
+                force,
+            } => advance(&api_url, execution_id, json, trim, pause_submitted, force).await,
             args::Execution::Upgrade {
                 api_url,
                 execution_id,
@@ -600,6 +601,7 @@ async fn replay(api_url: &str, execution_id: ExecutionId, json: bool) -> anyhow:
     send_and_print(req).await
 }
 
+/// Fetch replay response as JSON. Accepts both 200 (success) and 422 (replay failed with body).
 async fn replay_json(
     api_url: &str,
     execution_id: &ExecutionId,
@@ -612,7 +614,7 @@ async fn replay_json(
         .await
         .context("failed to send replay request")?;
     let status = resp.status();
-    if !status.is_success() {
+    if !status.is_success() && status != reqwest::StatusCode::CONFLICT {
         let body = resp.text().await.unwrap_or_default();
         bail!("server returned {status}: {body}");
     }
@@ -639,7 +641,10 @@ fn trim_replay(advance_request: &mut AdvanceRequestSer, trim: usize) {
     advance_request.captured_writes.truncate(trim);
 }
 
-fn replay_to_advanceable_request(replay: &serde_json::Value) -> anyhow::Result<AdvanceRequestSer> {
+fn replay_to_advanceable_request(
+    replay: &serde_json::Value,
+    force: bool,
+) -> anyhow::Result<AdvanceRequestSer> {
     let replay: ReplayResponseSer = serde_json::from_value(replay.clone())
         .context("failed to decode replay response as ReplayResponseSer")?;
     match replay {
@@ -652,6 +657,22 @@ fn replay_to_advanceable_request(replay: &serde_json::Value) -> anyhow::Result<A
         ReplayResponseSer::Blocked => {
             bail!("execution is blocked")
         }
+        ReplayResponseSer::ReplayFailed {
+            error,
+            captured_writes,
+        } => {
+            if force {
+                eprintln!(
+                    "Replay failed: {error}. Advancing with --force to persist execution error."
+                );
+                Ok(AdvanceRequestSer { captured_writes })
+            } else {
+                bail!(
+                    "replay failed: {error}, {} captured writes available (use --force to advance with execution error)",
+                    captured_writes.len()
+                )
+            }
+        }
     }
 }
 
@@ -661,9 +682,10 @@ async fn advance(
     json: bool,
     trim: Option<usize>,
     pause_submitted: bool,
+    force: bool,
 ) -> anyhow::Result<()> {
     let replay = replay_json(api_url, &execution_id).await?;
-    let mut advance_request = replay_to_advanceable_request(&replay)?;
+    let mut advance_request = replay_to_advanceable_request(&replay, force)?;
     if let Some(trim) = trim {
         trim_replay(&mut advance_request, trim);
     }

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -263,6 +263,13 @@ ffqn = "testing:integration/workflow-date-now.date-now"
 params = []
 return_type = "result<string, string>"
 
+[[workflow_js]]
+name = "test_return_wrong_type_workflow"
+location = "{ws}/crates/testing/test-programs/js/workflow/return_wrong_type.js"
+ffqn = "testing:integration/workflow-return-wrong-type.return-wrong-type"
+params = []
+return_type = "result<u32>"
+
 [[activity_js]]
 name = "test_hmac_sign_verify_activity"
 location = "{ws}/crates/testing/test-programs/js/activity/hmac_sign_verify.js"
@@ -833,6 +840,31 @@ enum TestExecutionClient {
     WebApi,
 }
 
+fn grpc_result_to_json(value: grpc::grpc_gen::SupportedFunctionResult) -> serde_json::Value {
+    match value.value {
+        Some(grpc::grpc_gen::supported_function_result::Value::Ok(ok)) => {
+            let return_value = ok.return_value.expect("ok return_value must exist");
+            let ok = serde_json::from_slice::<serde_json::Value>(&return_value.value)
+                .expect("server must send `return_value` as a valid JSON");
+            json!({ "ok": ok })
+        }
+        Some(grpc::grpc_gen::supported_function_result::Value::Error(err)) => {
+            let return_value = err.return_value.expect("err return_value must exist");
+            let err = serde_json::from_slice::<serde_json::Value>(&return_value.value)
+                .expect("server must send `return_value` as a valid JSON");
+            json!({ "err": err })
+        }
+        Some(grpc::grpc_gen::supported_function_result::Value::ExecutionFailure(failure)) => {
+            json!({ "execution_error": {
+                "kind": failure.kind,
+                "reason": failure.reason,
+                "detail": failure.detail,
+            }})
+        }
+        None => panic!("SupportedFunctionResult value must be set"),
+    }
+}
+
 #[derive(Debug)]
 struct ReplayCapturedWritesSummary {
     captured_writes_len: usize,
@@ -897,7 +929,30 @@ impl TestExecutionClient {
                             captured_writes_len: 0,
                         }
                     }
+                    grpc::grpc_gen::replay_execution_response::Outcome::ReplayFailed(failed) => {
+                        panic!("unexpected replay failure: {}", failed.error)
+                    }
                 }
+            }
+        }
+    }
+
+    async fn step_execution_until_finished(
+        self,
+        server: &TestServer,
+        ffqn: &str,
+        params: Vec<Value>,
+    ) -> AdvanceExecutionSummary {
+        match self {
+            TestExecutionClient::WebApi => {
+                server
+                    .step_execution_until_finished_webapi(ffqn, params)
+                    .await
+            }
+            TestExecutionClient::Grpc => {
+                server
+                    .step_execution_until_finished_grpc(ffqn, params)
+                    .await
             }
         }
     }
@@ -1056,19 +1111,16 @@ impl TestServer {
                 }
                 grpc::grpc_gen::replay_execution_response::Outcome::Finished(finished) => {
                     let value = finished.result.expect("finished result must be set");
-                    let ok_payload = match value.value {
-                        Some(grpc::grpc_gen::supported_function_result::Value::Ok(ok)) => ok,
-                        other => panic!("expected ok finished value, got {other:?}"),
-                    };
-                    let return_value = ok_payload.return_value.expect("ok return_value must exist");
                     return AdvanceExecutionSummary {
                         steps,
-                        retval: serde_json::from_slice(&return_value.value)
-                            .expect("server must send `return_value` as a valid JSON"),
+                        retval: grpc_result_to_json(value),
                     };
                 }
                 grpc::grpc_gen::replay_execution_response::Outcome::Blocked(_) => {
                     unreachable!("blocked state is not created by any test")
+                }
+                grpc::grpc_gen::replay_execution_response::Outcome::ReplayFailed(failed) => {
+                    failed.captured_writes
                 }
             };
 
@@ -1086,16 +1138,9 @@ impl TestServer {
             match advance.result.expect("advance result must be set") {
                 grpc::grpc_gen::advance_execution_response::Result::Success(success) => {
                     if let Some(value) = success.finished {
-                        let ok_payload = match value.value {
-                            Some(grpc::grpc_gen::supported_function_result::Value::Ok(ok)) => ok,
-                            other => panic!("expected ok finished value, got {other:?}"),
-                        };
-                        let ok = ok_payload.return_value.expect("ok return_value must exist");
-                        let ok = serde_json::from_slice::<serde_json::Value>(&ok.value)
-                            .expect("server must send `return_value` as a valid JSON");
                         return AdvanceExecutionSummary {
                             steps,
-                            retval: json!({"ok": ok}),
+                            retval: grpc_result_to_json(value),
                         };
                     }
                 }
@@ -1146,10 +1191,17 @@ impl TestServer {
         let mut steps = 0;
         loop {
             let replay = self.replay(&exec_id).await;
-            assert_eq!(replay.status().as_u16(), 200);
+            let replay_status = replay.status().as_u16();
+            assert!(
+                replay_status == 200 || replay_status == 409,
+                "unexpected replay status: {replay_status}"
+            );
             let replay_body: ReplayResponseSer = replay.json().await.unwrap();
             let captured_writes = match replay_body {
-                ReplayResponseSer::Advanceable { captured_writes } => captured_writes,
+                ReplayResponseSer::Advanceable { captured_writes }
+                | ReplayResponseSer::ReplayFailed {
+                    captured_writes, ..
+                } => captured_writes,
                 ReplayResponseSer::Finished { retval: _ } => {
                     panic!("should have been returned as `advance` response first");
                 }
@@ -1393,17 +1445,18 @@ async fn replaying_paused_workflow_should_return_preview_events(
     server.shutdown().await;
 }
 
-#[tokio::test]
-async fn replay_and_advance_paused_js_workflow_until_finished_grpc() {
-    let server = TestServer::start(test_addr!(64)).await;
-
-    let stepped = server
-        .step_execution_until_finished_grpc(
+async fn replay_and_advance_paused_js_workflow_until_finished(
+    client: TestExecutionClient,
+    addr: String,
+) {
+    let server = TestServer::start(addr).await;
+    let stepped = client
+        .step_execution_until_finished(
+            &server,
             "testing:integration/workflow-call-stub.call-stub",
             vec![json!(123_u64)],
         )
         .await;
-
     assert!(
         stepped.steps > 0,
         "step-through harness must execute at least one replay+advance round"
@@ -1413,23 +1466,46 @@ async fn replay_and_advance_paused_js_workflow_until_finished_grpc() {
 }
 
 #[tokio::test]
-async fn replay_and_advance_paused_js_workflow_until_finished_webapi() {
-    let server = TestServer::start(test_addr!(65)).await;
-
-    let stepped = server
-        .step_execution_until_finished_webapi(
-            "testing:integration/workflow-call-stub.call-stub",
-            vec![json!(123_u64)],
-        )
+async fn replay_and_advance_paused_js_workflow_until_finished_grpc() {
+    replay_and_advance_paused_js_workflow_until_finished(TestExecutionClient::Grpc, test_addr!(64))
         .await;
+}
 
+#[tokio::test]
+async fn replay_and_advance_paused_js_workflow_until_finished_webapi() {
+    replay_and_advance_paused_js_workflow_until_finished(
+        TestExecutionClient::WebApi,
+        test_addr!(65),
+    )
+    .await;
+}
+
+// ---- Workflow: replay failed (type mismatch) with advance --force ----
+
+const REPLAY_FAILED_FFQN: &str = "testing:integration/workflow-return-wrong-type.return-wrong-type";
+
+async fn replay_failed_js_workflow_then_advance(client: TestExecutionClient, addr: String) {
+    let server = TestServer::start(addr).await;
+    let stepped = client
+        .step_execution_until_finished(&server, REPLAY_FAILED_FFQN, vec![])
+        .await;
+    assert_eq!(stepped.steps, 1);
     assert!(
-        stepped.steps > 0,
-        "step-through harness must execute at least one replay+advance round"
+        stepped.retval["execution_error"].is_object(),
+        "expected execution_error in retval, got: {}",
+        stepped.retval
     );
-    assert_eq!(stepped.retval, json!({"ok":"stub-ok"}));
-
     server.shutdown().await;
+}
+
+#[tokio::test]
+async fn replay_failed_js_workflow_then_advance_webapi() {
+    replay_failed_js_workflow_then_advance(TestExecutionClient::WebApi, test_addr!(67)).await;
+}
+
+#[tokio::test]
+async fn replay_failed_js_workflow_then_advance_grpc() {
+    replay_failed_js_workflow_then_advance(TestExecutionClient::Grpc, test_addr!(68)).await;
 }
 
 // ---- Workflow: submit activity via join set + getResult ----

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -222,6 +222,13 @@ expression: components
   },
   {
     "component_id": {
+      "component_type": "workflow",
+      "name": "test_return_wrong_type_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_hello_webhook",
       "component_digest": "sha256:<REDACTED>"

--- a/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
@@ -95,5 +95,8 @@ expression: functions
   },
   {
     "ffqn": "testing:integration/workflow-date-now.date-now"
+  },
+  {
+    "ffqn": "testing:integration/workflow-return-wrong-type.return-wrong-type"
   }
 ]

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -822,12 +822,8 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             )
             .await
         };
-        let replay_response = replay_res.map_err(|err| {
-            info!("Replay failed: {err:?}");
-            tonic::Status::internal(format!("replay failed: {err}"))
-        })?;
-        let outcome = match replay_response {
-            ReplayResponse::Advanceable(replay) => {
+        let outcome = match replay_res {
+            Ok(ReplayResponse::Advanceable(replay)) => {
                 grpc_gen::replay_execution_response::Outcome::Advanceable(
                     grpc_gen::replay_execution_response::Advanceable {
                         captured_writes: replay
@@ -838,16 +834,35 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                     },
                 )
             }
-            ReplayResponse::Finished { result } => {
+            Ok(ReplayResponse::Finished { result }) => {
                 grpc_gen::replay_execution_response::Outcome::Finished(
                     grpc_gen::replay_execution_response::Finished {
                         result: Some(grpc_gen::SupportedFunctionResult::from(result)),
                     },
                 )
             }
-            ReplayResponse::Blocked => grpc_gen::replay_execution_response::Outcome::Blocked(
+            Ok(ReplayResponse::Blocked) => grpc_gen::replay_execution_response::Outcome::Blocked(
                 grpc_gen::replay_execution_response::Blocked {},
             ),
+            Err(wasm_workers::workflow::workflow_worker::ReplayError::ReplayFailed {
+                err,
+                captured_writes,
+            }) => {
+                info!("Replay failed: {err:?}");
+                grpc_gen::replay_execution_response::Outcome::ReplayFailed(
+                    grpc_gen::replay_execution_response::ReplayFailed {
+                        error: err.to_string(),
+                        captured_writes: captured_writes
+                            .into_iter()
+                            .map(grpc_mapping::captured_write_to_grpc)
+                            .collect(),
+                    },
+                )
+            }
+            Err(err) => {
+                info!("Replay error: {err:?}");
+                return Err(tonic::Status::internal(format!("replay error: {err}")));
+            }
         };
         Ok(tonic::Response::new(grpc_gen::ReplayExecutionResponse {
             outcome: Some(outcome),

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1678,6 +1678,10 @@ pub(crate) enum ReplayResponseSer {
         retval: serde_json::Value, // SupportedFunctionReturnValue -> RetVal
     },
     Blocked,
+    ReplayFailed {
+        error: String,
+        captured_writes: Vec<CapturedWriteSer>,
+    },
 }
 
 impl From<wasm_workers::workflow::workflow_worker::ReplayResponse> for ReplayResponseSer {
@@ -2002,7 +2006,7 @@ async fn stream_execution_response_task(
     responses(
         (status = 200, description = "Execution replayed", body = ReplayResponseSer),
         (status = 404, description = "Not found"),
-        (status = 422, description = "Replay failed")
+        (status = StatusCode::CONFLICT, description = "Replay failed", body = ReplayResponseSer)
     )
 )]
 #[instrument(skip_all, fields(execution_id))]
@@ -2011,19 +2015,35 @@ async fn execution_replay(
     state: State<Arc<WebApiState>>,
     accept: AcceptHeader,
 ) -> Result<Response, HttpResponse> {
-    let replay_response = replay_execution_internal(&state, &execution_id, accept).await?;
-    let ser = ReplayResponseSer::from(replay_response);
+    let ser = replay_execution_internal(&state, &execution_id, accept).await?;
+    let status = if matches!(ser, ReplayResponseSer::ReplayFailed { .. }) {
+        StatusCode::CONFLICT
+    } else {
+        StatusCode::OK
+    };
     Ok(match accept {
-        AcceptHeader::Json => Json(ser).into_response(),
-        AcceptHeader::Text => match ser {
-            ReplayResponseSer::Advanceable { captured_writes } => {
-                format!("outcome: advanceable, {} writes", captured_writes.len()).into_response()
-            }
-            ReplayResponseSer::Finished { retval } => {
-                format!("outcome: finished\nresult: {retval}").into_response()
-            }
-            ReplayResponseSer::Blocked => "outcome: blocked".into_response(),
-        },
+        AcceptHeader::Json => (status, Json(ser)).into_response(),
+        AcceptHeader::Text => {
+            let body = match ser {
+                ReplayResponseSer::Advanceable { captured_writes } => {
+                    format!("outcome: advanceable, {} writes", captured_writes.len())
+                }
+                ReplayResponseSer::Finished { retval } => {
+                    format!("outcome: finished\nresult: {retval}")
+                }
+                ReplayResponseSer::Blocked => "outcome: blocked".to_string(),
+                ReplayResponseSer::ReplayFailed {
+                    error,
+                    captured_writes,
+                } => {
+                    format!(
+                        "outcome: replay_failed, error: {error}, {} writes",
+                        captured_writes.len()
+                    )
+                }
+            };
+            (status, body).into_response()
+        }
     })
 }
 
@@ -2247,7 +2267,7 @@ async fn replay_execution_internal(
     state: &Arc<WebApiState>,
     execution_id: &ExecutionId,
     accept: AcceptHeader,
-) -> Result<wasm_workers::workflow::workflow_worker::ReplayResponse, HttpResponse> {
+) -> Result<ReplayResponseSer, HttpResponse> {
     let (deployment_id, component_registry_ro, replay_info, component_id) =
         get_replay_target(state, execution_id, accept).await?;
     let logs_storage_config = replay_info
@@ -2257,7 +2277,29 @@ async fn replay_execution_internal(
             log_sender: state.log_forwarder_sender.clone(),
         });
 
-    if let Some(js_info) = &replay_info.js_workflow_info {
+    let map_replay_err =
+        |err: wasm_workers::workflow::workflow_worker::ReplayError| -> Result<ReplayResponseSer, HttpResponse> {
+            use wasm_workers::workflow::workflow_worker::ReplayError;
+            match err {
+                ReplayError::ReplayFailed {
+                    err,
+                    captured_writes,
+                } => Ok(ReplayResponseSer::ReplayFailed {
+                    error: err.to_string(),
+                    captured_writes: captured_writes
+                        .into_iter()
+                        .map(CapturedWriteSer::from)
+                        .collect(),
+                }),
+                other => Err(HttpResponse {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    message: format!("Replay error: {other}"),
+                    accept,
+                }),
+            }
+        };
+
+    let replay_res = if let Some(js_info) = &replay_info.js_workflow_info {
         WorkflowJsWorker::replay(
             deployment_id,
             component_id,
@@ -2273,11 +2315,6 @@ async fn replay_execution_internal(
             &js_info.user_return_type,
         )
         .await
-        .map_err(|err| HttpResponse {
-            status: StatusCode::UNPROCESSABLE_ENTITY,
-            message: format!("Replay failed: {err}"),
-            accept,
-        })
     } else {
         WorkflowWorker::replay(
             deployment_id,
@@ -2292,11 +2329,10 @@ async fn replay_execution_internal(
             Now.clone_box(),
         )
         .await
-        .map_err(|err| HttpResponse {
-            status: StatusCode::UNPROCESSABLE_ENTITY,
-            message: format!("Replay failed: {err}"),
-            accept,
-        })
+    };
+    match replay_res {
+        Ok(response) => Ok(ReplayResponseSer::from(response)),
+        Err(err) => map_replay_err(err),
     }
 }
 


### PR DESCRIPTION
- **refactor(replay): Capture and persist `FatalError`s as execution errors**
- **refactor(replay): Send captured writes to persist execution errors in `ReplayError::ReplayFailed`**
- **refactor(grpc,webapi): Expose captured writes in replay failed error**
