### PR TITLE
refactor: Remove timestamps from `CapturedWrite` variants

### DIFF
--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1556,6 +1556,12 @@
               "type"
             ],
             "properties": {
+              "backtraces": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BacktraceInfoSer"
+                }
+              },
               "event": {
                 "type": "object"
               },
@@ -1585,6 +1591,12 @@
               "type"
             ],
             "properties": {
+              "backtraces": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BacktraceInfoSer"
+                }
+              },
               "current_time": {
                 "type": "string",
                 "format": "date-time"

--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -1584,7 +1584,6 @@
           {
             "type": "object",
             "required": [
-              "current_time",
               "events",
               "execution_id",
               "version",
@@ -1596,10 +1595,6 @@
                 "items": {
                   "$ref": "#/components/schemas/BacktraceInfoSer"
                 }
-              },
-              "current_time": {
-                "type": "string",
-                "format": "date-time"
               },
               "events": {
                 "type": "array",
@@ -1626,7 +1621,6 @@
           {
             "type": "object",
             "required": [
-              "current_time",
               "events",
               "execution_id",
               "version",
@@ -1646,10 +1640,6 @@
                 "items": {
                   "$ref": "#/components/schemas/CreateRequestSer"
                 }
-              },
-              "current_time": {
-                "type": "string",
-                "format": "date-time"
               },
               "events": {
                 "type": "array",
@@ -1680,14 +1670,9 @@
               "version",
               "events",
               "response",
-              "current_time",
               "type"
             ],
             "properties": {
-              "current_time": {
-                "type": "string",
-                "format": "date-time"
-              },
               "events": {
                 "type": "array",
                 "items": {
@@ -1703,7 +1688,7 @@
               "type": {
                 "type": "string",
                 "enum": [
-                  "append_batch_respond_to_parent"
+                  "append_stub_response"
                 ]
               },
               "version": {

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1003,12 +1003,14 @@ pub enum CapturedDbWrite {
         execution_id: ExecutionId,
         version: Version,
         req: AppendRequest,
+        backtraces: Vec<BacktraceInfo>,
     },
     AppendBatch {
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
         version: Version,
+        backtraces: Vec<BacktraceInfo>,
     },
     AppendBatchCreateNewExecution {
         current_time: DateTime<Utc>,
@@ -1022,6 +1024,7 @@ pub enum CapturedDbWrite {
         events: AppendEventsToExecution,
         response: AppendResponseToExecution,
         current_time: DateTime<Utc>,
+        // no backtraces as this is the second write (to the stub execution + current execution response)
     },
     AppendFinished {
         // TODO: Extract struct AppendFinished

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1,4 +1,6 @@
-use crate::worker::{FatalError, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk};
+use crate::worker::{
+    FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
+};
 use assert_matches::assert_matches;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, RunId};
@@ -513,11 +515,11 @@ impl ExecTask {
         unlock_expiry_on_limit_reached: Duration,
     ) -> Result<Option<AppendOrCancel>, DbErrorWrite> {
         Ok(match worker_result {
-            WorkerResult::Ok(WorkerResultOk::RunFinished {
+            WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                 retval: ref retval @ SupportedFunctionReturnValue::Err(ref result_err),
                 version,
                 http_client_traces,
-            }) if component_type == ComponentType::Activity
+            })) if component_type == ComponentType::Activity
                 && can_be_retried.is_some()
                 && !retval.is_permanent_variant() =>
             {
@@ -547,11 +549,11 @@ impl ExecTask {
                 }))
             }
 
-            WorkerResult::Ok(WorkerResultOk::RunFinished {
+            WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                 retval: result,
                 version,
                 http_client_traces,
-            }) => {
+            })) => {
                 info!("Execution finished: {result}");
                 let child_finished =
                     parent.map(
@@ -1016,11 +1018,11 @@ mod tests {
             db_pool,
             exec_config,
             Arc::new(SimpleWorker::with_single_result(WorkerResult::Ok(
-                WorkerResultOk::RunFinished {
+                WorkerResultOk::RunFinished(RunFinished {
                     retval: SUPPORTED_RETURN_VALUE_OK_EMPTY,
                     version: Version::new(2),
                     http_client_traces: None,
-                },
+                }),
             ))),
             tick_fn,
         )
@@ -1061,11 +1063,11 @@ mod tests {
         };
 
         let worker = Arc::new(SimpleWorker::with_single_result(WorkerResult::Ok(
-            WorkerResultOk::RunFinished {
+            WorkerResultOk::RunFinished(RunFinished {
                 retval: SUPPORTED_RETURN_VALUE_OK_EMPTY,
                 version: Version::new(2),
                 http_client_traces: None,
-            },
+            }),
         )));
         let db_connection = db_pool.connection_test().await.unwrap();
 
@@ -1247,11 +1249,11 @@ mod tests {
                 Version::new(4),
                 (
                     vec![],
-                    WorkerResult::Ok(WorkerResultOk::RunFinished {
+                    WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                         retval: SUPPORTED_RETURN_VALUE_OK_EMPTY,
                         version: Version::new(4),
                         http_client_traces: None,
-                    }),
+                    })),
                 ),
             )])),
         )));
