### PR TITLE
Merge latest back to main, fix eventual consistency in GH release creation

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - report: junit-default.xml
             script: "scripts/test.sh"
+          - report: junit-js-local.xml
+            script: "scripts/test-js-local.sh"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -32,8 +32,6 @@ jobs:
         include:
           - report: junit-default.xml
             script: "scripts/test.sh"
-          - report: junit-js-local.xml
-            script: "scripts/test-js-local.sh"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/release-2-cargo-publish.yml
+++ b/.github/workflows/release-2-cargo-publish.yml
@@ -48,6 +48,17 @@ jobs:
   cargo-publish:
     runs-on: ubuntu-24.04
     steps:
+      - name: Refuse to run from main
+        # Dispatching this workflow from `main` propagates `head_branch=main`
+        # to downstream `workflow_run` jobs (release-5-verify-*), which then
+        # check out stale sources. Releases must be dispatched from a release
+        # branch (e.g. `latest`).
+        run: |
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "::error::release-2-cargo-publish must not be dispatched from 'main'. Use a release branch such as 'latest'."
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.ref }} # Use the ref if provided, otherwise defaults to the current branch/commit

--- a/.github/workflows/release-3-create-github-release.yml
+++ b/.github/workflows/release-3-create-github-release.yml
@@ -60,6 +60,22 @@ jobs:
               "prerelease": false
             }' \
             https://api.github.com/repos/obeli-sk/obelisk/releases
