### PR TITLE
Add `ExecutionFunctionFilter`, fix `component_type` column

### DIFF
--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1230,12 +1230,40 @@ pub enum AppendDelayResponseOutcome {
 
 #[derive(Debug, Clone, Default)]
 pub struct ListExecutionsFilter {
-    pub ffqn_prefix: Option<String>,
+    pub function_name_filter: Option<FunctionNameFilter>,
     pub show_derived: bool,
     pub hide_finished: bool,
     pub execution_id_prefix: Option<String>,
     pub component_digest: Option<ComponentDigest>,
     pub deployment_id: Option<DeploymentId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FunctionNameFilter {
+    PackageName(String),
+    InterfaceName(String),
+    FunctionName(String),
+}
+
+impl FunctionNameFilter {
+    #[must_use]
+    pub fn like_pattern(&self) -> String {
+        match self {
+            Self::FunctionName(function_name) | Self::InterfaceName(function_name) => {
+                format!("{function_name}%")
+            }
+            Self::PackageName(package_name) => {
+                if let Some((pkg_fqn_without_version, version)) = package_name.rsplit_once('@')
+                    && !version.is_empty()
+                    && pkg_fqn_without_version.contains(':')
+                {
+                    format!("{pkg_fqn_without_version}/%@{version}.%")
+                } else {
+                    format!("{package_name}%")
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1107,7 +1107,7 @@ async fn list_executions(
     };
 
     let inner_sql = format!(
-        r"SELECT created_at, first_scheduled_at, component_id_input_digest, deployment_id,
+        r"SELECT created_at, first_scheduled_at, component_id_input_digest, component_type, deployment_id,
             state, execution_id, ffqn, corresponding_version, pending_expires_finished,
             last_lock_version, executor_id, run_id,
             join_set_id, join_set_closing,

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1066,11 +1066,11 @@ async fn list_executions(
     if !filter.show_derived {
         qb.add_where("is_top_level = true".to_string());
     }
-    let like = |str| format!("{str}%");
-    if let Some(ffqn_prefix) = filter.ffqn_prefix {
-        let placeholder = qb.add_param(like(ffqn_prefix));
+    if let Some(function_name_filter) = filter.function_name_filter {
+        let placeholder = qb.add_param(function_name_filter.like_pattern());
         qb.add_where(format!("ffqn LIKE {placeholder}"));
     }
+    let like = |value: String| format!("{value}%");
     if filter.hide_finished {
         qb.add_where(format!("state != '{STATE_FINISHED}'"));
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -32,7 +32,8 @@ use db_common::{
 use hashbrown::HashMap;
 use rusqlite::{
     CachedStatement, Connection, OpenFlags, OptionalExtension, Row, ToSql, Transaction,
-    TransactionBehavior, named_params, types::ToSqlOutput,
+    TransactionBehavior, named_params,
+    types::{ToSqlOutput, Value},
 };
 use sha2::{Digest as _, Sha256};
 use std::{
@@ -1468,17 +1469,12 @@ impl SqlitePool {
                 paginate(pagination, "execution_id", filter)?
             }
         };
-        let like = |str| format!("{str}%");
-
-        let ffqn_temporary;
-        if let Some(ffqn_prefix) = &filter.ffqn_prefix {
+        if let Some(function_name_filter) = &filter.function_name_filter {
+            let ffqn = ToSqlOutput::Owned(Value::from(function_name_filter.like_pattern()));
             statement_mod.where_vec.push("ffqn LIKE :ffqn".to_string());
-            ffqn_temporary = like(ffqn_prefix);
-            let ffqn = ffqn_temporary
-                .to_sql()
-                .expect("string conversion never fails");
             statement_mod.params.push((":ffqn", ffqn));
         }
+        let like = |value: &str| format!("{value}%");
 
         if filter.hide_finished {
             statement_mod

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -3,21 +3,22 @@ use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DEPLOYMENT_ID_DUMMY, DelayId, RunId};
 use concepts::storage::{
     self, AppendEventsToExecution, AppendRequest, AppendResponseToExecution, BacktraceFilter,
-    BacktraceInfo, CancelOutcome, CreateRequest, DbConnection, DbConnectionTest, ExecutionRequest,
-    ExpiredDelay, ExpiredLock, ExpiredTimer, FrameInfo, FrameSymbol, JoinSetRequest,
-    JoinSetResponse, JoinSetResponseEventOuter, LockedBy, LockedExecution, Pagination,
-    PendingState, PendingStateBlockedByJoinSet, PendingStateLocked, PendingStatePaused,
-    PendingStatePendingAt, ResponseCursor, TimeoutOutcome, Version, VersionType, WasmBacktrace,
+    BacktraceInfo, CancelOutcome, CreateRequest, DbConnection, DbConnectionTest,
+    ExecutionListPagination, ExecutionRequest, ExpiredDelay, ExpiredLock, ExpiredTimer, FrameInfo,
+    FrameSymbol, FunctionNameFilter, JoinSetRequest, JoinSetResponse, JoinSetResponseEventOuter,
+    LockedBy, LockedExecution, Pagination, PendingState, PendingStateBlockedByJoinSet,
+    PendingStateLocked, PendingStatePaused, PendingStatePendingAt, ResponseCursor, TimeoutOutcome,
+    Version, VersionType, WasmBacktrace,
 };
 use concepts::storage::{DbErrorWrite, DbPoolCloseable, DeploymentRecord, DeploymentStatus};
-use concepts::storage::{DbErrorWriteNonRetriable, HistoryEvent};
+use concepts::storage::{DbErrorWriteNonRetriable, HistoryEvent, ListExecutionsFilter};
 use concepts::storage::{HistoryEventScheduleAt, JoinSetResponseEvent, LogFilter};
 use concepts::storage::{LogEntry, LogInfoAppendRow};
 use concepts::time::ClockFn;
 use concepts::time::Now;
 use concepts::{ComponentId, Params, StrVariant, SupportedFunctionReturnValue};
 use concepts::{ComponentRetryConfig, JoinSetId, JoinSetKind, SUPPORTED_RETURN_VALUE_OK_EMPTY};
-use concepts::{ExecutionId, prefixed_ulid::ExecutorId};
+use concepts::{ExecutionId, FunctionFqn, prefixed_ulid::ExecutorId};
 use db_postgres::postgres_dao::{DbInitialzationOutcome, PostgresPool, ProvisionPolicy};
 use db_sqlite::sqlite_dao::{SqliteConfig, SqlitePool};
 use obeli_db_tests::SOME_FFQN;
@@ -4057,5 +4058,83 @@ async fn create_paused_workflow(database: Database) {
     }
 
     drop(db_connection);
+    db_close.close().await;
+}
+
+#[rstest]
+#[tokio::test]
+async fn list_executions_filters_by_versioned_package_name(
+    #[values(Database::Sqlite, Database::Postgres)] database: Database,
+) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let db_connection = db_pool.connection().await.unwrap();
+
+    let matching_execution_id = ExecutionId::generate();
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: matching_execution_id.clone(),
+            ffqn: FunctionFqn::new_static(
+                "obelisk-client:api-http/executions@1.0.0-beta",
+                "generate",
+            ),
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_activity(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
+
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: ExecutionId::generate(),
+            ffqn: FunctionFqn::new_static(
+                "obelisk-client:api-http/executions@2.0.0-beta",
+                "generate",
+            ),
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_activity(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
+
+    drop(db_connection);
+
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+    let executions = api_conn
+        .list_executions(
+            ListExecutionsFilter {
+                function_name_filter: Some(FunctionNameFilter::PackageName(
+                    "obelisk-client:api-http@1.0.0-beta".to_string(),
+                )),
+                ..Default::default()
+            },
+            ExecutionListPagination::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(1, executions.len());
+    assert_eq!(matching_execution_id, executions[0].execution_id);
+    assert_eq!(
+        "obelisk-client:api-http/executions@1.0.0-beta.generate",
+        executions[0].ffqn.to_string()
+    );
+
+    drop(api_conn);
     db_close.close().await;
 }

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -56,6 +56,13 @@ message GenerateExecutionIdResponse {
 }
 
 message ListExecutionsRequest {
+    message ExecutionFunctionFilter {
+        oneof scope {
+            string package_name = 1;
+            string interface_name = 2;
+            string function_name = 3;
+        }
+    }
     message Cursor {
         oneof cursor {
             ExecutionId execution_id = 1;
@@ -73,7 +80,7 @@ message ListExecutionsRequest {
         bool including_cursor = 3;
     }
 
-    optional string function_name_prefix = 1;
+    optional string function_name_prefix = 1 [deprecated = true];
 
     // Do not return child executions
     bool top_level_only = 2;
@@ -87,6 +94,7 @@ message ListExecutionsRequest {
 
     optional ContentDigest component_digest = 7;
     optional DeploymentId deployment_id = 8;
+    ExecutionFunctionFilter function_filter = 9;
 }
 
 message ExecutionSummary {

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -30,7 +30,6 @@ use concepts::storage::ExecutionListPagination;
 use concepts::storage::ExecutionRequest;
 use concepts::storage::LIST_DEPLOYMENT_STATES_DEFAULT_LENGTH;
 use concepts::storage::LIST_DEPLOYMENT_STATES_DEFAULT_PAGINATION;
-use concepts::storage::ListExecutionsFilter;
 use concepts::storage::LogFilter;
 use concepts::storage::LogInfoAppendRow;
 use concepts::storage::LogLevel;
@@ -39,6 +38,7 @@ use concepts::storage::Pagination;
 use concepts::storage::PendingState;
 use concepts::storage::Version;
 use concepts::storage::VersionType;
+use concepts::storage::{FunctionNameFilter, ListExecutionsFilter};
 use concepts::time::ClockFn;
 use concepts::time::Now;
 use grpc::TonicRespResult;
@@ -431,11 +431,31 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                     },
                 ));
 
+        #[allow(deprecated)]
         let filter = ListExecutionsFilter {
             show_derived: !request.top_level_only,
             hide_finished: request.hide_finished,
             execution_id_prefix: request.execution_id_prefix,
-            ffqn_prefix: request.function_name_prefix,
+            function_name_filter: request
+                .function_filter
+                .map(|filter| match filter.scope {
+                    Some(
+                        grpc_gen::list_executions_request::execution_function_filter::Scope::PackageName(package_name),
+                    ) => FunctionNameFilter::PackageName(package_name),
+                    Some(
+                        grpc_gen::list_executions_request::execution_function_filter::Scope::InterfaceName(interface_name),
+                    ) => FunctionNameFilter::InterfaceName(interface_name),
+                    Some(
+                        grpc_gen::list_executions_request::execution_function_filter::Scope::FunctionName(function_name),
+                    ) => FunctionNameFilter::FunctionName(function_name),
+                    None => unreachable!("`scope` is set when `function_filter` is present"),
+                })
+                .or_else(|| {
+                    // Map deprecated `function_name_prefix` to a FunctionName.
+                    // If this is a package name with a version, the search will not find anything as the
+                    // FFQN contains the version behind the interface.
+                    request.function_name_prefix.map(FunctionNameFilter::FunctionName)
+                }),
             component_digest: request
                 .component_digest
                 .map(ComponentDigest::try_from)

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -28,8 +28,9 @@ use concepts::{
     storage::{
         self, BacktraceFilter, CancelOutcome, DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout,
         DbErrorWrite, DbErrorWriteNonRetriable, DbPool, ExecutionEvent, ExecutionListPagination,
-        ExecutionRequest, ExecutionWithState, ListExecutionsFilter, LogInfoAppendRow, Pagination,
-        PendingState, ResponseCursor, ResponseWithCursor, TimeoutOutcome, Version, VersionType,
+        ExecutionRequest, ExecutionWithState, FunctionNameFilter, ListExecutionsFilter,
+        LogInfoAppendRow, Pagination, PendingState, ResponseCursor, ResponseWithCursor,
+        TimeoutOutcome, Version, VersionType,
     },
     time::{ClockFn as _, Now, Sleep as _},
 };
@@ -564,7 +565,12 @@ async fn executions_list(
         .map_err(|e| ErrorWrapper(e, accept))?;
 
     let filter = ListExecutionsFilter {
-        ffqn_prefix: params.ffqn_prefix,
+        function_name_filter: {
+            // Map `ffqn_prefix` to a FunctionName.
+            // If this is a package name with a version, the search will not find anything as the
+            // FFQN contains the version behind the interface.
+            params.ffqn_prefix.map(FunctionNameFilter::FunctionName)
+        },
         show_derived: params.show_derived,
         hide_finished: params.hide_finished,
         execution_id_prefix: params.execution_id_prefix,


### PR DESCRIPTION
- **refactor(grpc): Add `ExecutionFunctionFilter` to fix searching by package with version**
- **fix(pg): Restore component_type in list_executions select**
