### PR TITLE
Show execution errors in status - CLI, WebAPI

### DIFF
--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -391,7 +391,7 @@ pub enum ExecutionRequest {
         http_client_traces: Option<Vec<HttpClientTrace>>,
     },
     // Created by the executor holding the lock.
-    #[display("Finished")]
+    #[display("Finished: {retval}")]
     Finished {
         #[cfg_attr(any(test, feature = "test"), arbitrary(value = crate::SUPPORTED_RETURN_VALUE_OK_EMPTY))]
         retval: SupportedFunctionReturnValue,
@@ -2238,7 +2238,7 @@ pub enum PendingState {
     #[display("Paused({_0})")]
     Paused(PendingStatePaused),
 
-    #[display("Finished({_0})")]
+    #[display("Finished: {_0}")]
     Finished(PendingStateFinished),
 }
 
@@ -2357,7 +2357,7 @@ pub struct PendingStateFinished {
 impl Display for PendingStateFinished {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.result_kind {
-            PendingStateFinishedResultKind::Ok => write!(f, "ok"),
+            PendingStateFinishedResultKind::Ok => write!(f, "OK"),
             PendingStateFinishedResultKind::Err(err) => write!(f, "{err}"),
         }
     }
@@ -2398,9 +2398,9 @@ impl From<&SupportedFunctionReturnValue> for PendingStateFinishedResultKind {
 )]
 #[serde(rename_all = "snake_case")]
 pub enum PendingStateFinishedError {
-    #[display("{_0}")]
+    #[display("Execution failure ({_0})")]
     ExecutionFailure(ExecutionFailureKind),
-    #[display("completed with an error")]
+    #[display("Error")]
     Error,
 }
 

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -503,12 +503,35 @@ fn format_pending_status(pending_status: grpc_gen::ExecutionStatus) -> String {
                 closing = if closing { " (closing)" } else { "" }
             )
         }
-        Status::Finished(Finished { .. }) => {
-            // the final result will be sent in the next message, since we set `send_finished_status` to true.
-            "Finished".to_string()
+        Status::Finished(Finished { result_kind, .. }) => {
+            // The final result will be sent in the next message for `GetMode::Result`,
+            // but status mode still needs to distinguish success from failure.
+            format_finished_status(result_kind)
         }
         Status::Paused(grpc_gen::execution_status::Paused {}) => "Paused".to_string(),
         illegal @ Status::BlockedByJoinSet(_) => panic!("illegal state {illegal:?}"),
+    }
+}
+
+fn format_finished_status(result_kind: Option<grpc_gen::ResultKind>) -> String {
+    match result_kind.and_then(format_finished_result_kind) {
+        Some(result_kind) => format!("Finished: {result_kind}"),
+        None => "Finished".to_string(),
+    }
+}
+
+fn format_finished_result_kind(result_kind: grpc_gen::ResultKind) -> Option<String> {
+    use grpc_gen::result_kind::Value;
+
+    match result_kind.value {
+        Some(Value::Ok(_)) => Some("OK".to_string()),
+        Some(Value::Error(_)) => Some("Error".to_string()),
+        Some(Value::ExecutionFailureKind(kind)) => {
+            let kind = grpc_gen::ExecutionFailureKind::try_from(kind).ok()?;
+            let kind = ExecutionFailureKind::try_from(kind).ok()?;
+            Some(format!("Execution failure ({kind})"))
+        }
+        None => None,
     }
 }
 
@@ -991,10 +1014,12 @@ async fn advance(
 #[cfg(test)]
 mod tests {
     use super::{
-        execution_status_json_is_finished, pause_delays_in_replay, pause_submitted_in_replay,
+        execution_status_json_is_finished, format_finished_result_kind, format_finished_status,
+        pause_delays_in_replay, pause_submitted_in_replay,
     };
     use crate::server::web_api_server::{AdvanceRequestSer, CapturedWriteSer};
     use chrono::{DateTime, Utc};
+    use grpc::grpc_gen;
     use serde_json::json;
 
     #[test]
@@ -1009,6 +1034,53 @@ mod tests {
                 "status": "locked"
             }
         })));
+    }
+
+    #[test]
+    fn finished_status_includes_success_and_error_kind() {
+        assert_eq!(
+            format_finished_status(Some(grpc_gen::ResultKind {
+                value: Some(grpc_gen::result_kind::Value::Ok(
+                    grpc_gen::result_kind::Ok {},
+                )),
+            })),
+            "Finished: OK"
+        );
+        assert_eq!(
+            format_finished_status(Some(grpc_gen::ResultKind {
+                value: Some(grpc_gen::result_kind::Value::Error(
+                    grpc_gen::result_kind::Error {},
+                )),
+            })),
+            "Finished: Error"
+        );
+    }
+
+    #[test]
+    fn finished_status_includes_execution_failure_kind() {
+        assert_eq!(
+            format_finished_result_kind(grpc_gen::ResultKind {
+                value: Some(grpc_gen::result_kind::Value::ExecutionFailureKind(
+                    grpc_gen::ExecutionFailureKind::TimedOut.into(),
+                )),
+            }),
+            Some("Execution failure (TimedOut)".to_string())
+        );
+    }
+
+    #[test]
+    fn finished_status_falls_back_to_plain_finished_for_missing_or_unknown_result_kind() {
+        assert_eq!(format_finished_status(None), "Finished");
+        assert_eq!(
+            format_finished_status(Some(grpc_gen::ResultKind { value: None })),
+            "Finished"
+        );
+        assert_eq!(
+            format_finished_status(Some(grpc_gen::ResultKind {
+                value: Some(grpc_gen::result_kind::Value::ExecutionFailureKind(999)),
+            })),
+            "Finished"
+        );
     }
 
     #[test]

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3846,9 +3846,9 @@ mod tests {
     use super::format_execution_status_text;
     use chrono::{DateTime, Utc};
     use concepts::{
-        ExecutionFailureKind,
+        ExecutionFailureKind, SupportedFunctionReturnValue,
         storage::{
-            PendingState, PendingStateFinished, PendingStateFinishedError,
+            ExecutionRequest, PendingState, PendingStateFinished, PendingStateFinishedError,
             PendingStateFinishedResultKind,
         },
     };
@@ -3885,6 +3885,32 @@ mod tests {
                     ),
                 ),
             })),
