### PR TITLE
refactor(workflow-js): Make `joinNextTry` idiomatic

### DIFF
--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-05-23@sha256:2e6c01e12e1813491a5ad952cb287aa987d830af0c6305dd95af7ef0cef70123
+oci://docker.io/getobelisk/workflow-js-runtime:2026-05-23-1@sha256:6f36e25794bc5d02170a3eecf773757595afb64e189fca48cce702764b5f3167

--- a/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
+++ b/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
@@ -1,0 +1,64 @@
+// Exercise JS joinNextTry() semantics: pending -> undefined, success -> value,
+// failure -> throw err value, exhausted -> host error class.
+import { addSubmit } from 'testing:integration-obelisk-ext/activity';
+import { myStubSubmit } from 'testing:integration-obelisk-ext/stubs';
+import { myStubStub } from 'testing:integration-obelisk-stub/stubs';
+
+export default function join_next_try_semantics(id) {
+    const pendingJs = obelisk.createJoinSet();
+    addSubmit(pendingJs, 1, 2);
+    const pendingResult = pendingJs.joinNextTry();
+    // Deterministic because join-next-try host function never fetches new responses.
+    if (pendingResult !== undefined) {
+        throw `joinNextTry should return undefined while the join set is still pending, got: ${JSON.stringify(pendingResult)} (${typeof pendingResult})`;
+    }
+    pendingJs.close();
+
+    const delayJs = obelisk.createJoinSet();
+    delayJs.submitDelay({ milliseconds: 1 });
+    obelisk.sleep({ milliseconds: 10 });
+    const delayResult = delayJs.joinNextTry();
+    if (delayResult !== null) {
+        throw `expected completed delay to produce null, got: ${JSON.stringify(delayResult)}`;
+    }
+
+    const okJs = obelisk.createJoinSet();
+    const okExecId = myStubSubmit(okJs, id);
+    myStubStub(okExecId, { ok: 'stub-ok' }); // Writes the response to current execution
+    obelisk.sleep({ milliseconds: 1 }); // Submits a delay request.
+    // Stub response must have been fetched as it was written before the delay response.
+    const okResult = okJs.joinNextTry();
+    if (okResult !== 'stub-ok') {
+        throw `unexpected ok result: ${JSON.stringify(okResult)}`;
+    }
+    if (okJs.lastId !== okExecId) {
+        throw `lastId mismatch: ${okJs.lastId} !== ${okExecId}`;
+    }
+
+    try {
+        okJs.joinNextTry(); // Simulate programming error
+        throw 'expected join set exhaustion error';
+    } catch (e) {
+        if (!(e instanceof obelisk.JoinSetExhaustedError)) {
+            throw `expected JoinSetExhaustedError, got: ${e}`;
+        }
+        if (e.code !== 'OBELISK_JOIN_SET_EXHAUSTED') {
+            throw `unexpected exhaustion error code: ${e.code}`;
+        }
+    }
+
+    const errJs = obelisk.createJoinSet();
+    const errExecId = myStubSubmit(errJs, id + 1);
+    myStubStub(errExecId, { err: 'stub-err' });
+    obelisk.sleep({ milliseconds: 1 });
+    try {
+        errJs.joinNextTry();
+        throw 'expected stub error';
+    } catch (e) {
+        if (!String(e).includes('stub-err')) {
+            throw `unexpected thrown err value: ${e}`;
+        }
+    }
+
+    return okResult;
+}

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1135,12 +1135,17 @@ mod tests {
             const js = obelisk.createJoinSet();
             const delayId = js.submitDelay({ milliseconds: 10 });
             obelisk.sleep({ milliseconds: 20 });
-            const response = js.joinNextTry();
-            const afterResponse = js.joinNextTry();
+            const response = js.joinNextTry(); // First joinNextTry must succeed
+            let afterErrorCode = null;
+            try {
+                js.joinNextTry(); // Second joinNextTry must fail
+                throw 'unreachable';
+            } catch (e) {
+                afterErrorCode = e.code ?? null;
+            }
             return JSON.stringify({
-                responseType: response.type,
-                responseOk: response.ok,
-                afterStatus: afterResponse.status
+                responseIsNull: response === null,
+                afterErrorCode
             });
         }";
 
@@ -1151,9 +1156,11 @@ mod tests {
         harness.tick().await; // completes
 
         let result = harness.get_result_json().await;
-        assert_eq!(json!("delay"), result["responseType"]);
-        assert_eq!(json!(true), result["responseOk"]);
-        assert_eq!(json!("allProcessed"), result["afterStatus"]);
+        assert_eq!(json!(true), result["responseIsNull"]);
+        assert_eq!(
+            json!("OBELISK_JOIN_SET_EXHAUSTED"),
+            result["afterErrorCode"]
+        );
         drop(harness);
         db_close.close().await;
     }