@@ -1649,11 +1651,11 @@ mod tests {
     impl Worker for SleepyWorker {
         async fn run(&self, ctx: WorkerContext) -> WorkerResult {
             tokio::time::sleep(self.duration).await;
-            WorkerResult::Ok(WorkerResultOk::RunFinished {
+            WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                 retval: self.result.clone(),
                 version: ctx.version,
                 http_client_traces: None,
-            })
+            }))
         }
 
         fn exported_functions_noext(&self) -> &[FunctionMetadata] {

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -31,13 +31,8 @@ pub enum WorkerResultOk {
     #[display("db updated by worker or watcher")]
     DbUpdatedByWorkerOrWatcher,
     /// The execution run has returned a valid `retval`. Activity with retry budget returning `err` will be retried by the executor.
-    #[display("{retval}")]
-    // TODO: Extract
-    RunFinished {
-        retval: SupportedFunctionReturnValue,
-        version: Version,
-        http_client_traces: Option<Vec<HttpClientTrace>>,
-    },
+    #[display("{_0}")]
+    RunFinished(RunFinished),
 }
 
 #[derive(Debug, derive_more::Display)]

--- a/crates/grpc/src/grpc_gen.rs
+++ b/crates/grpc/src/grpc_gen.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::must_use_candidate)]
+#![allow(clippy::large_enum_variant)]
 tonic::include_proto!("obelisk");
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("descriptor");

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -1934,18 +1934,21 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                 execution_id,
                 version,
                 req,
+                backtraces,
             } => grpc_gen::captured_write::Write::Append(grpc_gen::captured_write::Append {
                 execution_id: Some(grpc_gen::ExecutionId {
                     id: execution_id.to_string(),
                 }),
                 version: version.0,
                 event: Some(append_request_to_grpc_event(req, version.0)),
+                backtraces: backtraces.into_iter().map(Into::into).collect(),
             }),
             CapturedDbWrite::AppendBatch {
                 current_time,
                 batch,
                 execution_id,
                 version,
+                backtraces,
             } => grpc_gen::captured_write::Write::AppendBatch(
                 grpc_gen::captured_write::AppendBatch {
                     current_time: Some(prost_wkt_types::Timestamp::from(current_time)),
@@ -1954,6 +1957,7 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                         id: execution_id.to_string(),
                     }),
                     version: version.0,
