### PR TITLE
build: Switch to upstream unreleased Refinery, remove default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "refinery"
 version = "0.9.0"
-source = "git+https://github.com/tomasol/refinery.git?rev=3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2#3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2"
+source = "git+https://github.com/rust-db/refinery.git?rev=14354f54c51a07c9615a78d6432861e0ef7a2db3#14354f54c51a07c9615a78d6432861e0ef7a2db3"
 dependencies = [
  "refinery-core",
  "refinery-macros",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "refinery-core"
 version = "0.9.0"
-source = "git+https://github.com/tomasol/refinery.git?rev=3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2#3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2"
+source = "git+https://github.com/rust-db/refinery.git?rev=14354f54c51a07c9615a78d6432861e0ef7a2db3#14354f54c51a07c9615a78d6432861e0ef7a2db3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4330,14 +4330,12 @@ dependencies = [
  "rusqlite",
  "rustls",
  "rustls-native-certs",
- "serde",
  "siphasher",
  "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
- "toml 1.1.2+spec-1.1.0",
  "url",
  "walkdir",
 ]
@@ -4345,7 +4343,7 @@ dependencies = [
 [[package]]
 name = "refinery-macros"
 version = "0.9.0"
-source = "git+https://github.com/tomasol/refinery.git?rev=3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2#3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2"
+source = "git+https://github.com/rust-db/refinery.git?rev=14354f54c51a07c9615a78d6432861e0ef7a2db3#14354f54c51a07c9615a78d6432861e0ef7a2db3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ prost = "0.14.3"
 prost-wkt-types = "0.7"
 quote = "1"
 rand = "0.9"
-refinery = { git = "https://github.com/tomasol/refinery.git", rev = "3b5a6eb7903e6d5d9ebce0fd17b518f9d1a5c1d2", features = ["rusqlite", "tokio-postgres-rustls"] }
+refinery = { git = "https://github.com/rust-db/refinery.git", rev = "14354f54c51a07c9615a78d6432861e0ef7a2db3", default-features = false, features = ["rusqlite", "tokio-postgres-rustls"] }
 reqwest = { version = "0.13", default-features = false, features = [
     "json",
     "rustls-no-provider",

--- a/deny.toml
+++ b/deny.toml
@@ -90,8 +90,6 @@ skip = [
     { name = "darling", version = "0.20" },
     { name = "darling_core", version = "0.20" },
     { name = "darling_macro", version = "0.20" },
-    # docker_credential 1.3.2 (latest) requires base64 0.21
-    { name = "base64", version = "0.21" },
     # tokio-postgres (via postgres-protocol) requires fallible-iterator 0.2
     { name = "fallible-iterator", version = "0.2" },
     # tokio-postgres-rustls 0.13 (latest) requires x509-cert 0.2 which uses const-oid 0.9;


### PR DESCRIPTION
- **build: Switch to upstream Refinery, remove default features**
- **chore: Update `deny.toml` after `docker_credential` update**
