### PR TITLE
feat(toml): Add `content` for specifying JS components inline

### DIFF
--- a/assets/schemas/deployment-canonical.json
+++ b/assets/schemas/deployment-canonical.json
@@ -34,7 +34,7 @@
         "$ref": "#/$defs/ActivityExecComponentConfigCanonical"
       }
     },
-    "workflows": {
+    "workflows_wasm": {
       "type": "array",
       "items": {
         "$ref": "#/$defs/WorkflowWasmComponentConfigCanonical"
@@ -46,7 +46,7 @@
         "$ref": "#/$defs/WorkflowJsComponentConfigCanonical"
       }
     },
-    "webhooks": {
+    "webhooks_wasm": {
       "type": "array",
       "items": {
         "$ref": "#/$defs/WebhookWasmComponentConfigCanonical"
@@ -72,9 +72,9 @@
     "activities_external",
     "activities_js",
     "activities_exec",
-    "workflows",
+    "workflows_wasm",
     "workflows_js",
-    "webhooks",
+    "webhooks_wasm",
     "webhooks_js"
   ],
   "$defs": {

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -552,7 +552,23 @@
         },
         "location": {
           "description": "Location of the JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).",
-          "$ref": "#/$defs/JsLocationToml"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/JsLocationToml"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "content": {
+          "description": "Inline JavaScript source embedded in the TOML.\nExactly one of `location` or `content` must be set.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         },
         "content_digest": {
           "description": "Content digest of the JS source file.",
@@ -645,7 +661,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "location",
         "ffqn"
       ]
     },
@@ -965,7 +980,23 @@
         },
         "location": {
           "description": "Location of the JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).",
-          "$ref": "#/$defs/JsLocationToml"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/JsLocationToml"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "content": {
+          "description": "Inline JavaScript source embedded in the TOML.\nExactly one of `location` or `content` must be set.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         },
         "content_digest": {
           "description": "Content digest of the JS source file.",
@@ -1037,7 +1068,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "location",
         "ffqn"
       ]
     },
@@ -1138,7 +1168,23 @@
         },
         "location": {
           "description": "Location of the JavaScript source file.\nSupports local file paths.",
-          "$ref": "#/$defs/JsLocationToml"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/JsLocationToml"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "content": {
+          "description": "Inline JavaScript source embedded in the TOML.\nExactly one of `location` or `content` must be set.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         },
         "content_digest": {
           "description": "Content digest of the JS source file.",
@@ -1191,7 +1237,6 @@
       "additionalProperties": false,
       "required": [
         "name",
-        "location",
         "routes"
       ]
     },

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -1167,7 +1167,7 @@
           "$ref": "#/$defs/ConfigName"
         },
         "location": {
-          "description": "Location of the JavaScript source file.\nSupports local file paths.",
+          "description": "Location of the JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).",
           "anyOf": [
             {
               "$ref": "#/$defs/JsLocationToml"

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -72,10 +72,17 @@
 ### JavaScript Activity components configuration
 # [[activity_js]]
 # name = "name"                              # Optional. Component name. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
-## Location of the JavaScript source file.
-## Supports local file paths.
-## OCI references are NOT supported for JS activities.
+## Source specification: exactly one of `location` or `content`.
+## `content`: JavaScript source embedded directly in the TOML.
+# content = '''
+# export default function hello(name) {
+#   return `Hello, ${name}!`;
+# }
+# '''
+## `location`: local path or OCI reference for the JavaScript source file.
+## Supports local file paths and `oci://...` references.
 # location = "path/to/source.js"
+# location = "oci://docker.io/repo/image:tag"
 # ffqn = "namespace:package/interface@version.function" # Required. Fully qualified function name.
 ## Custom parameters. If omitted, defaults to no parameters.
 ## Each entry has a `name` and a WIT `type` (e.g. `string`, `u32`, `list<string>`, `option<u64>`).
@@ -237,10 +244,17 @@
 ### JavaScript Workflow components configuration
 # [[workflow_js]]
 # name = "name"                              # Optional. Component name. Defaults to `{ifc_name}.{function_name}` from `ffqn`.
-## Location of the JavaScript source file.
-## Supports local file paths.
-## OCI references are NOT supported for JS workflows.
+## Source specification: exactly one of `location` or `content`.
+## `content`: JavaScript source embedded directly in the TOML.
+# content = '''
+# export default function run() {
+#   return "ok";
+# }
+# '''
+## `location`: local path or OCI reference for the JavaScript source file.
+## Supports local file paths and `oci://...` references.
 # location = "path/to/workflow.js"
+# location = "oci://docker.io/repo/image:tag"
 # ffqn = "namespace:package/interface@version.function" # Required. Fully qualified function name.
 ## Custom parameters. If omitted, defaults to no parameters.
 ## Each entry has a `name` and a WIT `type` (e.g. `string`, `u32`, `list<string>`, `option<u64>`).
@@ -306,10 +320,17 @@
 ### JavaScript Webhook Endpoint components configuration
 # [[webhook_endpoint_js]]
 # name = "name"                              # Required. Component name.
-## Location of the JavaScript source file.
-## Supports local file paths.
-## OCI references are NOT supported for JS webhook endpoints.
+## Source specification: exactly one of `location` or `content`.
+## `content`: JavaScript source embedded directly in the TOML.
+# content = '''
+# export default function handle() {
+#   return new Response("ok");
+# }
+# '''
+## `location`: local path or OCI reference for the JavaScript source file.
+## Supports local file paths and `oci://...` references.
 # location = "path/to/webhook.js"
+# location = "oci://docker.io/repo/image:tag"
 # http_server = "external"                   # link to a `http_server`'s name (built-in default, or one defined in server.toml)
 # routes = [{ methods = [ "GET" ], route = "/some"}, "/other"]  # Required. See Routes section above.
 ## Guest std stream forwarding to host: one of "none","stdout","stderr","db". Default is "none".

--- a/obelisk-testing-js-local.toml
+++ b/obelisk-testing-js-local.toml
@@ -1,5 +1,9 @@
 [[activity_js]]
-location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/activity/add.js"
+content = '''
+export default function add(a, b) {
+    return a + b;
+}
+'''
 ffqn = "testing:integration/activity.add"
 params = [
   { name = "a", type = "u32" },
@@ -9,7 +13,15 @@ max_retries = 0
 return_type = "result<u32>"
 
 [[workflow_js]]
-location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/workflow/add_via_activity.js"
+content = '''
+import * as activity from 'testing:integration/activity';
+
+export default function call_activity(a, b) {
+    const result = activity.add(a, b);
+    console.log('Got result:', result);
+    return result;
+}
+'''
 ffqn = "testing:integration/workflow-add-via-activity.add-via-activity"
 params = [
   { name = "a", type = "u32" },
@@ -99,7 +111,16 @@ return_type = "result<string, string>"
 
 [[webhook_endpoint_js]]
 name = "webhook_js_hello"
-location = "${DEPLOYMENT_DIR}/crates/testing/test-programs/js/webhook/hello.js"
+content = '''
+export default function handle(request) {
+    console.info("hello request", request);
+    const execId = obelisk.executionIdCurrent();
+    return new Response("Hello from JS webhook!", {
+        status: 200,
+        headers: { "content-type": "text/plain", "x-execution-id": execId },
+    });
+}
+'''
 routes = [{ methods = ["GET"], route = "/hello" }]
 
 [[webhook_endpoint_js]]

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -63,13 +63,14 @@ impl args::Component {
     }
 }
 
+#[derive(Debug)]
 enum ComponentPushData {
     Wasm {
         path: PathBuf,
         metadata: ComponentMetadataAnnotation,
     },
     Js {
-        path: PathBuf,
+        source: String,
         metadata: ComponentMetadataAnnotation,
     },
     Exec {
@@ -148,11 +149,21 @@ fn find_component_for_push(
                 .iter()
                 .find(|(_, n)| n.to_string() == name)
                 .expect("name is in map so it must be in the list");
-            let JsLocationToml::Path(ref path) = cfg.location else {
-                bail!("component '{name}' uses OCI, only local paths are supported for push");
+            let source = match (&cfg.location, &cfg.content) {
+                (None, Some(content)) => content.clone(),
+                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                    .with_context(|| format!("cannot read JS file {path:?}"))?,
+                (Some(JsLocationToml::Oci(_)), None) => {
+                    bail!(
+                        "component '{name}' uses OCI source, only local sources are supported for push"
+                    );
+                }
+                (None, None) | (Some(_), Some(_)) => {
+                    bail!("component '{name}' must set exactly one of `location` or `content`");
+                }
             };
             Ok(ComponentPushData::Js {
-                path: PathBuf::from(path),
+                source,
                 metadata: ComponentMetadataAnnotation::ActivityJs {
                     env_vars: cfg.env_vars.iter().map(env_var_key).collect(),
                     allowed_hosts: cfg.allowed_hosts.clone(),
@@ -169,11 +180,21 @@ fn find_component_for_push(
                 .iter()
                 .find(|(_, n)| n.to_string() == name)
                 .expect("name is in map so it must be in the list");
-            let JsLocationToml::Path(ref path) = cfg.location else {
-                bail!("component '{name}' uses OCI, only local paths are supported for push");
+            let source = match (&cfg.location, &cfg.content) {
+                (None, Some(content)) => content.clone(),
+                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                    .with_context(|| format!("cannot read JS file {path:?}"))?,
+                (Some(JsLocationToml::Oci(_)), None) => {
+                    bail!(
+                        "component '{name}' uses OCI source, only local sources are supported for push"
+                    );
+                }
+                (None, None) | (Some(_), Some(_)) => {
+                    bail!("component '{name}' must set exactly one of `location` or `content`");
+                }
             };
             Ok(ComponentPushData::Js {
-                path: PathBuf::from(path),
+                source,
                 metadata: ComponentMetadataAnnotation::WorkflowJs {
                     lock_duration: Some(cfg.exec.lock_expiry),
                     ffqn: cfg.ffqn.clone(),
@@ -189,11 +210,21 @@ fn find_component_for_push(
                 .iter()
                 .find(|c| c.name.to_string() == name)
                 .expect("name is in map so it must be in the list");
-            let JsLocationToml::Path(ref path) = cfg.location else {
-                bail!("component '{name}' uses OCI, only local paths are supported for push");
+            let source = match (&cfg.location, &cfg.content) {
+                (None, Some(content)) => content.clone(),
+                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                    .with_context(|| format!("cannot read JS file {path:?}"))?,
+                (Some(JsLocationToml::Oci(_)), None) => {
+                    bail!(
+                        "component '{name}' uses OCI source, only local sources are supported for push"
+                    );
+                }
+                (None, None) | (Some(_), Some(_)) => {
+                    bail!("component '{name}' must set exactly one of `location` or `content`");
+                }
             };
             Ok(ComponentPushData::Js {
-                path: PathBuf::from(path),
+                source,
                 metadata: ComponentMetadataAnnotation::WebhookEndpointJs {
                     env_vars: cfg.env_vars.iter().map(env_var_key).collect(),
                     allowed_hosts: cfg.allowed_hosts.clone(),
@@ -256,7 +287,9 @@ async fn push_component(
         crate::config::config_holder::load_deployment_validated(deployment_path).await?;
     match find_component_for_push(&validated, component_name)? {
         ComponentPushData::Wasm { path, metadata } => oci::push(path, reference, &metadata).await,
-        ComponentPushData::Js { path, metadata } => oci::push_js(path, reference, &metadata).await,
+        ComponentPushData::Js { source, metadata } => {
+            oci::push_js(source, reference, &metadata).await
+        }
         ComponentPushData::Exec { script, metadata } => {
             oci::push_exec(script, reference, &metadata).await
         }

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -85,7 +85,7 @@ fn find_component_for_push(
     name: &str,
 ) -> anyhow::Result<ComponentPushData> {
     let component_type = deployment
-        .component_type_by_name
+        .component_names_to_types
         .get(name)
         .copied()
         .with_context(|| format!("component '{name}' not found in deployment TOML"))?;
@@ -93,7 +93,6 @@ fn find_component_for_push(
     match component_type {
         TomlComponentType::ActivityWasm => {
             let cfg = deployment
-                .inner
                 .activities_wasm
                 .iter()
                 .find(|c| c.common.name.to_string() == name)
@@ -112,8 +111,7 @@ fn find_component_for_push(
         }
         TomlComponentType::WebhookEndpointWasm => {
             let cfg = deployment
-                .inner
-                .webhooks
+                .webhooks_wasm
                 .iter()
                 .find(|c| c.common.name.to_string() == name)
                 .expect("name is in map so it must be in the list");
@@ -130,8 +128,7 @@ fn find_component_for_push(
         }
         TomlComponentType::WorkflowWasm => {
             let cfg = deployment
-                .inner
-                .workflows
+                .workflows_wasm
                 .iter()
                 .find(|c| c.common.name.to_string() == name)
                 .expect("name is in map so it must be in the list");
@@ -205,7 +202,6 @@ fn find_component_for_push(
         }
         TomlComponentType::WebhookEndpointJs => {
             let cfg = deployment
-                .inner
                 .webhooks_js
                 .iter()
                 .find(|c| c.name.to_string() == name)
@@ -871,8 +867,8 @@ mod tests {
         let parsed: crate::config::toml::DeploymentToml =
             toml::from_str(&toml_str).expect("generated TOML must parse");
 
-        assert_eq!(parsed.webhooks.len(), 1);
-        let wh = &parsed.webhooks[0];
+        assert_eq!(parsed.webhooks_wasm.len(), 1);
+        let wh = &parsed.webhooks_wasm[0];
         assert_eq!(wh.common.name.to_string(), "my_webhook");
         assert_eq!(wh.env_vars.len(), 1);
         assert_eq!(wh.allowed_hosts.len(), 0);

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -597,13 +597,15 @@ async fn generate_wit_deps(
             }
         }
         for (c, name) in &deployment.activities_js {
-            if matches!(c.location, JsLocationToml::Path(_)) {
+            if c.content.is_some() || matches!(c.location, Some(JsLocationToml::Path(_))) {
                 skipped_names.insert(name.to_string());
             }
         }
-        // Exec activities are always local — skip them from WIT generation.
-        for (_, name) in &deployment.activities_exec {
-            skipped_names.insert(name.to_string());
+        for (config, name) in &deployment.activities_exec {
+            if config.content.is_some() || matches!(config.location, Some(JsLocationToml::Path(_)))
+            {
+                skipped_names.insert(name.to_string());
+            }
         }
         for c in &deployment.inner.workflows {
             if matches!(c.common.location, ComponentLocationToml::Path(_)) {
@@ -611,11 +613,11 @@ async fn generate_wit_deps(
             }
         }
         for (c, name) in &deployment.workflows_js {
-            if matches!(c.location, JsLocationToml::Path(_)) {
+            if c.content.is_some() || matches!(c.location, Some(JsLocationToml::Path(_))) {
                 skipped_names.insert(name.to_string());
             }
         }
-        // webhooks are skipped in any case
+        // webhooks are skipped in any case - nothing can depend on their WIT definition
         skipped_names
     } else {
         HashSet::new()

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -577,7 +577,7 @@ async fn generate_wit_deps(
         // When `--external-only` is set, build the set of component names that have an OCI location.
         // Local components will be skipped during WIT extraction.
         let mut skipped_names: HashSet<String> = HashSet::new();
-        for c in &deployment.inner.activities_wasm {
+        for c in &deployment.activities_wasm {
             if matches!(c.common.location, ComponentLocationToml::Path(_)) {
                 skipped_names.insert(c.common.name.to_string());
             }
@@ -607,7 +607,7 @@ async fn generate_wit_deps(
                 skipped_names.insert(name.to_string());
             }
         }
-        for c in &deployment.inner.workflows {
+        for c in &deployment.workflows_wasm {
             if matches!(c.common.location, ComponentLocationToml::Path(_)) {
                 skipped_names.insert(c.common.name.to_string());
             }

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2169,7 +2169,7 @@ impl DeploymentVerified {
         if let Some(api_listening_addr) = api_addr_if_webui_enabled {
             let target_url = format!("http://{api_listening_addr}");
             deployment
-                .webhooks
+                .webhooks_wasm
                 .push(webhook::WebhookWasmComponentConfigCanonical {
                     common: ComponentCommon {
                         name: ConfigName::new(StrVariant::Static("obelisk_webui")).unwrap(),
@@ -2199,7 +2199,7 @@ impl DeploymentVerified {
             let mut remaining_server_names_to_webhook_names = {
                 let mut map: hashbrown::HashMap<ConfigName, Vec<ConfigName>> =
                     hashbrown::HashMap::default();
-                for webhook in &deployment.webhooks {
+                for webhook in &deployment.webhooks_wasm {
                     map.entry(webhook.http_server.clone())
                         .or_default()
                         .push(webhook.common.name.clone());
@@ -2282,7 +2282,7 @@ impl DeploymentVerified {
             .collect::<Vec<_>>();
 
         let workflows = deployment
-            .workflows
+            .workflows_wasm
             .into_iter()
             .map(|workflow| {
                 tokio::spawn(
@@ -2300,7 +2300,7 @@ impl DeploymentVerified {
             })
             .collect::<Vec<_>>();
         let webhooks_wasm_by_names = deployment
-            .webhooks
+            .webhooks_wasm
             .into_iter()
             .map(|webhook| {
                 tokio::spawn({
@@ -3857,7 +3857,7 @@ mod tests {
                 .parse()
                 .unwrap();
         deployment.activities_wasm[0].component_digest = Some(shared_digest.clone());
-        deployment.workflows[0].component_digest = Some(shared_digest);
+        deployment.workflows_wasm[0].component_digest = Some(shared_digest);
 
         let prepared_dirs = prepare_dirs(
             &config,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1,4 +1,5 @@
 use super::{config_holder::PathPrefixes, env_var::EnvVarConfig};
+use crate::args::TomlComponentType;
 use crate::command::server::FrameFilesToSourceContent;
 use crate::config::config_holder::{CACHE_DIR_PREFIX, DATA_DIR_PREFIX};
 use crate::config::env_var::{
@@ -75,11 +76,11 @@ pub(crate) struct DeploymentToml {
     #[serde(default, rename = "activity_exec")]
     pub(crate) activities_exec: Vec<ActivityExecComponentConfigToml>,
     #[serde(default, rename = "workflow_wasm")]
-    pub(crate) workflows: Vec<WorkflowWasmComponentConfigToml>,
+    pub(crate) workflows_wasm: Vec<WorkflowWasmComponentConfigToml>,
     #[serde(default, rename = "workflow_js")]
     pub(crate) workflows_js: Vec<WorkflowJsComponentConfigToml>,
     #[serde(default, rename = "webhook_endpoint_wasm")]
-    pub(crate) webhooks: Vec<WebhookWasmComponentConfigToml>,
+    pub(crate) webhooks_wasm: Vec<WebhookWasmComponentConfigToml>,
     #[serde(default, rename = "webhook_endpoint_js")]
     pub(crate) webhooks_js: Vec<WebhookJsComponentConfigToml>,
     #[serde(default, rename = "cron")]
@@ -90,16 +91,24 @@ pub(crate) struct DeploymentToml {
 ///
 /// Components that support auto-derived names (`activity_js`, `activity_exec`,
 /// `workflow_js`) are stored as `(Config, ConfigName)` tuples with the resolved name
-/// pulled out of the `Option`. The remaining component types stay inside `inner`.
+/// pulled out of the `Option`.
 #[derive(Default)]
 pub(crate) struct DeploymentTomlValidated {
-    pub(crate) inner: DeploymentToml,
-    pub(crate) activities_js: Vec<(ActivityJsComponentConfigToml, ConfigName)>,
     pub(crate) activities_exec: Vec<(ActivityExecComponentConfigToml, ConfigName)>,
-    pub(crate) activities_stub: Vec<(ActivityStubComponentConfigToml, ConfigName)>,
     pub(crate) activities_external: Vec<(ActivityExternalComponentConfigToml, ConfigName)>,
+    pub(crate) activities_js: Vec<(ActivityJsComponentConfigToml, ConfigName)>,
+    pub(crate) activities_stub: Vec<(ActivityStubComponentConfigToml, ConfigName)>,
+    pub(crate) activities_wasm: Vec<ActivityWasmComponentConfigToml>,
+
     pub(crate) workflows_js: Vec<(WorkflowJsComponentConfigToml, ConfigName)>,
-    pub(crate) component_type_by_name: hashbrown::HashMap<String, crate::args::TomlComponentType>,
+    pub(crate) workflows_wasm: Vec<WorkflowWasmComponentConfigToml>,
+
+    pub(crate) webhooks_js: Vec<WebhookJsComponentConfigToml>,
+    pub(crate) webhooks_wasm: Vec<WebhookWasmComponentConfigToml>,
+
+    pub(crate) crons: Vec<CronComponentConfigToml>,
+
+    pub(crate) component_names_to_types: hashbrown::HashMap<String, crate::args::TomlComponentType>,
 }
 impl DeploymentTomlValidated {
     pub(crate) async fn canonicalize(self) -> Result<DeploymentCanonical, anyhow::Error> {
@@ -117,27 +126,54 @@ impl DeploymentToml {
     ) -> Result<DeploymentTomlValidated, anyhow::Error> {
         self.expand_deployment_dir_prefix(deployment_dir);
 
-        let activities_js = Self::resolve_names(std::mem::take(&mut self.activities_js))?;
-        let activities_exec = Self::resolve_names(std::mem::take(&mut self.activities_exec))?;
-        let activities_stub = Self::resolve_stub_names(std::mem::take(&mut self.activities_stub))?;
-        let activities_external =
-            Self::resolve_external_names(std::mem::take(&mut self.activities_external))?;
-        let workflows_js = Self::resolve_names(std::mem::take(&mut self.workflows_js))?;
         // Build the name→type index and check for duplicates.
-        let mut component_type_by_name = hashbrown::HashMap::new();
-        // Components remaining in `inner` (all have mandatory names).
-        for (name, component_type) in self.all_component_names_with_types() {
-            if component_type_by_name
+        let mut component_names_to_types = hashbrown::HashMap::new();
+        // Add components with mandatory names
+        let iter = self
+            .activities_wasm
+            .iter()
+            .map(|c| (c.common.name.0.as_ref(), TomlComponentType::ActivityWasm))
+            .chain(
+                self.workflows_wasm
+                    .iter()
+                    .map(|c| (c.common.name.0.as_ref(), TomlComponentType::WorkflowWasm)),
+            )
+            .chain(self.webhooks_wasm.iter().map(|c| {
+                (
+                    c.common.name.0.as_ref(),
+                    TomlComponentType::WebhookEndpointWasm,
+                )
+            }))
+            .chain(
+                self.webhooks_js
+                    .iter()
+                    .map(|c| (c.name.0.as_ref(), TomlComponentType::WebhookEndpointJs)),
+            )
+            .chain(
+                self.crons
+                    .iter()
+                    .map(|c| (c.name.0.as_ref(), TomlComponentType::Cron)),
+            );
+
+        for (name, component_type) in iter {
+            if component_names_to_types
                 .insert(name.to_string(), component_type)
                 .is_some()
             {
                 bail!("duplicate component name `{name}` in deployment");
             }
         }
-        // Components with resolved names.
-        use crate::args::TomlComponentType;
+
+        let activities_js = Self::resolve_names(self.activities_js);
+        let activities_exec = Self::resolve_names(self.activities_exec);
+        let activities_stub = Self::resolve_stub_names(self.activities_stub);
+        let activities_external = Self::resolve_external_names(self.activities_external);
+        let workflows_js = Self::resolve_names(self.workflows_js);
+
+        // Add components with optional names (now resolved)
+
         for (_, name) in &activities_js {
-            if component_type_by_name
+            if component_names_to_types
                 .insert(name.to_string(), TomlComponentType::ActivityJs)
                 .is_some()
             {
@@ -145,7 +181,7 @@ impl DeploymentToml {
             }
         }
         for (_, name) in &activities_exec {
-            if component_type_by_name
+            if component_names_to_types
                 .insert(name.to_string(), TomlComponentType::ActivityExec)
                 .is_some()
             {
@@ -153,7 +189,7 @@ impl DeploymentToml {
             }
         }
         for (_, name) in &activities_stub {
-            if component_type_by_name
+            if component_names_to_types
                 .insert(name.to_string(), TomlComponentType::ActivityStub)
                 .is_some()
             {
@@ -161,7 +197,7 @@ impl DeploymentToml {
             }
         }
         for (_, name) in &activities_external {
-            if component_type_by_name
+            if component_names_to_types
                 .insert(name.to_string(), TomlComponentType::ActivityExternal)
                 .is_some()
             {
@@ -169,7 +205,7 @@ impl DeploymentToml {
             }
         }
         for (_, name) in &workflows_js {
-            if component_type_by_name
+            if component_names_to_types
                 .insert(name.to_string(), TomlComponentType::WorkflowJs)
                 .is_some()
             {
@@ -177,40 +213,27 @@ impl DeploymentToml {
             }
         }
         Ok(DeploymentTomlValidated {
-            inner: self,
-            activities_js,
             activities_exec,
-            activities_stub,
             activities_external,
+            activities_js,
+            activities_stub,
+            activities_wasm: self.activities_wasm,
+
             workflows_js,
-            component_type_by_name,
+            workflows_wasm: self.workflows_wasm,
+
+            webhooks_js: self.webhooks_js,
+            webhooks_wasm: self.webhooks_wasm,
+
+            crons: self.crons,
+
+            component_names_to_types,
         })
     }
 
-    fn resolve_names<T: HasOptionalNameAndFfqn>(
-        configs: Vec<T>,
-    ) -> Result<Vec<(T, ConfigName)>, anyhow::Error> {
-        let mut resolved_names: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
-        for c in &configs {
-            if c.config_name().is_none() {
-                let derived = ConfigName::from_ffqn(c.ffqn());
-                resolved_names
-                    .entry(derived.0.as_ref().to_string())
-                    .or_default()
-                    .push(c.ffqn().to_string());
-            }
-        }
-        for (name, ffqns) in &resolved_names {
-            if ffqns.len() > 1 {
-                bail!(
-                    "multiple components derive the same name `{name}` from their FFQNs: {}. \
-                     Please specify an explicit `name` for each of these components",
-                    ffqns.join(", ")
-                );
-            }
-        }
-
-        Ok(configs
+    // Resolve optional names from FFQN.
+    fn resolve_names<T: HasOptionalNameAndFfqn>(configs: Vec<T>) -> Vec<(T, ConfigName)> {
+        configs
             .into_iter()
             .map(|c| {
                 let name = c
@@ -219,37 +242,15 @@ impl DeploymentToml {
                     .unwrap_or_else(|| ConfigName::from_ffqn(c.ffqn()));
                 (c, name)
             })
-            .collect())
+            .collect()
     }
 
     /// Resolve names for `ActivityStubComponentConfigToml` enum variants.
     /// File variants always have an explicit name; Inline variants may derive from FFQN.
     fn resolve_stub_names(
         configs: Vec<ActivityStubComponentConfigToml>,
-    ) -> Result<Vec<(ActivityStubComponentConfigToml, ConfigName)>, anyhow::Error> {
-        // Check for clashes among auto-derived inline names.
-        let mut auto_names: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
-        for c in &configs {
-            if let ActivityStubComponentConfigToml::Inline(inline) = c
-                && inline.name.is_none()
-            {
-                let derived = ConfigName::from_ffqn(&inline.ffqn);
-                auto_names
-                    .entry(derived.0.as_ref().to_string())
-                    .or_default()
-                    .push(inline.ffqn.to_string());
-            }
-        }
-        for (name, ffqns) in &auto_names {
-            if ffqns.len() > 1 {
-                bail!(
-                    "multiple components derive the same name `{name}` from their FFQNs: {}. \
-                     Please specify an explicit `name` for each of these components",
-                    ffqns.join(", ")
-                );
-            }
-        }
-        Ok(configs
+    ) -> Vec<(ActivityStubComponentConfigToml, ConfigName)> {
+        configs
             .into_iter()
             .map(|c| {
                 let name = match &c {
@@ -261,35 +262,14 @@ impl DeploymentToml {
                 };
                 (c, name)
             })
-            .collect())
+            .collect()
     }
 
     /// Resolve names for `ActivityExternalComponentConfigToml` enum variants.
     fn resolve_external_names(
         configs: Vec<ActivityExternalComponentConfigToml>,
-    ) -> Result<Vec<(ActivityExternalComponentConfigToml, ConfigName)>, anyhow::Error> {
-        let mut auto_names: hashbrown::HashMap<String, Vec<String>> = hashbrown::HashMap::new();
-        for c in &configs {
-            if let ActivityExternalComponentConfigToml::Inline(inline) = c
-                && inline.name.is_none()
-            {
-                let derived = ConfigName::from_ffqn(&inline.ffqn);
-                auto_names
-                    .entry(derived.0.as_ref().to_string())
-                    .or_default()
-                    .push(inline.ffqn.to_string());
-            }
-        }
-        for (name, ffqns) in &auto_names {
-            if ffqns.len() > 1 {
-                bail!(
-                    "multiple components derive the same name `{name}` from their FFQNs: {}. \
-                     Please specify an explicit `name` for each of these components",
-                    ffqns.join(", ")
-                );
-            }
-        }
-        Ok(configs
+    ) -> Vec<(ActivityExternalComponentConfigToml, ConfigName)> {
+        configs
             .into_iter()
             .map(|c| {
                 let name = match &c {
@@ -301,7 +281,7 @@ impl DeploymentToml {
                 };
                 (c, name)
             })
-            .collect())
+            .collect()
     }
 
     fn expand_deployment_dir(s: &mut String, is_dir: bool, deployment_dir: &std::path::Path) {
@@ -351,7 +331,7 @@ impl DeploymentToml {
                 Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
-        for c in &mut self.workflows {
+        for c in &mut self.workflows_wasm {
             expand_loc(&mut c.common.location);
             expand_backtrace(&mut c.backtrace);
         }
@@ -360,7 +340,7 @@ impl DeploymentToml {
                 Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
-        for c in &mut self.webhooks {
+        for c in &mut self.webhooks_wasm {
             expand_loc(&mut c.common.location);
             expand_backtrace(&mut c.backtrace);
         }
@@ -369,39 +349,6 @@ impl DeploymentToml {
                 Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
-    }
-
-    fn all_component_names_with_types(
-        &self,
-    ) -> impl Iterator<Item = (&str, crate::args::TomlComponentType)> {
-        use crate::args::TomlComponentType;
-        self.activities_wasm
-            .iter()
-            .map(|c| (c.common.name.0.as_ref(), TomlComponentType::ActivityWasm))
-            // activities_stub, activities_external, activities_js, activities_exec,
-            // workflows_js are handled separately via DeploymentTomlValidated's
-            // resolved-name fields.
-            .chain(
-                self.workflows
-                    .iter()
-                    .map(|c| (c.common.name.0.as_ref(), TomlComponentType::WorkflowWasm)),
-            )
-            .chain(self.webhooks.iter().map(|c| {
-                (
-                    c.common.name.0.as_ref(),
-                    TomlComponentType::WebhookEndpointWasm,
-                )
-            }))
-            .chain(
-                self.webhooks_js
-                    .iter()
-                    .map(|c| (c.name.0.as_ref(), TomlComponentType::WebhookEndpointJs)),
-            )
-            .chain(
-                self.crons
-                    .iter()
-                    .map(|c| (c.name.0.as_ref(), TomlComponentType::Cron)),
-            )
     }
 }
 
@@ -2617,9 +2564,9 @@ pub(crate) struct DeploymentCanonical {
     pub(crate) activities_external: Vec<ActivityExternalComponentConfigCanonical>,
     pub(crate) activities_js: Vec<ActivityJsComponentConfigCanonical>,
     pub(crate) activities_exec: Vec<ActivityExecComponentConfigCanonical>,
-    pub(crate) workflows: Vec<WorkflowWasmComponentConfigCanonical>,
+    pub(crate) workflows_wasm: Vec<WorkflowWasmComponentConfigCanonical>,
     pub(crate) workflows_js: Vec<WorkflowJsComponentConfigCanonical>,
-    pub(crate) webhooks: Vec<webhook::WebhookWasmComponentConfigCanonical>,
+    pub(crate) webhooks_wasm: Vec<webhook::WebhookWasmComponentConfigCanonical>,
     pub(crate) webhooks_js: Vec<webhook::WebhookJsComponentConfigCanonical>,
     #[serde(default)]
     pub(crate) crons: Vec<CronComponentConfigToml>,
@@ -2651,10 +2598,9 @@ async fn resolve_local_refs_to_canonical(
         });
     }
 
-    let deployment_inner = deployment.inner;
-    let mut workflows = Vec::with_capacity(deployment_inner.workflows.len());
-    for w in deployment_inner.workflows {
-        workflows.push(WorkflowWasmComponentConfigCanonical {
+    let mut workflows_wasm = Vec::with_capacity(deployment.workflows_wasm.len());
+    for w in deployment.workflows_wasm {
+        workflows_wasm.push(WorkflowWasmComponentConfigCanonical {
             common: w.common,
             component_digest: w.component_digest,
             exec: w.exec,
@@ -2685,9 +2631,9 @@ async fn resolve_local_refs_to_canonical(
         });
     }
 
-    let mut webhooks = Vec::with_capacity(deployment_inner.webhooks.len());
-    for w in deployment_inner.webhooks {
-        webhooks.push(webhook::WebhookWasmComponentConfigCanonical {
+    let mut webhooks_wasm = Vec::with_capacity(deployment.webhooks_wasm.len());
+    for w in deployment.webhooks_wasm {
+        webhooks_wasm.push(webhook::WebhookWasmComponentConfigCanonical {
             common: w.common,
             http_server: w.http_server,
             routes: w.routes,
@@ -2700,8 +2646,8 @@ async fn resolve_local_refs_to_canonical(
         });
     }
 
-    let mut webhooks_js = Vec::with_capacity(deployment_inner.webhooks_js.len());
-    for w in deployment_inner.webhooks_js {
+    let mut webhooks_js = Vec::with_capacity(deployment.webhooks_js.len());
+    for w in deployment.webhooks_js {
         webhooks_js.push(webhook::WebhookJsComponentConfigCanonical {
             location: resolve_js_toml_to_canonical(w.location, w.content, w.name.to_string())
                 .await?,
@@ -2797,16 +2743,16 @@ async fn resolve_local_refs_to_canonical(
         .collect();
 
     Ok(DeploymentCanonical {
-        activities_wasm: deployment_inner.activities_wasm,
+        activities_wasm: deployment.activities_wasm,
         activities_stub,
         activities_external,
         activities_js,
         activities_exec,
-        workflows,
+        workflows_wasm,
         workflows_js,
-        webhooks,
+        webhooks_wasm,
         webhooks_js,
-        crons: deployment_inner.crons,
+        crons: deployment.crons,
     })
 }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -116,7 +116,7 @@ impl DeploymentToml {
         deployment_dir: &std::path::Path,
     ) -> Result<DeploymentTomlValidated, anyhow::Error> {
         self.expand_deployment_dir_prefix(deployment_dir);
-        // Resolve optional names from FFQN and drain vectors out of `self`.
+
         let activities_js = Self::resolve_names(std::mem::take(&mut self.activities_js))?;
         let activities_exec = Self::resolve_names(std::mem::take(&mut self.activities_exec))?;
         let activities_stub = Self::resolve_stub_names(std::mem::take(&mut self.activities_stub))?;
@@ -342,7 +342,7 @@ impl DeploymentToml {
             }
         }
         for c in &mut self.activities_js {
-            if let JsLocationToml::Path(p) = &mut c.location {
+            if let Some(JsLocationToml::Path(p)) = &mut c.location {
                 Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
@@ -356,7 +356,7 @@ impl DeploymentToml {
             expand_backtrace(&mut c.backtrace);
         }
         for c in &mut self.workflows_js {
-            if let JsLocationToml::Path(p) = &mut c.location {
+            if let Some(JsLocationToml::Path(p)) = &mut c.location {
                 Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
@@ -365,7 +365,7 @@ impl DeploymentToml {
             expand_backtrace(&mut c.backtrace);
         }
         for c in &mut self.webhooks_js {
-            if let JsLocationToml::Path(p) = &mut c.location {
+            if let Some(JsLocationToml::Path(p)) = &mut c.location {
                 Self::expand_deployment_dir(p, false, deployment_dir);
             }
         }
@@ -1609,7 +1609,12 @@ pub(crate) struct ActivityJsComponentConfigToml {
     pub(crate) name: Option<ConfigName>,
     /// Location of the JavaScript source file.
     /// Supports local file paths and OCI registry references (`oci://...`).
-    pub(crate) location: JsLocationToml,
+    #[serde(default)]
+    pub(crate) location: Option<JsLocationToml>,
+    /// Inline JavaScript source embedded in the TOML.
+    /// Exactly one of `location` or `content` must be set.
+    #[serde(default)]
+    pub(crate) content: Option<String>,
     /// Content digest of the JS source file.
     #[serde(default)]
     #[schemars(with = "Option<String>")]
@@ -2023,7 +2028,12 @@ pub(crate) struct WorkflowJsComponentConfigToml {
     pub(crate) name: Option<ConfigName>,
     /// Location of the JavaScript source file.
     /// Supports local file paths and OCI registry references (`oci://...`).
-    pub(crate) location: JsLocationToml,
+    #[serde(default)]
+    pub(crate) location: Option<JsLocationToml>,
+    /// Inline JavaScript source embedded in the TOML.
+    /// Exactly one of `location` or `content` must be set.
+    #[serde(default)]
+    pub(crate) content: Option<String>,
     /// Content digest of the JS source file.
     #[serde(default)]
     #[schemars(with = "Option<String>")]
@@ -2623,8 +2633,8 @@ async fn resolve_local_refs_to_canonical(
     let mut activities_js = Vec::with_capacity(deployment.activities_js.len());
     for (a, name) in deployment.activities_js {
         activities_js.push(ActivityJsComponentConfigCanonical {
+            location: resolve_js_toml_to_canonical(a.location, a.content, name.to_string()).await?,
             name,
-            location: resolve_js_to_canonical(&a.location).await?,
             content_digest: a.content_digest,
             component_digest: a.component_digest,
             ffqn: a.ffqn,
@@ -2660,8 +2670,8 @@ async fn resolve_local_refs_to_canonical(
     let mut workflows_js = Vec::with_capacity(deployment.workflows_js.len());
     for (w, name) in deployment.workflows_js {
         workflows_js.push(WorkflowJsComponentConfigCanonical {
+            location: resolve_js_toml_to_canonical(w.location, w.content, name.to_string()).await?,
             name,
-            location: resolve_js_to_canonical(&w.location).await?,
             content_digest: w.content_digest,
             component_digest: w.component_digest,
             ffqn: w.ffqn,
@@ -2693,8 +2703,9 @@ async fn resolve_local_refs_to_canonical(
     let mut webhooks_js = Vec::with_capacity(deployment_inner.webhooks_js.len());
     for w in deployment_inner.webhooks_js {
         webhooks_js.push(webhook::WebhookJsComponentConfigCanonical {
+            location: resolve_js_toml_to_canonical(w.location, w.content, w.name.to_string())
+                .await?,
             name: w.name,
-            location: resolve_js_to_canonical(&w.location).await?,
             content_digest: w.content_digest,
             http_server: w.http_server,
             routes: w.routes,
@@ -2799,15 +2810,23 @@ async fn resolve_local_refs_to_canonical(
     })
 }
 
-async fn resolve_js_to_canonical(location: &JsLocationToml) -> anyhow::Result<JsLocationCanonical> {
-    match location {
-        JsLocationToml::Path(path) => {
-            let file_name = std::path::Path::new(path)
+async fn resolve_js_toml_to_canonical(
+    location: Option<JsLocationToml>,
+    content: Option<String>,
+    default_file_stem: String,
+) -> anyhow::Result<JsLocationCanonical> {
+    match (location, content) {
+        (None, Some(content)) => Ok(JsLocationCanonical::Content {
+            content,
+            file_name: format!("{default_file_stem}.js"),
+        }),
+        (Some(JsLocationToml::Path(path)), None) => {
+            let file_name = std::path::Path::new(&path)
                 .file_name()
                 .and_then(|n| n.to_str())
-                .unwrap_or(path)
+                .unwrap_or(&path)
                 .to_string();
-            let full_path = PathBuf::from(path);
+            let full_path = PathBuf::from(&path);
             if !full_path.exists() {
                 bail!("file does not exist: {full_path:?}");
             }
@@ -2816,9 +2835,12 @@ async fn resolve_js_to_canonical(location: &JsLocationToml) -> anyhow::Result<Js
                 .with_context(|| format!("cannot read JS file {full_path:?}"))?;
             Ok(JsLocationCanonical::Content { content, file_name })
         }
-        JsLocationToml::Oci(reference) => Ok(JsLocationCanonical::Oci {
+        (Some(JsLocationToml::Oci(reference)), None) => Ok(JsLocationCanonical::Oci {
             image: reference.whole(),
         }),
+        (None, None) | (Some(_), Some(_)) => {
+            bail!("exactly one of `location` or `content` must be set for JS components")
+        }
     }
 }
 
@@ -3303,8 +3325,13 @@ pub(crate) mod webhook {
     pub(crate) struct WebhookJsComponentConfigToml {
         pub(crate) name: ConfigName,
         /// Location of the JavaScript source file.
-        /// Supports local file paths.
-        pub(crate) location: JsLocationToml,
+        /// Supports local file paths and OCI registry references (`oci://...`).
+        #[serde(default)]
+        pub(crate) location: Option<JsLocationToml>,
+        /// Inline JavaScript source embedded in the TOML.
+        /// Exactly one of `location` or `content` must be set.
+        #[serde(default)]
+        pub(crate) content: Option<String>,
         /// Content digest of the JS source file.
         #[serde(default)]
         #[schemars(with = "Option<String>")]

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -502,18 +502,15 @@ pub(crate) async fn push(
     Ok(())
 }
 
-/// Push a JS source file to an OCI registry.
+/// Push a JS source string to an OCI registry.
 pub(crate) async fn push_js(
-    js_path: PathBuf,
+    js_source: String,
     reference: &Reference,
     metadata: &ComponentMetadataAnnotation,
 ) -> Result<(), anyhow::Error> {
     if reference.digest().is_some() {
         bail!("cannot push a digest reference");
     }
-    let js_source = tokio::fs::read_to_string(&js_path)
-        .await
-        .with_context(|| format!("cannot read JS file {js_path:?}"))?;
 
     let layer = oci_client::client::ImageLayer::new(
         js_source.into_bytes(),


### PR DESCRIPTION
- **feat(toml): Allow `content` for JS components**
- **refactor(db)!: Add `_wasm` suffixes to workflows and webhooks, simplify uniquensss checks**
