### PR TITLE
build: Move `*.wasm` to `target/wasm-cache`, skip build if already present

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -48,10 +48,14 @@ jobs:
       - name: Populate the nix store
         run: nix develop --command echo
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          cache-on-failure: true
-          key: ${{ matrix.report }}
+          path: |
+            target
+            test-codegen-cache
+          key: cargo-target-${{ matrix.report }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-target-${{ matrix.report }}-
 
       - name: Build tests
         run: nix develop --command cargo nextest run --workspace --no-run
@@ -65,6 +69,12 @@ jobs:
           TEST_POSTGRES_PASSWORD: "postgres"
           TEST_POSTGRES_DATABASE_PREFIX: "obelisk_test"
           CARGO_INSTA_TEST: true # reject unreferenced snapshots
+
+      # Reduce cache size — hashed WASMs are in target/wasm-cache/
+      - name: Clean build artifacts before caching
+        if: always()
+        run: |
+          rm -rf target/debug/incremental target/release_testprograms target/release_wasm_runtime
 
       # Report results
       - name: Rename test report

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,16 +92,3 @@ jobs:
 
       - name: cargo clippy
         run: nix develop --command cargo clippy --workspace --all-targets -- -D warnings
-
-  nix-dev-build:
-    name: nix build obeliskLibcNixDev
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build nix dev package
-        run: nix build .#obeliskLibcNixDev

--- a/crates/testing/component-builder/src/lib.rs
+++ b/crates/testing/component-builder/src/lib.rs
@@ -1,4 +1,4 @@
-use cargo_metadata::camino::Utf8Path;
+use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeSet,
@@ -40,7 +40,7 @@ impl BuildConfig {
 /// the `--target` directory to the output of [`get_target_dir`].
 #[expect(clippy::must_use_candidate)]
 pub fn build_activity(conf: BuildConfig) -> PathBuf {
-    build_internal(WASI_P2, ComponentType::Activity, conf)
+    build_internal(WASI_P2, ComponentType::Activity, conf).into_std_path_buf()
 }
 
 /// Build the parent webhook endpoint WASM component and place it into the `target` directory.
@@ -51,7 +51,7 @@ pub fn build_activity(conf: BuildConfig) -> PathBuf {
 /// the `--target` directory to the output of [`get_target_dir`].
 #[expect(clippy::must_use_candidate)]
 pub fn build_webhook_endpoint(conf: BuildConfig) -> PathBuf {
-    build_internal(WASI_P2, ComponentType::WebhookEndpoint, conf)
+    build_internal(WASI_P2, ComponentType::WebhookEndpoint, conf).into_std_path_buf()
 }
 
 /// Build the parent workflow WASM component and place it into the `target` directory.
@@ -62,7 +62,7 @@ pub fn build_webhook_endpoint(conf: BuildConfig) -> PathBuf {
 /// the `--target` directory to the output of [`get_target_dir`].
 #[expect(clippy::must_use_candidate)]
 pub fn build_workflow(conf: BuildConfig) -> PathBuf {
-    build_internal(WASM_CORE_MODULE, ComponentType::Workflow, conf)
+    build_internal(WASM_CORE_MODULE, ComponentType::Workflow, conf).into_std_path_buf()
 }
 
 /// Build a workflow that requires WASI P2 (e.g., due to embedded runtime like Boa JS).
@@ -71,7 +71,7 @@ pub fn build_workflow(conf: BuildConfig) -> PathBuf {
 /// use `wasm32-wasip2` target.
 #[expect(clippy::must_use_candidate)]
 pub fn build_workflow_wasi_p2(conf: BuildConfig) -> PathBuf {
-    build_internal(WASI_P2, ComponentType::Workflow, conf)
+    build_internal(WASI_P2, ComponentType::Workflow, conf).into_std_path_buf()
 }
 
 enum ComponentType {
@@ -132,7 +132,10 @@ fn hash_directory_contents(hasher: &mut Sha256, dir: &Path, base: &Path) {
         let rel = file_path.strip_prefix(base).unwrap_or(file_path);
         hasher.update(rel.to_string_lossy().as_bytes());
         hasher.update(b"\x00");
-        hasher.update(std::fs::read(file_path).unwrap());
+        hasher.update(
+            std::fs::read(file_path)
+                .unwrap_or_else(|e| panic!("cannot read {file_path:?} - {e:?}")),
+        );
         hasher.update(b"\x00");
     }
 }
@@ -217,7 +220,7 @@ fn build_internal(
     target_tripple: &str,
     component_type: ComponentType,
     conf: BuildConfig,
-) -> PathBuf {
+) -> Utf8PathBuf {
     let dst_target_dir = conf.custom_dst_target_dir.unwrap_or_else(get_target_dir);
     let pkg_name = std::env::var("CARGO_PKG_NAME").unwrap();
     let pkg_name = pkg_name.strip_suffix("-builder").unwrap();
@@ -239,11 +242,9 @@ fn build_internal(
         &meta,
         package,
     );
-    if std::env::var("RUST_LOG").is_ok() {
-        println!("cargo:warning=Built `{pkg_name}` - {wasm_path:?}");
-    }
+    println!("cargo:warning=Built `{pkg_name}` - {wasm_path:?}");
 
-    generate_code(&wasm_path, pkg_name, component_type);
+    generate_code(wasm_path.as_std_path(), pkg_name, component_type);
 
     // Register rerun-if-changed dependencies
     add_dependency(&package.manifest_path); // Cargo.toml
@@ -377,27 +378,39 @@ fn run_cargo_build(
     rust_flags: &str,
     meta: &cargo_metadata::Metadata,
     package: &cargo_metadata::Package,
-) -> PathBuf {
+) -> Utf8PathBuf {
     let name_snake_case = to_snake_case(name);
-    let output_dir = dst_target_dir.join(tripple).join(profile);
     let hash = compute_inputs_hash(meta, package, tripple, profile, rust_flags);
     let needs_component_transform = is_transformation_to_wasm_component_needed(tripple);
 
-    // Determine the final cached path
-    let cached_path = if needs_component_transform {
-        output_dir.join(format!("{name_snake_case}_{hash}_component.wasm"))
+    // Store hashed artifacts in target/wasm-cache/ so inner build dirs can be cleaned.
+    let cache_dir = get_target_dir().join("wasm-cache");
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    let (cached_path, symlink_path) = if needs_component_transform {
+        (
+            Utf8PathBuf::from_path_buf(
+                cache_dir.join(format!("{name_snake_case}_component_{hash}.wasm")),
+            )
+            .unwrap(),
+            Utf8PathBuf::from_path_buf(cache_dir.join(format!("{name_snake_case}_component.wasm")))
+                .unwrap(),
+        )
     } else {
-        output_dir.join(format!("{name_snake_case}_{hash}.wasm"))
+        (
+            Utf8PathBuf::from_path_buf(cache_dir.join(format!("{name_snake_case}_{hash}.wasm")))
+                .unwrap(),
+            Utf8PathBuf::from_path_buf(cache_dir.join(format!("{name_snake_case}.wasm"))).unwrap(),
+        )
     };
 
     // Cache hit — skip cargo build entirely
-    if cached_path.exists() {
+    if cached_path.exists() && symlink_path.exists() {
         println!("cargo:warning=Cache hit for `{name}` ({hash})");
         return cached_path;
     }
 
     // Cache miss — clean up old hashed files
-    cleanup_old_hashed_files(&output_dir, &name_snake_case);
+    cleanup_old_hashed_files(&cache_dir, &name_snake_case);
 
     // Run cargo build
     let mut cmd = Command::new("cargo");
@@ -406,7 +419,6 @@ fn run_cargo_build(
         .arg(format!("--target={tripple}"))
         .arg(format!("--package={name}"))
         .env("CARGO_TARGET_DIR", dst_target_dir)
-        .env("CARGO_PROFILE_RELEASE_DEBUG", "limited") // debug = 1, retain line numbers
         .env("RUSTFLAGS", rust_flags)
         .env_remove("CARGO_ENCODED_RUSTFLAGS")
         .env_remove("CLIPPY_ARGS"); // do not pass clippy parameters
@@ -433,11 +445,7 @@ fn run_cargo_build(
                     .expect("only utf-8 encoded paths are supported"),
             )
             .arg("--output")
-            .arg(
-                cached_path
-                    .to_str()
-                    .expect("only utf-8 encoded paths are supported"),
-            );
+            .arg(&cached_path);
         let status = cmd.status().unwrap();
         assert!(status.success());
     } else {
@@ -448,5 +456,14 @@ fn run_cargo_build(
         cached_path.exists(),
         "Cached path must exist: {cached_path:?}"
     );
+    if symlink_path.exists() {
+        std::fs::remove_file(&symlink_path).expect("cannot replace existing symlink");
+    }
+    #[cfg(unix)]
+    {
+        let src = cached_path.file_name().unwrap();
+        println!("cargo:warning=Adding `ln -s {src:?} {symlink_path:?}`");
+        std::os::unix::fs::symlink(src, &symlink_path).expect("cannot create symlink");
+    }
     cached_path
 }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -4,6 +4,9 @@ use crate::http_hooks::{HttpClientTracesContainer, HttpHooks};
 use crate::std_output_stream::{LogStream, StdOutput, StdOutputConfig, StdOutputConfigWithSender};
 use crate::webhook::webhook_registry::WebhookStateWatcher;
 use crate::webhook::webhook_trigger::types::obelisk::types::join_set::JoinNextError;
+use crate::webhook::webhook_trigger::types::{
+    GetErrorTrappable, GetStatusErrorTrappable, ScheduleJsonErrorTrappable, TryGetErrorTrappable,
+};
 use crate::workflow::host_exports::{SUFFIX_FN_SCHEDULE, history_event_schedule_at_from_wast_val};
 use crate::{RunnableComponent, WasmFileError};
 use assert_matches::assert_matches;
@@ -82,48 +85,48 @@ pub(crate) mod types {
             "obelisk:types/join-set.join-set": concepts::JoinSetId,
         },
         trappable_error_type: {
-            "obelisk:types/execution.schedule-json-error" => crate::webhook::webhook_trigger::ScheduleJsonErrorTrappable,
-            "obelisk:webhook/webhook-support.get-error" => crate::webhook::webhook_trigger::GetErrorTrappable,
-            "obelisk:webhook/webhook-support.get-status-error" => crate::webhook::webhook_trigger::GetStatusErrorTrappable,
-            "obelisk:webhook/webhook-support.try-get-error" => crate::webhook::webhook_trigger::TryGetErrorTrappable,
+            "obelisk:types/execution.schedule-json-error" => crate::webhook::webhook_trigger::types::ScheduleJsonErrorTrappable,
+            "obelisk:webhook/webhook-support.get-error" => crate::webhook::webhook_trigger::types::GetErrorTrappable,
+            "obelisk:webhook/webhook-support.get-status-error" => crate::webhook::webhook_trigger::types::GetStatusErrorTrappable,
+            "obelisk:webhook/webhook-support.try-get-error" => crate::webhook::webhook_trigger::types::TryGetErrorTrappable,
         },
     });
-}
 
-/// Trappable wrapper for `ScheduleJsonError` - user errors vs infrastructure failures.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ScheduleJsonErrorTrappable {
-    #[error(transparent)]
-    Normal(#[from] types::obelisk::types::execution::ScheduleJsonError),
-    #[error(transparent)]
-    Trap(#[from] wasmtime::Error),
-}
+    /// Trappable wrapper for `ScheduleJsonError` - user errors vs infrastructure failures.
+    #[derive(Debug, thiserror::Error)]
+    pub enum ScheduleJsonErrorTrappable {
+        #[error(transparent)]
+        Normal(#[from] obelisk::types::execution::ScheduleJsonError),
+        #[error(transparent)]
+        Trap(#[from] wasmtime::Error),
+    }
 
-/// Trappable wrapper for `GetError` - user errors vs infrastructure failures.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum GetErrorTrappable {
-    #[error(transparent)]
-    Normal(#[from] types::obelisk::webhook::webhook_support::GetError),
-    #[error(transparent)]
-    Trap(#[from] wasmtime::Error),
-}
+    /// Trappable wrapper for `GetError` - user errors vs infrastructure failures.
+    #[derive(Debug, thiserror::Error)]
+    pub enum GetErrorTrappable {
+        #[error(transparent)]
+        Normal(#[from] obelisk::webhook::webhook_support::GetError),
+        #[error(transparent)]
+        Trap(#[from] wasmtime::Error),
+    }
 
-/// Trappable wrapper for `GetStatusError` - user errors vs infrastructure failures.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum GetStatusErrorTrappable {
-    #[error(transparent)]
-    Normal(#[from] types::obelisk::webhook::webhook_support::GetStatusError),
-    #[error(transparent)]
-    Trap(#[from] wasmtime::Error),
-}
+    /// Trappable wrapper for `GetStatusError` - user errors vs infrastructure failures.
+    #[derive(Debug, thiserror::Error)]
+    pub enum GetStatusErrorTrappable {
+        #[error(transparent)]
+        Normal(#[from] obelisk::webhook::webhook_support::GetStatusError),
+        #[error(transparent)]
+        Trap(#[from] wasmtime::Error),
+    }
 
-/// Trappable wrapper for `TryGetError` - user errors vs infrastructure failures.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum TryGetErrorTrappable {
-    #[error(transparent)]
-    Normal(#[from] types::obelisk::webhook::webhook_support::TryGetError),
-    #[error(transparent)]
-    Trap(#[from] wasmtime::Error),
+    /// Trappable wrapper for `TryGetError` - user errors vs infrastructure failures.
+    #[derive(Debug, thiserror::Error)]
+    pub enum TryGetErrorTrappable {
+        #[error(transparent)]
+        Normal(#[from] obelisk::webhook::webhook_support::TryGetError),
+        #[error(transparent)]
+        Trap(#[from] wasmtime::Error),
+    }
 }
 
 // Conversions from webhook types to internal types

--- a/dev-deps.txt
+++ b/dev-deps.txt
@@ -5,7 +5,7 @@ litecli litecli, version 1.17.1
 nixpkgs-fmt 1.3.0
 pkg-config 0.29.2
 libprotoc 34.1
-rustc 1.95.0 (59807616e 2026-04-14)
+rustc 1.96.0 (ac68faa20 2026-05-25)
 wasm-tools 1.249.0
 wasmtime 44.0.1
 cargo-zigbuild 0.22.3

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779938491,
-        "narHash": "sha256-khIekZCrhy3lQom4AZTmgBPV3DOFgAiopLUyUtbVGhY=",
+        "lastModified": 1780024773,
+        "narHash": "sha256-aU9nlrS9S+IJ2EiCzsaxzOXUhggogqTrJojBicE6Oeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "02f536e36eaee387594ce2a02d90ff678d056e0f",
+        "rev": "40b0a3a193e0840c76174b4a322874c8f6dd0a63",
         "type": "github"
       },
       "original": {

--- a/obelisk-testing-wasm-local.toml
+++ b/obelisk-testing-wasm-local.toml
@@ -1,29 +1,29 @@
 [[activity_wasm]]
 name = "test_programs_fibo_activity"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_fibo_activity.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_fibo_activity.wasm"
 max_retries = 0
 
 [[workflow_wasm]]
 name = "test_programs_fibo_workflow"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-unknown-unknown/release_testprograms/test_programs_fibo_workflow.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_fibo_workflow_component.wasm"
 exec.lock_expiry.seconds = 2
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/fibo/workflow/src/lib.rs" }
 
 [[workflow_wasm]]
 name = "test_programs_fibo_workflow_outer"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-unknown-unknown/release_testprograms/test_programs_fibo_workflow_outer.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_fibo_workflow_outer_component.wasm"
 exec.lock_expiry.seconds = 2
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/fibo/workflow-outer/src/lib.rs" }
 
 [[webhook_endpoint_wasm]]
 name = "test_programs_fibo_webhook"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_fibo_webhook.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_fibo_webhook.wasm"
 routes = [{ methods = ["GET"], route = "/fibo/:N/:ITERATIONS" }]
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/fibo/webhook/src/lib.rs" }
 
 [[activity_wasm]]
 name = "test_programs_http_get_activity"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_http_get_activity.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_http_get_activity.wasm"
 max_retries = 0
 exec.lock_expiry.seconds = 5
 [[activity_wasm.allowed_host]]
@@ -37,39 +37,39 @@ secrets = {env_vars = [{key = "API_KEY", value = "foo"}], replace_in = ["headers
 
 [[workflow_wasm]]
 name = "test_programs_http_get_workflow"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-unknown-unknown/release_testprograms/test_programs_http_get_workflow.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_http_get_workflow_component.wasm"
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/http/workflow/src/lib.rs" }
 
 [[activity_wasm]]
 name = "test_programs_sleep_activity"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_sleep_activity.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_sleep_activity.wasm"
 exec.lock_expiry.seconds = 10
 
 [[workflow_wasm]]
 name = "test_programs_sleep_workflow"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-unknown-unknown/release_testprograms/test_programs_sleep_workflow.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_sleep_workflow_component.wasm"
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/sleep/workflow/src/lib.rs" }
 
 [[webhook_endpoint_wasm]]
 name = "test_programs_sleep_webhook"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_sleep_webhook.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_sleep_webhook.wasm"
 routes = [{ methods = ["GET"], route = "/sleep/:SECONDS" }]
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/sleep/webhook/src/lib.rs" }
 
 [[activity_wasm]]
 name = "test_programs_serde_activity"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_serde_activity.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_serde_activity.wasm"
 max_retries = 0
 
 [[workflow_wasm]]
 name = "test_programs_serde_workflow"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-unknown-unknown/release_testprograms/test_programs_serde_workflow.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_serde_workflow_component.wasm"
 
 [[activity_stub]]
 name = "test_programs_stub_activity_dummy"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-wasip2/release_testprograms/test_programs_stub_activity.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_stub_activity.wasm"
 
 [[workflow_wasm]]
 name = "test_programs_stub_workflow"
-location = "${DEPLOYMENT_DIR}/target/release_testprograms/wasm32-unknown-unknown/release_testprograms/test_programs_stub_workflow.wasm"
+location = "${DEPLOYMENT_DIR}/target/wasm-cache/test_programs_stub_workflow_component.wasm"
 backtrace.sources = { ".../src/lib.rs" = "${DEPLOYMENT_DIR}/crates/testing/test-programs/stub/workflow/src/lib.rs" }

--- a/rust-toolchain-cross.toml
+++ b/rust-toolchain-cross.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 targets = [
     "wasm32-unknown-unknown",
     "wasm32-wasip2",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 targets = ["wasm32-unknown-unknown", "wasm32-wasip2"]
 components = ["rustfmt", "clippy", "rust-src", "rust-analyzer", "cargo"]

--- a/scripts/push-webhook-js-runtime.sh
+++ b/scripts/push-webhook-js-runtime.sh
@@ -21,7 +21,7 @@ if [ "$TAG" != "dry-run" ]; then
     cat > "$TMP_TOML" <<EOF
 [[webhook_endpoint_wasm]]
 name = "pushed"
-location = "$(pwd)/target/release_wasm_runtime/wasm32-wasip2/release_wasm_runtime/webhook_js_runtime.wasm"
+location = "$(pwd)/target/wasm-cache/webhook_js_runtime.wasm"
 routes = [""]
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \

--- a/scripts/push-workflow-js-runtime.sh
+++ b/scripts/push-workflow-js-runtime.sh
@@ -21,7 +21,7 @@ if [ "$TAG" != "dry-run" ]; then
     cat > "$TMP_TOML" <<EOF
 [[workflow_wasm]]
 name = "pushed"
-location = "$(pwd)/target/release_wasm_runtime/wasm32-unknown-unknown/release_wasm_runtime/workflow_js_runtime_component.wasm"
+location = "$(pwd)/target/wasm-cache/workflow_js_runtime_component.wasm"
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \
         pushed "oci://docker.io/getobelisk/workflow-js-runtime:$TAG")


### PR DESCRIPTION
- **chore: Update Rust to 1.96**
- **style: Fix clippy**
- **ci: Remove `nix-dev-build` check**
- **build: Move `*.wasm` to `target/wasm-cache`, skip build if already present**
