### PR TITLE
refactor(js)!: Unify JS result APIs — return ok value, throw err value

### DIFF
--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-05-15@sha256:fff9406d5f7d587dc31b2b2138befefb10eb13bf37de599b43bc595fae28caf8
+oci://docker.io/getobelisk/webhook-js-runtime:2026-05-23-1@sha256:835684028f3098feb8cfa7fcadda6c1ebd7d73cf7323f9fdd3efa5f364a47cfa

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-05-21-1@sha256:cac97f8d48c408a6715ce59ccc9589906a2e234edc6b078ceebbfbba3f1a68e6
+oci://docker.io/getobelisk/workflow-js-runtime:2026-05-23@sha256:2e6c01e12e1813491a5ad952cb287aa987d830af0c6305dd95af7ef0cef70123

--- a/crates/testing/test-programs/js/workflow/add_via_activity.js
+++ b/crates/testing/test-programs/js/workflow/add_via_activity.js
@@ -9,7 +9,7 @@ export default function add_via_activity(a, b) {
     }
     const result = obelisk.getResult(response.id);
     console.log('Got result:', JSON.stringify(result));
-    return result.ok;
+    return result;
 }
 
 function createJoinSet() {

--- a/crates/testing/test-programs/js/workflow/call_stub.js
+++ b/crates/testing/test-programs/js/workflow/call_stub.js
@@ -5,5 +5,5 @@ export default function call_stub(id) {
     console.log("stubbed id", execId);
     obelisk.stub(execId, { 'ok': 'stub-ok' });
     js.joinNext();
-    return obelisk.getResult(execId).ok;
+    return obelisk.getResult(execId);
 }

--- a/crates/testing/test-programs/js/workflow/import_ext_activity.js
+++ b/crates/testing/test-programs/js/workflow/import_ext_activity.js
@@ -4,7 +4,7 @@ import { addSubmit, addAwaitNext } from 'testing:integration-obelisk-ext/activit
 export default function add_via_activity(a, b) {
     const js = obelisk.createJoinSet();
     addSubmit(js, a, b);
-    const [execId, result] = addAwaitNext(js);
-    console.log('Got execId:', execId, 'result:', JSON.stringify(result));
-    return result.val;
+    const result = addAwaitNext(js);
+    console.log('Got execId:', js.lastId, 'result:', JSON.stringify(result));
+    return result;
 }

--- a/crates/testing/test-programs/js/workflow/import_stub_activity.js
+++ b/crates/testing/test-programs/js/workflow/import_stub_activity.js
@@ -6,6 +6,6 @@ export default function call_stub(id) {
     const js = obelisk.createJoinSet();
     const execId = myStubSubmit(js, id);
     myStubStub(execId, { 'ok': 'stub-ok' });
-    const [, result] = myStubAwaitNext(js);
-    return result.val;
+    const result = myStubAwaitNext(js);
+    return result;
 }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -3427,7 +3427,7 @@ pub(crate) mod tests {
                     const execId = obelisk.executionIdGenerate();
                     obelisk.schedule(execId, "testing:fibo/fibo.fibo", [10]);
                     const result = obelisk.tryGet(execId);
-                    return Response.json({ result });
+                    return Response.json({ pending: result === undefined });
                 }
             "#;
 
@@ -3438,8 +3438,8 @@ pub(crate) mod tests {
             assert_eq!(resp.status().as_u16(), 200);
             let body: serde_json::Value = resp.json().await.unwrap();
 
-            // Should return pending since activity hasn't run yet
-            assert_eq!(body["result"]["pending"], serde_json::json!(true));
+            // Should return undefined since activity hasn't run yet
+            assert_eq!(body["pending"], serde_json::json!(true));
         }
 
         #[tokio::test]

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1241,7 +1241,7 @@ mod tests {
             if (response1.type === 'execution') {
                 const result = obelisk.getResult(response1.id);
                 console.log('Got fibo result:', JSON.stringify(result));
-                fiboResult = result.ok;
+                fiboResult = result;
                 loser = delayId;
             } else {
                 loser = execId;
@@ -1654,7 +1654,7 @@ mod tests {
         let result = harness.get_result_json().await;
         assert_eq!(json!("execution"), result["responseType"]);
         assert_eq!(json!(true), result["responseOk"]);
-        assert_eq!(json!("stubbed-result-42"), result["result"]["ok"]);
+        assert_eq!(json!("stubbed-result-42"), result["result"]);
         drop(harness);
         db_close.close().await;
     }
@@ -1673,8 +1673,13 @@ mod tests {
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-param']);
             obelisk.stub(execId, {'err': null}); // result<string> has no error type
             const response = js.joinNext();
-            const result = obelisk.getResult(execId);
-            return JSON.stringify({ responseOk: response.ok, result: result });
+            let caughtErr = 'none';
+            try {
+                obelisk.getResult(execId);
+            } catch (e) {
+                caughtErr = e.message;
+            }
+            return JSON.stringify({ responseOk: response.ok, caughtErr: caughtErr });
         }";
 
         let harness =
@@ -1684,7 +1689,7 @@ mod tests {
 
         let result = harness.get_result_json().await;
         assert_eq!(json!(false), result["responseOk"]);
-        assert_eq!(json!(null), result["result"]["err"]);
+        assert_eq!(json!("child execution failed"), result["caughtErr"]);
         drop(harness);
         db_close.close().await;
     }
@@ -1749,7 +1754,7 @@ mod tests {
 
         let result = harness.get_result_json().await;
         assert_eq!(json!(true), result["responseOk"]);
-        assert_eq!(json!("same-value"), result["result"]["ok"]);
+        assert_eq!(json!("same-value"), result["result"]);
         drop(harness);
         db_close.close().await;
     }
@@ -1779,7 +1784,7 @@ mod tests {
 
         let result = harness.get_result_json().await;
         assert_eq!(json!(true), result["responseOk"]);
-        assert_eq!(json!(null), result["result"]["ok"]);
+        assert_eq!(json!(null), result["result"]);
         drop(harness);
         db_close.close().await;
     }
@@ -1830,7 +1835,7 @@ mod tests {
             "Expected 'Conflict' in error, got: {error_msg}"
         );
         assert_eq!(json!(true), result["responseOk"]);
-        assert_eq!(json!("first-value"), result["result"]["ok"]);
+        assert_eq!(json!("first-value"), result["result"]);
         drop(harness);
         db_close.close().await;
     }
@@ -2399,7 +2404,7 @@ mod tests {
             obelisk.stub(execId, { 'ok': 'hello' });
             const response = js.joinNext();
             if (!response.ok) throw 'stub failed';
-            return obelisk.getResult(execId).ok;
+            return obelisk.getResult(execId);
         }";
 
         let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");
@@ -2540,7 +2545,7 @@ mod tests {
             obelisk.stub(execId, { 'ok': 'hello' });
             const response = js.joinNext();
             if (!response.ok) throw 'stub failed';
-            return obelisk.getResult(execId).ok;
+            return obelisk.getResult(execId);
         }";
 
         let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -60,7 +60,7 @@
 //! ```js
 //! // Synchronous call - blocks until completion
 //! const result = obelisk.call("ns:pkg/ifc.func", [arg1, arg2]);
-//! // result = { ok: value } or { err: value }
+//! // Returns ok value, throws err value
 //! ```
 //!
 //! ## Check Execution Status
@@ -74,11 +74,11 @@
 //! ```js
 //! // Blocking - waits until execution completes
 //! const result = obelisk.get(execId);
-//! // result = { ok/err: value }
+//! // Returns ok value, throws err value
 //!
 //! // Non-blocking - returns immediately
 //! const result = obelisk.tryGet(execId);
-//! // result = `{ pending: true }` or `{ ok/err: value }`
+//! // Returns ok value, throws err value, returns undefined if not finished yet.
 //! ```
 //!
 //! ## Environment Variables
@@ -463,6 +463,23 @@ fn capture_backtrace(ctx: &Context) -> WasmBacktrace {
     WasmBacktrace { frames }
 }
 
+/// Unwrap a `Result<Option<String>, Option<String>>` into a JS value:
+/// returns the ok value, throws the err value.
+/// Matches the semantics of direct call proxies.
+fn unwrap_result(
+    inner_result: Result<Option<String>, Option<String>>,
+    ctx: &mut Context,
+) -> JsResult<JsValue> {
+    match inner_result {
+        Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
+        Ok(None) => Ok(JsValue::null()),
+        Err(Some(err_str)) => Err(JsNativeError::error().with_message(err_str).into()),
+        Err(None) => Err(JsNativeError::error()
+            .with_message("child execution failed")
+            .into()),
+    }
+}
+
 /// Set up the global `obelisk` object with webhook support functions.
 fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
     let obelisk = new_object(context);
@@ -624,7 +641,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         context,
     )?;
 
-    // obelisk.get(executionId) - blocking get
+    // obelisk.get(executionId) - blocking get, returns ok value, throws err value
     let get_fn = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let exec_id_str = args
             .get_or_undefined(0)
@@ -636,26 +653,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
 
         let backtrace = capture_backtrace(ctx);
         match webhook_support::get(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => {
-                let result_obj = new_object(ctx);
-                match inner_result {
-                    Ok(Some(json_str)) => {
-                        let parsed = ctx.eval(Source::from_bytes(&format!("({})", json_str)))?;
-                        result_obj.set(js_string!("ok"), parsed, false, ctx)?;
-                    }
-                    Ok(None) => {
-                        result_obj.set(js_string!("ok"), JsValue::null(), false, ctx)?;
-                    }
-                    Err(Some(err_str)) => {
-                        let parsed = ctx.eval(Source::from_bytes(&format!("({})", err_str)))?;
-                        result_obj.set(js_string!("err"), parsed, false, ctx)?;
-                    }
-                    Err(None) => {
-                        result_obj.set(js_string!("err"), JsValue::null(), false, ctx)?;
-                    }
-                }
-                Ok(result_obj.into())
-            }
+            Ok(inner_result) => unwrap_result(inner_result, ctx),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("get failed: {:?}", e))
                 .into()),
