### PR TITLE
Prepare v0.38.2-alpha.0

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - report: junit-default.xml
             script: "scripts/test.sh"
+          - report: junit-js-local.xml
+            script: "scripts/test-js-local.sh"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -32,8 +32,6 @@ jobs:
         include:
           - report: junit-default.xml
             script: "scripts/test.sh"
-          - report: junit-js-local.xml
-            script: "scripts/test-js-local.sh"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/pr-fix.yml
+++ b/.github/workflows/pr-fix.yml
@@ -136,45 +136,7 @@ jobs:
         run: |
           case "${{ matrix.part }}" in
             cargo-hash)
-              python3 - <<'PY'
-              import re
-              from pathlib import Path
-              path = Path("flake.nix")
-              text = path.read_text()
-              new_text, count = re.subn(r'cargoHash = .*?;', 'cargoHash = pkgs.lib.fakeHash;', text, count=1)
-              if count != 1:
-                  raise SystemExit(f"expected one cargoHash assignment in {path}, found {count}")
-              path.write_text(new_text)
-              PY
-
-              set +e
-              nix build -L .#obeliskLibcNixDev > /tmp/cargo-hash.log 2>&1
-              status=$?
-              set -e
-
-              if [ "$status" -eq 0 ]; then
-                echo "::error::Expected fake cargoHash build to fail with a hash mismatch."
-                exit 1
-              fi
-
-              computed_hash="$(sed -n 's/.*got:[[:space:]]*\\(sha256-[A-Za-z0-9+/=]*\\).*/\\1/p' /tmp/cargo-hash.log | tail -n1)"
-              if [ -z "$computed_hash" ]; then
-                cat /tmp/cargo-hash.log
-                echo "::error::Could not extract computed cargoHash from nix build output."
-                exit 1
-              fi
-
-              python3 - "$computed_hash" <<'PY'
-              import re
-              import sys
-              from pathlib import Path
-              path = Path("flake.nix")
-              text = path.read_text()
-              new_text, count = re.subn(r'cargoHash = .*?;', f'cargoHash = "{sys.argv[1]}";', text, count=1)
-              if count != 1:
-                  raise SystemExit(f"expected one cargoHash assignment in {path}, found {count}")
-              path.write_text(new_text)
-              PY
+              ./scripts/update-cargo-hash.sh
               ;;
             schemas)
               nix develop --command scripts/update-schemas.sh

--- a/.github/workflows/release-1-validate.yml
+++ b/.github/workflows/release-1-validate.yml
@@ -90,6 +90,7 @@ jobs:
 
       - name: Validate Nix dev build
         run: nix build .#obeliskLibcNixDev
+        if: ${{ !contains(inputs.extra-args, '--no-verify') }}
 
   call_child:
     needs: validate

--- a/.github/workflows/release-2-cargo-publish.yml
+++ b/.github/workflows/release-2-cargo-publish.yml
@@ -48,17 +48,6 @@ jobs:
   cargo-publish:
     runs-on: ubuntu-24.04
     steps:
-      - name: Refuse to run from main
-        # Dispatching this workflow from `main` propagates `head_branch=main`
-        # to downstream `workflow_run` jobs (release-5-verify-*), which then
-        # check out stale sources. Releases must be dispatched from a release
-        # branch (e.g. `latest`).
-        run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "::error::release-2-cargo-publish must not be dispatched from 'main'. Use a release branch such as 'latest'."
-            exit 1
-          fi
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.ref }} # Use the ref if provided, otherwise defaults to the current branch/commit
@@ -86,4 +75,5 @@ jobs:
     uses: ./.github/workflows/release-3-create-github-release.yml
     secrets: inherit
     with:
+      ref: ${{ inputs.ref }}
       skip_latest: ${{ inputs.skip_latest }}

--- a/.github/workflows/release-3-create-github-release.yml
+++ b/.github/workflows/release-3-create-github-release.yml
@@ -12,6 +12,7 @@ on:
         description: "The ref (branch or SHA) to process"
         required: false
         type: string
