### PR TITLE
Persist component metadada per deployment

### DIFF
--- a/assets/db/schema.json
+++ b/assets/db/schema.json
@@ -15,13 +15,17 @@
     },
     "wasm_backtrace": {
       "$ref": "#/$defs/WasmBacktrace"
+    },
+    "persisted_function_metadata": {
+      "$ref": "#/$defs/PersistedFunctionMetadata"
     }
   },
   "required": [
     "execution_event",
     "pending_state",
     "join_set_response",
-    "wasm_backtrace"
+    "wasm_backtrace",
+    "persisted_function_metadata"
   ],
   "$defs": {
     "ExecutionEvent": {
@@ -1865,6 +1869,67 @@
           "minimum": 0
         }
       }
+    },
+    "PersistedFunctionMetadata": {
+      "type": "object",
+      "properties": {
+        "ffqn": {
+          "type": "string"
+        },
+        "parameter_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PersistedParameterType"
+          }
+        },
+        "return_type": {
+          "type": "string"
+        },
+        "extension": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FunctionExtension"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submittable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ffqn",
+        "parameter_types",
+        "return_type",
+        "submittable"
+      ]
+    },
+    "PersistedParameterType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "wit_type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "wit_type"
+      ]
+    },
+    "FunctionExtension": {
+      "type": "string",
+      "enum": [
+        "submit",
+        "await_next",
+        "schedule",
+        "stub",
+        "get"
+      ]
     }
   }
 }