+
+          for attempt in {1..30}; do
+            if curl --fail -L \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/obeli-sk/obelisk/releases/tags/$TAG"; then
+              exit 0
+            fi
+
+            echo "Release tag $TAG not readable yet, retrying ($attempt/30)"
+            sleep 2
+          done
+
+          echo "Timed out waiting for release tag $TAG to become readable"
+          exit 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ steps.git-info.outputs.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,123 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0](https://github.com/obeli-sk/obelisk/compare/v0.37.7...v0.38.0)
+
+This release adds stepwise execution debugging and recovery with `execution replay` / `execution advance`,
+including support for creating paused executions and pausing delays or submitted child executions while advancing.
+
+This release also adds first-class native executable activities in `deployment.toml`:
+
+```toml
+[[activity_exec]]
+ffqn = "myapp:ops/tasks.run"
+location = "${DEPLOYMENT_DIR}/scripts/run-task.sh"
+params = [{ name = "name", type = "string" }]
+return_type = "result<string, string>"
+env_vars = ["PATH", { key = "MODE", value = "prod" }]
+
+[activity_exec.secrets]
+env_vars = [{ name = "API_TOKEN", value = "${HOST_API_TOKEN}" }]
+```
+Result of exec activity execution is read from the process's stdout, which must be encoded as JSON.
+Both stdout and stderr are collected and can be viewed using `obelisk execution logs`.
+Because of this change, the more limited preopened-directory/process support has been removed from WASM activities.
+
+Deployment configuration is broader and more self-contained: JavaScript components can now use inline `content` or
+OCI-backed `location`s.
+It also includes several user-visible CLI and API changes, including `execution status` / `execution result`,
+more detailed failure reporting and logs, and breaking
+protocol/storage changes such as the new `AdvanceExecution` RPC, schema migrations.
+
+
+### Added
+
+- *(activity)* Interrupt activities in `pause` RPC - ([62d1d76](https://github.com/obeli-sk/obelisk/commit/62d1d76fbec8f830654da344c3d5ac18e8fe9691))
+- *(activity_exec)* Stream std streams, only apply limit to stdout - ([b5450d0](https://github.com/obeli-sk/obelisk/commit/b5450d0a3bb7c3bac37c6169b76f900c15a4ddf0))
+- *(advance)* Allow changing the paused state of created executions - ([8b17890](https://github.com/obeli-sk/obelisk/commit/8b1789049c3c190819b6adebe3b70b7df3b084d0))
+- *(advance)* Allow sending trimmed events - ([df52922](https://github.com/obeli-sk/obelisk/commit/df5292220c0deb7ea3b5a58a4208c2b5ab8f6c31))
+- *(cli)* Show std streams in `execution logs` unless disabled - ([ecd0e63](https://github.com/obeli-sk/obelisk/commit/ecd0e639ab4ed5249757c7124a9654e7e292e568))
+- *(exec,oci,toml)* Add OCI support for exec activities - ([81734de](https://github.com/obeli-sk/obelisk/commit/81734de2317563d8c870b257d47d705b320048d9))
+- *(grpc)* [**breaking**] Implement `AdvanceExecution` RPC - ([8ce19f5](https://github.com/obeli-sk/obelisk/commit/8ce19f59e1a306e03d111b29db6e13d5f2d94ad0))
+- *(grpc,webapi)* Add `version` to replay response - ([d65aa44](https://github.com/obeli-sk/obelisk/commit/d65aa44b64e7931a6dd1499d23df2712a5f4ff92))
+- *(grpc,webapi)* Extend replay response with next events and return value - ([9be37fd](https://github.com/obeli-sk/obelisk/commit/9be37fd8044dfeb0e0f46082ade99a85ac173d09))
+- *(grpc,webapi,cli)* Allow creation of paused executions - ([3a91e1b](https://github.com/obeli-sk/obelisk/commit/3a91e1bc567cf53c0b89312d40f8d391ae517e06))
+- *(grpc,webapi,cli,db)* [**breaking**] Allow pausing and unpausing of delay requests - ([47296ef](https://github.com/obeli-sk/obelisk/commit/47296ef0b5f822d005a169983f31d9639857b8d2))
+- *(pg,sqlite)* Persist component metadada per deployment - ([e2db54a](https://github.com/obeli-sk/obelisk/commit/e2db54af8f687519b59d28d2848066765c68ba64))
+- *(toml)* Allow `content` for JS components - ([c1e2c0b](https://github.com/obeli-sk/obelisk/commit/c1e2c0b7515cee92446ca4b585b8542058ad62bd))
+- *(toml)* Add optional per-executor task limiter - ([63b8b0b](https://github.com/obeli-sk/obelisk/commit/63b8b0bd8ed90b1810a60b84f518ce002de58d45))
+- *(webapi,cli)* Add `replay`, `advance` - ([35233a3](https://github.com/obeli-sk/obelisk/commit/35233a3eb9c9c6751ce226272a2eba114df30b7c))
+- *(webhook-js)* Add support for direct and `-schedule` imports - ([e178a0b](https://github.com/obeli-sk/obelisk/commit/e178a0b9ecd75be9349f22be8e0aed4170e9bd3c))
+- *(wit,workflow_js)* Add `sleep-named-bt`, allowing to pass name to `sleep` - ([6772e8e](https://github.com/obeli-sk/obelisk/commit/6772e8ecbec0f2f672299372612bd77bfe0e0558))
+- *(workflow-js)* Add stub imports - ([38d6511](https://github.com/obeli-sk/obelisk/commit/38d6511ca2c1f5a16411ed8588eef3f153f82e6a))
+- *(workflow-js)* Add support for workflow extension imports - ([8d2b7a9](https://github.com/obeli-sk/obelisk/commit/8d2b7a914f231dc6cb3c81a60d150accae334e11))
+- *(workflow-js)* Add support for `-schedule` imports - ([f8f1832](https://github.com/obeli-sk/obelisk/commit/f8f1832fbd9c7b77041ccf1050cf9167be86879e))
+- *(workflow-js)* Enable star imports - ([c055875](https://github.com/obeli-sk/obelisk/commit/c055875500b5f54060840c44a3be9b1fc258ab38))
+- *(workflow-js)* Add support for idiomatic direct child call - ([e919857](https://github.com/obeli-sk/obelisk/commit/e91985711056e07f30e43c0209b1d767e44a0163))
+- *(workflow-js)* Add `obelisk.executionIdCurrent()` - ([7d923ff](https://github.com/obeli-sk/obelisk/commit/7d923ff3d57d373039a43c3733ef2812a3d7500c))
+- Implement `activity_exec` - ([1604d1a](https://github.com/obeli-sk/obelisk/commit/1604d1a1e4be6324da8163089d5854a33aa8e5eb))
+- *(db)* [**breaking**] Manage database schemas using Refinery - ([d85cfdf](https://github.com/obeli-sk/obelisk/commit/d85cfdf4324638835f57124cdf6a86617757bc10))
+- *(workflow)* Add `fn advance` - ([f8db923](https://github.com/obeli-sk/obelisk/commit/f8db92365a5cf0dcf0f895391e914b134931fa33))
+
+### Fixed
+- *(cli,js,exec)* Handle multiple functions of same interface in `wit-deps` - ([c80af7b](https://github.com/obeli-sk/obelisk/commit/c80af7b1b3e3bdb1d14fb011b5ce939362e93083))
+
+### Changed
+
+- *(advance)* Capture and send app logs - ([5186c87](https://github.com/obeli-sk/obelisk/commit/5186c877fc2517f31ade8e65ea2fca82189acf06))
+- *(advance)* Apply cancellations during `advance` - ([c8f91c5](https://github.com/obeli-sk/obelisk/commit/c8f91c583131661a0796dee543e1be377971b463))
+- *(ci)* Add `--json` flag to `generate` subcommands - ([a358a95](https://github.com/obeli-sk/obelisk/commit/a358a95032aeb1e4babcbdff1a11517c3d4520c6))
+- *(cli)* Show execution errors and failures in `execution status` - ([210a49c](https://github.com/obeli-sk/obelisk/commit/210a49c1326c563c1d59bb8cc586175017a42f6e))
+- *(cli)* Add `--pause-all` to `execution advance` - ([044bcdd](https://github.com/obeli-sk/obelisk/commit/044bcddaa8b0018ccaaa575277b5fe689d5c22ac))
+- *(cli)* Add `--pause-delays` flag to `execution advance` - ([69ac356](https://github.com/obeli-sk/obelisk/commit/69ac356c525f64f73b4787e92a3219108bcac01b))
+- *(cli)* Let `generate prompt` accept unquoted arguments - ([f57d4d7](https://github.com/obeli-sk/obelisk/commit/f57d4d745c0dd05b2cfa39f9dfcd15a44aea9ead))
+- *(cli)* Simplify `generate prompt` - ([fbc4af2](https://github.com/obeli-sk/obelisk/commit/fbc4af2dd237eba65c120a8a843e712a4e9d9cbb))
+- *(cli)* Use `DeploymentId` for `deployment show` - ([561e443](https://github.com/obeli-sk/obelisk/commit/561e4432df0b638038a62eb4676d1fbb887426f1))
+- *(cli)* Make all flags use snake_case, placeholders all caps - ([8f7f36f](https://github.com/obeli-sk/obelisk/commit/8f7f36f4a2be4e81f4cee1993b14c79ddb50eebb))
+- *(cli)* [**breaking**] Unify `generate` overwrite flags under `--force` - ([f8b1a30](https://github.com/obeli-sk/obelisk/commit/f8b1a301c9fcf97d5e285b091fa7ceb7cc8ac0e3))
+- *(cli)* Split `execution get` to `status` and `result` - ([1420a6a](https://github.com/obeli-sk/obelisk/commit/1420a6ab3766b56701572cba73a0e93e42f39e7c))
+- *(cli)* Add `--trim` option to `execution advance` - ([c5b9d8c](https://github.com/obeli-sk/obelisk/commit/c5b9d8c90ad8593190eebec0fd3626e8d559cad9))
+- *(cli)* Fix pagination parsing when plaintext logs contain `\n` - ([dd57bfa](https://github.com/obeli-sk/obelisk/commit/dd57bfac7d83580bcadcd956299921eee4dfb451))
+- *(db)* [**breaking**] Add `_wasm` suffixes to workflows and webhooks, simplify uniquensss checks - ([065656e](https://github.com/obeli-sk/obelisk/commit/065656e263e1575ebc89e5f593a16598dd787cb0))
+- *(db)* [**breaking**] Rename execution error to execution failure - ([e7ef62d](https://github.com/obeli-sk/obelisk/commit/e7ef62d9959b19747c47c4fcc26bdbf09052d70f))
+- *(db)* Remove `PendingStatePaused::Locked` - ([4fe1e73](https://github.com/obeli-sk/obelisk/commit/4fe1e73af3452eb4fef4184f7e73ff8927d5e14a))
+- *(db)* Append `Unlocked` on pausing a locked exe, ignore `Paused(Locked)` in `get_expired_timers` - ([c6aab25](https://github.com/obeli-sk/obelisk/commit/c6aab25af9d9903205545337e46661749691ee26))
+- *(db)* Fix paused execution creation - ([49b7c49](https://github.com/obeli-sk/obelisk/commit/49b7c49403e93a508cb123cf05a3aefe8430262c))
+- *(exec)* Rename `task_limiter` to `task_limiter_global` - ([276ff7f](https://github.com/obeli-sk/obelisk/commit/276ff7fceb89dd13640db28a105f46d9f99268c5))
+- *(exec)* Remove exposing `PATH` when `env_vars` is empty - ([3de69a2](https://github.com/obeli-sk/obelisk/commit/3de69a27b01715f23c0c5bd58c9cf06659776589))
+- *(grpc)* Add `ExecutionFunctionFilter` to fix searching by package with version - ([3e59cab](https://github.com/obeli-sk/obelisk/commit/3e59cabc66ccfbac852c00d95edbe419b2f16a5a))
+- *(grpc)* Make it no-op when a delay is already (un)paused - ([a4874e6](https://github.com/obeli-sk/obelisk/commit/a4874e65a4861aedb597f1d54cb3d26ef51ad4bb))
+- *(grpc)* Split `Cancel` to `CancelActivity` and `CancelDelay` - ([d758da4](https://github.com/obeli-sk/obelisk/commit/d758da451a873dcbe7202dd3c691a04656cab2c7))
+- *(grpc)* Send `finished_result` in `AdvanceExecutionResponse` - ([3902070](https://github.com/obeli-sk/obelisk/commit/3902070dea6d799eb74d05d6abca1088105ec0f1))
+- *(grpc,webapi)* Add optional `deployment_id` to the WIT query - ([8f1c6ca](https://github.com/obeli-sk/obelisk/commit/8f1c6ca54400a207c7f01cc519e0043f6d9c05ac))
+- *(grpc,webapi)* Collect backtraces for captured `AppendStubResponse` - ([8c0e4b6](https://github.com/obeli-sk/obelisk/commit/8c0e4b639a5534bf6a96a27918351ad1814c0cf3))
+- *(grpc,webapi)* Expose captured writes in replay failed error - ([eb2e43d](https://github.com/obeli-sk/obelisk/commit/eb2e43dcfc630562453d1a0e70a46fc407231877))
+- *(grpc,webapi)* Send finished events, remove retval and version from replay response - ([b0d7e42](https://github.com/obeli-sk/obelisk/commit/b0d7e423c3f76fecce9e2278ec38d03f8149ef85))
+- *(js)* [**breaking**] Unify JS result APIs — return ok value, throw err value - ([89968e9](https://github.com/obeli-sk/obelisk/commit/89968e9ea9b5b3d4f699b28292c4cc059b8fa949))
+- *(js,exec)* Make unit type accept any response - ([068eb4c](https://github.com/obeli-sk/obelisk/commit/068eb4c83ed8bed530b5404b16d16737f9ba3a7d))
+- *(replay)* Send captured writes to persist execution errors in `ReplayError::ReplayFailed` - ([04f4343](https://github.com/obeli-sk/obelisk/commit/04f4343167b362571ca52c54e6c4fa364caa4511))
+- *(replay)* Capture and persist `FatalError`s as execution errors - ([da5bca4](https://github.com/obeli-sk/obelisk/commit/da5bca4e0772a58affe0c912b3d13f53494c8b82))
+- *(replay)* Capture WASM backtrace - ([4c6d2bf](https://github.com/obeli-sk/obelisk/commit/4c6d2bf347531e01069b3b2391c5dee427eb80b5))
+- *(replay)* Do not append `Finished` event on `ReplayKind::Finished` - ([3348e75](https://github.com/obeli-sk/obelisk/commit/3348e75f2b54826ac3593e95d5970a2afb5e2822))
+- *(replay)* Interrupt replay in `get_stub_create_request` instead of flush - ([f0a35a8](https://github.com/obeli-sk/obelisk/commit/f0a35a869f3ae6505f9f1ccf7c250bfe383e1744))
+- *(toml)* Honor `--missing-env-vars` when verifying exec with secrets - ([6589a78](https://github.com/obeli-sk/obelisk/commit/6589a78e553d6c886aca93ccf8f213596dc6c3ef))
+- *(toml)* Make names optional for inline stub and external activities - ([2a6cab8](https://github.com/obeli-sk/obelisk/commit/2a6cab8a7991fe13a42fb3142fd322ddd0b1298d))
+- *(toml)* Make name optional for `workflow_js`,`activity_js`,`activity_exec` - ([203ec9a](https://github.com/obeli-sk/obelisk/commit/203ec9a63b65fc0cac425ec49fc9ac3a221885c3))
+- *(webapi)* Show error / execution failure in `/events` - ([8249a1c](https://github.com/obeli-sk/obelisk/commit/8249a1cf02f88b7a49afaa8fcfb8e378abcece24))
+- *(webapi)* Show error / failure in plaintext execution status response - ([1b23900](https://github.com/obeli-sk/obelisk/commit/1b2390071b2ae149d19dfc6388ba06e84f58b675))
+- *(webapi)* [**breaking**] Use `error` instead of `err` for retval - ([0adaef6](https://github.com/obeli-sk/obelisk/commit/0adaef6b80bfa6f96b8a8c61c00925b0e652df28))
+- *(webhook)* Gracefully shutdown connection on hot redeply - ([9f6041f](https://github.com/obeli-sk/obelisk/commit/9f6041ff4824530a7aee668bf68ea1b73c208847))
+- *(wit)* Bump `obelisk_webhook` to 5.2.0, add `execution-id-current` - ([6a46e14](https://github.com/obeli-sk/obelisk/commit/6a46e149b62f3bc7339cdc76d5c7d8a708cd91a2))
+- *(wit)* Bump `workflow-support` to 5.1.0 - ([2302566](https://github.com/obeli-sk/obelisk/commit/23025664081747ea4e763a1ae6038718c2b7209e))
+- *(workflow-js)* Make `joinNextTry` idiomatic - ([1026d31](https://github.com/obeli-sk/obelisk/commit/1026d31965e6fad234afe7e07a0024c1b9b6e617))
+- *(workflow-js,replay)* Transform `AppendFinished` to user specified type - ([ecf16cd](https://github.com/obeli-sk/obelisk/commit/ecf16cd5108e4dcd45615034b0195e73149e3e5b))
+- Drop `Option` from `ExecutionMetadata` - ([ffdc544](https://github.com/obeli-sk/obelisk/commit/ffdc5441973b060f526cee9c1a51ea787463b885))
+
+### Removed
+
+- *(activity_wasm)* [**breaking**] Remove preopened dir and process API - ([33ab372](https://github.com/obeli-sk/obelisk/commit/33ab37259c4976d11881bc44e513ee3490d8820b))
+
+
 ## [0.37.7](https://github.com/obeli-sk/obelisk/compare/v0.37.6...v0.37.7)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,6 +3444,7 @@ dependencies = [
 name = "obelisk"
 version = "0.38.0"
 dependencies = [
+ "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3521,8 +3522,10 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
+ "webhook-js-runtime-builder",
  "wit-component 0.248.0",
  "wit-parser 0.248.0",
+ "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -349,7 +349,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-mem"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "chrono",
  "http",
@@ -3313,7 +3313,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "activity-js-runtime-builder",
  "anyhow",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "quote",
  "syn",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5200,14 +5200,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5217,14 +5217,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5235,14 +5235,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5251,14 +5251,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5268,14 +5268,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5285,14 +5285,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5301,14 +5301,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5317,14 +5317,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5349,14 +5349,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5366,14 +5366,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5383,14 +5383,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5399,14 +5399,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5415,14 +5415,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6915,7 +6915,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.38.0-rc.5"
+version = "0.38.0"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,7 +3444,6 @@ dependencies = [
 name = "obelisk"
 version = "0.38.0"
 dependencies = [
- "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3522,10 +3521,8 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
- "webhook-js-runtime-builder",
  "wit-component 0.248.0",
  "wit-parser 0.248.0",
- "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
-activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
-webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
-workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -127,9 +124,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = ["dep:activity-js-runtime-builder"]
-"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
-"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
+"activity-js-local" = []
+"webhook-js-local" = []
+"workflow-js-local" = []
 default = ["otlp"]
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
+activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -124,9 +127,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = []
-"webhook-js-local" = []
-"workflow-js-local" = []
+"activity-js-local" = ["dep:activity-js-runtime-builder"]
+"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
+"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
 default = ["otlp"]
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.38.0-rc.5"
+version = "0.38.0"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -204,14 +204,14 @@ rust-version = "1.91.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.0-rc.5" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.0-rc.5" }
-db-mem = { package = "obeli-sk-db-mem", path = "crates/db-mem", version = "0.38.0-rc.5" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.0-rc.5" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.0-rc.5" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.0" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.0" }
+db-mem = { package = "obeli-sk-db-mem", path = "crates/db-mem", version = "0.38.0" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.0" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.0" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.0-rc.5" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.0-rc.5" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.0" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.0" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -229,9 +229,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.0-rc.5" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.0-rc.5" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.0-rc.5" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.0" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.0" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.0" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }


### PR DESCRIPTION
- **chore: Prepare v0.38.0**
- **chore: Strip local deps before release**
- **Revert "chore: Strip local deps before release"**
- **Revert "ci: Remove refusal to run from `main`"**
- **ci: Loop after GH release is created but tag is not yet available**