+        default: "latest"
       skip_latest:
         description: "skip_latest: Tag latest will be pushed to Docker Hub unless skip_latest=true"
         required: true
@@ -19,6 +20,11 @@ on:
         default: false
   workflow_call:
     inputs:
+      ref:
+        description: "The ref (branch or SHA) to process"
+        required: false
+        type: string
+        default: "latest"
       skip_latest:
         description: "skip_latest: Tag latest will be pushed to Docker Hub unless skip_latest=true"
         required: true
@@ -34,8 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |
@@ -87,4 +92,5 @@ jobs:
     uses: ./.github/workflows/release-3.1-upload-artifacts.yml
     secrets: inherit
     with:
+      ref: ${{ inputs.ref }}
       skip_latest: "${{inputs.skip_latest}}"

--- a/.github/workflows/release-3.1-upload-artifacts.yml
+++ b/.github/workflows/release-3.1-upload-artifacts.yml
@@ -12,6 +12,7 @@ on:
         description: "The ref (branch or SHA) to process"
         required: false
         type: string
+        default: "latest"
       skip_latest:
         description: "skip_latest: Tag latest will be pushed to Docker Hub unless skip_latest=true"
         required: true
@@ -19,6 +20,11 @@ on:
         default: false
   workflow_call:
     inputs:
+      ref:
+        description: "The ref (branch or SHA) to process"
+        required: false
+        type: string
+        default: "latest"
       skip_latest:
         description: "skip_latest: Tag latest will be pushed to Docker Hub unless skip_latest=true"
         required: true
@@ -65,8 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |
@@ -120,4 +125,5 @@ jobs:
     uses: ./.github/workflows/release-4-push-docker-image.yml
     secrets: inherit
     with:
+      ref: ${{ inputs.ref }}
       skip_latest: "${{inputs.skip_latest}}"

--- a/.github/workflows/release-4-push-docker-image.yml
+++ b/.github/workflows/release-4-push-docker-image.yml
@@ -9,6 +9,7 @@ on:
         description: "The ref (branch or SHA) to process"
         required: false
         type: string
+        default: "latest"
       skip_latest:
         description: "skip_latest: Tag latest will be pushed to Docker Hub unless skip_latest=true"
         required: true
@@ -16,6 +17,11 @@ on:
         default: false
   workflow_call:
     inputs:
+      ref:
+        description: "The ref (branch or SHA) to process"
+        required: false
+        type: string
+        default: "latest"
       skip_latest:
         description: "skip_latest: Tag latest will be pushed to Docker Hub unless skip_latest=true"
         required: true
@@ -49,8 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |
@@ -86,3 +91,45 @@ jobs:
             "${TAGS[@]}"
         env:
           VERSION: ${{ steps.git-info.outputs.version }}
+
+  verify-github-release:
+    needs: push-image
+    uses: ./.github/workflows/release-5-verify-github-release.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+
+  verify-download-sh:
+    needs: push-image
+    uses: ./.github/workflows/release-5-verify-download-sh.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+
+  verify-run-nix:
+    needs: push-image
+    uses: ./.github/workflows/release-5-verify-run-nix.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+
+  verify-cargo-install:
+    needs: push-image
+    uses: ./.github/workflows/release-5-verify-cargo-install.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+
+  verify-cargo-binstall:
+    needs: push-image
+    uses: ./.github/workflows/release-5-verify-cargo-binstall.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+
+  verify-docker:
+    needs: push-image
+    uses: ./.github/workflows/release-5-verify-docker.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/release-5-verify-cargo-binstall.yml
+++ b/.github/workflows/release-5-verify-cargo-binstall.yml
@@ -7,11 +7,14 @@ on:
         description: "The ref (branch or SHA) to obtain the tag"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - release-2-cargo-publish