--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -22,6 +22,15 @@
         "operationId": "components_list",
         "parameters": [
           {
+            "name": "deployment_id",
+            "in": "query",
+            "description": "Filter by deployment ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "type",
             "in": "query",
             "description": "Filter by component type (workflow, activity, webhook)",

--- a/assets/openapi.json
+++ b/assets/openapi.json
@@ -136,6 +136,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "deployment_id",
+            "in": "query",
+            "description": "Filter by deployment ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -915,7 +915,14 @@ pub const SUFFIX_FN_STUB: &str = "-stub";
 pub const SUFFIX_FN_GET: &str = "-get";
 
 #[derive(
-    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, strum::EnumIter,
+    Debug,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    strum::EnumIter,
     schemars::JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -916,6 +916,7 @@ pub const SUFFIX_FN_GET: &str = "-get";
 
 #[derive(
     Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, strum::EnumIter,
+    schemars::JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum FunctionExtension {

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1539,7 +1539,9 @@ pub struct DeploymentComponentDetail {
     pub wit: String,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, schemars::JsonSchema,
+)]
 pub struct PersistedFunctionMetadata {
     pub ffqn: FunctionFqn,
     pub parameter_types: Vec<PersistedParameterType>,
@@ -1548,7 +1550,9 @@ pub struct PersistedFunctionMetadata {
     pub submittable: bool,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, schemars::JsonSchema,
+)]
 pub struct PersistedParameterType {
     pub name: String,
     pub wit_type: String,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1539,7 +1539,7 @@ pub struct DeploymentComponentDetail {
     pub wit: String,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct PersistedFunctionMetadata {
     pub ffqn: FunctionFqn,
     pub parameter_types: Vec<PersistedParameterType>,
@@ -1548,7 +1548,7 @@ pub struct PersistedFunctionMetadata {
     pub submittable: bool,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct PersistedParameterType {
     pub name: String,
     pub wit_type: String,
@@ -2527,6 +2527,7 @@ pub struct DbStorageSchema {
     pub pending_state: PendingState,
     pub join_set_response: JoinSetResponse,
     pub wasm_backtrace: WasmBacktrace,
+    pub persisted_function_metadata: PersistedFunctionMetadata,
 }
 
 #[cfg(test)]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -5,7 +5,9 @@ use crate::ExecutionFailureKind;
 use crate::ExecutionId;
 use crate::ExecutionMetadata;
 use crate::FinishedExecutionError;
+use crate::FunctionExtension;
 use crate::FunctionFqn;
+use crate::FunctionMetadata;
 use crate::JoinSetId;
 use crate::Params;
 use crate::StrVariant;
@@ -1295,6 +1297,32 @@ pub trait DbExternalApi: DbConnection {
         file: &str,
     ) -> Result<Option<String>, DbErrorRead>;
 
+    /// Insert or reuse normalized component metadata rows.
+    async fn upsert_component_metadata(
+        &self,
+        records: Vec<ComponentMetadataRecord>,
+    ) -> Result<(), DbErrorWrite>;
+
+    /// Insert deployment-local component bindings for a deployment.
+    async fn insert_deployment_components(
+        &self,
+        deployment_id: DeploymentId,
+        records: Vec<DeploymentComponentRecord>,
+    ) -> Result<(), DbErrorWrite>;
+
+    /// List all components visible in a deployment, including persisted imports, exports and WIT.
+    async fn list_deployment_components(
+        &self,
+        deployment_id: DeploymentId,
+    ) -> Result<Vec<DeploymentComponentDetail>, DbErrorRead>;
+
+    /// Get the WIT for a component digest scoped to a deployment.
+    async fn get_deployment_component_wit(
+        &self,
+        deployment_id: DeploymentId,
+        component_digest: &ComponentDigest,
+    ) -> Result<Option<String>, DbErrorRead>;
+
     /// Returns executions sorted in descending order.
     async fn list_executions(
         &self,
@@ -1480,9 +1508,70 @@ pub struct DeploymentRecord {
     /// Set when the deployment becomes Active; None if it has never been active.
     pub last_active_at: Option<DateTime<Utc>>,
     pub status: DeploymentStatus,
-    pub config_json: String,
+    pub config_json: String, // Serialized `DeploymentCanonical`
     pub obelisk_version: String,
     pub created_by: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentMetadataRecord {
+    pub component_digest: ComponentDigest,
+    pub imports: Vec<PersistedFunctionMetadata>,
+    pub exports: Vec<PersistedFunctionMetadata>,
+    pub wit: String,
+    pub wit_origin: String,
+}
+
+/// Relation between a deployment and its components
+#[derive(Debug, Clone)]
+pub struct DeploymentComponentRecord {
+    pub deployment_id: DeploymentId,
+    pub component_name: StrVariant,
+    pub component_digest: ComponentDigest,
+    pub component_type: ComponentType,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeploymentComponentDetail {
+    pub component_id: ComponentId,
+    pub imports: Vec<PersistedFunctionMetadata>,
+    pub exports: Vec<PersistedFunctionMetadata>,
+    pub wit: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct PersistedFunctionMetadata {
+    pub ffqn: FunctionFqn,
+    pub parameter_types: Vec<PersistedParameterType>,
+    pub return_type: String,
+    pub extension: Option<FunctionExtension>,
+    pub submittable: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct PersistedParameterType {
+    pub name: String,
+    pub wit_type: String,
+}
+
+impl From<FunctionMetadata> for PersistedFunctionMetadata {
+    fn from(value: FunctionMetadata) -> Self {
+        PersistedFunctionMetadata {
+            ffqn: value.ffqn,
+            parameter_types: value
+                .parameter_types
+                .0
+                .into_iter()
+                .map(|param| PersistedParameterType {
+                    name: param.name.to_string(),
+                    wit_type: param.wit_type.to_string(),
+                })
+                .collect(),
+            return_type: value.return_type.wit_type().to_string(),
+            extension: value.extension,
+            submittable: value.submittable,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/db-postgres/migrations/V2__deployment_component_metadata.sql
+++ b/crates/db-postgres/migrations/V2__deployment_component_metadata.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS t_component_metadata (
+    component_digest BYTEA NOT NULL,
+    imports_json     JSONB NOT NULL,
+    exports_json     JSONB NOT NULL,
+    wit              TEXT NOT NULL,
+    wit_origin       TEXT NOT NULL,
+    PRIMARY KEY (component_digest)
+);
+
+CREATE TABLE IF NOT EXISTS t_deployment_component (
+    deployment_id    TEXT  NOT NULL,
+    component_name   TEXT  NOT NULL,
+    component_type   TEXT  NOT NULL,
+    component_digest BYTEA NOT NULL,
+    PRIMARY KEY (deployment_id, component_name),
+    FOREIGN KEY (deployment_id) REFERENCES t_deployment(deployment_id),
+    FOREIGN KEY (component_digest) REFERENCES t_component_metadata(component_digest)
+);
+
+CREATE INDEX IF NOT EXISTS idx_t_deployment_component_deployment_list
+ON t_deployment_component (deployment_id, component_type, component_name);
+
+CREATE INDEX IF NOT EXISTS idx_t_deployment_component_deployment_digest
+ON t_deployment_component (deployment_id, component_digest);

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -8,10 +8,11 @@ use concepts::{
     prefixed_ulid::{DelayId, DeploymentId, ExecutionIdDerived, ExecutorId, RunId},
     storage::{
         AppendBatchResponse, AppendDelayResponseOutcome, AppendEventsToExecution, AppendRequest,
-        AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo, CreateRequest,
-        DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead,
-        DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
-        DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentRecord, DeploymentState,
+        AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo,
+        ComponentMetadataRecord, CreateRequest, DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection,
+        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite,
+        DbErrorWriteNonRetriable, DbExecutor, DbExternalApi, DbPool, DbPoolCloseable,
+        DeploymentComponentDetail, DeploymentComponentRecord, DeploymentRecord, DeploymentState,
         DeploymentStatus, ExecutionEvent, ExecutionListPagination, ExecutionRequest,
         ExecutionWithState, ExecutionWithStateRequestsResponses, ExpiredDelay, ExpiredLock,
         ExpiredTimer, HISTORY_EVENT_TYPE_JOIN_NEXT, HistoryEvent, JoinSetRequest, JoinSetResponse,
@@ -311,6 +312,42 @@ fn deployment_record_from_pg_row(row: &Row) -> Result<DeploymentRecord, DbErrorR
         config_json: get(row, "config_json")?,
         obelisk_version: get(row, "obelisk_version")?,
         created_by: get(row, "created_by")?,
+    })
+}
+
+fn deployment_component_detail_from_pg_row(
+    row: &Row,
+) -> Result<DeploymentComponentDetail, DbErrorRead> {
+    let component_name: String = get(row, "component_name")?;
+    let component_type: ComponentType =
+        get::<String, _>(row, "component_type")?
+            .parse()
+            .map_err(|err| {
+                DbErrorRead::Generic(consistency_db_err(format!("invalid component_type: {err}")))
+            })?;
+    let component_digest = ComponentDigest(Digest(
+        get::<Vec<u8>, _>(row, "component_digest")?
+            .try_into()
+            .map_err(|_| {
+                DbErrorRead::Generic(consistency_db_err("invalid component_digest length"))
+            })?,
+    ));
+    let component_id = ComponentId::new(
+        component_type,
+        StrVariant::from(component_name),
+        component_digest,
+    )
+    .map_err(|err| DbErrorRead::Generic(consistency_db_err(err.to_string())))?;
+    let imports =
+        get::<Json<Vec<concepts::storage::PersistedFunctionMetadata>>, _>(row, "imports_json")?.0;
+    let exports =
+        get::<Json<Vec<concepts::storage::PersistedFunctionMetadata>>, _>(row, "exports_json")?.0;
+    let wit: String = get(row, "wit")?;
+    Ok(DeploymentComponentDetail {
+        component_id,
+        imports,
+        exports,
+        wit,
     })
 }
 
@@ -4003,6 +4040,108 @@ impl DbExternalApi for PostgresConnection {
                 Ok(None)
             }
         }
+    }
+
+    #[instrument(skip_all)]
+    async fn upsert_component_metadata(
+        &self,
+        records: Vec<ComponentMetadataRecord>,
+    ) -> Result<(), DbErrorWrite> {
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+        for record in records {
+            tx.execute(
+                "INSERT INTO t_component_metadata \
+                 (component_digest, imports_json, exports_json, wit, wit_origin) \
+                 VALUES ($1, $2, $3, $4, $5) \
+                 ON CONFLICT (component_digest) DO NOTHING",
+                &[
+                    &record.component_digest.as_slice(),
+                    &Json(&record.imports),
+                    &Json(&record.exports),
+                    &record.wit,
+                    &record.wit_origin,
+                ],
+            )
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn insert_deployment_components(
+        &self,
+        deployment_id: DeploymentId,
+        records: Vec<DeploymentComponentRecord>,
+    ) -> Result<(), DbErrorWrite> {
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+        for record in records {
+            debug_assert_eq!(record.deployment_id, deployment_id);
+            tx.execute(
+                "INSERT INTO t_deployment_component \
+                 (deployment_id, component_name, component_type, component_digest) \
+                 VALUES ($1, $2, $3, $4) \
+                 ON CONFLICT (deployment_id, component_name) DO NOTHING",
+                &[
+                    &deployment_id.to_string(),
+                    &record.component_name.to_string(),
+                    &record.component_type.to_string(),
+                    &record.component_digest.as_slice(),
+                ],
+            )
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn list_deployment_components(
+        &self,
+        deployment_id: DeploymentId,
+    ) -> Result<Vec<DeploymentComponentDetail>, DbErrorRead> {
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+        let rows = tx
+            .query(
+                "SELECT dc.component_name, dc.component_type, dc.component_digest, \
+                        cm.imports_json, cm.exports_json, cm.wit \
+                 FROM t_deployment_component dc \
+                 JOIN t_component_metadata cm ON dc.component_digest = cm.component_digest \
+                 WHERE dc.deployment_id = $1 \
+                 ORDER BY dc.component_type, dc.component_name",
+                &[&deployment_id.to_string()],
+            )
+            .await?;
+        tx.commit().await?;
+        rows.iter()
+            .map(deployment_component_detail_from_pg_row)
+            .collect()
+    }
+
+    #[instrument(skip_all)]
+    async fn get_deployment_component_wit(
+        &self,
+        deployment_id: DeploymentId,
+        component_digest: &ComponentDigest,
+    ) -> Result<Option<String>, DbErrorRead> {
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+        let row = tx
+            .query_opt(
+                "SELECT cm.wit \
+                 FROM t_deployment_component dc \
+                 JOIN t_component_metadata cm ON dc.component_digest = cm.component_digest \
+                 WHERE dc.deployment_id = $1 AND dc.component_digest = $2 \
+                 LIMIT 1",
+                &[&deployment_id.to_string(), &component_digest.as_slice()],
+            )
+            .await?;
+        tx.commit().await?;
+        row.map(|row| get::<String, _>(&row, "wit").map_err(DbErrorRead::Generic))
+            .transpose()
     }
 
     #[instrument(skip(self))]

--- a/crates/db-sqlite/migrations/V2__deployment_component_metadata.sql
+++ b/crates/db-sqlite/migrations/V2__deployment_component_metadata.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS t_component_metadata (
+    component_digest BLOB NOT NULL,
+    imports_json     TEXT NOT NULL,
+    exports_json     TEXT NOT NULL,
+    wit              TEXT NOT NULL,
+    wit_origin       TEXT NOT NULL,
+    PRIMARY KEY (component_digest)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS t_deployment_component (
+    deployment_id    TEXT NOT NULL,
+    component_name   TEXT NOT NULL,
+    component_type   TEXT NOT NULL,
+    component_digest BLOB NOT NULL,
+    PRIMARY KEY (deployment_id, component_name),
+    FOREIGN KEY (deployment_id) REFERENCES t_deployment(deployment_id),
+    FOREIGN KEY (component_digest) REFERENCES t_component_metadata(component_digest)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_t_deployment_component_deployment_list
+ON t_deployment_component (deployment_id, component_type, component_name);
+
+CREATE INDEX IF NOT EXISTS idx_t_deployment_component_deployment_digest
+ON t_deployment_component (deployment_id, component_digest);

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2,16 +2,17 @@ use crate::{histograms::Histograms, sqlite_dao::conversions::to_generic_error};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::{
-    ComponentId, ComponentRetryConfig, ExecutionId, FunctionFqn, JoinSetId, StrVariant,
-    SupportedFunctionReturnValue,
+    ComponentId, ComponentRetryConfig, ComponentType, ExecutionId, FunctionFqn, JoinSetId,
+    StrVariant, SupportedFunctionReturnValue,
     component_id::ComponentDigest,
     prefixed_ulid::{DelayId, DeploymentId, ExecutionIdDerived, ExecutorId, RunId},
     storage::{
         AppendBatchResponse, AppendDelayResponseOutcome, AppendEventsToExecution, AppendRequest,
-        AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo, CreateRequest,
-        DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead,
-        DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
-        DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentRecord, DeploymentState,
+        AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo,
+        ComponentMetadataRecord, CreateRequest, DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection,
+        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite,
+        DbErrorWriteNonRetriable, DbExecutor, DbExternalApi, DbPool, DbPoolCloseable,
+        DeploymentComponentDetail, DeploymentComponentRecord, DeploymentRecord, DeploymentState,
         DeploymentStatus, ExecutionEvent, ExecutionListPagination, ExecutionRequest,
         ExecutionWithState, ExecutionWithStateRequestsResponses, ExpiredDelay, ExpiredLock,
         ExpiredTimer, HISTORY_EVENT_TYPE_JOIN_NEXT, HistoryEvent, JoinSetRequest, JoinSetResponse,
@@ -427,6 +428,48 @@ fn deployment_record_from_row(row: &Row<'_>) -> rusqlite::Result<DeploymentRecor
         config_json: row.get("config_json")?,
         obelisk_version: row.get("obelisk_version")?,
         created_by: row.get("created_by")?,
+    })
+}
+
+fn deployment_component_detail_from_row(
+    row: &Row<'_>,
+) -> Result<DeploymentComponentDetail, DbErrorGeneric> {
+    let component_name: String = row
+        .get("component_name")
+        .map_err(|err| consistency_db_err(format!("invalid component_name: {err}")))?;
+    let component_type: String = row
+        .get("component_type")
+        .map_err(|err| consistency_db_err(format!("invalid component_type: {err}")))?;
+    let component_type = component_type
+        .parse::<ComponentType>()
+        .map_err(|err| consistency_db_err(format!("invalid component_type: {err}")))?;
+    let component_digest: ComponentDigest = row
+        .get("component_digest")
+        .map_err(|err| consistency_db_err(format!("invalid component_digest: {err}")))?;
+    let component_id = ComponentId::new(
+        component_type,
+        StrVariant::from(component_name),
+        component_digest,
+    )
+    .map_err(|err| consistency_db_err(err.to_string()))?;
+    let imports: String = row
+        .get("imports_json")
+        .map_err(|err| consistency_db_err(format!("invalid imports_json: {err}")))?;
+    let imports = serde_json::from_str(&imports)
+        .map_err(|err| consistency_db_err(format!("invalid imports_json: {err}")))?;
+    let exports: String = row
+        .get("exports_json")
+        .map_err(|err| consistency_db_err(format!("invalid exports_json: {err}")))?;
+    let exports = serde_json::from_str(&exports)
+        .map_err(|err| consistency_db_err(format!("invalid exports_json: {err}")))?;
+    let wit: String = row
+        .get("wit")
+        .map_err(|err| consistency_db_err(format!("invalid wit: {err}")))?;
+    Ok(DeploymentComponentDetail {
+        component_id,
+        imports,
+        exports,
+        wit,
     })
 }
 
@@ -3872,6 +3915,135 @@ impl DbExternalApi for SqlitePool {
             },
             TxType::Other,
             "get_source_file",
+        )
+        .await
+    }
+
+    #[instrument(skip_all)]
+    async fn upsert_component_metadata(
+        &self,
+        records: Vec<ComponentMetadataRecord>,
+    ) -> Result<(), DbErrorWrite> {
+        self.transaction(
+            move |tx| {
+                let mut stmt = tx.prepare(
+                    "INSERT OR IGNORE INTO t_component_metadata \
+                     (component_digest, imports_json, exports_json, wit, wit_origin) \
+                     VALUES (:component_digest, :imports_json, :exports_json, :wit, :wit_origin)",
+                )?;
+                for record in &records {
+                    let imports_json = serde_json::to_string(&record.imports)
+                        .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?;
+                    let exports_json = serde_json::to_string(&record.exports)
+                        .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?;
+                    stmt.execute(named_params! {
+                        ":component_digest": record.component_digest.clone(),
+                        ":imports_json": imports_json,
+                        ":exports_json": exports_json,
+                        ":wit": record.wit.clone(),
+                        ":wit_origin": record.wit_origin.clone(),
+                    })?;
+                }
+                Ok(())
+            },
+            TxType::MultipleWrites,
+            "upsert_component_metadata",
+        )
+        .await
+    }
+
+    #[instrument(skip_all)]
+    async fn insert_deployment_components(
+        &self,
+        deployment_id: DeploymentId,
+        records: Vec<DeploymentComponentRecord>,
+    ) -> Result<(), DbErrorWrite> {
+        self.transaction(
+            move |tx| {
+                let mut stmt = tx.prepare(
+                    "INSERT OR IGNORE INTO t_deployment_component \
+                     (deployment_id, component_name, component_type, component_digest) \
+                     VALUES (:deployment_id, :component_name, :component_type, :component_digest)",
+                )?;
+                for record in &records {
+                    debug_assert_eq!(record.deployment_id, deployment_id);
+                    stmt.execute(named_params! {
+                        ":deployment_id": deployment_id.to_string(),
+                        ":component_name": record.component_name.to_string(),
+                        ":component_type": record.component_type.to_string(),
+                        ":component_digest": record.component_digest.clone(),
+                    })?;
+                }
+                Ok(())
+            },
+            TxType::MultipleWrites,
+            "insert_deployment_components",
+        )
+        .await
+    }
+
+    #[instrument(skip_all)]
+    async fn list_deployment_components(
+        &self,
+        deployment_id: DeploymentId,
+    ) -> Result<Vec<DeploymentComponentDetail>, DbErrorRead> {
+        self.transaction(
+            move |tx| {
+                let mut stmt = tx.prepare(
+                    "SELECT dc.component_name, dc.component_type, dc.component_digest, \
+                            cm.imports_json, cm.exports_json, cm.wit \
+                     FROM t_deployment_component dc \
+                     JOIN t_component_metadata cm ON dc.component_digest = cm.component_digest \
+                     WHERE dc.deployment_id = :deployment_id \
+                     ORDER BY dc.component_type, dc.component_name",
+                )?;
+                let rows = stmt
+                    .query_map(
+                        named_params! { ":deployment_id": deployment_id.to_string() },
+                        |row| {
+                            deployment_component_detail_from_row(row).map_err(|err| {
+                                rusqlite::Error::ToSqlConversionFailure(Box::new(err))
+                            })
+                        },
+                    )?
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(rows)
+            },
+            TxType::Other,
+            "list_deployment_components",
+        )
+        .await
+    }
+
+    #[instrument(skip_all)]
+    async fn get_deployment_component_wit(
+        &self,
+        deployment_id: DeploymentId,
+        component_digest: &ComponentDigest,
+    ) -> Result<Option<String>, DbErrorRead> {
+        let component_digest = component_digest.clone();
+        self.transaction(
+            move |tx| {
+                tx.prepare(
+                    "SELECT cm.wit \
+                     FROM t_deployment_component dc \
+                     JOIN t_component_metadata cm ON dc.component_digest = cm.component_digest \
+                     WHERE dc.deployment_id = :deployment_id \
+                       AND dc.component_digest = :component_digest \
+                     LIMIT 1",
+                )?
+                .query_row(
+                    named_params! {
+                        ":deployment_id": deployment_id.to_string(),
+                        ":component_digest": component_digest,
+                    },
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(DbErrorRead::from)
+            },
+            TxType::Other,
+            "get_deployment_component_wit",
         )
         .await
     }

--- a/crates/testing/db-tests/tests/deployment_components.rs
+++ b/crates/testing/db-tests/tests/deployment_components.rs
@@ -1,0 +1,387 @@
+use concepts::component_id::ComponentDigest;
+use concepts::prefixed_ulid::DeploymentId;
+use concepts::storage::{
+    ComponentMetadataRecord, DbExternalApi, DbPoolCloseable, DeploymentComponentRecord,
+    DeploymentRecord, DeploymentStatus, PersistedFunctionMetadata,
+};
+use concepts::time::ClockFn;
+use concepts::{
+    ComponentType, FunctionFqn, FunctionMetadata, ParameterTypes, RETURN_TYPE_DUMMY, StrVariant,
+};
+use obeli_db_tests::Database;
+use rstest::rstest;
+use test_db_macro::expand_enum_database;
+use test_utils::set_up;
+use test_utils::sim_clock::SimClock;
+
+fn mk_function(ffqn: &str, submittable: bool) -> FunctionMetadata {
+    FunctionMetadata {
+        ffqn: ffqn.parse::<FunctionFqn>().unwrap(),
+        parameter_types: ParameterTypes::default(),
+        return_type: RETURN_TYPE_DUMMY,
+        extension: None,
+        submittable,
+    }
+}
+
+fn mk_deployment_record(
+    deployment_id: DeploymentId,
+    now: chrono::DateTime<chrono::Utc>,
+) -> DeploymentRecord {
+    DeploymentRecord {
+        deployment_id,
+        created_at: now,
+        last_active_at: None,
+        status: DeploymentStatus::Inactive,
+        config_json: "{}".to_string(),
+        obelisk_version: "0.0.0-test".to_string(),
+        created_by: None,
+    }
+}
+
+async fn insert_deployment(
+    api_conn: &dyn DbExternalApi,
+    deployment_id: DeploymentId,
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    api_conn
+        .insert_deployment(mk_deployment_record(deployment_id, now))
+        .await
+        .unwrap();
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn deployment_components_roundtrip(database: Database) {
+    if database == Database::Memory {
+        return;
+    }
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+
+    let deployment_id = DeploymentId::generate();
+    insert_deployment(api_conn.as_ref(), deployment_id, sim_clock.now()).await;
+
+    let digest_a: ComponentDigest =
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+    let digest_b: ComponentDigest =
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+            .parse()
+            .unwrap();
+
+    api_conn
+        .upsert_component_metadata(vec![
+            ComponentMetadataRecord {
+                component_digest: digest_a.clone(),
+                imports: vec![PersistedFunctionMetadata::from(mk_function(
+                    "testing:pkg/imported-a.fn",
+                    false,
+                ))],
+                exports: vec![PersistedFunctionMetadata::from(mk_function(
+                    "testing:pkg/exported-a.fn",
+                    true,
+                ))],
+                wit: "package testing:pkg;".to_string(),
+                wit_origin: "wasm".to_string(),
+            },
+            ComponentMetadataRecord {
+                component_digest: digest_b.clone(),
+                imports: vec![],
+                exports: vec![PersistedFunctionMetadata::from(mk_function(
+                    "testing:pkg/exported-b.fn",
+                    true,
+                ))],
+                wit: "package testing:pkg-b;".to_string(),
+                wit_origin: "synthesized".to_string(),
+            },
+        ])
+        .await
+        .unwrap();
+    api_conn
+        .insert_deployment_components(
+            deployment_id,
+            vec![
+                DeploymentComponentRecord {
+                    deployment_id,
+                    component_name: StrVariant::from("b_workflow"),
+                    component_digest: digest_b.clone(),
+                    component_type: ComponentType::Workflow,
+                },
+                DeploymentComponentRecord {
+                    deployment_id,
+                    component_name: StrVariant::from("a_activity"),
+                    component_digest: digest_a.clone(),
+                    component_type: ComponentType::Activity,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+    let components = api_conn
+        .list_deployment_components(deployment_id)
+        .await
+        .unwrap();
+
+    assert_eq!(2, components.len());
+    assert_eq!(
+        ComponentType::Activity,
+        components[0].component_id.component_type
+    );
+    assert_eq!("a_activity", components[0].component_id.name.as_ref());
+    assert_eq!(digest_a, components[0].component_id.component_digest);
+    assert_eq!(1, components[0].imports.len());
+    assert_eq!(1, components[0].exports.len());
+    assert_eq!("package testing:pkg;", components[0].wit);
+
+    assert_eq!(
+        ComponentType::Workflow,
+        components[1].component_id.component_type
+    );
+    assert_eq!("b_workflow", components[1].component_id.name.as_ref());
+    assert_eq!(digest_b, components[1].component_id.component_digest);
+    assert!(components[1].imports.is_empty());
+    assert_eq!(1, components[1].exports.len());
+    assert_eq!("package testing:pkg-b;", components[1].wit);
+
+    drop(api_conn);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn component_metadata_deduplicates_by_digest_across_deployments(database: Database) {
+    if database == Database::Memory {
+        return;
+    }
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+
+    let dep_a = DeploymentId::generate();
+    let dep_b = DeploymentId::generate();
+    insert_deployment(api_conn.as_ref(), dep_a, sim_clock.now()).await;
+    insert_deployment(api_conn.as_ref(), dep_b, sim_clock.now()).await;
+
+    let digest: ComponentDigest =
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .parse()
+            .unwrap();
+
+    api_conn
+        .upsert_component_metadata(vec![ComponentMetadataRecord {
+            component_digest: digest.clone(),
+            imports: vec![PersistedFunctionMetadata::from(mk_function(
+                "testing:pkg/imported.fn",
+                false,
+            ))],
+            exports: vec![PersistedFunctionMetadata::from(mk_function(
+                "testing:pkg/exported.fn",
+                true,
+            ))],
+            wit: "package testing:pkg;".to_string(),
+            wit_origin: "wasm".to_string(),
+        }])
+        .await
+        .unwrap();
+
+    api_conn
+        .insert_deployment_components(
+            dep_a,
+            vec![DeploymentComponentRecord {
+                deployment_id: dep_a,
+                component_name: StrVariant::from("component_a"),
+                component_digest: digest.clone(),
+                component_type: ComponentType::Activity,
+            }],
+        )
+        .await
+        .unwrap();
+    api_conn
+        .insert_deployment_components(
+            dep_b,
+            vec![DeploymentComponentRecord {
+                deployment_id: dep_b,
+                component_name: StrVariant::from("component_b"),
+                component_digest: digest.clone(),
+                component_type: ComponentType::Activity,
+            }],
+        )
+        .await
+        .unwrap();
+
+    let a_components = api_conn.list_deployment_components(dep_a).await.unwrap();
+    let b_components = api_conn.list_deployment_components(dep_b).await.unwrap();
+
+    assert_eq!(1, a_components.len());
+    assert_eq!(1, b_components.len());
+    assert_eq!(digest, a_components[0].component_id.component_digest);
+    assert_eq!(digest, b_components[0].component_id.component_digest);
+    assert_eq!("component_a", a_components[0].component_id.name.as_ref());
+    assert_eq!("component_b", b_components[0].component_id.name.as_ref());
+    assert_eq!(1, a_components[0].exports.len());
+    assert_eq!(1, b_components[0].exports.len());
+    assert_eq!(
+        a_components[0].exports[0].ffqn.to_string(),
+        b_components[0].exports[0].ffqn.to_string()
+    );
+    assert_eq!(a_components[0].wit, b_components[0].wit);
+
+    drop(api_conn);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn deployment_component_insert_is_idempotent(database: Database) {
+    if database == Database::Memory {
+        return;
+    }
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+
+    let deployment_id = DeploymentId::generate();
+    insert_deployment(api_conn.as_ref(), deployment_id, sim_clock.now()).await;
+
+    let digest: ComponentDigest =
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            .parse()
+            .unwrap();
+    api_conn
+        .upsert_component_metadata(vec![ComponentMetadataRecord {
+            component_digest: digest.clone(),
+            imports: vec![],
+            exports: vec![PersistedFunctionMetadata::from(mk_function(
+                "testing:pkg/exported.fn",
+                true,
+            ))],
+            wit: "package testing:pkg;".to_string(),
+            wit_origin: "wasm".to_string(),
+        }])
+        .await
+        .unwrap();
+
+    let record = DeploymentComponentRecord {
+        deployment_id,
+        component_name: StrVariant::from("same_name"),
+        component_digest: digest.clone(),
+        component_type: ComponentType::Activity,
+    };
+    api_conn
+        .insert_deployment_components(deployment_id, vec![record.clone()])
+        .await
+        .unwrap();
+    api_conn
+        .insert_deployment_components(deployment_id, vec![record])
+        .await
+        .unwrap();
+
+    let components = api_conn
+        .list_deployment_components(deployment_id)
+        .await
+        .unwrap();
+    assert_eq!(1, components.len());
+    assert_eq!("same_name", components[0].component_id.name.as_ref());
+
+    drop(api_conn);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn list_deployment_components_orders_by_type_then_name(database: Database) {
+    if database == Database::Memory {
+        return;
+    }
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+
+    let deployment_id = DeploymentId::generate();
+    insert_deployment(api_conn.as_ref(), deployment_id, sim_clock.now()).await;
+
+    let digests = [
+        (
+            "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "z_activity",
+            ComponentType::Activity,
+        ),
+        (
+            "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "a_workflow",
+            ComponentType::Workflow,
+        ),
+        (
+            "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "a_activity_stub",
+            ComponentType::ActivityStub,
+        ),
+        (
+            "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "b_activity",
+            ComponentType::Activity,
+        ),
+    ];
+    let metadata: Vec<_> = digests
+        .iter()
+        .map(|(digest, _, _)| ComponentMetadataRecord {
+            component_digest: digest.parse().unwrap(),
+            imports: vec![],
+            exports: vec![],
+            wit: format!("package {};", &digest[7..11]),
+            wit_origin: "wasm".to_string(),
+        })
+        .collect();
+    api_conn.upsert_component_metadata(metadata).await.unwrap();
+    let records: Vec<_> = digests
+        .into_iter()
+        .map(|(digest, name, component_type)| DeploymentComponentRecord {
+            deployment_id,
+            component_name: StrVariant::from(name),
+            component_digest: digest.parse().unwrap(),
+            component_type,
+        })
+        .collect();
+    api_conn
+        .insert_deployment_components(deployment_id, records)
+        .await
+        .unwrap();
+
+    let components = api_conn
+        .list_deployment_components(deployment_id)
+        .await
+        .unwrap();
+    let ordered: Vec<_> = components
+        .into_iter()
+        .map(|c| {
+            (
+                c.component_id.component_type.to_string(),
+                c.component_id.name.to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        vec![
+            ("activity".to_string(), "b_activity".to_string()),
+            ("activity".to_string(), "z_activity".to_string()),
+            ("activity_stub".to_string(), "a_activity_stub".to_string()),
+            ("workflow".to_string(), "a_workflow".to_string()),
+        ],
+        ordered
+    );
+
+    drop(api_conn);
+    db_close.close().await;
+}

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -52,19 +52,19 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
             execution_id,
             version,
             req,
-            backtraces,
+            backtraces: _,
         } => CapturedDbWrite::Append {
             execution_id,
             version,
             req: normalize_append_request_for_matching(req),
-            backtraces,
+            backtraces: vec![],
         },
         CapturedDbWrite::AppendBatch {
             current_time: _,
             batch,
             execution_id,
             version,
-            backtraces,
+            backtraces: _,
         } => CapturedDbWrite::AppendBatch {
             current_time: DateTime::UNIX_EPOCH,
             batch: batch
@@ -73,7 +73,7 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
                 .collect(),
             execution_id,
             version,
-            backtraces,
+            backtraces: vec![],
         },
         CapturedDbWrite::AppendBatchCreateNewExecution {
             current_time: _,
@@ -81,7 +81,7 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
             execution_id,
             version,
             child_req,
-            backtraces,
+            backtraces: _,
         } => CapturedDbWrite::AppendBatchCreateNewExecution {
             current_time: DateTime::UNIX_EPOCH,
             batch: batch
@@ -94,13 +94,13 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
                 .into_iter()
                 .map(normalize_create_request_for_matching)
                 .collect(),
-            backtraces,
+            backtraces: vec![],
         },
         CapturedDbWrite::AppendStubResponse {
             events,
             response,
             current_time: _,
-            backtraces,
+            backtraces: _,
         } => CapturedDbWrite::AppendStubResponse {
             events: AppendEventsToExecution {
                 execution_id: events.execution_id,
@@ -120,7 +120,7 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
                 result: response.result,
             },
             current_time: DateTime::UNIX_EPOCH,
-            backtraces,
+            backtraces: vec![],
         },
         CapturedDbWrite::AppendFinished {
             execution_id,

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_full_replay_1.snap
@@ -210,7 +210,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_1.snap
@@ -210,7 +210,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_2.snap
@@ -147,7 +147,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_3.snap
@@ -41,7 +41,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_1_replay_1.snap
@@ -210,7 +210,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_1.snap
@@ -422,7 +422,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_2.snap
@@ -41,7 +41,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_3.snap
@@ -41,7 +41,7 @@ expression: redact_replay(&replay)
                 },
                 {
                   "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h0e8d9ba882be7d50",
+                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
                   "symbols": [
                     {
                       "func_name": "fibo_await_next",

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -4783,6 +4783,7 @@ pub(crate) mod tests {
     fn redact_replay(replay: &ReplayAdvanceable) -> serde_json::Value {
         let replay = serde_json::to_value(replay).unwrap();
         let replay = redact_backtrace_file(replay);
+        let replay = redact_rust_symbol_hash(replay);
         redact_component_digest(replay)
     }
 
@@ -4810,6 +4811,45 @@ pub(crate) mod tests {
             ),
             other => other,
         }
+    }
+
+    /// Strip Rust symbol hash suffixes (e.g. `::h0e8d9ba882be7d50`) from `func_name` values.
+    /// These hashes are not stable across rebuilds and cause snapshot churn.
+    fn redact_rust_symbol_hash(value: Value) -> Value {
+        match value {
+            Value::Array(items) => {
+                Value::Array(items.into_iter().map(redact_rust_symbol_hash).collect())
+            }
+            Value::Object(map) => Value::Object(
+                map.into_iter()
+                    .map(|(key, value)| {
+                        if key == "func_name"
+                            && let Value::String(s) = value
+                        {
+                            (key, Value::String(strip_rust_symbol_hash(&s)))
+                        } else {
+                            (key, redact_rust_symbol_hash(value))
+                        }
+                    })
+                    .collect(),
+            ),
+            other => other,
+        }
+    }
+
+    /// If `s` ends with `::h` followed by exactly 16 hex digits, replace that suffix with `::h<REDACTED>`.
+    fn strip_rust_symbol_hash(s: &str) -> String {
+        // `::h` + 16 hex chars = 19 bytes from the end
+        if s.len() >= 19 {
+            let (prefix, suffix) = s.split_at(s.len() - 19);
+            if suffix.starts_with("::h")
+                && suffix[3..].len() == 16
+                && suffix[3..].chars().all(|c| c.is_ascii_hexdigit())
+            {
+                return format!("{prefix}::h<REDACTED>");
+            }
+        }
+        s.to_string()
     }
 
     async fn advance_paused_workflow_until_finished(

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -117,6 +117,7 @@ message ListComponentsRequest {
     optional FunctionName function_name = 1;
     optional ContentDigest component_digest = 2;
     bool extensions = 3;
+    optional DeploymentId deployment_id = 4;
 }
 
 message ListComponentsResponse {

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -676,6 +676,7 @@ message ListExecutionEventsAndResponsesResponse {
 
 message GetWitRequest {
     ContentDigest component_digest = 1;
+    optional DeploymentId deployment_id = 2;
 }
 
 message GetWitResponse {

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -572,6 +572,7 @@ pub(crate) async fn list_components(
             function_name: None,
             component_digest: None,
             extensions,
+            deployment_id: None,
         }))
         .await?
         .into_inner()

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -263,6 +263,7 @@ pub(crate) async fn submit(
                     function_name: None,
                     component_digest: None,
                     extensions: false,
+                    deployment_id: None,
                 }))
                 .await?
                 .into_inner()
@@ -1442,6 +1443,7 @@ async fn upgrade(
             function_name: Some(grpc_gen::FunctionName::from(&ffqn)),
             component_digest: None,
             extensions: false,
+            deployment_id: None,
         }))
         .await
         .context("failed to list components")?

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -1,8 +1,8 @@
 use crate::args::Generate;
 use crate::args::shadow::PKG_VERSION;
 use crate::command::server::{
-    PrepareDirsParams, VerifyParams, create_engines, deployment_verify_config_compile_link,
-    prepare_dirs, server_verify,
+    PrepareDirsParams, VerifyParams, create_engines, deployment_compile_link,
+    deployment_verify_config, prepare_dirs, server_verify,
 };
 use crate::command::termination_notifier::termination_notifier;
 use crate::config::config_holder::{ConfigHolder, load_deployment_validated};
@@ -382,10 +382,17 @@ pub(crate) async fn generate_wit_deps(
     let engines = create_engines(&config, &prepared_dirs)?;
 
     let server_verified = Box::pin(server_verify(config, engines)).await?;
-    let compiled_and_linked = deployment_verify_config_compile_link(
-        server_verified,
+    let deployment_verified = deployment_verify_config(
+        &server_verified,
         &prepared_dirs,
         deployment,
+        verify_params.clone(),
+        &mut termination_watcher,
+    )
+    .await?;
+    let compiled_and_linked = deployment_compile_link(
+        server_verified,
+        deployment_verified,
         DeploymentId::generate(),
         verify_params,
         &mut termination_watcher,

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -708,15 +708,70 @@ impl TestServer {
     }
 
     async fn list_components(&self) -> Value {
-        self.client
-            .get(format!("{}/v1/components", self.base_url))
+        self.list_components_for_deployment(None).await
+    }
+
+    async fn list_components_for_deployment(&self, deployment_id: Option<DeploymentId>) -> Value {
+        let url = match deployment_id {
+            Some(deployment_id) => format!(
+                "{}/v1/components?deployment_id={deployment_id}",
+                self.base_url
+            ),
+            None => format!("{}/v1/components", self.base_url),
+        };
+        let resp = self
+            .client
+            .get(url)
             .header("Accept", "application/json")
             .send()
             .await
-            .expect("components request failed")
-            .json()
+            .expect("components request failed");
+        let status = resp.status();
+        let body = resp.text().await.expect("components body read failed");
+        assert!(
+            status.is_success(),
+            "components request failed: {status} - {body}"
+        );
+        serde_json::from_str(&body).expect("components parse failed")
+    }
+
+    async fn grpc_list_components(
+        &self,
+        deployment_id: Option<DeploymentId>,
+    ) -> grpc::grpc_gen::ListComponentsResponse {
+        let mut fn_client =
+            FunctionRepositoryClient::connect(format!("http://{}", self.api_addr()))
+                .await
+                .unwrap();
+        fn_client
+            .list_components(ListComponentsRequest {
+                function_name: None,
+                component_digest: None,
+                extensions: false,
+                deployment_id: deployment_id.map(|deployment_id| GrpcDeploymentId {
+                    id: deployment_id.to_string(),
+                }),
+            })
             .await
-            .expect("components parse failed")
+            .unwrap()
+            .into_inner()
+    }
+
+    async fn submit_modified_deployment(
+        &self,
+        mutate: impl FnOnce(&mut DeploymentCanonical),
+    ) -> DeploymentId {
+        let pool = SqlitePool::new(&self.sqlite_file, SqliteConfig::default())
+            .await
+            .unwrap();
+        let conn = pool.external_api_conn().await.unwrap();
+        let active = conn.get_active_deployment().await.unwrap().unwrap();
+        pool.close().await;
+        let mut new_deployment: DeploymentCanonical =
+            serde_json::from_str(&active.config_json).unwrap();
+        mutate(&mut new_deployment);
+        let new_config_json = crate::config::toml::compute_config_json(&new_deployment);
+        self.webapi_submit_deployment(&new_config_json).await
     }
 
     async fn list_executions(&self) -> Value {
@@ -1320,12 +1375,239 @@ async fn list_components() {
 }
 
 #[tokio::test]
+async fn list_components_webapi_by_explicit_deployment_id() {
+    let server = TestServer::start(test_addr!(40_100)).await;
+    const NEW_STUB_NAME: &str = "explicit_deployment_stub";
+
+    let second_deployment_id = server
+        .submit_modified_deployment(|new_deployment| {
+            new_deployment
+                .activities_stub
+                .push(ActivityStubComponentConfigCanonical::Inline(
+                    ActivityStubExtInlineConfigCanonical {
+                        name: ConfigName::new(concepts::StrVariant::from(NEW_STUB_NAME)).unwrap(),
+                        ffqn: "testing:integration/stubs.explicit-deployment-stub"
+                            .parse()
+                            .unwrap(),
+                        params: Some(vec![]),
+                        return_type: Some("result<string, string>".to_string()),
+                    },
+                ));
+        })
+        .await;
+
+    let current_components = server.list_components().await;
+    assert!(
+        !current_components
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|component| component["component_id"]["name"] == NEW_STUB_NAME),
+        "inactive deployment component must not appear without explicit deployment_id"
+    );
+
+    let explicit_components = server
+        .list_components_for_deployment(Some(second_deployment_id))
+        .await;
+    assert!(
+        explicit_components
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|component| component["component_id"]["name"] == NEW_STUB_NAME),
+        "explicit deployment_id must return the submitted deployment's components"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn list_components_webapi_filters_with_explicit_deployment_id() {
+    let server = TestServer::start(test_addr!(40_101)).await;
+    const NEW_STUB_NAME: &str = "explicit_deployment_stub_filters";
+
+    let second_deployment_id = server
+        .submit_modified_deployment(|new_deployment| {
+            new_deployment
+                .activities_stub
+                .push(ActivityStubComponentConfigCanonical::Inline(
+                    ActivityStubExtInlineConfigCanonical {
+                        name: ConfigName::new(concepts::StrVariant::from(NEW_STUB_NAME)).unwrap(),
+                        ffqn: "testing:integration/stubs.explicit-deployment-filters"
+                            .parse()
+                            .unwrap(),
+                        params: Some(vec![]),
+                        return_type: Some("result<string, string>".to_string()),
+                    },
+                ));
+        })
+        .await;
+
+    let explicit_components = server
+        .list_components_for_deployment(Some(second_deployment_id))
+        .await;
+    let target = explicit_components
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|component| component["component_id"]["name"] == NEW_STUB_NAME)
+        .unwrap();
+    let digest = target["component_id"]["component_digest"].as_str().unwrap();
+
+    let filtered: Value = server
+        .client
+        .get(format!(
+            "{}/v1/components?deployment_id={}&name={}&type=activity_stub&digest={}&exports=true&submittable=false",
+            server.base_url, second_deployment_id, NEW_STUB_NAME, digest
+        ))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let filtered = filtered.as_array().unwrap();
+    assert_eq!(1, filtered.len());
+    assert_eq!(NEW_STUB_NAME, filtered[0]["component_id"]["name"]);
+    assert_eq!(
+        "activity_stub",
+        filtered[0]["component_id"]["component_type"]
+    );
+    assert_eq!(digest, filtered[0]["component_id"]["component_digest"]);
+    assert_eq!(1, filtered[0]["exports"].as_array().unwrap().len());
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn list_functions() {
     let server = TestServer::start(test_addr!(3)).await;
 
     let functions = server.list_functions().await;
     let functions = sanitize_json(&functions);
     insta::assert_json_snapshot!("list_functions", functions);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn list_components_grpc_by_explicit_deployment_id() {
+    let server = TestServer::start(test_addr!(40_102)).await;
+    const NEW_STUB_NAME: &str = "explicit_deployment_stub_grpc";
+    const NEW_STUB_FFQN: &str = "testing:integration/stubs.explicit-deployment-grpc";
+
+    let second_deployment_id = server
+        .submit_modified_deployment(|new_deployment| {
+            new_deployment
+                .activities_stub
+                .push(ActivityStubComponentConfigCanonical::Inline(
+                    ActivityStubExtInlineConfigCanonical {
+                        name: ConfigName::new(concepts::StrVariant::from(NEW_STUB_NAME)).unwrap(),
+                        ffqn: NEW_STUB_FFQN.parse().unwrap(),
+                        params: Some(vec![]),
+                        return_type: Some("result<string, string>".to_string()),
+                    },
+                ));
+        })
+        .await;
+
+    let current_components = server.grpc_list_components(None).await;
+    assert!(
+        !current_components.components.iter().any(|component| {
+            component.exports.iter().any(|export| {
+                export.function_name.as_ref().is_some_and(|function_name| {
+                    function_name.function_name == "explicit-deployment-grpc"
+                })
+            })
+        }),
+        "inactive deployment component must not appear without explicit deployment_id"
+    );
+
+    let explicit_components = server
+        .grpc_list_components(Some(second_deployment_id))
+        .await;
+    assert!(
+        explicit_components.components.iter().any(|component| {
+            component
+                .component_id
+                .as_ref()
+                .is_some_and(|component_id| component_id.name == NEW_STUB_NAME)
+        }),
+        "explicit deployment_id must return the submitted deployment's components"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn list_components_grpc_filters_with_explicit_deployment_id() {
+    let server = TestServer::start(test_addr!(40_103)).await;
+    const NEW_STUB_NAME: &str = "explicit_deployment_stub_grpc_filters";
+    const NEW_STUB_FFQN: &str = "testing:integration/stubs.explicit-deployment-grpc-filters";
+
+    let second_deployment_id = server
+        .submit_modified_deployment(|new_deployment| {
+            new_deployment
+                .activities_stub
+                .push(ActivityStubComponentConfigCanonical::Inline(
+                    ActivityStubExtInlineConfigCanonical {
+                        name: ConfigName::new(concepts::StrVariant::from(NEW_STUB_NAME)).unwrap(),
+                        ffqn: NEW_STUB_FFQN.parse().unwrap(),
+                        params: Some(vec![]),
+                        return_type: Some("result<string, string>".to_string()),
+                    },
+                ));
+        })
+        .await;
+
+    let explicit_components = server
+        .grpc_list_components(Some(second_deployment_id))
+        .await;
+    let target = explicit_components
+        .components
+        .iter()
+        .find(|component| {
+            component
+                .component_id
+                .as_ref()
+                .is_some_and(|component_id| component_id.name == NEW_STUB_NAME)
+        })
+        .unwrap();
+    let digest = target
+        .component_id
+        .as_ref()
+        .unwrap()
+        .digest
+        .as_ref()
+        .unwrap()
+        .digest
+        .clone();
+
+    let mut fn_client = FunctionRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap();
+    let filtered = fn_client
+        .list_components(ListComponentsRequest {
+            function_name: Some(grpc::grpc_gen::FunctionName::from(
+                &NEW_STUB_FFQN.parse::<FunctionFqn>().unwrap(),
+            )),
+            component_digest: Some(grpc::grpc_gen::ContentDigest { digest }),
+            extensions: false,
+            deployment_id: Some(GrpcDeploymentId {
+                id: second_deployment_id.to_string(),
+            }),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(1, filtered.components.len());
+    assert_eq!(
+        NEW_STUB_NAME,
+        filtered.components[0].component_id.as_ref().unwrap().name
+    );
+
     server.shutdown().await;
 }
 
@@ -2316,6 +2598,7 @@ async fn hot_redeploy_registry_impl(server: &TestServer, deploy_client: &TestDep
                 function_name: None,
                 component_digest: None,
                 extensions: false,
+                deployment_id: None,
             })
             .await
             .unwrap()

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -62,9 +62,10 @@ use concepts::storage::DbErrorWriteNonRetriable;
 use concepts::storage::DbExternalApi;
 use concepts::storage::DbPool;
 use concepts::storage::DbPoolCloseable;
+use concepts::storage::DeploymentComponentRecord;
 use concepts::storage::LogInfoAppendRow;
 use concepts::storage::LogLevel;
-use concepts::storage::{DeploymentRecord, DeploymentStatus};
+use concepts::storage::{ComponentMetadataRecord, DeploymentRecord, DeploymentStatus};
 use concepts::time::ClockFn;
 use concepts::time::Now;
 use concepts::time::TokioSleep;
@@ -644,26 +645,35 @@ pub(crate) async fn deployment_verify_config_compile_link(
     termination_watcher: &mut watch::Receiver<()>,
 ) -> Result<ServerCompiledLinked, anyhow::Error> {
     info!("Verifying deployment configuration, compiling WASM components");
-    // Verify deployment
-    let config = Box::pin(ConfigVerified::fetch_and_verify_all(
+    let deployment_verified = deployment_verify_config(
+        &server_verified,
+        prepared_dirs,
         deployment,
-        server_verified.http_servers,
-        prepared_dirs.wasm_cache_dir.clone(),
-        prepared_dirs.metadata_dir.clone(),
-        params.ignore_missing_env_vars,
-        server_verified.global_backtrace_persist,
-        server_verified.global_executor_instance_limiter,
-        server_verified.fuel,
+        params.clone(),
         termination_watcher,
-        server_verified.database_subscription_interruption,
-        server_verified.api_addr_if_webui_enabled,
-    ))
+    )
     .await?;
-    trace!("Verified config: {config:#?}");
+    deployment_compile_link(
+        server_verified,
+        deployment_verified,
+        deployment_id,
+        params,
+        termination_watcher,
+    )
+    .await
+}
 
+#[instrument(skip_all, fields(%deployment_id))]
+pub(crate) async fn deployment_compile_link(
+    server_verified: ServerVerified,
+    deployment_verified: DeploymentVerified,
+    deployment_id: DeploymentId,
+    params: VerifyParams,
+    termination_watcher: &mut watch::Receiver<()>,
+) -> Result<ServerCompiledLinked, anyhow::Error> {
     let compiled_and_linked = ServerCompiledLinked::new(
         deployment_id,
-        config,
+        deployment_verified,
         server_verified.launch,
         termination_watcher,
         params.suppress_type_checking_errors,
@@ -676,6 +686,32 @@ pub(crate) async fn deployment_verify_config_compile_link(
         warn!("Obelisk configuration was verified with supressed errors");
     }
     Ok(compiled_and_linked)
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn deployment_verify_config(
+    server_verified: &ServerVerified,
+    prepared_dirs: &PreparedDirs,
+    deployment: DeploymentCanonical,
+    params: VerifyParams,
+    termination_watcher: &mut watch::Receiver<()>,
+) -> Result<DeploymentVerified, anyhow::Error> {
+    let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(
+        deployment,
+        server_verified.http_servers.clone(),
+        prepared_dirs.wasm_cache_dir.clone(),
+        prepared_dirs.metadata_dir.clone(),
+        params.ignore_missing_env_vars,
+        server_verified.global_backtrace_persist,
+        server_verified.global_executor_instance_limiter.clone(),
+        server_verified.fuel,
+        termination_watcher,
+        server_verified.database_subscription_interruption,
+        server_verified.api_addr_if_webui_enabled.clone(),
+    ))
+    .await?;
+    trace!("Verified deployment: {deployment_verified:#?}");
+    Ok(deployment_verified)
 }
 
 /// Look up the current deployment from the database.
@@ -945,6 +981,16 @@ pub(crate) async fn run_internal(
     ))
     .instrument(span.clone())
     .await?;
+    let api_conn = db_pool
+        .external_api_conn()
+        .await
+        .context("cannot get db connection for component metadata persistence")?;
+    persist_deployment_component_metadata(
+        api_conn.as_ref(),
+        active_deployment_id,
+        &compiled_and_linked.component_registry_ro,
+    )
+    .await?;
 
     let cancel_registry = CancelRegistry::new();
     let subscription_interruption = database.get_subscription_interruption();
@@ -1169,26 +1215,42 @@ pub(crate) struct ServerCompiledLinked {
 impl ServerCompiledLinked {
     async fn new(
         deployment_id: DeploymentId,
-        config: ConfigVerified,
+        deployment_verified: DeploymentVerified,
         server_verified: ServerVerifiedLaunch,
         termination_watcher: &mut watch::Receiver<()>,
         suppress_type_checking_errors: bool,
         suppress_linking_errors: bool,
     ) -> Result<Self, anyhow::Error> {
+        trace!("Verified deployment: {deployment_verified:#?}");
+        let DeploymentVerified {
+            activities_wasm,
+            activities_js,
+            activities_exec,
+            activities_stub_ext,
+            activities_stub_ext_inline,
+            workflows,
+            workflows_js,
+            webhooks_wasm_by_names,
+            webhooks_js_by_names,
+            crons,
+            http_servers_to_webhook_names,
+            global_backtrace_persist,
+            fuel,
+        } = deployment_verified;
         let linked = compile_and_link(
             &server_verified.engines,
-            config.activities_wasm,
-            config.activities_js,
-            config.activities_exec,
-            config.activities_stub_ext,
-            config.activities_stub_ext_inline,
-            config.workflows,
-            config.workflows_js,
-            config.webhooks_wasm_by_names,
-            config.webhooks_js_by_names,
-            config.crons,
-            config.global_backtrace_persist,
-            config.fuel,
+            activities_wasm,
+            activities_js,
+            activities_exec,
+            activities_stub_ext,
+            activities_stub_ext_inline,
+            workflows,
+            workflows_js,
+            webhooks_wasm_by_names,
+            webhooks_js_by_names,
+            crons,
+            global_backtrace_persist,
+            fuel,
             server_verified.build_semaphore,
             server_verified.workflows_lock_extension_leeway,
             termination_watcher,
@@ -1198,9 +1260,9 @@ impl ServerCompiledLinked {
         if !suppress_type_checking_errors && linked.supressed_errors.is_some() {
             bail!("type checking errors detected");
         }
-        let http_server_len = config.http_servers_to_webhook_names.len();
+        let http_server_len = http_servers_to_webhook_names.len();
         let http_servers_to_webhooks = Self::connect_http_servers_to_webhooks(
-            &config.http_servers_to_webhook_names,
+            &http_servers_to_webhook_names,
             linked.webhooks_wasm_by_names,
         );
         assert_eq!(
@@ -1304,6 +1366,104 @@ pub(crate) async fn upsert_backtrace_sources(
     }
 }
 
+fn build_component_metadata_records(
+    deployment_id: DeploymentId,
+    component_registry_ro: &ComponentConfigRegistryRO,
+) -> (
+    Vec<ComponentMetadataRecord>,   // List of components as stored in db
+    Vec<DeploymentComponentRecord>, // List of relations to each component for the depoloyment ID.
+) {
+    let components = component_registry_ro.list(true);
+    let mut metadata_by_digest = HashMap::<ComponentDigest, ComponentMetadataRecord>::new();
+    let mut component_type_by_digest = HashMap::<ComponentDigest, ComponentType>::new();
+    let mut deployment_components = Vec::with_capacity(components.len());
+    for component in components {
+        let component_type = component.component_id.component_type;
+        let component_digest = component.component_id.component_digest.clone();
+        let exports: Vec<concepts::storage::PersistedFunctionMetadata> = component
+            .workflow_or_activity_config
+            .as_ref()
+            .map(|config| {
+                config
+                    .exports_ext
+                    .clone()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let imports = component
+            .imports
+            .clone()
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        let wit_origin = component.wit_origin.to_string();
+        match metadata_by_digest.entry(component_digest.clone()) {
+            hashbrown::hash_map::Entry::Occupied(occupied) => {
+                let existing = occupied.get();
+                assert_eq!(
+                    component_type_by_digest.get(&component_digest),
+                    Some(&component_type),
+                    "component digest reused across different component types"
+                );
+                assert_eq!(
+                    existing.imports, imports,
+                    "component digest reused with different imports"
+                );
+                assert_eq!(
+                    existing.exports, exports,
+                    "component digest reused with different exports"
+                );
+                assert_eq!(
+                    existing.wit, component.wit,
+                    "component digest reused with different WIT"
+                );
+                assert_eq!(
+                    existing.wit_origin, wit_origin,
+                    "component digest reused with different WIT origins"
+                );
+            }
+            hashbrown::hash_map::Entry::Vacant(vacant) => {
+                component_type_by_digest.insert(component_digest.clone(), component_type);
+                vacant.insert(ComponentMetadataRecord {
+                    component_digest: component_digest.clone(),
+                    imports,
+                    exports,
+                    wit: component.wit.clone(),
+                    wit_origin,
+                });
+            }
+        }
+        deployment_components.push(DeploymentComponentRecord {
+            deployment_id,
+            component_name: component.component_id.name,
+            component_digest: component.component_id.component_digest,
+            component_type,
+        });
+    }
+    (
+        metadata_by_digest.into_values().collect(),
+        deployment_components,
+    )
+}
+
+pub(crate) async fn persist_deployment_component_metadata(
+    conn: &dyn DbExternalApi,
+    deployment_id: DeploymentId,
+    component_registry_ro: &ComponentConfigRegistryRO,
+) -> anyhow::Result<()> {
+    let (component_metadata, deployment_components) =
+        build_component_metadata_records(deployment_id, component_registry_ro);
+    conn.upsert_component_metadata(component_metadata)
+        .await
+        .context("cannot insert component metadata")?;
+    conn.insert_deployment_components(deployment_id, deployment_components)
+        .await
+        .context("cannot insert deployment components")?;
+    Ok(())
+}
+
 /// Shared logic for submitting a deployment (used by both gRPC and web API).
 /// Parses, verifies, and inserts the deployment record.
 #[instrument(skip_all)]
@@ -1354,6 +1514,13 @@ pub(crate) async fn submit_deployment(
         created_by,
         config_json: canonical_config,
     })
+    .await?;
+
+    persist_deployment_component_metadata(
+        conn.as_ref(),
+        deployment_id,
+        &server_compiled.component_registry_ro,
+    )
     .await?;
 
     upsert_backtrace_sources(conn.as_ref(), &server_compiled).await;
@@ -1870,7 +2037,7 @@ async fn start_http_servers(
 }
 
 #[derive(Debug)]
-struct ConfigVerified {
+pub(crate) struct DeploymentVerified {
     activities_wasm: Vec<ActivityWasmConfigVerified>,
     activities_js: Vec<ActivityJsConfigVerified>,
     activities_exec: Vec<ActivityExecConfigVerified>,
@@ -1886,7 +2053,92 @@ struct ConfigVerified {
     fuel: Option<u64>,
 }
 
-impl ConfigVerified {
+impl DeploymentVerified {
+    fn validate_component_digests(&self) -> Result<(), anyhow::Error> {
+        fn record_component_ids<'a>(
+            component_ids_by_digest: &mut HashMap<ComponentDigest, ComponentId>,
+            component_ids: impl IntoIterator<Item = &'a ComponentId>,
+        ) -> Result<(), anyhow::Error> {
+            for component_id in component_ids {
+                if let Some(existing) = component_ids_by_digest
+                    .insert(component_id.component_digest.clone(), component_id.clone())
+                    && existing.component_type != component_id.component_type
+                {
+                    bail!(
+                        "component digest `{}` is shared between component types `{}` ({}) and `{}` ({})",
+                        component_id.component_digest,
+                        existing.component_type,
+                        existing.name,
+                        component_id.component_type,
+                        component_id.name,
+                    );
+                }
+            }
+            Ok(())
+        }
+
+        let mut component_ids_by_digest = HashMap::<ComponentDigest, ComponentId>::new();
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.activities_wasm
+                .iter()
+                .map(ActivityWasmConfigVerified::component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.activities_js
+                .iter()
+                .map(ActivityJsConfigVerified::component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.activities_exec
+                .iter()
+                .map(ActivityExecConfigVerified::component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.activities_stub_ext
+                .iter()
+                .map(|activity| &activity.component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.activities_stub_ext_inline
+                .iter()
+                .map(|activity| &activity.component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.workflows
+                .iter()
+                .map(WorkflowConfigVerified::component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.workflows_js
+                .iter()
+                .map(WorkflowJsConfigVerified::component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.webhooks_wasm_by_names
+                .values()
+                .map(|webhook| &webhook.component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.webhooks_js_by_names
+                .values()
+                .map(|webhook| &webhook.component_id),
+        )?;
+        record_component_ids(
+            &mut component_ids_by_digest,
+            self.crons.iter().map(|cron| &cron.component_id),
+        )?;
+        Ok(())
+    }
+
     #[instrument(skip_all)]
     #[expect(clippy::too_many_arguments)]
     async fn fetch_and_verify_all(
@@ -1901,7 +2153,7 @@ impl ConfigVerified {
         termination_watcher: &mut watch::Receiver<()>,
         subscription_interruption: Option<Duration>,
         api_addr_if_webui_enabled: Option<String>,
-    ) -> Result<ConfigVerified, anyhow::Error> {
+    ) -> Result<DeploymentVerified, anyhow::Error> {
         trace!("Using deployment toml: {deployment:#?}");
         // Check uniqueness of http_server names.
         if http_servers.len()
@@ -2215,7 +2467,7 @@ impl ConfigVerified {
                     })?);
                 }
 
-                Ok(ConfigVerified {
+                let deployment_verified = DeploymentVerified {
                     activities_wasm,
                     activities_js: activities_js_verified,
                     activities_exec: activities_exec_verified,
@@ -2229,7 +2481,9 @@ impl ConfigVerified {
                     http_servers_to_webhook_names,
                     global_backtrace_persist,
                     fuel
-                })
+                };
+                deployment_verified.validate_component_digests()?;
+                Ok(deployment_verified)
             },
             _ = termination_watcher.changed() => {
                 warn!("Received SIGINT, canceling while resolving the WASM files");
@@ -3473,8 +3727,9 @@ pub(crate) fn gen_trace_id() -> String {
 mod tests {
     use crate::{
         command::server::{
-            ConfigVerified, PrepareDirsParams, ServerCompiledLinked, ServerVerified, VerifyParams,
-            compile_activity_inline, create_engines, prepare_dirs,
+            DeploymentVerified, PrepareDirsParams, ServerCompiledLinked, ServerVerified,
+            VerifyParams, compile_activity_inline, create_engines, deployment_verify_config,
+            prepare_dirs,
         },
         config::config_holder::{ConfigHolder, load_deployment_canonical},
     };
@@ -3556,7 +3811,7 @@ mod tests {
         let webui_enabled = None;
 
         // Verify deployment
-        let config = Box::pin(ConfigVerified::fetch_and_verify_all(
+        let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(
             deployment,
             server_verified.http_servers,
             prepared_dirs.wasm_cache_dir.clone(),
@@ -3573,7 +3828,7 @@ mod tests {
 
         let _compiled_and_linked = ServerCompiledLinked::new(
             DeploymentId::generate(),
-            config,
+            deployment_verified,
             server_verified.launch,
             &mut termination_watcher,
             params.suppress_type_checking_errors,
@@ -3581,6 +3836,54 @@ mod tests {
         )
         .await?;
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deployment_verify_rejects_digest_shared_across_component_types()
+    -> Result<(), anyhow::Error> {
+        test_utils::set_up();
+
+        let workspace = get_workspace_dir();
+        let project_dirs = crate::project_dirs();
+        let base_dirs = BaseDirs::new();
+        let config_holder = ConfigHolder::new(
+            project_dirs,
+            base_dirs,
+            Some(workspace.join("server-sqlite.toml")),
+        )?;
+        let config = config_holder.load_config().await?;
+
+        let mut deployment =
+            load_deployment_canonical(&workspace.join("obelisk-testing-wasm-local.toml")).await?;
+        let shared_digest: ComponentDigest =
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                .parse()
+                .unwrap();
+        deployment.activities_wasm[0].component_digest = Some(shared_digest.clone());
+        deployment.workflows[0].component_digest = Some(shared_digest);
+
+        let prepared_dirs = prepare_dirs(
+            &config,
+            &PrepareDirsParams::default(),
+            &config_holder.path_prefixes,
+        )
+        .await?;
+
+        let (_termination_sender, mut termination_watcher) = watch::channel(());
+        let engines = create_engines(&config, &prepared_dirs)?;
+        let server_verified = Box::pin(ServerVerified::new(engines, config)).await?;
+        let err = deployment_verify_config(
+            &server_verified,
+            &prepared_dirs,
+            deployment,
+            VerifyParams::default(),
+            &mut termination_watcher,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(err.to_string().contains("shared between component types"));
         Ok(())
     }
 }

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -6,69 +6,6 @@ expression: components
   {
     "component_id": {
       "component_type": "activity",
-      "name": "test_add_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_greet_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_fetch_denied_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_fetch_allowed_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_read_env_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_make_record_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_throw_variant_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_throw_null_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "test_hmac_sign_verify_activity",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
       "name": "exec-add.add",
       "component_digest": "sha256:<REDACTED>"
     }
@@ -76,21 +13,7 @@ expression: components
   {
     "component_id": {
       "component_type": "activity",
-      "name": "exec-greet.greet-include",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "exec-greet.greet-external",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "activity",
-      "name": "exec-greet.greet-inline",
+      "name": "exec-args.echo-args",
       "component_digest": "sha256:<REDACTED>"
     }
   },
@@ -111,6 +34,27 @@ expression: components
   {
     "component_id": {
       "component_type": "activity",
+      "name": "exec-greet.greet-external",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "exec-greet.greet-include",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "exec-greet.greet-inline",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
       "name": "exec-record.make-record",
       "component_digest": "sha256:<REDACTED>"
     }
@@ -125,7 +69,7 @@ expression: components
   {
     "component_id": {
       "component_type": "activity",
-      "name": "exec-void.void-ok",
+      "name": "exec-stream.stream-test",
       "component_digest": "sha256:<REDACTED>"
     }
   },
@@ -139,14 +83,70 @@ expression: components
   {
     "component_id": {
       "component_type": "activity",
-      "name": "exec-args.echo-args",
+      "name": "exec-void.void-ok",
       "component_digest": "sha256:<REDACTED>"
     }
   },
   {
     "component_id": {
       "component_type": "activity",
-      "name": "exec-stream.stream-test",
+      "name": "test_add_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_fetch_allowed_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_fetch_denied_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_greet_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_hmac_sign_verify_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_make_record_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_read_env_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_throw_null_activity",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "activity",
+      "name": "test_throw_variant_activity",
       "component_digest": "sha256:<REDACTED>"
     }
   },
@@ -159,120 +159,29 @@ expression: components
   },
   {
     "component_id": {
-      "component_type": "workflow",
-      "name": "test_add_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_add_via_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_call_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_import_call_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_import_star_call_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_import_schedule_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_import_ext_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_import_stub_activity_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_make_record_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_throw_variant_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_throw_null_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_call_stub_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_math_random_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_date_now_workflow",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "workflow",
-      "name": "test_return_wrong_type_workflow",
+      "component_type": "webhook_endpoint",
+      "name": "test_body_form_data_webhook",
       "component_digest": "sha256:<REDACTED>"
     }
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
-      "name": "test_hello_webhook",
+      "name": "test_body_json_webhook",
       "component_digest": "sha256:<REDACTED>"
     }
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
-      "name": "test_headers_webhook",
+      "name": "test_body_text_webhook",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "webhook_endpoint",
+      "name": "test_call_activity_webhook",
       "component_digest": "sha256:<REDACTED>"
     }
   },
@@ -293,21 +202,21 @@ expression: components
   {
     "component_id": {
       "component_type": "webhook_endpoint",
-      "name": "test_call_activity_webhook",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "webhook_endpoint",
-      "name": "test_read_env_webhook",
-      "component_digest": "sha256:<REDACTED>"
-    }
-  },
-  {
-    "component_id": {
-      "component_type": "webhook_endpoint",
       "name": "test_generate_execution_id_webhook",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "webhook_endpoint",
+      "name": "test_headers_webhook",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "webhook_endpoint",
+      "name": "test_hello_webhook",
       "component_digest": "sha256:<REDACTED>"
     }
   },
@@ -328,21 +237,112 @@ expression: components
   {
     "component_id": {
       "component_type": "webhook_endpoint",
-      "name": "test_body_text_webhook",
+      "name": "test_read_env_webhook",
       "component_digest": "sha256:<REDACTED>"
     }
   },
   {
     "component_id": {
-      "component_type": "webhook_endpoint",
-      "name": "test_body_json_webhook",
+      "component_type": "workflow",
+      "name": "test_add_via_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
     }
   },
   {
     "component_id": {
-      "component_type": "webhook_endpoint",
-      "name": "test_body_form_data_webhook",
+      "component_type": "workflow",
+      "name": "test_add_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_call_activity_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_call_stub_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_date_now_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_import_call_activity_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_import_ext_activity_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_import_schedule_activity_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_import_star_call_activity_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_import_stub_activity_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_make_record_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_math_random_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_return_wrong_type_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_throw_null_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_throw_variant_workflow",
       "component_digest": "sha256:<REDACTED>"
     }
   }

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -12,7 +12,6 @@ use concepts::ComponentId;
 use concepts::ExecutionId;
 use concepts::FunctionExtension;
 use concepts::FunctionFqn;
-use concepts::FunctionMetadata;
 use concepts::SupportedFunctionReturnValue;
 use concepts::component_id::ComponentDigest;
 use concepts::prefixed_ulid::DelayId;
@@ -36,6 +35,8 @@ use concepts::storage::LogLevel;
 use concepts::storage::LogStreamType;
 use concepts::storage::Pagination;
 use concepts::storage::PendingState;
+use concepts::storage::PersistedFunctionMetadata;
+use concepts::storage::PersistedParameterType;
 use concepts::storage::Version;
 use concepts::storage::VersionType;
 use concepts::storage::{FunctionNameFilter, ListExecutionsFilter};
@@ -1495,13 +1496,20 @@ impl grpc_gen::function_repository_server::FunctionRepository for GrpcServer {
         request: tonic::Request<grpc_gen::ListComponentsRequest>,
     ) -> TonicRespResult<grpc_gen::ListComponentsResponse> {
         let request = request.into_inner();
-        let component_registry_ro = self
-            .deployment_ctx
-            .read()
+        let deployment_id = if let Some(deployment_id) = request.deployment_id {
+            DeploymentId::try_from(deployment_id)?
+        } else {
+            self.deployment_ctx.read().await.deployment_id
+        };
+        let conn = self
+            .db_pool
+            .external_api_conn()
             .await
-            .component_registry_ro
-            .clone();
-        let mut components = component_registry_ro.list(request.extensions);
+            .map_err(|err| tonic::Status::internal(err.to_string()))?;
+        let mut components = conn
+            .list_deployment_components(deployment_id)
+            .await
+            .map_err(|err| tonic::Status::internal(err.to_string()))?;
 
         if let Some(digest) = request
             .component_digest
@@ -1516,12 +1524,10 @@ impl grpc_gen::function_repository_server::FunctionRepository for GrpcServer {
             .transpose()?
         {
             components.retain(|c| {
-                c.workflow_or_activity_config.as_ref().is_some_and(|exp| {
-                    exp.exports_ext
-                        .iter()
-                        .find(|fn_meta| fn_meta.ffqn == ffqn)
-                        .is_some()
-                })
+                filtered_exports(c, request.extensions)
+                    .iter()
+                    .find(|fn_meta| fn_meta.ffqn == ffqn)
+                    .is_some()
             });
         }
 
@@ -1529,13 +1535,8 @@ impl grpc_gen::function_repository_server::FunctionRepository for GrpcServer {
         for component in components {
             // Transform to gRPC Component.
             let res_component = grpc_gen::Component {
-                component_id: Some(component.component_id.into()),
-                exports: component
-                    .workflow_or_activity_config
-                    .map(|workflow_or_activity_config| {
-                        list_fns(workflow_or_activity_config.exports_ext)
-                    })
-                    .unwrap_or_default(),
+                component_id: Some(component.component_id.clone().into()),
+                exports: list_fns(filtered_exports(&component, request.extensions)),
                 imports: list_fns(component.imports),
             };
             grpc_components.push(res_component);
@@ -1574,9 +1575,9 @@ impl grpc_gen::function_repository_server::FunctionRepository for GrpcServer {
     }
 }
 
-fn list_fns(functions: Vec<FunctionMetadata>) -> Vec<grpc_gen::FunctionDetail> {
+fn list_fns(functions: Vec<PersistedFunctionMetadata>) -> Vec<grpc_gen::FunctionDetail> {
     let mut vec = Vec::with_capacity(functions.len());
-    for FunctionMetadata {
+    for PersistedFunctionMetadata {
         ffqn,
         parameter_types,
         return_type,
@@ -1586,23 +1587,22 @@ fn list_fns(functions: Vec<FunctionMetadata>) -> Vec<grpc_gen::FunctionDetail> {
     {
         let fun = grpc_gen::FunctionDetail {
             params: parameter_types
-                .0
                 .into_iter()
-                .map(|param| grpc_gen::FunctionParameter {
-                    name: param.name.to_string(),
-                    r#type: Some(grpc_gen::WitType {
-                        wit_type: param.wit_type.to_string(),
-                        type_wrapper: serde_json::to_string(&param.type_wrapper)
-                            .expect("`TypeWrapper` must be serializable"),
-                        wit_type_inline: param.type_wrapper.to_string(),
-                    }),
-                })
+                .map(
+                    |param: PersistedParameterType| grpc_gen::FunctionParameter {
+                        name: param.name,
+                        r#type: Some(grpc_gen::WitType {
+                            wit_type: param.wit_type.clone(),
+                            type_wrapper: param.wit_type.clone(),
+                            wit_type_inline: param.wit_type,
+                        }),
+                    },
+                )
                 .collect(),
             return_type: Some(grpc_gen::WitType {
-                wit_type: return_type.wit_type().to_string(),
-                type_wrapper: serde_json::to_string(&return_type.type_wrapper())
-                    .expect("`TypeWrapper` must be serializable"),
-                wit_type_inline: return_type.type_wrapper().to_string(),
+                wit_type: return_type.clone(),
+                type_wrapper: return_type.clone(),
+                wit_type_inline: return_type,
             }),
             function_name: Some(ffqn.into()),
             extension: extension.map(|it| {
@@ -1620,6 +1620,17 @@ fn list_fns(functions: Vec<FunctionMetadata>) -> Vec<grpc_gen::FunctionDetail> {
         vec.push(fun);
     }
     vec
+}
+
+fn filtered_exports(
+    component: &concepts::storage::DeploymentComponentDetail,
+    extensions: bool,
+) -> Vec<PersistedFunctionMetadata> {
+    let mut exports = component.exports.clone();
+    if !extensions {
+        exports.retain(|fn_metadata| !fn_metadata.ffqn.ifc_fqn.is_extension());
+    }
+    exports
 }
 
 impl From<SubmitError> for tonic::Status {

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1556,21 +1556,27 @@ impl grpc_gen::function_repository_server::FunctionRepository for GrpcServer {
                 .component_digest
                 .argument_must_exist("component_digest")?,
         )?;
-        let component_registry_ro = self
-            .deployment_ctx
-            .read()
+        let deployment_id = if let Some(deployment_id) = request.deployment_id {
+            DeploymentId::try_from(deployment_id)?
+        } else {
+            self.deployment_ctx.read().await.deployment_id
+        };
+        let conn = self
+            .db_pool
+            .external_api_conn()
             .await
-            .component_registry_ro
-            .clone();
-        let wit = component_registry_ro
-            .get_wit(&component_digest)
+            .map_err(|err| tonic::Status::internal(err.to_string()))?;
+        let wit = conn
+            .get_deployment_component_wit(deployment_id, &component_digest)
+            .await
+            .map_err(|err| tonic::Status::internal(err.to_string()))?
             .ok_or_else(|| {
                 tonic::Status::not_found(format!(
                     "WIT not found for component digest '{component_digest}'"
                 ))
             })?;
         Ok(tonic::Response::new(grpc_gen::GetWitResponse {
-            content: Some(wit.to_string()),
+            content: Some(wit),
         }))
     }
 }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -2637,13 +2637,22 @@ pub(crate) mod components {
         submittable: Option<bool>,
     }
 
+    #[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
+    #[into_params(parameter_in = Query)]
+    pub(crate) struct ComponentWitParams {
+        /// Filter by deployment ID
+        #[param(value_type = Option<String>)]
+        deployment_id: Option<DeploymentId>,
+    }
+
     /// Get WIT definition for a component
     #[utoipa::path(
         get,
         path = "/v1/components/{digest}/wit",
         tag = "components",
         params(
-            ("digest" = String, Path, description = "Component content digest")
+            ("digest" = String, Path, description = "Component content digest"),
+            ComponentWitParams,
         ),
         responses(
             (status = 200, description = "WIT definition", body = String),
@@ -2654,20 +2663,35 @@ pub(crate) mod components {
     pub(crate) async fn component_wit(
         Path(digest): Path<ComponentDigest>,
         state: State<Arc<WebApiState>>,
+        Query(params): Query<ComponentWitParams>,
     ) -> Result<Response, HttpResponse> {
-        let component_registry_ro = state
-            .deployment_ctx
-            .read()
+        let deployment_id = if let Some(deployment_id) = params.deployment_id {
+            deployment_id
+        } else {
+            state.deployment_ctx.read().await.deployment_id
+        };
+        let conn = state.db_pool.external_api_conn().await.map_err(|err| {
+            HttpResponse {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                message: err.to_string(),
+                accept: AcceptHeader::Text,
+            }
+        })?;
+        let wit = conn
+            .get_deployment_component_wit(deployment_id, &digest)
             .await
-            .component_registry_ro
-            .clone();
-        let Some(wit) = component_registry_ro.get_wit(&digest) else {
-            return Err(HttpResponse::not_found(
+            .map_err(|err| HttpResponse {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                message: err.to_string(),
+                accept: AcceptHeader::Text,
+            })?;
+        match wit {
+            Some(wit) => Ok(wit.into_response()),
+            None => Err(HttpResponse::not_found(
                 AcceptHeader::Text,
                 Some("component"),
-            ));
-        };
-        Ok(wit.to_string().into_response())
+            )),
+        }
     }
 
     /// List components

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -2670,13 +2670,15 @@ pub(crate) mod components {
         } else {
             state.deployment_ctx.read().await.deployment_id
         };
-        let conn = state.db_pool.external_api_conn().await.map_err(|err| {
-            HttpResponse {
+        let conn = state
+            .db_pool
+            .external_api_conn()
+            .await
+            .map_err(|err| HttpResponse {
                 status: StatusCode::INTERNAL_SERVER_ERROR,
                 message: err.to_string(),
                 accept: AcceptHeader::Text,
-            }
-        })?;
+            })?;
         let wit = conn
             .get_deployment_component_wit(deployment_id, &digest)
             .await

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -2601,6 +2601,8 @@ pub(crate) mod components {
     use concepts::{
         ComponentId, ComponentType, FunctionExtension, FunctionMetadata, ParameterType,
         component_id::ComponentDigest,
+        prefixed_ulid::DeploymentId,
+        storage::{DeploymentComponentDetail, PersistedFunctionMetadata, PersistedParameterType},
     };
     use itertools::Itertools;
     use std::fmt::{Debug, Write as _};
@@ -2608,6 +2610,9 @@ pub(crate) mod components {
     #[derive(Deserialize, Debug, IntoParams)]
     #[into_params(parameter_in = Query)]
     pub(crate) struct ComponentsListParams {
+        /// Filter by deployment ID
+        #[param(value_type = Option<String>)]
+        deployment_id: Option<DeploymentId>,
         /// Filter by component type (workflow, activity, webhook)
         #[param(value_type = Option<String>)]
         r#type: Option<ComponentType>,
@@ -2680,13 +2685,32 @@ pub(crate) mod components {
         Query(params): Query<ComponentsListParams>,
         accept: AcceptHeader,
     ) -> Response {
-        let component_registry_ro = state
-            .deployment_ctx
-            .read()
-            .await
-            .component_registry_ro
-            .clone();
-        let mut components = component_registry_ro.list(params.extensions);
+        let deployment_id = if let Some(deployment_id) = params.deployment_id {
+            deployment_id
+        } else {
+            state.deployment_ctx.read().await.deployment_id
+        };
+        let mut components = match state.db_pool.external_api_conn().await {
+            Ok(conn) => match conn.list_deployment_components(deployment_id).await {
+                Ok(components) => components,
+                Err(err) => {
+                    return HttpResponse {
+                        status: StatusCode::INTERNAL_SERVER_ERROR,
+                        message: err.to_string(),
+                        accept,
+                    }
+                    .into_response();
+                }
+            },
+            Err(err) => {
+                return HttpResponse {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: err.to_string(),
+                    accept,
+                }
+                .into_response();
+            }
+        };
 
         if let Some(name) = params.name {
             components.retain(|c| c.component_id.name.as_ref() == name);
@@ -2696,12 +2720,10 @@ pub(crate) mod components {
         }
         if let Some(ffqn) = params.ffqn {
             components.retain(|c| {
-                c.workflow_or_activity_config.as_ref().is_some_and(|exp| {
-                    exp.exports_ext
-                        .iter()
-                        .find(|fn_meta| fn_meta.ffqn == ffqn)
-                        .is_some()
-                })
+                filtered_exports(c, params.extensions)
+                    .iter()
+                    .find(|fn_meta| fn_meta.ffqn == ffqn)
+                    .is_some()
             });
         }
         if let Some(ty) = params.r#type {
@@ -2712,10 +2734,8 @@ pub(crate) mod components {
             .map(|c| {
                 let exports = if params.exports {
                     let mut exports = Vec::new();
-                    for export in c
-                        .workflow_or_activity_config
+                    for export in filtered_exports(&c, params.extensions)
                         .into_iter()
-                        .flat_map(|c| c.exports_ext)
                         .filter(|e| {
                             if let Some(submittable) = params.submittable {
                                 e.submittable == submittable
@@ -2826,6 +2846,21 @@ pub(crate) mod components {
             }
         }
     }
+    impl From<PersistedFunctionMetadata> for FunctionMetadataLite {
+        fn from(value: PersistedFunctionMetadata) -> Self {
+            FunctionMetadataLite {
+                ffqn: value.ffqn,
+                parameter_types: value
+                    .parameter_types
+                    .into_iter()
+                    .map(ParameterTypeLite::from)
+                    .collect(),
+                return_type: value.return_type,
+                extension: value.extension,
+                submittable: value.submittable,
+            }
+        }
+    }
 
     /// Parameter type information
     #[derive(serde::Serialize, derive_more::Display, ToSchema)]
@@ -2844,6 +2879,25 @@ pub(crate) mod components {
                 wit_type: value.wit_type.to_string(),
             }
         }
+    }
+    impl From<PersistedParameterType> for ParameterTypeLite {
+        fn from(value: PersistedParameterType) -> Self {
+            ParameterTypeLite {
+                name: value.name,
+                wit_type: value.wit_type,
+            }
+        }
+    }
+
+    fn filtered_exports(
+        component: &DeploymentComponentDetail,
+        extensions: bool,
+    ) -> Vec<PersistedFunctionMetadata> {
+        let mut exports = component.exports.clone();
+        if !extensions {
+            exports.retain(|fn_metadata| !fn_metadata.ffqn.ifc_fqn.is_extension());
+        }
+        exports
     }
 }
 


### PR DESCRIPTION
- **feat(pg,sqlite): Persist component metadada per deployment**
- **refactor: Stop comparing backtraces in `advance_from_log`**
- **refactor: Add `PersistedFunctionMetadata` to the database JSON schema**
- **refactor(grpc,webapi): Add optional `deployment_id` to the WIT query**
- **stlye: Run clippy**