@@ -669,6 +667,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
     )?;
 
     // obelisk.tryGet(executionId) - non-blocking get
+    // Returns ok value, throws err value, returns undefined if not finished yet
     let try_get_fn = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let exec_id_str = args
             .get_or_undefined(0)
@@ -680,31 +679,8 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
 
         let backtrace = capture_backtrace(ctx);
         match webhook_support::try_get(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => {
-                let result_obj = new_object(ctx);
-                match inner_result {
-                    Ok(Some(json_str)) => {
-                        let parsed = ctx.eval(Source::from_bytes(&format!("({})", json_str)))?;
-                        result_obj.set(js_string!("ok"), parsed, false, ctx)?;
-                    }
-                    Ok(None) => {
-                        result_obj.set(js_string!("ok"), JsValue::null(), false, ctx)?;
-                    }
-                    Err(Some(err_str)) => {
-                        let parsed = ctx.eval(Source::from_bytes(&format!("({})", err_str)))?;
-                        result_obj.set(js_string!("err"), parsed, false, ctx)?;
-                    }
-                    Err(None) => {
-                        result_obj.set(js_string!("err"), JsValue::null(), false, ctx)?;
-                    }
-                }
-                Ok(result_obj.into())
-            }
-            Err(webhook_support::TryGetError::NotFinishedYet) => {
-                let result_obj = new_object(ctx);
-                result_obj.set(js_string!("pending"), JsValue::from(true), false, ctx)?;
-                Ok(result_obj.into())
-            }
+            Ok(inner_result) => unwrap_result(inner_result, ctx),
+            Err(webhook_support::TryGetError::NotFinishedYet) => Ok(JsValue::undefined()),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("tryGet failed: {:?}", e))
                 .into()),

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -36,10 +36,14 @@
 //! // Wait for next result (blocks until a child completes)
 //! const response = js.joinNext();
 //! // response = { type: "execution"|"delay", id: string, ok: boolean }