-    types:
-      - completed
+        default: "latest"
+  workflow_call:
+    inputs:
+      ref:
+        description: "The ref (branch or SHA) to obtain the tag"
+        required: false
+        type: string
+        default: "latest"
 
 defaults:
   run:
@@ -21,7 +24,6 @@ jobs:
   verify-cargo-binstall:
     name: verify-cargo-binstall-${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,8 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |
@@ -64,12 +65,10 @@ jobs:
 
   cargo-binstall-alpine:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |

--- a/.github/workflows/release-5-verify-cargo-install.yml
+++ b/.github/workflows/release-5-verify-cargo-install.yml
@@ -9,11 +9,14 @@ on:
         description: "The ref (branch or SHA) to obtain the tag"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - release-2-cargo-publish
-    types:
-      - completed
+        default: "latest"
+  workflow_call:
+    inputs:
+      ref:
+        description: "The ref (branch or SHA) to obtain the tag"
+        required: false
+        type: string
+        default: "latest"
 
 defaults:
   run:
@@ -22,14 +25,12 @@ defaults:
 jobs:
   verify-assets:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |

--- a/.github/workflows/release-5-verify-docker.yml
+++ b/.github/workflows/release-5-verify-docker.yml
@@ -7,11 +7,14 @@ on:
         description: "The ref (branch or SHA) to obtain the tag"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - release-4-push-docker-image
-    types:
-      - completed
+        default: "latest"
+  workflow_call:
+    inputs:
+      ref:
+        description: "The ref (branch or SHA) to obtain the tag"
+        required: false
+        type: string
+        default: "latest"
 
 defaults:
   run:
@@ -21,7 +24,6 @@ jobs:
   verify-docker-image:
     name: verify-${{ matrix.image_tag }}
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,8 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |

--- a/.github/workflows/release-5-verify-download-sh.yml
+++ b/.github/workflows/release-5-verify-download-sh.yml
@@ -7,11 +7,14 @@ on:
         description: "The ref (branch or SHA) to obtain the tag"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - release-2-cargo-publish
-    types:
-      - completed
+        default: "latest"
+  workflow_call:
+    inputs:
+      ref:
+        description: "The ref (branch or SHA) to obtain the tag"
+        required: false
+        type: string
+        default: "latest"
 
 defaults:
   run:
@@ -21,7 +24,6 @@ jobs:
   verify-using-vm:
     name: verify-using-vm-${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,8 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |
@@ -54,7 +55,6 @@ jobs:
   verify-using-docker:
     name: verify-using-docker-${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -64,8 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |

--- a/.github/workflows/release-5-verify-github-release.yml
+++ b/.github/workflows/release-5-verify-github-release.yml
@@ -7,11 +7,14 @@ on:
         description: "The ref (branch or SHA) to obtain the tag"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - release-2-cargo-publish
-    types:
-      - completed
+        default: "latest"
+  workflow_call:
+    inputs:
+      ref:
+        description: "The ref (branch or SHA) to obtain the tag"
+        required: false
+        type: string
+        default: "latest"
 
 defaults:
   run:
@@ -21,7 +24,6 @@ jobs:
   verify-assets:
     name: ${{ matrix.runner }}-${{ matrix.file }}
     runs-on: ${{ matrix.runner }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -37,8 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |

--- a/.github/workflows/release-5-verify-run-nix.yml
+++ b/.github/workflows/release-5-verify-run-nix.yml
@@ -7,11 +7,14 @@ on:
         description: "The ref (branch or SHA) to obtain the tag"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - release-2-cargo-publish
-    types:
-      - completed
+        default: "latest"
+  workflow_call:
+    inputs:
+      ref:
+        description: "The ref (branch or SHA) to obtain the tag"
+        required: false
+        type: string
+        default: "latest"
 
 defaults:
   run:
@@ -29,12 +32,10 @@ jobs:
             os: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Use the ref if provided, otherwise obtain the parent workflow branch, defaults to main.
-          ref: ${{ github.event.inputs.ref || github.event.workflow_run.head_branch }}
+          ref: ${{ inputs.ref }}
 
       - id: git-info
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.1](https://github.com/obeli-sk/obelisk/compare/v0.38.0...v0.38.1)
+
+### Fixed
+
+- Use fetchCargoVendor for Nix cargo deps - ([1ec52d0](https://github.com/obeli-sk/obelisk/commit/1ec52d067855ac8485da7ad2674e00bb41342234))
+
+### Changed
+
+- *(toml)* Make `cancel_watcher` mandatory, removing `enabled` property - ([a30ef54](https://github.com/obeli-sk/obelisk/commit/a30ef54d451ce2467ec822e9e360ea51e53d1d02))
+
+
 ## [0.38.0](https://github.com/obeli-sk/obelisk/compare/v0.37.7...v0.38.0)
 
 This release adds stepwise execution debugging and recovery with `execution replay` / `execution advance`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -349,7 +349,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-mem"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "chrono",
  "http",
@@ -3313,7 +3313,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "activity-js-runtime-builder",
  "anyhow",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "quote",
  "syn",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5200,14 +5200,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5217,14 +5217,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5235,14 +5235,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5251,14 +5251,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5268,14 +5268,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5285,14 +5285,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5301,14 +5301,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5317,14 +5317,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5349,14 +5349,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5366,14 +5366,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5383,14 +5383,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5399,14 +5399,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5415,14 +5415,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6915,7 +6915,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -349,7 +349,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-mem"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "chrono",
  "http",
@@ -3313,7 +3313,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "activity-js-runtime-builder",
  "anyhow",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "quote",
  "syn",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5200,14 +5200,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5217,14 +5217,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5235,14 +5235,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5251,14 +5251,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5268,14 +5268,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5285,14 +5285,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5301,14 +5301,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5317,14 +5317,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5333,14 +5333,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5349,14 +5349,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5366,14 +5366,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5383,14 +5383,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5399,14 +5399,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "wit-bindgen 0.57.1",
@@ -5415,14 +5415,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6915,7 +6915,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,6 +3444,7 @@ dependencies = [
 name = "obelisk"
 version = "0.38.1"
 dependencies = [
+ "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3521,8 +3522,10 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
+ "webhook-js-runtime-builder",
  "wit-component 0.248.0",
  "wit-parser 0.248.0",
+ "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3444,7 +3444,6 @@ dependencies = [
 name = "obelisk"
 version = "0.38.1"
 dependencies = [
- "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3522,10 +3521,8 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
- "webhook-js-runtime-builder",
  "wit-component 0.248.0",
  "wit-parser 0.248.0",
- "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,6 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
-activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
-webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
-workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -127,9 +124,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = ["dep:activity-js-runtime-builder"]
-"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
-"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
+"activity-js-local" = []
+"webhook-js-local" = []
+"workflow-js-local" = []
 default = ["otlp"]
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
+activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -124,9 +127,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = []
-"webhook-js-local" = []
-"workflow-js-local" = []
+"activity-js-local" = ["dep:activity-js-runtime-builder"]
+"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
+"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
 default = ["otlp"]
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.38.1"
+version = "0.38.2-alpha.0"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -204,14 +204,14 @@ rust-version = "1.91.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.1" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.1" }
-db-mem = { package = "obeli-sk-db-mem", path = "crates/db-mem", version = "0.38.1" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.1" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.1" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.2-alpha.0" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.2-alpha.0" }
+db-mem = { package = "obeli-sk-db-mem", path = "crates/db-mem", version = "0.38.2-alpha.0" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.2-alpha.0" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.2-alpha.0" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.1" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.1" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.2-alpha.0" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.2-alpha.0" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -229,9 +229,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.1" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.1" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.1" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.2-alpha.0" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.2-alpha.0" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.2-alpha.0" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.38.0"
+version = "0.38.1"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -204,14 +204,14 @@ rust-version = "1.91.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.0" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.0" }
-db-mem = { package = "obeli-sk-db-mem", path = "crates/db-mem", version = "0.38.0" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.0" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.0" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.1" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.1" }
+db-mem = { package = "obeli-sk-db-mem", path = "crates/db-mem", version = "0.38.1" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.1" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.1" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.0" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.0" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.1" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.1" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -229,9 +229,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.0" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.0" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.0" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.1" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.1" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.1" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
                 pname = "obelisk";
                 inherit version;
                 src = ./.;
-                cargoHash = "sha256-2mTU74CWlXvS7ctdcZzvY/cQuomRGnbp1jv1Y2D8WGw=";
+                cargoHash = "sha256-KKAH0SU/BBDNVCBYuX5xe2K7Gv7AzbGiH0O+uB3k6r4=";
 
                 nativeBuildInputs = with pkgs; [
                   (rust-bin.fromRustupToolchainFile rustToolchainToml)

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
                 pname = "obelisk";
                 inherit version;
                 src = ./.;
-                cargoHash = "sha256-KKAH0SU/BBDNVCBYuX5xe2K7Gv7AzbGiH0O+uB3k6r4=";
+                cargoHash = "sha256-3F2uq7QysY6z6GM7UI3u8L4aFG8IY2yMI/EFQurKMBo=";
 
                 nativeBuildInputs = with pkgs; [
                   (rust-bin.fromRustupToolchainFile rustToolchainToml)

--- a/scripts/strip-js-local-deps.sh
+++ b/scripts/strip-js-local-deps.sh
@@ -16,3 +16,5 @@ sed -i 's/"workflow-js-local" = \["dep:workflow-js-runtime-builder"\]/"workflow-
 
 # Remove the js-local test matrix entry from the CI workflow
 sed -i '/junit-js-local.xml/,+1d' .github/workflows/check-test.yml
+
+cargo check

--- a/scripts/update-cargo-hash.sh
+++ b/scripts/update-cargo-hash.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+flake_file="flake.nix"
+log_file="${TMPDIR:-/tmp}/cargo-hash.log"
+tmp_file="${TMPDIR:-/tmp}/flake.nix.tmp.$$"
+
+if ! grep -q 'cargoHash = ' "$flake_file"; then
+  echo "cargoHash assignment not found in $flake_file" >&2
+  exit 1
+fi
+
+replace_cargo_hash() {
+  local replacement="$1"
+  awk -v replacement="$replacement" '
+    !done && /cargoHash = / {
+      print replacement
+      done = 1
+      next
+    }
+    { print }
+  ' "$flake_file" >"$tmp_file"
+  mv "$tmp_file" "$flake_file"
+}
+
+replace_cargo_hash '                cargoHash = pkgs.lib.fakeHash;'
+
+set +e
+nix build -L .#obeliskLibcNixDev >"$log_file" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  echo "Expected fake cargoHash build to fail with a hash mismatch." >&2
+  exit 1
+fi
+
+computed_hash="$(
+  sed -n 's/.*got:[[:space:]]*\(sha256-[A-Za-z0-9+/=]*\).*/\1/p' "$log_file" | tail -n1
+)"
+
+if [ -z "$computed_hash" ]; then
+  cat "$log_file"
+  echo "Could not extract computed cargoHash from nix build output." >&2
+  exit 1
+fi
+
+replace_cargo_hash "                cargoHash = \"$computed_hash\";"


### PR DESCRIPTION
- **chore: Prepare v0.38.1**
- **build: Update `Cargo.lock` in `strip-js-local-deps.sh`**
- **chore: Strip local dependencies before build**
- **build: Extract `update-cargo-hash.sh`**
- **chore: Update `cargoHash`**
- **ci: Skip `nix build` on `--no-verify`**
- **Revert "chore: Strip local dependencies before build"**
- **ci: Pass `inputs.ref` in release steps, wire `release-5-*` as child workflows**
- **chore: Bump to v0.38.2-alpha.0**