+                    backtraces: backtraces.into_iter().map(Into::into).collect(),
                 },
             ),
             CapturedDbWrite::AppendBatchCreateNewExecution {
@@ -2033,6 +2037,11 @@ pub fn captured_write_from_grpc(
                 .try_into()?,
             version: Version::new(append.version),
             req: append_request_from_grpc_event(append.event.argument_must_exist("event")?)?,
+            backtraces: append
+                .backtraces
+                .into_iter()
+                .map(BacktraceInfo::try_from)
+                .collect::<Result<Vec<BacktraceInfo>, _>>()?,
         }),
         grpc_gen::captured_write::Write::AppendBatch(batch) => Ok(CapturedDbWrite::AppendBatch {
             current_time: batch
@@ -2049,6 +2058,11 @@ pub fn captured_write_from_grpc(
                 .argument_must_exist("execution_id")?
                 .try_into()?,
             version: Version::new(batch.version),
+            backtraces: batch
+                .backtraces
+                .into_iter()
+                .map(BacktraceInfo::try_from)
+                .collect::<Result<Vec<BacktraceInfo>, _>>()?,
         }),
         grpc_gen::captured_write::Write::AppendBatchCreateNewExecution(batch) => {
             Ok(CapturedDbWrite::AppendBatchCreateNewExecution {

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -1944,14 +1944,13 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                 backtraces: backtraces.into_iter().map(Into::into).collect(),
             }),
             CapturedDbWrite::AppendBatch {
-                current_time,
+                current_time: _,
                 batch,
                 execution_id,
                 version,
                 backtraces,
             } => grpc_gen::captured_write::Write::AppendBatch(
                 grpc_gen::captured_write::AppendBatch {
-                    current_time: Some(prost_wkt_types::Timestamp::from(current_time)),
                     events: append_requests_to_grpc_events(batch, version.0),
                     execution_id: Some(grpc_gen::ExecutionId {
                         id: execution_id.to_string(),
@@ -1961,7 +1960,7 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                 },
             ),
             CapturedDbWrite::AppendBatchCreateNewExecution {
-                current_time,
+                current_time: _,
                 batch,
                 execution_id,
                 version,
@@ -1969,7 +1968,6 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                 backtraces,
             } => grpc_gen::captured_write::Write::AppendBatchCreateNewExecution(
                 grpc_gen::captured_write::AppendBatchCreateNewExecution {
-                    current_time: Some(prost_wkt_types::Timestamp::from(current_time)),
                     events: append_requests_to_grpc_events(batch, version.0),
                     execution_id: Some(grpc_gen::ExecutionId {
                         id: execution_id.to_string(),
@@ -1982,9 +1980,9 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
             CapturedDbWrite::AppendStubResponse {
                 events,
                 response,
-                current_time,
-            } => grpc_gen::captured_write::Write::AppendBatchRespondToParent(
-                grpc_gen::captured_write::AppendBatchRespondToParent {
+                current_time: _,
+            } => grpc_gen::captured_write::Write::AppendStubResponse(
+                grpc_gen::captured_write::AppendStubResponse {
                     execution_id: Some(grpc_gen::ExecutionId {
                         id: events.execution_id.to_string(),
                     }),
@@ -2000,8 +1998,6 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                     result: Some(grpc_gen::SupportedFunctionResult::from(
                         response.result.clone(),
                     )),
-                    current_time: Some(prost_wkt_types::Timestamp::from(current_time)),
-                    created_at: Some(prost_wkt_types::Timestamp::from(response.created_at)),
                     finished_version: response.finished_version.0,
                 },
             ),
@@ -2044,10 +2040,7 @@ pub fn captured_write_from_grpc(
                 .collect::<Result<Vec<BacktraceInfo>, _>>()?,
         }),
         grpc_gen::captured_write::Write::AppendBatch(batch) => Ok(CapturedDbWrite::AppendBatch {
-            current_time: batch
-                .current_time
-                .argument_must_exist("current_time")?
-                .into(),
+            current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
             batch: batch
                 .events
                 .into_iter()
@@ -2066,10 +2059,7 @@ pub fn captured_write_from_grpc(
         }),
         grpc_gen::captured_write::Write::AppendBatchCreateNewExecution(batch) => {
             Ok(CapturedDbWrite::AppendBatchCreateNewExecution {
-                current_time: batch
-                    .current_time
-                    .argument_must_exist("current_time")?
-                    .into(),
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
                 batch: batch
                     .events
                     .into_iter()
@@ -2092,7 +2082,7 @@ pub fn captured_write_from_grpc(
                     .collect::<Result<Vec<BacktraceInfo>, _>>()?,
             })
         }
-        grpc_gen::captured_write::Write::AppendBatchRespondToParent(batch) => {
+        grpc_gen::captured_write::Write::AppendStubResponse(batch) => {
             let execution_id = batch
                 .execution_id
                 .argument_must_exist("execution_id")?
@@ -2112,7 +2102,7 @@ pub fn captured_write_from_grpc(
                         .parent_execution_id
                         .argument_must_exist("parent_execution_id")?
                         .try_into()?,
-                    created_at: batch.created_at.argument_must_exist("created_at")?.into(),
+                    created_at: DateTime::UNIX_EPOCH, // will be replaced in `advance`
                     join_set_id: batch
                         .join_set_id
                         .argument_must_exist("join_set_id")?
@@ -2132,10 +2122,7 @@ pub fn captured_write_from_grpc(
                     finished_version: Version::new(batch.finished_version),
                     result: batch.result.argument_must_exist("result")?.try_into()?,
                 },
-                current_time: batch
-                    .current_time
-                    .argument_must_exist("current_time")?
-                    .into(),
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
             })
         }
         grpc_gen::captured_write::Write::AppendFinished(append_finished) => {

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -15,7 +15,7 @@ use concepts::{
     ReturnTypeExtendable,
 };
 use executor::worker::{
-    FatalError, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
+    FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
 };
 use secrecy::{ExposeSecret, SecretString};
 use std::sync::Arc;
@@ -436,11 +436,11 @@ impl Worker for ActivityExecWorker {
                 version.clone(),
             )?
         };
-        Ok(WorkerResultOk::RunFinished {
+        Ok(WorkerResultOk::RunFinished(RunFinished {
             retval,
             version,
             http_client_traces: None,
-        })
+        }))
     }
 }
 

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -16,7 +16,7 @@ use concepts::{
     SupportedFunctionReturnValue,
 };
 use executor::worker::{
-    FatalError, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
+    FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -161,7 +161,7 @@ impl Worker for ActivityJsWorker {
         let inner_worker_ok = self.inner.run(ctx).await?;
         debug!("Activity worker returned {inner_worker_ok:?}");
 
-        let (retval, version, http_client_traces) = assert_matches!(inner_worker_ok, WorkerResultOk::RunFinished { retval, version,  http_client_traces }
+        let (retval, version, http_client_traces) = assert_matches!(inner_worker_ok, WorkerResultOk::RunFinished(RunFinished { retval, version,  http_client_traces })
             => (retval, version,  http_client_traces), "activity_js_runtime runs in ActivityWorker");
 
         match retval {
@@ -185,11 +185,11 @@ impl Worker for ActivityJsWorker {
                     &self.user_return_type,
                     version.clone(),
                 )?;
-                Ok(WorkerResultOk::RunFinished {
+                Ok(WorkerResultOk::RunFinished(RunFinished {
                     retval,
                     version,
                     http_client_traces,
-                })
+                }))
             }
 
             SupportedFunctionReturnValue::Ok(Some(WastValWithType {
@@ -212,11 +212,11 @@ impl Worker for ActivityJsWorker {
                     &self.user_return_type,
                     version.clone(),
                 )?;
-                Ok(WorkerResultOk::RunFinished {
+                Ok(WorkerResultOk::RunFinished(RunFinished {
                     retval,
                     version,
                     http_client_traces,
-                })
+                }))
             }
 
             SupportedFunctionReturnValue::Err(Some(js_runtime_err)) => {
@@ -270,11 +270,11 @@ impl Worker for ActivityJsWorker {
             }
 
             retval @ SupportedFunctionReturnValue::ExecutionError(_) => {
-                Ok(WorkerResultOk::RunFinished {
+                Ok(WorkerResultOk::RunFinished(RunFinished {
                     retval,
                     version,
                     http_client_traces,
-                })
+                }))
             }
 
             other => unreachable!("unexpected SupportedFunctionReturnValue: {other:?}"),
@@ -520,7 +520,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "hello world");
@@ -540,7 +540,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "hello world");
@@ -560,7 +560,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "hello world");
@@ -582,7 +582,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &["World".to_string(), "Hello".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "Hello, World!");
@@ -602,7 +602,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         // For result<string, string>, a throw becomes Err
         let err_val = assert_matches!(retval, SupportedFunctionReturnValue::Err(err) => err);
         let err_val = err_val.expect("should have err value");
@@ -623,7 +623,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         // For result<string, string>, a throw becomes Err
         let err_val = assert_matches!(retval, SupportedFunctionReturnValue::Err(err) => err);
         let err_val = err_val.expect("should have err value");
@@ -648,7 +648,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &["test".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "logged");
@@ -808,7 +808,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "fetch works");
@@ -851,7 +851,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "ok");
@@ -888,7 +888,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "status:404");
@@ -909,7 +909,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let err_val = assert_matches!(retval, SupportedFunctionReturnValue::Err(err) => err);
         let err_str = err_val.expect("should have error value");
         let msg = extract_string(&err_str.value);
@@ -930,7 +930,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &["hello".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "sync result: hello");
@@ -968,7 +968,7 @@ mod tests {
         let ctx = make_worker_context_custom(ffqn, vec![json!("World"), json!(3)]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(
@@ -991,7 +991,7 @@ mod tests {
         let ctx = make_worker_context_custom(ffqn, vec![]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "no args works");
@@ -1032,7 +1032,7 @@ mod tests {
         );
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "APPLE, BANANA, CHERRY");
@@ -1059,7 +1059,7 @@ mod tests {
         let result = worker.run(ctx).await.expect("worker should succeed");
         let elapsed = start.elapsed();
 
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "delayed result");
@@ -1104,7 +1104,7 @@ mod tests {
         let result = worker.run(ctx).await.expect("worker should succeed");
         let elapsed = start.elapsed();
 
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "first, second");
@@ -1154,7 +1154,7 @@ mod tests {
 
         let result = worker.run(ctx).await.expect("worker should succeed");
 
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "done");
@@ -1275,7 +1275,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let wvt = assert_matches!(retval, SupportedFunctionReturnValue::Ok(Some(wvt)) => wvt);
         assert_eq!(wvt.r#type, TypeWrapper::U32);
         assert_eq!(wvt.value, WastVal::U32(42));
@@ -1306,7 +1306,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let wvt = assert_matches!(retval, SupportedFunctionReturnValue::Ok(Some(wvt)) => wvt);
         assert_eq!(wvt.r#type, TypeWrapper::List(Box::new(TypeWrapper::String)));
         assert_eq!(
@@ -1344,7 +1344,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let err_wvt = assert_matches!(retval, SupportedFunctionReturnValue::Err(Some(wvt)) => wvt);
         assert_eq!(err_wvt.r#type, TypeWrapper::String);
         assert_eq!(
@@ -1382,7 +1382,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         assert_matches!(retval, SupportedFunctionReturnValue::Ok(None));
     }
 
@@ -1421,7 +1421,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let err_wvt = assert_matches!(retval, SupportedFunctionReturnValue::Err(Some(wvt)) => wvt);
         assert_eq!(err_wvt.r#type, err_variant);
         assert_eq!(
@@ -1457,10 +1457,10 @@ mod tests {
         let worker_ok = worker.run(ctx).await.unwrap();
         assert_matches!(
             worker_ok,
-            WorkerResultOk::RunFinished {
+            WorkerResultOk::RunFinished(RunFinished {
                 retval: SupportedFunctionReturnValue::Err(None),
                 ..
-            }
+            })
         );
     }
 
@@ -1490,7 +1490,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         assert_matches!(retval, SupportedFunctionReturnValue::Err(None));
     }
 
@@ -1526,7 +1526,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let wvt = assert_matches!(retval, SupportedFunctionReturnValue::Ok(Some(wvt)) => wvt);
         assert_eq!(wvt.r#type, TypeWrapper::Enum(cases));
         assert_eq!(

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -14,7 +14,7 @@ use concepts::{
     ComponentId, FunctionFqn, PackageIfcFns, Params, SupportedFunctionReturnValue, TrapKind,
 };
 use concepts::{FunctionMetadata, ResultParsingError};
-use executor::worker::{FatalError, WorkerContext, WorkerResult, WorkerResultOk};
+use executor::worker::{FatalError, RunFinished, WorkerContext, WorkerResult, WorkerResultOk};
 use executor::worker::{Worker, WorkerError};
 use itertools::Itertools;
 use std::sync::Arc;
@@ -437,11 +437,11 @@ impl ActivityWorker {
                 .collect_vec(),
         );
         match res {
-            Ok(Ok(result)) => WorkerResult::Ok(WorkerResultOk::RunFinished {
+            Ok(Ok(result)) => WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                 retval: result,
                 version: version.clone(),
                 http_client_traces,
-            }),
+            })),
             Ok(Err(result_parsing_err)) => WorkerResult::Err(WorkerError::FatalError(
                 FatalError::ResultParsingError(result_parsing_err),
                 version.clone(),

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -52,16 +52,19 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
             execution_id,
             version,
             req,
+            backtraces,
         } => CapturedDbWrite::Append {
             execution_id,
             version,
             req: normalize_append_request_for_matching(req),
+            backtraces,
         },
         CapturedDbWrite::AppendBatch {
             current_time: _,
             batch,
             execution_id,
             version,
+            backtraces,
         } => CapturedDbWrite::AppendBatch {
             current_time: DateTime::UNIX_EPOCH,
             batch: batch
@@ -70,6 +73,7 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
                 .collect(),
             execution_id,
             version,
+            backtraces,
         },
         CapturedDbWrite::AppendBatchCreateNewExecution {
             current_time: _,

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -366,8 +366,13 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         assert_eq!(self.execution_id, execution_id);
         let version = self.version.clone();
         let next_version = Version::new(version.0 + 1);
-        let backtraces =
-            make_backtrace(&execution_id, component_id, &version, &next_version, wasm_backtrace);
+        let backtraces = make_backtrace(
+            &execution_id,
+            component_id,
+            &version,
+            &next_version,
+            wasm_backtrace,
+        );
         self.collector.push_write(CapturedDbWrite::Append {
             execution_id,
             version: version.clone(),
@@ -395,8 +400,13 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         // only CachingDbConnection can assert the flush outcome as here `flush_non_blocking_event_cache` is stateless.
         let version = self.version.clone();
         let next_version = Version::new(version.0 + 1);
-        let backtraces =
-            make_backtrace(&execution_id, component_id, &version, &next_version, wasm_backtrace);
+        let backtraces = make_backtrace(
+            &execution_id,
+            component_id,
+            &version,
+            &next_version,
+            wasm_backtrace,
+        );
 
         self.collector.push_write_with_cancellations(
             CapturedDbWrite::Append {
@@ -428,7 +438,8 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 "closing join next is not appended using `append_batch`"
             );
         }
-        let backtraces = make_backtrace(&execution_id, component_id, &version, &next, wasm_backtrace);
+        let backtraces =
+            make_backtrace(&execution_id, component_id, &version, &next, wasm_backtrace);
         self.collector.push_write(CapturedDbWrite::AppendBatch {
             current_time,
             batch,

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -115,16 +115,29 @@ async fn apply_captured_write(
             execution_id,
             version,
             req,
-        } => conn.append(execution_id, version, req).await.map(Some),
+            backtraces,
+        } => {
+            let result = conn.append(execution_id, version, req).await?;
+            if !backtraces.is_empty() {
+                conn.append_backtrace_batch(backtraces).await?;
+            }
+            Ok(Some(result))
+        }
         CapturedDbWrite::AppendBatch {
             current_time,
             batch,
             execution_id,
             version,
-        } => conn
-            .append_batch(current_time, batch, execution_id, version)
-            .await
-            .map(Some),
+            backtraces,
+        } => {
+            let result = conn
+                .append_batch(current_time, batch, execution_id, version)
+                .await?;
+            if !backtraces.is_empty() {
+                conn.append_backtrace_batch(backtraces).await?;
+            }
+            Ok(Some(result))
+        }
         CapturedDbWrite::AppendBatchCreateNewExecution {
             current_time,
             batch,
@@ -212,6 +225,25 @@ impl ReplayWorkflowDbConnection {
     pub(crate) fn execution_id(&self) -> &ExecutionId {
         &self.execution_id
     }
+}
+
+fn make_backtrace(
+    execution_id: &ExecutionId,
+    component_id: &ComponentId,
+    version: &Version,
+    next_version: &Version,
+    wasm_backtrace: Option<storage::WasmBacktrace>,
+) -> Vec<BacktraceInfo> {
+    wasm_backtrace
+        .map(|wasm_backtrace| BacktraceInfo {
+            execution_id: execution_id.clone(),
+            component_id: component_id.clone(),
+            version_min_including: version.clone(),
+            version_max_excluding: next_version.clone(),
+            wasm_backtrace,
+        })
+        .into_iter()
+        .collect()
 }
 
 fn next_version(curr_version: &Version, batch_size: usize) -> Version {
@@ -317,6 +349,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 execution_id: self.execution_id.clone(),
                 version: version.clone(),
                 req: request,
+                backtraces: backtrace.into_iter().collect(),
             });
         }
         self.version = Version::new(version.0 + 1);
@@ -327,17 +360,21 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         &mut self,
         execution_id: ExecutionId,
         req: AppendRequest,
-        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
-        _component_id: &ComponentId,
+        wasm_backtrace: Option<storage::WasmBacktrace>,
+        component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
         let version = self.version.clone();
+        let next_version = Version::new(version.0 + 1);
+        let backtraces =
+            make_backtrace(&execution_id, component_id, &version, &next_version, wasm_backtrace);
         self.collector.push_write(CapturedDbWrite::Append {
             execution_id,
             version: version.clone(),
             req,
+            backtraces,
         });
-        self.version = Version::new(version.0 + 1);
+        self.version = next_version;
         Ok(())
     }
 
@@ -347,8 +384,8 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         execution_id: ExecutionId,
         req: AppendRequest,
         cancellations: Option<JoinSetCloseCancellations>,
-        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
-        _component_id: &ComponentId,
+        wasm_backtrace: Option<storage::WasmBacktrace>,
+        component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
         assert!(
@@ -357,16 +394,20 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         );
         // only CachingDbConnection can assert the flush outcome as here `flush_non_blocking_event_cache` is stateless.
         let version = self.version.clone();
+        let next_version = Version::new(version.0 + 1);
+        let backtraces =
+            make_backtrace(&execution_id, component_id, &version, &next_version, wasm_backtrace);
 
         self.collector.push_write_with_cancellations(
             CapturedDbWrite::Append {
                 execution_id,
                 version: version.clone(),
                 req,
+                backtraces,
             },
             cancellations,
         );
-        self.version = Version::new(version.0 + 1);
+        self.version = next_version;
         Ok(())
     }
 
@@ -375,8 +416,8 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
-        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
-        _component_id: &ComponentId,
+        wasm_backtrace: Option<storage::WasmBacktrace>,
+        component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
         let version = self.version.clone();
@@ -387,11 +428,13 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 "closing join next is not appended using `append_batch`"
             );
         }
+        let backtraces = make_backtrace(&execution_id, component_id, &version, &next, wasm_backtrace);
         self.collector.push_write(CapturedDbWrite::AppendBatch {
             current_time,
             batch,
             execution_id,
             version,
+            backtraces,
         });
         self.version = next;
         Ok(())
@@ -403,8 +446,8 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
         child_req: Vec<CreateRequest>,
-        _wasm_backtrace: Option<storage::WasmBacktrace>, // TODO: Add backtrace
-        _component_id: &ComponentId,
+        wasm_backtrace: Option<storage::WasmBacktrace>,
+        component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
         let version = self.version.clone();
@@ -415,6 +458,8 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 "closing join next is not appended using `append_batch_create_new_execution`"
             );
         }
+        let backtraces =
+            make_backtrace(&execution_id, component_id, &version, &next, wasm_backtrace);
         self.collector
             .push_write(CapturedDbWrite::AppendBatchCreateNewExecution {
                 current_time,
@@ -422,7 +467,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 execution_id,
                 version,
                 child_req,
-                backtraces: Vec::new(),
+                backtraces,
             });
         self.version = next;
         Ok(())

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_full_replay_1.snap
@@ -18,7 +18,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     },
     {
@@ -94,7 +95,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_1.snap
@@ -18,7 +18,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     },
     {
@@ -94,7 +95,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_2.snap
@@ -77,7 +77,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_3.snap
@@ -21,7 +21,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_1_replay_1.snap
@@ -18,7 +18,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     },
     {
@@ -94,7 +95,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_1.snap
@@ -18,7 +18,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     },
     {
@@ -206,7 +207,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_2.snap
@@ -21,7 +21,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_3.snap
@@ -21,7 +21,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_1.snap
@@ -18,7 +18,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000000",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 2,
+            "version_max_excluding": 3,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 3,
+                      "col": 45
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_3.snap
@@ -25,7 +25,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
           }
         ],
         "execution_id": "E_00000000000000000000000000",
-        "version": 4
+        "version": 4,
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000000",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 4,
+            "version_max_excluding": 5,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 5,
+                      "col": 25
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -45,7 +73,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000000",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 5,
+            "version_max_excluding": 6,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 6,
+                      "col": 41
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_replay_1.snap
@@ -18,7 +18,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_0000000000000000000000000A",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 2,
+            "version_max_excluding": 3,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "submit_and_return",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 3,
+                      "col": 45
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -121,7 +149,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_1.snap
@@ -18,7 +18,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_0000000000000000000000000B",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 2,
+            "version_max_excluding": 3,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "submit_and_return",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 3,
+                      "col": 45
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -121,7 +149,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_2.snap
@@ -104,7 +104,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_3.snap
@@ -21,7 +21,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_1.snap
@@ -18,7 +18,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000001",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 2,
+            "version_max_excluding": 3,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 3,
+                      "col": 45
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_4.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_4.snap
@@ -25,7 +25,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
           }
         ],
         "execution_id": "E_00000000000000000000000001",
-        "version": 4
+        "version": 4,
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000001",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 4,
+            "version_max_excluding": 5,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 5,
+                      "col": 25
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {
@@ -45,7 +73,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000001",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 5,
+            "version_max_excluding": 6,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 6,
+                      "col": 41
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_5.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_5.snap
@@ -21,7 +21,35 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
               }
             }
           }
-        }
+        },
+        "backtraces": [
+          {
+            "execution_id": "E_00000000000000000000000001",
+            "component_id": {
+              "component_type": "workflow",
+              "name": "test_js_workflow",
+              "component_digest": "sha256:<REDACTED>"
+            },
+            "version_min_including": 5,
+            "version_max_excluding": 6,
+            "wasm_backtrace": {
+              "frames": [
+                {
+                  "module": "unknown",
+                  "func_name": "call_stub",
+                  "symbols": [
+                    {
+                      "func_name": null,
+                      "file": null,
+                      "line": 6,
+                      "col": 41
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -2805,7 +2805,7 @@ pub(crate) mod tests {
     use concepts::{FunctionMetadata, ParameterTypes};
     use db_tests::Database;
     use executor::executor::LockingStrategy;
-    use executor::worker::WorkerResultOk;
+    use executor::worker::{RunFinished, WorkerResultOk};
     use executor::{
         executor::{ExecConfig, ExecTask},
         expired_timers_watcher,
@@ -3118,11 +3118,11 @@ pub(crate) mod tests {
             let res = match workflow_ctx.join_sets_close_on_finish().await {
                 Ok(()) => {
                     info!("Finishing");
-                    WorkerResult::Ok(WorkerResultOk::RunFinished {
+                    WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                         retval: SUPPORTED_RETURN_VALUE_OK_EMPTY,
                         version: workflow_ctx.db_connection.version().clone(),
                         http_client_traces: None,
-                    })
+                    }))
                 }
                 Err(ApplyError::InterruptDbUpdated) => {
                     info!("Interrupting");
@@ -3535,7 +3535,7 @@ pub(crate) mod tests {
             }
             let (finished_value, version) = assert_matches!(
                 worker_result,
-                WorkerResult::Ok(WorkerResultOk::RunFinished { retval, version, http_client_traces:_ }) => (retval, version),
+                WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished { retval, version, http_client_traces:_ })) => (retval, version),
                 "should be finished"
             );
             info!("Appending finished result");

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -219,27 +219,17 @@ impl Worker for WorkflowJsWorker {
             WorkerResultOk::DbUpdatedByWorkerOrWatcher => {
                 Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
             }
-            WorkerResultOk::RunFinished {
+            WorkerResultOk::RunFinished(RunFinished {
                 retval,
                 version,
                 http_client_traces,
-            } => transform_to_outer_result(
+            }) => transform_to_outer_result(
                 retval,
                 version,
                 http_client_traces,
                 &self.user_return_type,
             )
-            .map(
-                |RunFinished {
-                     retval,
-                     version,
-                     http_client_traces,
-                 }| WorkerResultOk::RunFinished {
-                    retval,
-                    version,
-                    http_client_traces,
-                },
-            )
+            .map(WorkerResultOk::RunFinished)
             .map_err(|(err, version)| WorkerError::FatalError(err, version)),
         }
     }
@@ -742,7 +732,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "hello world");
@@ -794,7 +784,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &["World".to_string(), "Hello".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
         let ok_val = output.expect("should have ok value");
         assert_eq!(extract_string(&ok_val.value), "Hello, World!");
@@ -814,7 +804,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         // For result<string, string>, a throw becomes Err
         let err_val = assert_matches!(retval, SupportedFunctionReturnValue::Err(err) => err);
         let err_val = err_val.expect("should have err value");
@@ -1768,7 +1758,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         assert_matches!(retval, SupportedFunctionReturnValue::Ok(None));
     }
 
@@ -1795,7 +1785,7 @@ mod tests {
         let ctx = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
-        let retval = assert_matches!(result, WorkerResultOk::RunFinished { retval, .. } => retval);
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
         assert_matches!(retval, SupportedFunctionReturnValue::Err(None));
     }
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -27,7 +27,7 @@ use concepts::{
     FunctionMetadata, PackageIfcFns, Params, ResultParsingError, StrVariant, TrapKind,
 };
 use concepts::{FunctionRegistry, SupportedFunctionReturnValue};
-use executor::worker::{FatalError, WorkerContext, WorkerResult, WorkerResultOk};
+use executor::worker::{FatalError, RunFinished, WorkerContext, WorkerResult, WorkerResultOk};
 use executor::worker::{Worker, WorkerError};
 use itertools::Either;
 use std::future;
@@ -815,11 +815,11 @@ impl WorkflowWorker {
             WorkerResultRefactored::Ok(retval, mut workflow_ctx) => {
                 match Self::close_join_sets(&mut workflow_ctx).await {
                     Ok(Either::Left(CloseJoinSetOk::Ok)) => Ok((
-                        Either::Left(WorkerResultOk::RunFinished {
+                        Either::Left(WorkerResultOk::RunFinished(RunFinished {
                             retval,
                             version: workflow_ctx.db_connection.version().clone(),
                             http_client_traces: None,
-                        }),
+                        })),
                         workflow_ctx.db_connection,
                     )),
                     Ok(Either::Left(CloseJoinSetOk::DbUpdatedByWorkerOrWatcher)) => Ok((
@@ -998,7 +998,7 @@ impl WorkflowWorker {
             .run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind))
             .await
         {
-            Ok((Either::Left(WorkerResultOk::RunFinished { retval, .. }), db)) => {
+            Ok((Either::Left(WorkerResultOk::RunFinished(RunFinished { retval, .. })), db)) => {
                 Ok((Some(retval), db, None))
             }
             Ok((_, db)) => Ok((None, db, None)), // replay interrupted or db updated (both have writes) or execution is waiting

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -757,12 +757,14 @@ message CapturedWrite {
     ExecutionId execution_id = 1;
     uint32 version = 2;
     ExecutionEvent event = 3;
+    repeated CapturedBacktrace backtraces = 4;
   }
   message AppendBatch {
     google.protobuf.Timestamp current_time = 1;
     repeated ExecutionEvent events = 2;
     ExecutionId execution_id = 3;
     uint32 version = 4;
+    repeated CapturedBacktrace backtraces = 5;
   }
   message AppendBatchCreateNewExecution {
     google.protobuf.Timestamp current_time = 1;

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -760,21 +760,21 @@ message CapturedWrite {
     repeated CapturedBacktrace backtraces = 4;
   }
   message AppendBatch {
-    google.protobuf.Timestamp current_time = 1;
+    reserved 1;
     repeated ExecutionEvent events = 2;
     ExecutionId execution_id = 3;
     uint32 version = 4;
     repeated CapturedBacktrace backtraces = 5;
   }
   message AppendBatchCreateNewExecution {
-    google.protobuf.Timestamp current_time = 1;
+    reserved 1;
     repeated ExecutionEvent events = 2;
     ExecutionId execution_id = 3;
     uint32 version = 4;
     repeated CreateExecutionRequest child_requests = 5;
     repeated CapturedBacktrace backtraces = 6;
   }
-  message AppendBatchRespondToParent {
+  message AppendStubResponse {
     ExecutionId execution_id = 1;
     uint32 version = 2;
     repeated ExecutionEvent events = 3;
@@ -782,8 +782,7 @@ message CapturedWrite {
     JoinSetId join_set_id = 5;
     ExecutionId child_execution_id = 6;
     SupportedFunctionResult result = 7;
-    google.protobuf.Timestamp current_time = 8;
-    google.protobuf.Timestamp created_at = 9;
+    reserved 8, 9;
     uint32 finished_version = 10;
   }
   message AppendFinished {
@@ -795,7 +794,7 @@ message CapturedWrite {
     Append append = 1;
     AppendBatch append_batch = 2;
     AppendBatchCreateNewExecution append_batch_create_new_execution = 3;
-    AppendBatchRespondToParent append_batch_respond_to_parent = 4;
+    AppendStubResponse append_stub_response = 4;
     AppendFinished append_finished = 5;
   }
 }

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -715,19 +715,16 @@ mod tests {
     #[test]
     fn pause_submitted_marks_only_new_child_requests_as_paused() {
         let current_time: DateTime<Utc> = "2026-01-01T00:00:00Z".parse().unwrap();
-        // TODO: construct `AdvanceRequestSer` directly
         let mut advance_request = serde_json::from_value::<AdvanceRequestSer>(json!({
             "captured_writes": [
                 {
                     "type": "append_batch",
-                    "current_time": current_time,
                     "execution_id": "Exec_01",
                     "version": 1,
                     "events": []
                 },
                 {
                     "type": "append_batch_create_new_execution",
-                    "current_time": current_time,
                     "events": [],
                     "execution_id": "Exec_01",
                     "version": 2,

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1487,7 +1487,6 @@ pub(crate) enum CapturedWriteSer {
         backtraces: Vec<backtrace::BacktraceInfoSer>,
     },
     AppendBatch {
-        current_time: DateTime<Utc>,
         #[schema(value_type = Vec<Object>)]
         events: Vec<concepts::storage::AppendRequest>,
         execution_id: String,
@@ -1496,7 +1495,6 @@ pub(crate) enum CapturedWriteSer {
         backtraces: Vec<backtrace::BacktraceInfoSer>,
     },
     AppendBatchCreateNewExecution {
-        current_time: DateTime<Utc>,
         #[schema(value_type = Vec<Object>)]
         events: Vec<concepts::storage::AppendRequest>,
         execution_id: String,
@@ -1504,13 +1502,12 @@ pub(crate) enum CapturedWriteSer {
         child_requests: Vec<CreateRequestSer>,
         backtraces: Vec<backtrace::BacktraceInfoSer>,
     },
-    AppendBatchRespondToParent {
+    AppendStubResponse {
         execution_id: String,
         version: u32,
         #[schema(value_type = Vec<Object>)]
         events: Vec<concepts::storage::AppendRequest>,
         response: StubResponseSer,
-        current_time: DateTime<Utc>,
     },
     AppendFinished {
         execution_id: String,
@@ -1539,13 +1536,12 @@ impl From<concepts::storage::CapturedDbWrite> for CapturedWriteSer {
                     .collect(),
             },
             CapturedDbWrite::AppendBatch {
-                current_time,
+                current_time: _,
                 batch,
                 execution_id,
                 version,
                 backtraces,
             } => CapturedWriteSer::AppendBatch {
-                current_time,
                 events: batch,
                 execution_id: execution_id.to_string(),
                 version: version.0,
@@ -1555,14 +1551,13 @@ impl From<concepts::storage::CapturedDbWrite> for CapturedWriteSer {
                     .collect(),
             },
             CapturedDbWrite::AppendBatchCreateNewExecution {
-                current_time,
+                current_time: _,
                 batch,
                 execution_id,
                 version,
                 child_req,
                 backtraces,
             } => CapturedWriteSer::AppendBatchCreateNewExecution {
-                current_time,
                 events: batch,
                 execution_id: execution_id.to_string(),
                 version: version.0,
@@ -1575,13 +1570,12 @@ impl From<concepts::storage::CapturedDbWrite> for CapturedWriteSer {
             CapturedDbWrite::AppendStubResponse {
                 events,
                 response,
-                current_time,
-            } => CapturedWriteSer::AppendBatchRespondToParent {
+                current_time: _,
+            } => CapturedWriteSer::AppendStubResponse {
                 execution_id: events.execution_id.to_string(),
                 version: events.version.0,
                 events: events.batch,
                 response: StubResponseSer::from(response),
-                current_time,
             },
             CapturedDbWrite::AppendFinished {
                 execution_id,
@@ -1619,13 +1613,12 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                     .collect::<Result<Vec<_>, _>>()?,
             }),
             CapturedWriteSer::AppendBatch {
-                current_time,
                 events,
                 execution_id,
                 version,
                 backtraces,
             } => Ok(Self::AppendBatch {
-                current_time,
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
                 batch: events,
                 execution_id: execution_id
                     .parse()
@@ -1637,14 +1630,13 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                     .collect::<Result<Vec<_>, _>>()?,
             }),
             CapturedWriteSer::AppendBatchCreateNewExecution {
-                current_time,
                 events,
                 execution_id,
                 version,
                 child_requests,
                 backtraces,
             } => Ok(Self::AppendBatchCreateNewExecution {
-                current_time,
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
                 batch: events,
                 execution_id: execution_id
                     .parse()
@@ -1659,12 +1651,11 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                     .map(concepts::storage::BacktraceInfo::try_from)
                     .collect::<Result<Vec<_>, _>>()?,
             }),
-            CapturedWriteSer::AppendBatchRespondToParent {
+            CapturedWriteSer::AppendStubResponse {
                 execution_id,
                 version,
                 events,
                 response,
-                current_time,
             } => Ok(Self::AppendStubResponse {
                 events: concepts::storage::AppendEventsToExecution {
                     execution_id: execution_id
@@ -1674,7 +1665,7 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                     batch: events,
                 },
                 response: response.try_into()?,
-                current_time,
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
             }),
             CapturedWriteSer::AppendFinished {
                 execution_id,

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1483,6 +1483,8 @@ pub(crate) enum CapturedWriteSer {
         version: u32,
         #[schema(value_type = Object)]
         event: concepts::storage::AppendRequest,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        backtraces: Vec<backtrace::BacktraceInfoSer>,
     },
     AppendBatch {
         current_time: DateTime<Utc>,
@@ -1490,6 +1492,8 @@ pub(crate) enum CapturedWriteSer {
         events: Vec<concepts::storage::AppendRequest>,
         execution_id: String,
         version: u32,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        backtraces: Vec<backtrace::BacktraceInfoSer>,
     },
     AppendBatchCreateNewExecution {
         current_time: DateTime<Utc>,
@@ -1524,21 +1528,31 @@ impl From<concepts::storage::CapturedDbWrite> for CapturedWriteSer {
                 execution_id,
                 version,
                 req,
+                backtraces,
             } => CapturedWriteSer::Append {
                 execution_id: execution_id.to_string(),
                 version: version.0,
                 event: req,
+                backtraces: backtraces
+                    .into_iter()
+                    .map(backtrace::BacktraceInfoSer::from)
+                    .collect(),
             },
             CapturedDbWrite::AppendBatch {
                 current_time,
                 batch,
                 execution_id,
                 version,
+                backtraces,
             } => CapturedWriteSer::AppendBatch {
                 current_time,
                 events: batch,
                 execution_id: execution_id.to_string(),
                 version: version.0,
+                backtraces: backtraces
+                    .into_iter()
+                    .map(backtrace::BacktraceInfoSer::from)
+                    .collect(),
             },
             CapturedDbWrite::AppendBatchCreateNewExecution {
                 current_time,
@@ -1592,18 +1606,24 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                 execution_id,
                 version,
                 event,
+                backtraces,
             } => Ok(Self::Append {
                 execution_id: execution_id
                     .parse()
                     .map_err(|err| format!("invalid execution_id - {err}"))?,
                 version: Version::new(version),
                 req: event,
+                backtraces: backtraces
+                    .into_iter()
+                    .map(concepts::storage::BacktraceInfo::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
             }),
             CapturedWriteSer::AppendBatch {
                 current_time,
                 events,
                 execution_id,
                 version,
+                backtraces,
             } => Ok(Self::AppendBatch {
                 current_time,
                 batch: events,
@@ -1611,6 +1631,10 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                     .parse()
                     .map_err(|err| format!("invalid execution_id - {err}"))?,
                 version: Version::new(version),
+                backtraces: backtraces
+                    .into_iter()
+                    .map(concepts::storage::BacktraceInfo::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
             }),
             CapturedWriteSer::AppendBatchCreateNewExecution {
                 current_time,


### PR DESCRIPTION
- **refactor(replay): Collect and persist backtraces to `CapturedDbWrite` variants**
- **refactor: Extract `WorkerResultOk::RunFinished(RunFinished)`**
- **chore: Update OpenAPI schema**
- **test: Update test snapshots**
- **refactor: Remove timestamps from `CapturedWrite` variants**
