### PR TITLE
refactor(toml): Make `cancel_watcher` mandatory, removing `enabled` property

### DIFF
--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -581,10 +581,6 @@
     "CancelWatcherTomlConfig": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "default": true
-        },
         "tick_sleep": {
           "$ref": "#/$defs/DurationConfig",
           "default": {

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1816,13 +1816,8 @@ async fn spawn_tasks_and_threads(
         None
     };
 
-    let cancel_watcher = if cancel_watcher.enabled {
-        Some(
-            cancel_registry.spawn_cancel_watcher(db_pool.clone(), cancel_watcher.tick_sleep.into()),
-        )
-    } else {
-        None
-    };
+    let cancel_watcher =
+        cancel_registry.spawn_cancel_watcher(db_pool.clone(), cancel_watcher.tick_sleep.into());
 
     server_compiled_linked
         .create_missing_cron_seeds(&db_pool, deployment_id)
@@ -1901,13 +1896,11 @@ async fn spawn_tasks_and_threads(
 struct ServerInit {
     server_verified: ServerVerified,
     deployment_ctx: DeploymentContextHandle,
-    // deployment_id: DeploymentId,
     db_pool: Arc<dyn DbPool>,
     db_close: Pin<Box<dyn Future<Output = ()> + Send>>,
     engines: Engines,
-    // exec_join_handles: Vec<ExecutorTaskHandle>,
     timers_watcher: Option<AbortOnDropHandle>,
-    cancel_watcher: Option<AbortOnDropHandle>,
+    cancel_watcher: AbortOnDropHandle,
     http_servers_handles: Vec<AbortOnDropHandle>,
     epoch_ticker: EpochTicker,
     log_db_forarder: AbortOnDropHandle,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -715,15 +715,12 @@ impl Default for TimersWatcherTomlConfig {
 #[derive(Debug, Deserialize, JsonSchema, Clone, Copy)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CancelWatcherTomlConfig {
-    #[serde(default = "default_cancel_watcher_enabled")]
-    pub(crate) enabled: bool,
     #[serde(default = "default_cancel_watcher_tick_sleep")]
     pub(crate) tick_sleep: DurationConfig,
 }
 impl Default for CancelWatcherTomlConfig {
     fn default() -> Self {
         Self {
-            enabled: default_cancel_watcher_enabled(),
             tick_sleep: default_cancel_watcher_tick_sleep(),
         }
     }
@@ -3781,9 +3778,6 @@ fn default_timers_watcher_tick_sleep() -> DurationConfig {
     DurationConfig::Milliseconds(100)
 }
 
-fn default_cancel_watcher_enabled() -> bool {
-    true
-}
 fn default_cancel_watcher_tick_sleep() -> DurationConfig {
     DurationConfig::Seconds(1)
 }


### PR DESCRIPTION
Cancel watcher cleans up the `tokens` hash map from `CancelRegistry`.