+            "Finished: Execution failure (Uncategorized)"
+        );
+    }
+
+    #[test]
+    fn finished_event_display_is_explicit() {
+        assert_eq!(
+            ExecutionRequest::Finished {
+                retval: SupportedFunctionReturnValue::Err(None),
+                http_client_traces: None,
+            }
+            .to_string(),
+            "Finished: Error"
+        );
+        assert_eq!(
+            ExecutionRequest::Finished {
+                retval: SupportedFunctionReturnValue::ExecutionFailure(
+                    concepts::FinishedExecutionFailure {
+                        kind: ExecutionFailureKind::Uncategorized,
+                        reason: None,
+                        detail: None,
+                    },
+                ),
+                http_client_traces: None,
+            }
+            .to_string(),
             "Finished: Execution failure (Uncategorized)"
         );
     }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -29,8 +29,9 @@ use concepts::{
         self, BacktraceFilter, CancelOutcome, DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout,
         DbErrorWrite, DbErrorWriteNonRetriable, DbPool, ExecutionEvent, ExecutionListPagination,
         ExecutionRequest, ExecutionWithState, FunctionNameFilter, ListExecutionsFilter,
-        LogInfoAppendRow, Pagination, PendingState, ResponseCursor, ResponseWithCursor,
-        TimeoutOutcome, Version, VersionType,
+        LogInfoAppendRow, Pagination, PendingState, PendingStateFinishedError,
+        PendingStateFinishedResultKind, ResponseCursor, ResponseWithCursor, TimeoutOutcome,
+        Version, VersionType,
     },
     time::{ClockFn as _, Now, Sleep as _},
 };
@@ -1287,8 +1288,32 @@ async fn execution_status_get(
             StatusCode::OK,
             &ExecutionWithStateSer::from(execution_with_state),
         ),
-        AcceptHeader::Text => execution_with_state.to_string().into_response(),
+        AcceptHeader::Text => {
+            format_execution_status_text(&execution_with_state.pending_state).into_response()
+        }
     })
+}
+
+fn format_execution_status_text(pending_state: &PendingState) -> String {
+    match pending_state {
+        PendingState::Locked(_) => "Locked".to_string(),
+        PendingState::PendingAt(pending) => format!("Pending at {}", pending.scheduled_at),
+        PendingState::BlockedByJoinSet(blocked) => format!(
+            "Blocked by {}{}",
+            blocked.join_set_id,
+            if blocked.closing { " (closing)" } else { "" }
+        ),
+        PendingState::Paused(_) => "Paused".to_string(),
+        PendingState::Finished(finished) => match finished.result_kind {
+            PendingStateFinishedResultKind::Ok => "Finished: OK".to_string(),
+            PendingStateFinishedResultKind::Err(PendingStateFinishedError::Error) => {
+                "Finished: Error".to_string()
+            }
+            PendingStateFinishedResultKind::Err(PendingStateFinishedError::ExecutionFailure(
+                kind,
+            )) => format!("Finished: Execution failure ({kind})"),
+        },
+    }
 }
 
 /// Payload for stubbing an execution result
@@ -3813,5 +3838,58 @@ impl From<ErrorWrapper<SubmitError>> for HttpResponse {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_execution_status_text;
+    use chrono::{DateTime, Utc};
+    use concepts::{
+        ExecutionFailureKind,
+        storage::{
+            PendingState, PendingStateFinished, PendingStateFinishedError,
+            PendingStateFinishedResultKind,
+        },
+    };
+
+    #[test]
+    fn text_status_for_finished_ok_and_error_is_explicit() {
+        assert_eq!(
+            format_execution_status_text(&PendingState::Finished(PendingStateFinished {
+                version: 1,
+                finished_at: parse_dt("2026-01-01T00:00:00Z"),
+                result_kind: PendingStateFinishedResultKind::Ok,
+            })),
+            "Finished: OK"
+        );
+        assert_eq!(
+            format_execution_status_text(&PendingState::Finished(PendingStateFinished {
+                version: 1,
+                finished_at: parse_dt("2026-01-01T00:00:00Z"),
+                result_kind: PendingStateFinishedResultKind::Err(PendingStateFinishedError::Error),
+            })),
+            "Finished: Error"
+        );
+    }
+
+    #[test]
+    fn text_status_for_finished_execution_failure_is_explicit() {
+        assert_eq!(
+            format_execution_status_text(&PendingState::Finished(PendingStateFinished {
+                version: 1,
+                finished_at: parse_dt("2026-01-01T00:00:00Z"),
+                result_kind: PendingStateFinishedResultKind::Err(
+                    PendingStateFinishedError::ExecutionFailure(
+                        ExecutionFailureKind::Uncategorized,
+                    ),
+                ),
+            })),
+            "Finished: Execution failure (Uncategorized)"
+        );
+    }
+
+    fn parse_dt(value: &str) -> DateTime<Utc> {
+        value.parse().unwrap()
     }
 }


### PR DESCRIPTION
- **refactor(cli): Show execution errors and failures in `execution status`**
- **refactor(webapi): Show error / failure in plaintext execution status response**
