### PR TITLE
Disallow `Paused(Locked)` state

### DIFF
--- a/assets/schemas/db.json
+++ b/assets/schemas/db.json
@@ -147,7 +147,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Returns execution to [`PendingState::PendingAt`] state at the specified time.\nThis can happen when:\n- executor is running out of resources like [`WorkerError::LimitReached`]\n- workflow made progress but then its lock expired.\n- executor is being closed (shutdown or hot redeploy requested)",
+          "description": "Returns execution to [`PendingState::PendingAt`] state at the specified time.\nThis can happen when:\n- executor is running out of resources like [`WorkerError::LimitReached`]\n- workflow made progress but then its lock expired.\n- executor is being closed (shutdown or hot redeploy requested)\n- activity is paused",
           "type": "object",
           "properties": {
             "unlocked": {
@@ -1521,7 +1521,7 @@
           ]
         },
         {
-          "description": "State of execution before it was paused.",
+          "description": "State of execution before it was paused.\n\nPausing a locked execution must first append `Unlocked` and only then `Paused`.",
           "type": "object",
           "properties": {
             "status": {
@@ -1530,17 +1530,6 @@
             }
           },
           "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "Locked": {
-                  "$ref": "#/$defs/PendingStateLocked"
-                }
-              },
-              "required": [
-                "Locked"
-              ]
-            },
             {
               "type": "object",
               "properties": {

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1424,6 +1424,8 @@ pub trait DbExternalApi: DbConnection {
     ) -> Result<Vec<DeploymentRecord>, DbErrorRead>;
 
     /// Pause an execution. Only pending executions can be paused.
+    /// If the execution is currently locked, implementations must release the lock first
+    /// and then record the paused state.
     async fn pause_execution(
         &self,
         execution_id: &ExecutionId,
@@ -2277,10 +2279,6 @@ impl From<PendingState> for PendingStateMergedPause {
             },
 
             PendingState::Paused(paused) => match paused {
-                PendingStatePaused::Locked(s) => PendingStateMergedPause::Locked {
-                    state: s,
-                    paused: true,
-                },
                 PendingStatePaused::PendingAt(s) => PendingStateMergedPause::PendingAt {
                     state: s,
                     paused: true,
@@ -2324,10 +2322,10 @@ pub struct PendingStateBlockedByJoinSet {
 }
 
 /// State of execution before it was paused.
+///
+/// Pausing a locked execution must first append `Unlocked` and only then `Paused`.
 #[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub enum PendingStatePaused {
-    #[display("Locked({_0})")]
-    Locked(PendingStateLocked),
     #[display("PendingAt({_0})")]
     PendingAt(PendingStatePendingAt),
     #[display("BlockedByJoinSet({_0})")]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -365,6 +365,7 @@ pub enum ExecutionRequest {
     /// - executor is running out of resources like [`WorkerError::LimitReached`]
     /// - workflow made progress but then its lock expired.
     /// - executor is being closed (shutdown or hot redeploy requested)
+    /// - activity is paused
     #[display("Unlocked(`{backoff_expires_at}`)")]
     Unlocked {
         backoff_expires_at: DateTime<Utc>,

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -311,42 +311,6 @@ impl CombinedState {
                     },
                 )),
             },
-            // Paused - Locked
-            CombinedStateDTO {
-                execution_id,
-                created_at,
-                first_scheduled_at,
-                state,
-                ffqn,
-                component_digest,
-                component_type,
-                deployment_id,
-                pending_expires_finished: lock_expires_at,
-                last_lock_version: Some(_),
-                executor_id: Some(executor_id),
-                run_id: Some(run_id),
-                join_set_id: None,
-                join_set_closing: None,
-                result_kind: None,
-                is_paused: true,
-            } if state == STATE_LOCKED => ExecutionWithState {
-                component_digest,
-                component_type,
-                deployment_id,
-                execution_id,
-                ffqn,
-                created_at,
-                first_scheduled_at,
-                pending_state: PendingState::Paused(PendingStatePaused::Locked(
-                    PendingStateLocked {
-                        locked_by: LockedBy {
-                            executor_id,
-                            run_id,
-                        },
-                        lock_expires_at,
-                    },
-                )),
-            },
             // Paused - BlockedByJoinSet
             CombinedStateDTO {
                 execution_id,

--- a/crates/db-mem/src/journal.rs
+++ b/crates/db-mem/src/journal.rs
@@ -163,6 +163,17 @@ impl ExecutionJournal {
         }
 
         match &event {
+            ExecutionRequest::Paused if matches!(self.pending_state, PendingState::Locked(_)) => {
+                return Err(DbErrorWriteNonRetriable::IllegalState {
+                    reason:
+                        "cannot append Paused event when execution is locked; use pause_execution"
+                            .into(),
+                    context: tracing_error::SpanTrace::capture(),
+                    source: None,
+                    loc: std::panic::Location::caller(),
+                }
+                .into());
+            }
             ExecutionRequest::Paused if self.pending_state.is_paused() => {
                 return Err(DbErrorWriteNonRetriable::IllegalState {
                     reason: "cannot pause, execution is already paused".into(),
@@ -341,9 +352,8 @@ impl ExecutionJournal {
             });
         }
 
-        // Find the underlying state (ignoring Paused/Unpaused for now), store it in
-        // `PendingStatePaused` independent of whether the execution is actually paused.
-        let underlying_state: PendingStatePaused = self
+        // Find the underlying state, ignoring Paused/Unpaused events for now.
+        let underlying_state: PendingState = self
             .execution_events
             .iter()
             .enumerate()
@@ -353,7 +363,7 @@ impl ExecutionJournal {
                     unreachable!("finished state was already handled above")
                 }
                 ExecutionRequest::Created { scheduled_at, .. } => {
-                    Some(PendingStatePaused::PendingAt(PendingStatePendingAt {
+                    Some(PendingState::PendingAt(PendingStatePendingAt {
                         scheduled_at: *scheduled_at,
                         last_lock: None,
                     }))
@@ -366,7 +376,7 @@ impl ExecutionJournal {
                     component_id: _,
                     deployment_id: _,
                     retry_config: _,
-                }) => Some(PendingStatePaused::Locked(PendingStateLocked {
+                }) => Some(PendingState::Locked(PendingStateLocked {
                     locked_by: LockedBy {
                         executor_id: *executor_id,
                         run_id: *run_id,
@@ -385,7 +395,7 @@ impl ExecutionJournal {
                 | ExecutionRequest::Unlocked {
                     backoff_expires_at: expires_at,
                     ..
-                } => Some(PendingStatePaused::PendingAt(PendingStatePendingAt {
+                } => Some(PendingState::PendingAt(PendingStatePendingAt {
                     scheduled_at: *expires_at,
                     last_lock: self.find_last_lock().map(LockedBy::from),
                 })),
@@ -428,13 +438,13 @@ impl ExecutionJournal {
                     if let Some(nth_created_at) = resp {
                         // Original executor has a chance to continue, but after expiry any executor can pick up the execution.
                         let scheduled_at = max(*lock_expires_at, *nth_created_at);
-                        Some(PendingStatePaused::PendingAt(PendingStatePendingAt {
+                        Some(PendingState::PendingAt(PendingStatePendingAt {
                             scheduled_at,
                             last_lock: self.find_last_lock().map(LockedBy::from),
                         }))
                     } else {
                         // Still waiting for response
-                        Some(PendingStatePaused::BlockedByJoinSet(
+                        Some(PendingState::BlockedByJoinSet(
                             PendingStateBlockedByJoinSet {
                                 join_set_id: expected_join_set_id.clone(),
                                 lock_expires_at: *lock_expires_at,
@@ -500,21 +510,26 @@ impl ExecutionJournal {
 
         // Check if execution is finished (overrides paused state)
 
-        {
-            if is_paused {
-                PendingState::Paused(underlying_state)
-            } else {
-                // Convert PendingStatePaused to PendingState
-                match underlying_state {
-                    PendingStatePaused::Locked(locked) => PendingState::Locked(locked),
-                    PendingStatePaused::PendingAt(pending_at) => {
-                        PendingState::PendingAt(pending_at)
-                    }
-                    PendingStatePaused::BlockedByJoinSet(blocked) => {
-                        PendingState::BlockedByJoinSet(blocked)
-                    }
+        if is_paused {
+            match underlying_state {
+                PendingState::PendingAt(pending_at) => {
+                    PendingState::Paused(PendingStatePaused::PendingAt(pending_at))
+                }
+                PendingState::BlockedByJoinSet(blocked) => {
+                    PendingState::Paused(PendingStatePaused::BlockedByJoinSet(blocked))
+                }
+                PendingState::Locked(_) => {
+                    panic!("invalid state: execution cannot be both paused and locked")
+                }
+                PendingState::Paused(_) => {
+                    unreachable!("underlying state must ignore paused markers")
+                }
+                PendingState::Finished(_) => {
+                    unreachable!("finished state was already handled above")
                 }
             }
+        } else {
+            underlying_state
         }
     }
 

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2060,6 +2060,17 @@ async fn append(
                 PendingState::Finished { .. } => {
                     unreachable!("handled above");
                 }
+                PendingState::Locked(..) => {
+                    return Err(DbErrorWriteNonRetriable::IllegalState {
+                        reason:
+                            "cannot append Paused event when execution is locked; use pause_execution"
+                                .into(),
+                        context: SpanTrace::capture(),
+                        source: None,
+                        loc: Location::caller(),
+                    }
+                    .into());
+                }
                 PendingState::Paused(..) => {
                     return Err(DbErrorWriteNonRetriable::IllegalState {
                         reason: "cannot pause, execution is already paused".into(),
@@ -3745,17 +3756,22 @@ impl DbConnection for PostgresConnection {
         // Expired Locks
         let rows = tx.query(
             &format!(
-                "SELECT execution_id, last_lock_version, corresponding_version, intermittent_event_count, max_retries, retry_exp_backoff_millis, executor_id, run_id \
+                "SELECT execution_id, last_lock_version, corresponding_version, intermittent_event_count, max_retries, retry_exp_backoff_millis, executor_id, run_id, is_paused \
                  FROM t_state \
-                 WHERE pending_expires_finished <= $1 AND state = '{STATE_LOCKED}' AND NOT is_paused"
+                 WHERE pending_expires_finished <= $1 AND state = '{STATE_LOCKED}'"
             ),
             &[&at]
         ).await?;
 
         for row in rows {
-            let unpack = || -> Result<ExpiredTimer, DbErrorGeneric> {
+            let unpack = || -> Result<Option<ExpiredTimer>, DbErrorGeneric> {
                 let execution_id: String = get(&row, "execution_id")?;
                 let execution_id = ExecutionId::from_str(&execution_id)?;
+                let is_paused: bool = get(&row, "is_paused")?;
+                if is_paused {
+                    error!(%execution_id, "encountered invalid paused locked execution while scanning expired locks");
+                    return Ok(None);
+                }
                 let last_lock_version: i64 = get(&row, "last_lock_version")?;
                 let last_lock_version = Version::try_from(last_lock_version)?;
 
@@ -3780,7 +3796,7 @@ impl DbConnection for PostgresConnection {
                 let run_id: String = get(&row, "run_id")?;
                 let run_id = RunId::from_str(&run_id)?;
 
-                Ok(ExpiredTimer::Lock(ExpiredLock {
+                Ok(Some(ExpiredTimer::Lock(ExpiredLock {
                     execution_id,
                     locked_at_version: last_lock_version,
                     next_version: corresponding_version.increment(),
@@ -3791,11 +3807,12 @@ impl DbConnection for PostgresConnection {
                         executor_id,
                         run_id,
                     },
-                }))
+                })))
             };
 
             match unpack() {
-                Ok(timer) => expired_timers.push(timer),
+                Ok(Some(timer)) => expired_timers.push(timer),
+                Ok(None) => {}
                 Err(err) => warn!("Skipping corrupted row in get_expired_timers (locks): {err:?}"),
             }
         }

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -3747,7 +3747,7 @@ impl DbConnection for PostgresConnection {
             &format!(
                 "SELECT execution_id, last_lock_version, corresponding_version, intermittent_event_count, max_retries, retry_exp_backoff_millis, executor_id, run_id \
                  FROM t_state \
-                 WHERE pending_expires_finished <= $1 AND state = '{STATE_LOCKED}'"
+                 WHERE pending_expires_finished <= $1 AND state = '{STATE_LOCKED}' AND NOT is_paused"
             ),
             &[&at]
         ).await?;
@@ -4510,17 +4510,37 @@ impl DbExternalApi for PostgresConnection {
         let combined_state = get_combined_state(&tx, execution_id).await?;
         let appending_version = combined_state.get_next_version_fail_if_finished()?;
         debug!("Pausing with {appending_version}");
-        let (next_version, _) = append(
+        let next_version = if matches!(
+            combined_state.execution_with_state.pending_state,
+            PendingState::Locked(_)
+        ) {
+            let (next_version, _notifier) = append(
+                &tx,
+                execution_id,
+                AppendRequest {
+                    created_at: paused_at,
+                    event: ExecutionRequest::Unlocked {
+                        backoff_expires_at: paused_at,
+                        reason: StrVariant::Static("paused"),
+                    },
+                },
+                appending_version,
+            )
+            .await?;
+            next_version
+        } else {
+            appending_version
+        };
+        let (next_version, _notifier) = append(
             &tx,
             execution_id,
             AppendRequest {
                 created_at: paused_at,
                 event: ExecutionRequest::Paused,
             },
-            appending_version,
+            next_version,
         )
         .await?;
-
         tx.commit().await?;
         Ok(next_version)
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -3355,14 +3355,34 @@ impl SqlitePool {
         let combined_state = Self::get_combined_state(tx, execution_id)?;
         let appending_version = combined_state.get_next_version_fail_if_finished()?;
         debug!("Pausing with {appending_version}");
-        let (next_version, _) = Self::append(
+        let next_version = if matches!(
+            combined_state.execution_with_state.pending_state,
+            PendingState::Locked(_)
+        ) {
+            let (next_version, _notifier) = Self::append(
+                tx,
+                execution_id,
+                AppendRequest {
+                    created_at: paused_at,
+                    event: ExecutionRequest::Unlocked {
+                        backoff_expires_at: paused_at,
+                        reason: StrVariant::Static("paused"),
+                    },
+                },
+                appending_version,
+            )?;
+            next_version
+        } else {
+            appending_version
+        };
+        let (next_version, _notifier) = Self::append(
             tx,
             execution_id,
             AppendRequest {
                 created_at: paused_at,
                 event: ExecutionRequest::Paused,
             },
-            appending_version,
+            next_version,
         )?;
         Ok(next_version)
     }
@@ -4786,7 +4806,7 @@ impl DbConnection for SqlitePool {
                     SELECT execution_id, last_lock_version, corresponding_version, intermittent_event_count, max_retries, retry_exp_backoff_millis,
                     executor_id, run_id
                     FROM t_state
-                    WHERE pending_expires_finished <= :at AND state = "{STATE_LOCKED}"
+                    WHERE pending_expires_finished <= :at AND state = "{STATE_LOCKED}" AND NOT is_paused
                     "#
                 )
                 )?

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2079,6 +2079,17 @@ impl SqlitePool {
                     PendingState::Finished { .. } => {
                         unreachable!("handled above");
                     }
+                    PendingState::Locked(..) => {
+                        return Err(DbErrorWriteNonRetriable::IllegalState {
+                            reason:
+                                "cannot append Paused event when execution is locked; use pause_execution"
+                                    .into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        }
+                        .into());
+                    }
                     PendingState::Paused(..) => {
                         return Err(DbErrorWriteNonRetriable::IllegalState {
                             reason: "cannot pause, execution is already paused".into(),
@@ -4804,9 +4815,9 @@ impl DbConnection for SqlitePool {
                 // Extend with expired locks
                 let expired = conn.prepare(&format!(r#"
                     SELECT execution_id, last_lock_version, corresponding_version, intermittent_event_count, max_retries, retry_exp_backoff_millis,
-                    executor_id, run_id
+                    executor_id, run_id, is_paused
                     FROM t_state
-                    WHERE pending_expires_finished <= :at AND state = "{STATE_LOCKED}" AND NOT is_paused
+                    WHERE pending_expires_finished <= :at AND state = "{STATE_LOCKED}"
                     "#
                 )
                 )?
@@ -4816,6 +4827,11 @@ impl DbConnection for SqlitePool {
                         },
                         |row| {
                             let execution_id = row.get("execution_id")?;
+                            let is_paused: bool = row.get("is_paused")?;
+                            if is_paused {
+                                error!(%execution_id, "encountered invalid paused locked execution while scanning expired locks");
+                                return Ok(None);
+                            }
                             let locked_at_version = Version::new(row.get("last_lock_version")?);
                             let next_version = Version::new(row.get("corresponding_version")?).increment();
                             let intermittent_event_count = row.get("intermittent_event_count")?;
@@ -4832,11 +4848,11 @@ impl DbConnection for SqlitePool {
                                 retry_exp_backoff: Duration::from_millis(retry_exp_backoff_millis),
                                 locked_by: LockedBy { executor_id, run_id },
                             };
-                            Ok(ExpiredTimer::Lock(lock))
+                            Ok(Some(ExpiredTimer::Lock(lock)))
                         }
                     )?
                     .collect::<Result<Vec<_>, _>>()?;
-                expired_timers.extend(expired);
+                expired_timers.extend(expired.into_iter().flatten());
                 if !expired_timers.is_empty() {
                     debug!("get_expired_timers found {expired_timers:?}");
                 }

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2178,14 +2178,18 @@ async fn pause_finished_execution_should_fail(database: Database) {
     db_close.close().await;
 }
 
-#[expand_enum_database]
 #[rstest]
+#[case(Database::Sqlite)]
+#[case(Database::Postgres)]
 #[tokio::test]
-async fn pause_and_unpause_locked_execution_should_return_to_locked(database: Database) {
+async fn pause_and_unpause_locked_execution_should_return_to_pending_at(
+    #[case] database: Database,
+) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
     let db_connection = db_pool.connection().await.unwrap();
+    let db_external = db_pool.external_api_conn().await.unwrap();
 
     let execution_id = ExecutionId::generate();
     // Create with current scheduled time (ready to run)
@@ -2224,7 +2228,86 @@ async fn pause_and_unpause_locked_execution_should_return_to_locked(database: Da
     let (found_locked_by, found_lock_expires_at) = assert_matches!(log.pending_state,
         PendingState::Locked(PendingStateLocked{ locked_by, lock_expires_at }) => (locked_by, lock_expires_at));
     assert_eq!(lock_expires_at, found_lock_expires_at);
-    // Pause the locked execution
+    let paused_at = sim_clock.now();
+    // Pause the locked execution through the public API.
+    db_external
+        .pause_execution(&execution_id, paused_at)
+        .await
+        .unwrap();
+
+    // Verify the lock was released before the execution was paused.
+    let log = db_connection.get(&execution_id).await.unwrap();
+    let paused_pending_at = assert_matches!(log.pending_state,
+        PendingState::Paused(PendingStatePaused::PendingAt(PendingStatePendingAt { scheduled_at, last_lock })) => (scheduled_at, last_lock));
+    assert_eq!(paused_at, paused_pending_at.0);
+    assert_eq!(Some(found_locked_by.clone()), paused_pending_at.1);
+    let (backoff_expires_at, reason) = assert_matches!(
+        &log.events[2].event,
+        ExecutionRequest::Unlocked {
+            backoff_expires_at,
+            reason,
+        } => (*backoff_expires_at, reason)
+    );
+    assert_eq!(paused_at, backoff_expires_at);
+    assert_eq!("paused", reason.as_ref());
+    assert_matches!(log.events[3].event, ExecutionRequest::Paused);
+
+    // Unpause and verify it returns to pending state instead of reviving the old lock.
+    db_external
+        .unpause_execution(&execution_id, sim_clock.now())
+        .await
+        .unwrap();
+
+    let log = db_connection.get(&execution_id).await.unwrap();
+    let pending_at = assert_matches!(log.pending_state,
+        PendingState::PendingAt(PendingStatePendingAt { scheduled_at, last_lock }) => (scheduled_at, last_lock));
+    assert_eq!(paused_at, pending_at.0);
+    assert_eq!(Some(found_locked_by), pending_at.1);
+
+    drop(db_connection);
+    drop(db_external);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn paused_locked_execution_should_not_be_reported_as_expired(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let db_connection = db_pool.connection().await.unwrap();
+
+    let execution_id = ExecutionId::generate();
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: execution_id.clone(),
+            ffqn: SOME_FFQN,
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_activity(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
+
+    let lock_expires_at = sim_clock.now() + Duration::from_secs(30);
+    lock(
+        db_connection.as_ref(),
+        &execution_id,
+        &sim_clock,
+        ExecutorId::generate(),
+        lock_expires_at,
+        RunId::generate(),
+    )
+    .await;
+
+    // Simulate a legacy/manual pause that preserves the underlying Locked state.
     db_connection
         .append(
             execution_id.clone(),
@@ -2237,29 +2320,12 @@ async fn pause_and_unpause_locked_execution_should_return_to_locked(database: Da
         .await
         .unwrap();
 
-    // Verify state is paused
-    let log = db_connection.get(&execution_id).await.unwrap();
-    assert_matches!(log.pending_state, PendingState::Paused(..));
-
-    // Unpause and verify it returns to the same state as before pausing.
-    db_connection
-        .append(
-            execution_id.clone(),
-            Version::new(3),
-            AppendRequest {
-                created_at: sim_clock.now(),
-                event: ExecutionRequest::Unpaused,
-            },
-        )
+    sim_clock.move_time_forward(Duration::from_secs(31));
+    let expired = db_connection
+        .get_expired_timers(sim_clock.now())
         .await
         .unwrap();
-
-    // Since lock_expires_at is in the future, it should be preserved
-    let log = db_connection.get(&execution_id).await.unwrap();
-    let (found_locked_by_2, found_lock_expires_at_2) = assert_matches!(log.pending_state,
-        PendingState::Locked(PendingStateLocked{ locked_by, lock_expires_at }) => (locked_by, lock_expires_at));
-    assert_eq!(lock_expires_at, found_lock_expires_at_2);
-    assert_eq!(found_locked_by, found_locked_by_2);
+    assert!(expired.is_empty(), "{expired:?}");
 
     drop(db_connection);
     db_close.close().await;

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2272,7 +2272,7 @@ async fn pause_and_unpause_locked_execution_should_return_to_pending_at(
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn paused_locked_execution_should_not_be_reported_as_expired(database: Database) {
+async fn cannot_append_paused_to_locked_execution(database: Database) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
@@ -2307,8 +2307,7 @@ async fn paused_locked_execution_should_not_be_reported_as_expired(database: Dat
     )
     .await;
 
-    // Simulate a legacy/manual pause that preserves the underlying Locked state.
-    db_connection
+    let err = db_connection
         .append(
             execution_id.clone(),
             Version::new(2),
@@ -2318,14 +2317,12 @@ async fn paused_locked_execution_should_not_be_reported_as_expired(database: Dat
             },
         )
         .await
-        .unwrap();
-
-    sim_clock.move_time_forward(Duration::from_secs(31));
-    let expired = db_connection
-        .get_expired_timers(sim_clock.now())
-        .await
-        .unwrap();
-    assert!(expired.is_empty(), "{expired:?}");
+        .unwrap_err();
+    let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
+    assert_eq!(
+        "cannot append Paused event when execution is locked; use pause_execution",
+        reason.as_ref()
+    );
 
     drop(db_connection);
     db_close.close().await;
@@ -2460,6 +2457,21 @@ async fn pause_then_join_next_then_unpause_should_restore_blocked_by_join_set(da
                             result: Ok(()),
                         },
                     },
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    version = db_connection
+        .append(
+            execution_id.clone(),
+            version,
+            AppendRequest {
+                created_at: sim_clock.now(),
+                event: ExecutionRequest::Unlocked {
+                    backoff_expires_at: sim_clock.now(),
+                    reason: StrVariant::Static("paused"),
                 },
             },
         )


### PR DESCRIPTION
- **refactor(cli): Show execution errors and failures in `execution status`**
- **refactor(webapi): Show error / failure in plaintext execution status response**
- **refactor(webapi): Show error / execution failure in `/events`**
- **refactor(db): Append `Unlocked` on pausing a locked exe, ignore `Paused(Locked)` in `get_expired_timers`**
- **refactor(db): Remove `PendingStatePaused::Locked`**