@@ -1214,9 +1221,15 @@ mod tests {
             const js2 = obelisk.createJoinSet({ name: 'my-named-set' });
             console.log('Created named join set:', js2.id());
 
-            /* Test joinNextTry on empty join set - should return allProcessed */
-            const tryEmpty = js2.joinNextTry();
-            console.log('joinNextTry on empty:', JSON.stringify(tryEmpty));
+            /* Test joinNextTry on empty join set - should throw JoinSetExhaustedError */
+            let tryEmptyErrorCode = null;
+            try {
+                js2.joinNextTry();
+                throw 'unreachable';
+            } catch (e) {
+                tryEmptyErrorCode = e.code ?? null;
+            }
+            console.log('joinNextTry on empty error code:', tryEmptyErrorCode);
 
             /* Submit fibo(10) activity call */
             const fiboFfqn = 'testing:fibo/fibo.fibo';
@@ -1227,7 +1240,7 @@ mod tests {
             const delayId = js1.submitDelay({ milliseconds: 100 });
             console.log('Submitted delay, delayId:', delayId);
 
-            /* Test joinNextTry before any response is ready - should return pending */
+            /* Test joinNextTry before any response is ready - should return undefined */
             const tryPending = js1.joinNextTry();
             console.log('joinNextTry pending:', JSON.stringify(tryPending));
 
@@ -1258,8 +1271,8 @@ mod tests {
                 fiboResult: fiboResult,
                 response1Type: response1.type,
                 loser,
-                joinNextTryEmpty: tryEmpty.status,
-                joinNextTryPending: tryPending.status
+                joinNextTryEmptyErrorCode: tryEmptyErrorCode,
+                joinNextTryPendingIsUndefined: tryPending === undefined
             });
         }";
 
@@ -1399,14 +1412,14 @@ mod tests {
             "random string length should be in range [5, 10)"
         );
         assert_eq!(
-            json!("allProcessed"),
-            result["joinNextTryEmpty"],
-            "joinNextTry on empty join set should return allProcessed"
+            json!("OBELISK_JOIN_SET_EXHAUSTED"),
+            result["joinNextTryEmptyErrorCode"],
+            "joinNextTry on empty join set should throw JoinSetExhaustedError"
         );
         assert_eq!(
-            json!("pending"),
-            result["joinNextTryPending"],
-            "joinNextTry before response ready should return pending"
+            json!(true),
+            result["joinNextTryPendingIsUndefined"],
+            "joinNextTry before response ready should return undefined"
         );
         if activity_should_win {
             assert_eq!(

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -40,7 +40,9 @@
 //!
 //! // Non-blocking variant:
 //! const tryResponse = js.joinNextTry();
-//! // Same as joinNext(), or { status: "allProcessed"|"pending" }
+//! // undefined if no child finished yet
+//! // otherwise returns the child ok value, or throws on err
+//! // throws obelisk.JoinSetExhaustedError when the join set is exhausted
 //!
 //! // Get the actual result value (returns ok value, throws err value)
 //! const result = obelisk.getResult(execId);
@@ -471,6 +473,32 @@ fn unwrap_result(
         Err(None) => Err(JsNativeError::error()
             .with_message("child execution failed")
             .into()),
+    }
+}
+
+fn new_join_set_exhausted_error(ctx: &mut Context) -> JsError {
+    let message = "JoinSetEmpty: all responses processed";
+    let fallback = || JsNativeError::error().with_message(message).into();
+
+    let err = (|| -> JsResult<JsError> {
+        let global = ctx.global_object();
+        let obelisk = global
+            .get(js_string!("obelisk"), ctx)?
+            .as_object()
+            .ok_or_else(|| JsNativeError::error().with_message("global obelisk object missing"))?;
+        let ctor = obelisk
+            .get(js_string!("JoinSetExhaustedError"), ctx)?
+            .as_object()
+            .ok_or_else(|| {
+                JsNativeError::error().with_message("obelisk.JoinSetExhaustedError missing")
+            })?;
+        let err_obj = ctor.construct(&[JsValue::from(js_string!(message))], None, ctx)?;
+        Ok(JsError::from_opaque(err_obj.into()))
+    })();
+
+    match err {
+        Ok(err) => err,
+        Err(_) => fallback(),
     }
 }
 
@@ -1051,6 +1079,15 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
 
     // Set obelisk as global
     context.register_global_property(js_string!("obelisk"), obelisk, Attribute::all())?;
+    context.eval(Source::from_bytes(
+        "obelisk.JoinSetExhaustedError = class JoinSetExhaustedError extends Error {\n\
+            constructor(message) {\n\
+                super(message);\n\
+                this.name = 'JoinSetExhaustedError';\n\
+                this.code = 'OBELISK_JOIN_SET_EXHAUSTED';\n\
+            }\n\
+        };",
+    ))?;
 
     Ok(())
 }