+//! // js.lastId is also set to the id of the completed child
 //!
-//! // Get the actual result value
+//! // Non-blocking variant:
+//! const tryResponse = js.joinNextTry();
+//! // Same as joinNext(), or { status: "allProcessed"|"pending" }
+//!
+//! // Get the actual result value (returns ok value, throws err value)
 //! const result = obelisk.getResult(execId);
-//! // result = { ok: value } or { err: value }
 //!
 //! // Close the join set when done
 //! js.close();
@@ -386,7 +390,10 @@ fn create_ext_submit_proxy(
 /// Create a `NativeFunction` that proxies `join-next-bt` + `get-result-json-bt`
 /// for extension imports.
 ///
-/// JS signature: `addAwaitNext(joinSet) → [execId, { tag: 'ok'|'err', val }]`
+/// JS signature: `addAwaitNext(joinSet) → okValue` (throws err value)
+///
+/// The execution ID of the child that completed is stored on the join set
+/// object as `lastId` (readable via `js.lastId`).
 fn create_ext_await_next_proxy(context: &mut Context) -> JsValue {
     let native = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let js_obj = args.get_or_undefined(0).as_object().ok_or_else(|| {
@@ -399,16 +406,17 @@ fn create_ext_await_next_proxy(context: &mut Context) -> JsValue {
 
         match join_result {
             Ok((ResponseId::ExecutionId(exec_id), _ok_status)) => {
+                // Store the execution ID on the join set object for later retrieval
+                js_obj.set(
+                    js_string!("lastId"),
+                    js_string!(exec_id.id.as_str()),
+                    false,
+                    ctx,
+                )?;
+
                 let get_result = get_result_json_bt(&exec_id, Some(&backtrace));
                 match get_result {
-                    Ok(inner_result) => {
-                        let result_obj = build_tagged_result(inner_result, ctx)?;
-                        // Return [execId, result]
-                        let array = boa_engine::object::builtins::JsArray::new(ctx)?;
-                        array.set(0u32, js_string!(exec_id.id), false, ctx)?;
-                        array.set(1u32, result_obj, false, ctx)?;
-                        Ok(array.into())
-                    }
+                    Ok(inner_result) => unwrap_result(inner_result, ctx),
                     Err(e) => Err(JsNativeError::error()
                         .with_message(format!("get result failed: {:?}", e))
                         .into()),
@@ -427,7 +435,7 @@ fn create_ext_await_next_proxy(context: &mut Context) -> JsValue {
 
 /// Create a `NativeFunction` that proxies `get-result-json-bt` for extension imports.
 ///
-/// JS signature: `addGet(execId) → { tag: 'ok'|'err', val }`
+/// JS signature: `addGet(execId) → okValue` (throws on err)
 fn create_ext_get_proxy(context: &mut Context) -> JsValue {
     let native = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let exec_id_str = args
@@ -440,7 +448,7 @@ fn create_ext_get_proxy(context: &mut Context) -> JsValue {
         let backtrace = capture_backtrace(ctx);
 
         match get_result_json_bt(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => build_tagged_result(inner_result, ctx),
+            Ok(inner_result) => unwrap_result(inner_result, ctx),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("get result failed: {:?}", e))
                 .into()),
@@ -449,34 +457,21 @@ fn create_ext_get_proxy(context: &mut Context) -> JsValue {
     native.to_js_function(context.realm()).into()
 }
 
-/// Build a `{ tag: 'ok', val }` or `{ tag: 'err', val }` JS object from a
-/// `Result<Option<String>, Option<String>>` returned by `get-result-json-bt`.
-fn build_tagged_result(
+/// Unwrap a `Result<Option<String>, Option<String>>` from `get-result-json-bt`
+/// into a JS value: returns the ok value, throws the err value.
+/// Matches the semantics of direct call proxies.
+fn unwrap_result(
     inner_result: Result<Option<String>, Option<String>>,
     ctx: &mut Context,
 ) -> JsResult<JsValue> {
-    let result_obj = new_object(ctx);
     match inner_result {
-        Ok(Some(json_str)) => {
-            result_obj.set(js_string!("tag"), js_string!("ok"), false, ctx)?;
-            let parsed = ctx.eval(Source::from_bytes(&format!("({})", json_str)))?;
-            result_obj.set(js_string!("val"), parsed, false, ctx)?;
-        }
-        Ok(None) => {
-            result_obj.set(js_string!("tag"), js_string!("ok"), false, ctx)?;
-            result_obj.set(js_string!("val"), JsValue::null(), false, ctx)?;
-        }
-        Err(Some(err_str)) => {
-            result_obj.set(js_string!("tag"), js_string!("err"), false, ctx)?;
-            let parsed = ctx.eval(Source::from_bytes(&format!("({})", err_str)))?;
-            result_obj.set(js_string!("val"), parsed, false, ctx)?;
-        }
-        Err(None) => {
-            result_obj.set(js_string!("tag"), js_string!("err"), false, ctx)?;
-            result_obj.set(js_string!("val"), JsValue::null(), false, ctx)?;
-        }
+        Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
+        Ok(None) => Ok(JsValue::null()),
+        Err(Some(err_str)) => Err(JsNativeError::error().with_message(err_str).into()),
+        Err(None) => Err(JsNativeError::error()
+            .with_message("child execution failed")
+            .into()),
     }
-    Ok(result_obj.into())
 }
 
 /// Create a `NativeFunction` that proxies `stub-json` for stub imports.
@@ -902,7 +897,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
     )?;
 
     // obelisk.call(ffqn, params, [config])
-    // Convenience: createJoinSet → submit → joinNext → getResult → close, return result
+    // Convenience: createJoinSet → submit → joinNext → getResult → close, return ok value, throw err value
     let call_fn = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let ffqn = args
             .get_or_undefined(0)
@@ -948,7 +943,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         context,
     )?;
 
-    // obelisk.getResult(executionId)
+    // obelisk.getResult(executionId) — returns ok value, throws err value
     let get_result_fn = NativeFunction::from_fn_ptr(|_this, args, ctx| {
         let exec_id_str = args
             .get_or_undefined(0)
@@ -960,27 +955,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         let backtrace = capture_backtrace(ctx);
 
         match get_result_json_bt(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => {
-                let result_obj = new_object(ctx);
-                match inner_result {
-                    Ok(Some(json_str)) => {
-                        // Parse the JSON result
-                        let parsed = ctx.eval(Source::from_bytes(&format!("({})", json_str)))?;
-                        result_obj.set(js_string!("ok"), parsed, false, ctx)?;
-                    }
-                    Ok(None) => {
-                        result_obj.set(js_string!("ok"), JsValue::null(), false, ctx)?;
-                    }
-                    Err(Some(err_str)) => {
-                        let parsed = ctx.eval(Source::from_bytes(&format!("({})", err_str)))?;
-                        result_obj.set(js_string!("err"), parsed, false, ctx)?;
-                    }
-                    Err(None) => {
-                        result_obj.set(js_string!("err"), JsValue::null(), false, ctx)?;
-                    }
-                }
-                Ok(result_obj.into())
-            }
+            Ok(inner_result) => unwrap_result(inner_result, ctx),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("Failed to get result: {:?}", e))
                 .into()),
@@ -1270,13 +1245,25 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
                 match response_id {
                     ResponseId::ExecutionId(exec_id) => {
                         result_obj.set(js_string!("type"), js_string!("execution"), false, ctx)?;
-                        result_obj.set(js_string!("id"), js_string!(exec_id.id), false, ctx)?;
+                        result_obj.set(
+                            js_string!("id"),
+                            js_string!(exec_id.id.clone()),
+                            false,
+                            ctx,
+                        )?;
                         result_obj.set(js_string!("ok"), result.is_ok(), false, ctx)?;
+                        this_obj.set(js_string!("lastId"), js_string!(exec_id.id), false, ctx)?;
                     }
                     ResponseId::DelayId(delay_id) => {
                         result_obj.set(js_string!("type"), js_string!("delay"), false, ctx)?;
-                        result_obj.set(js_string!("id"), js_string!(delay_id.id), false, ctx)?;
+                        result_obj.set(
+                            js_string!("id"),
+                            js_string!(delay_id.id.clone()),
+                            false,
+                            ctx,
+                        )?;
                         result_obj.set(js_string!("ok"), result.is_ok(), false, ctx)?;
+                        this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
                     }
                 }
 
@@ -1313,12 +1300,24 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
                 match response_id {
                     ResponseId::ExecutionId(exec_id) => {
                         result_obj.set(js_string!("type"), js_string!("execution"), false, ctx)?;
-                        result_obj.set(js_string!("id"), js_string!(exec_id.id), false, ctx)?;
+                        result_obj.set(
+                            js_string!("id"),
+                            js_string!(exec_id.id.clone()),
+                            false,
+                            ctx,
+                        )?;
                         result_obj.set(js_string!("ok"), result.is_ok(), false, ctx)?;
+                        this_obj.set(js_string!("lastId"), js_string!(exec_id.id), false, ctx)?;
                     }
                     ResponseId::DelayId(delay_id) => {
                         result_obj.set(js_string!("type"), js_string!("delay"), false, ctx)?;
-                        result_obj.set(js_string!("id"), js_string!(delay_id.id), false, ctx)?;
+                        result_obj.set(
+                            js_string!("id"),
+                            js_string!(delay_id.id.clone()),
+                            false,
+                            ctx,
+                        )?;
+                        this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
                         match result {
                             Ok(()) => {
                                 result_obj.set(js_string!("ok"), true, false, ctx)?;


### PR DESCRIPTION
All result-returning APIs (`getResult`, `get`, `tryGet`,
extensions `fooAwaitNext`/`fooGet`)
now use consistent semantics: return the ok value directly, throw the
err value. Removes `{ ok, err }`, `{ tag, val }` wrapper objects.
`tryGet` returns `undefined` (not `{ pending: true }`) for pending executions,
avoiding ambiguity with ok values that happen to contain `{ pending: true }`.