@@ -1294,59 +1331,30 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
         let join_result = with_join_set(idx, |js| join_next_try_bt(js, Some(&backtrace)))?;
 
         match join_result {
-            Ok((response_id, result)) => {
-                let result_obj = new_object(ctx);
-
-                match response_id {
-                    ResponseId::ExecutionId(exec_id) => {
-                        result_obj.set(js_string!("type"), js_string!("execution"), false, ctx)?;
-                        result_obj.set(
-                            js_string!("id"),
-                            js_string!(exec_id.id.clone()),
-                            false,
-                            ctx,
-                        )?;
-                        result_obj.set(js_string!("ok"), result.is_ok(), false, ctx)?;
-                        this_obj.set(js_string!("lastId"), js_string!(exec_id.id), false, ctx)?;
-                    }
-                    ResponseId::DelayId(delay_id) => {
-                        result_obj.set(js_string!("type"), js_string!("delay"), false, ctx)?;
-                        result_obj.set(
-                            js_string!("id"),
-                            js_string!(delay_id.id.clone()),
-                            false,
-                            ctx,
-                        )?;
-                        this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
-                        match result {
-                            Ok(()) => {
-                                result_obj.set(js_string!("ok"), true, false, ctx)?;
-                            }
-                            Err(()) => {
-                                result_obj.set(js_string!("ok"), false, false, ctx)?;
-                                result_obj.set(
-                                    js_string!("error"),
-                                    js_string!("cancelled"),
-                                    false,
-                                    ctx,
-                                )?;
-                            }
-                        }
-                    }
+            Ok((ResponseId::ExecutionId(exec_id), _)) => {
+                this_obj.set(
+                    js_string!("lastId"),
+                    js_string!(exec_id.id.as_str()),
+                    false,
+                    ctx,
+                )?;
+                let get_result = get_result_json_bt(&exec_id, Some(&backtrace));
+                match get_result {
+                    Ok(inner_result) => unwrap_result(inner_result, ctx),
+                    Err(e) => Err(JsNativeError::error()
+                        .with_message(format!("get result failed: {:?}", e))
+                        .into()),
                 }
-
-                Ok(result_obj.into())
             }
-            Err(JoinNextTryError::AllProcessed) => {
-                let result_obj = new_object(ctx);
-                result_obj.set(js_string!("status"), js_string!("allProcessed"), false, ctx)?;
-                Ok(result_obj.into())
+            Ok((ResponseId::DelayId(delay_id), result)) => {
+                this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
+                match result {
+                    Ok(()) => Ok(JsValue::null()),
+                    Err(()) => Err(JsNativeError::error().with_message("cancelled").into()),
+                }
             }
-            Err(JoinNextTryError::Pending) => {
-                let result_obj = new_object(ctx);
-                result_obj.set(js_string!("status"), js_string!("pending"), false, ctx)?;
-                Ok(result_obj.into())
-            }
+            Err(JoinNextTryError::AllProcessed) => Err(new_join_set_exhausted_error(ctx)),
+            Err(JoinNextTryError::Pending) => Ok(JsValue::undefined()),
         }
     });
     obj.set(

--- a/obelisk-testing-exec.toml
+++ b/obelisk-testing-exec.toml
@@ -7,6 +7,7 @@ echo "line1" >&2
 sleep 0.1
 echo "line2" >&2
 '''
+env_vars = ["PATH"] # for sleep
 
 [[activity_exec]]
 ffqn = "testing:integration/exec-greet.greet-include"

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -299,6 +299,15 @@ params = [
 return_type = "result<string, string>"
 
 [[workflow_js]]
+name = "test_join_next_try_semantics_workflow"
+location = "{ws}/crates/testing/test-programs/js/workflow/join_next_try_semantics.js"
+ffqn = "testing:integration/workflow-join-next-try-semantics.join-next-try-semantics"
+params = [
+  {{ name = "id", type = "u64" }},
+]
+return_type = "result<string, string>"
+
+[[workflow_js]]
 name = "test_math_random_workflow"
 location = "{ws}/crates/testing/test-programs/js/workflow/math_random.js"
 ffqn = "testing:integration/workflow-math-random.math-random"
@@ -2067,6 +2076,22 @@ async fn submit_workflow_with_import_stub() {
     let resp = server
         .submit_follow(
             "testing:integration/workflow-import-stub-activity.call-stub",
+            vec![json!(42u64)],
+        )
+        .await;
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body, json!({ "ok": "stub-ok" }));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn submit_workflow_with_join_next_try_semantics() {
+    let server = TestServer::start(test_addr!(77)).await;
+    let resp = server
+        .submit_follow(
+            "testing:integration/workflow-join-next-try-semantics.join-next-try-semantics",
             vec![json!(42u64)],
         )
         .await;

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -42,7 +42,7 @@ use std::{path::PathBuf, time::Duration};
 use test_utils::sanitize_json;
 use tokio::{sync::watch, task::JoinHandle};
 use tokio_stream::StreamExt;
-use tracing::{debug, instrument};
+use tracing::{debug, info, instrument};
 
 #[cfg(test)]
 mod populate_js_codegen_cache {
@@ -552,6 +552,18 @@ impl TestServer {
             .await
             .unwrap();
 
+        let base_url = format!("http://{ip}:{API_PORT}");
+        let client = reqwest::Client::new();
+        if client
+            .get(format!("{base_url}/v1/functions"))
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .is_ok()
+        {
+            panic!("{base_url} is reachable before server started");
+        }
+
         let server_handle = tokio::spawn(async move {
             Box::pin(run_internal(
                 config,
@@ -563,9 +575,7 @@ impl TestServer {
             ))
             .await
         });
-
-        let base_url = format!("http://{ip}:{API_PORT}");
-        let client = reqwest::Client::new();
+        debug!("Spawned server task");
 
         // Poll until the server is ready.
         loop {
@@ -582,6 +592,7 @@ impl TestServer {
             if let Ok(resp) = resp
                 && resp.status().is_success()
             {
+                debug!("Pinging server OK");
                 break;
             }
             debug!("Pinging sever failed");

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -436,6 +436,7 @@ echo "line1" >&2
 sleep 0.1
 echo "line2" >&2
 '''
+env_vars = ["PATH"] # for sleep
 
 [[activity_stub]]
 ffqn = "testing:integration/stubs.my-stub"
@@ -3282,6 +3283,7 @@ async fn activity_exec_stream_logs() {
     let server = TestServer::start(test_addr!(61)).await;
     let exec_id = server.generate_execution_id().await;
 
+    info!("About to submit the execution");
     let resp = server
         .submit_follow_with_id(
             &exec_id,
@@ -3290,20 +3292,30 @@ async fn activity_exec_stream_logs() {
         )
         .await;
     assert_eq!(resp.status().as_u16(), 201);
+
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body, json!({ "ok": null }));
 
-    // Allow log forwarding to flush.
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    let logs = server.get_logs(&exec_id).await;
-
-    // Filter for stderr stream entries.
-    let stderr_entries: Vec<&Value> = logs
-        .as_array()
-        .expect("logs must be an array")
-        .iter()
-        .filter(|entry| entry["type"] == "stream" && entry["stream_type"] == "stderr")
-        .collect();
+    // FIXME: Make accepting logs deterministic
+    let stderr_entries = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let logs = server.get_logs(&exec_id).await;
+            debug!("Fetched logs: {logs:?}");
+            let stderr_entries: Vec<Value> = logs
+                .as_array()
+                .expect("logs must be an array")
+                .iter()
+                .filter(|entry| entry["type"] == "stream" && entry["stream_type"] == "stderr")
+                .cloned()
+                .collect();
+            if stderr_entries.len() >= 2 {
+                break stderr_entries;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for stderr stream entries");
 
     // Streaming must produce at least 2 separate stderr entries (one per echo).
     assert!(

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -314,6 +314,13 @@ expression: components
   {
     "component_id": {
       "component_type": "workflow",
+      "name": "test_join_next_try_semantics_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
       "name": "test_make_record_workflow",
       "component_digest": "sha256:<REDACTED>"
     }

--- a/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
@@ -106,6 +106,9 @@ expression: functions
     "ffqn": "testing:integration/workflow-call-stub.call-stub"
   },
   {
+    "ffqn": "testing:integration/workflow-join-next-try-semantics.join-next-try-semantics"
+  },
+  {
     "ffqn": "testing:integration/workflow-math-random.math-random"
   },
   {


### PR DESCRIPTION
- **refactor(workflow-js): Make `joinNextTry` idiomatic**
- **test: Make an API request before starting IT harness server**
- **test: Add `PATH` to `stream-test`, fetch logs in a loop**
- **chore: Push workflow JS runtime**
