### PR TITLE
refactor(workflow,grpc,webapi): Record auto-upgrade outcome in history

### DIFF
--- a/assets/schemas/db.json
+++ b/assets/schemas/db.json
@@ -147,24 +147,11 @@
           "additionalProperties": false
         },
         {
-          "description": "Returns execution to [`PendingState::PendingAt`] state at the specified time.\nThis can happen when:\n- executor is running out of resources like [`WorkerError::LimitReached`]\n- executor is being closed (shutdown or hot redeploy requested)\n- activity is paused\n- workflow made progress but then its lock expired\n- workflow attempted to auto-upgrade an execution and failed, recording its digest in `incompatible_digest`",
+          "description": "Releases a lock.\n\nState transition semantics:\n- [`PendingState::Locked`] becomes [`PendingState::PendingAt`] at\n  [`Unlocked::backoff_expires_at`]. The field name is kept for persisted JSON and gRPC\n  compatibility, but it is the next pending instant for every unlock reason.\n- [`PendingState::PendingAt`], [`PendingState::BlockedByJoinSet`],\n  [`PendingState::Paused`], and [`PendingState::Finished`] reject this event.",
           "type": "object",
           "properties": {
             "unlocked": {
-              "type": "object",
-              "properties": {
-                "backoff_expires_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "reason": {
-                  "$ref": "#/$defs/UnlockedReason"
-                }
-              },
-              "required": [
-                "backoff_expires_at",
-                "reason"
-              ]
+              "$ref": "#/$defs/Unlocked"
             }
           },
           "required": [
@@ -173,9 +160,10 @@
           "additionalProperties": false
         },
         {
+          "description": "Does not change `PendingState`.",
           "type": "object",
           "properties": {
-            "component_upgraded": {
+            "component_upgrade_finished": {
               "type": "object",
               "properties": {
                 "component_digest": {
@@ -184,19 +172,19 @@
                 "deployment_id": {
                   "type": "string"
                 },
-                "reason": {
-                  "$ref": "#/$defs/ComponentUpgradeReason"
+                "outcome": {
+                  "$ref": "#/$defs/ComponentUpgradeOutcome"
                 }
               },
               "required": [
                 "component_digest",
                 "deployment_id",
-                "reason"
+                "outcome"
               ]
             }
           },
           "required": [
-            "component_upgraded"
+            "component_upgrade_finished"
           ],
           "additionalProperties": false
         },
@@ -410,17 +398,34 @@
         "nanos"
       ]
     },
-    "UnlockedReason": {
+    "Unlocked": {
+      "type": "object",
+      "properties": {
+        "backoff_expires_at": {
+          "description": "Instant used when releasing a currently locked execution back to\n[`PendingState::PendingAt`]. This field keeps the released JSON and gRPC name.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "backoff_expires_at",
+        "reason"
+      ]
+    },
+    "ComponentUpgradeOutcome": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
             "reason": {
-              "type": "string"
+              "$ref": "#/$defs/ComponentUpgradeReason"
             },
             "type": {
               "type": "string",
-              "const": "other"
+              "const": "success"
             }
           },
           "required": [
@@ -431,26 +436,23 @@
         {
           "type": "object",
           "properties": {
-            "target_digest": {
-              "type": "string"
-            },
             "reason": {
               "type": "string"
             },
             "type": {
               "type": "string",
-              "const": "auto_upgrade_failed"
+              "const": "failed"
             }
           },
           "required": [
             "type",
-            "target_digest",
             "reason"
           ]
         }
       ]
     },
     "ComponentUpgradeReason": {
+      "description": "Reason for auditing only",
       "oneOf": [
         {
           "type": "object",

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -360,26 +360,24 @@ pub enum ExecutionRequest {
         scheduled_by: Option<ExecutionId>,
     },
     Locked(Locked),
-    /// Returns execution to [`PendingState::PendingAt`] state at the specified time.
-    /// This can happen when:
-    /// - executor is running out of resources like [`WorkerError::LimitReached`]
-    /// - executor is being closed (shutdown or hot redeploy requested)
-    /// - activity is paused
-    /// - workflow made progress but then its lock expired
-    /// - workflow attempted to auto-upgrade an execution and failed, recording its digest in `incompatible_digest`
-    #[display("Unlocked(`{backoff_expires_at}`)")]
-    Unlocked {
-        backoff_expires_at: DateTime<Utc>,
-        #[cfg_attr(any(test, feature = "test"), arbitrary(value = UnlockedReason::Other { reason: StrVariant::Static("reason") }))]
-        reason: UnlockedReason,
-    },
-    #[display("ComponentUpgraded({component_digest})")]
-    ComponentUpgraded {
+    /// Releases a lock.
+    ///
+    /// State transition semantics:
+    /// - [`PendingState::Locked`] becomes [`PendingState::PendingAt`] at
+    ///   [`Unlocked::backoff_expires_at`]. The field name is kept for persisted JSON and gRPC
+    ///   compatibility, but it is the next pending instant for every unlock reason.
+    /// - [`PendingState::PendingAt`], [`PendingState::BlockedByJoinSet`],
+    ///   [`PendingState::Paused`], and [`PendingState::Finished`] reject this event.
+    #[display("Unlocked({_0})")]
+    Unlocked(Unlocked),
+    /// Does not change `PendingState`.
+    #[display("ComponentUpgradeFinished({component_digest})")]
+    ComponentUpgradeFinished {
         #[cfg_attr(any(test, feature = "test"), arbitrary(value = ComponentId::dummy_activity().component_digest))]
         component_digest: ComponentDigest,
         #[cfg_attr(any(test, feature = "test"), arbitrary(value = DeploymentId::from_parts(0, 0)))]
         deployment_id: DeploymentId,
-        reason: ComponentUpgradeReason,
+        outcome: ComponentUpgradeOutcome,
     },
     // Created by the executor holding the lock.
     // After expiry interpreted as pending.
@@ -419,24 +417,7 @@ pub enum ExecutionRequest {
     Unpaused,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::Display, Serialize, schemars::JsonSchema)]
-#[cfg_attr(any(test, feature = "test"), derive(arbitrary::Arbitrary))]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum UnlockedReason {
-    #[display("{reason}")]
-    Other {
-        #[cfg_attr(any(test, feature = "test"), arbitrary(value = StrVariant::Static("reason")))]
-        reason: StrVariant,
-    },
-    #[display("auto-upgrade failed: {reason}")]
-    AutoUpgradeFailed {
-        #[cfg_attr(any(test, feature = "test"), arbitrary(value = ComponentId::dummy_activity().component_digest))]
-        target_digest: ComponentDigest,
-        #[cfg_attr(any(test, feature = "test"), arbitrary(value = StrVariant::Static("reason")))]
-        reason: StrVariant,
-    },
-}
-
+/// Reason for auditing only
 #[derive(
     Clone, Debug, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, schemars::JsonSchema,
 )]
@@ -449,91 +430,32 @@ pub enum ComponentUpgradeReason {
     Manual { force: bool },
 }
 
-impl<'de> Deserialize<'de> for UnlockedReason {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        unlocked_reason_compat::deserialize(deserializer)
-    }
+#[derive(
+    Clone, Debug, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[cfg_attr(any(test, feature = "test"), derive(arbitrary::Arbitrary))]
+#[display("{reason}, pending at {backoff_expires_at}")]
+pub struct Unlocked {
+    /// Instant used when releasing a currently locked execution back to
+    /// [`PendingState::PendingAt`]. This field keeps the released JSON and gRPC name.
+    pub backoff_expires_at: DateTime<Utc>,
+    #[cfg_attr(any(test, feature = "test"), arbitrary(value = StrVariant::Static("reason")))]
+    pub reason: StrVariant,
 }
 
-mod unlocked_reason_compat {
-    use super::{ComponentDigest, StrVariant, UnlockedReason};
-    use serde::Deserialize;
-
-    // TODO: Delete this compatibility module with the next DB-breaking release.
-    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<UnlockedReason, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        Compat::deserialize(deserializer).map(Into::into)
-    }
-
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Compat {
-        Current(Current),
-        Legacy(StrVariant),
-    }
-
-    #[derive(Deserialize)]
-    #[serde(tag = "type", rename_all = "snake_case")]
-    enum Current {
-        Other {
-            reason: StrVariant,
-        },
-        AutoUpgradeFailed {
-            target_digest: ComponentDigest,
-            reason: StrVariant,
-        },
-    }
-
-    impl From<Compat> for UnlockedReason {
-        fn from(value: Compat) -> Self {
-            match value {
-                Compat::Current(current) => current.into(),
-                Compat::Legacy(reason) => Self::Other { reason },
-            }
-        }
-    }
-
-    impl From<Current> for UnlockedReason {
-        fn from(value: Current) -> Self {
-            match value {
-                Current::Other { reason } => Self::Other { reason },
-                Current::AutoUpgradeFailed {
-                    target_digest,
-                    reason,
-                } => Self::AutoUpgradeFailed {
-                    target_digest,
-                    reason,
-                },
-            }
-        }
-    }
-}
-
-impl From<StrVariant> for UnlockedReason {
-    fn from(value: StrVariant) -> Self {
-        Self::Other { reason: value }
-    }
-}
-
-impl From<String> for UnlockedReason {
-    fn from(value: String) -> Self {
-        Self::Other {
-            reason: StrVariant::from(value),
-        }
-    }
-}
-
-impl From<&'static str> for UnlockedReason {
-    fn from(value: &'static str) -> Self {
-        Self::Other {
-            reason: StrVariant::Static(value),
-        }
-    }
+#[derive(
+    Clone, Debug, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[cfg_attr(any(test, feature = "test"), derive(arbitrary::Arbitrary))]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ComponentUpgradeOutcome {
+    #[display("success({reason})")]
+    Success { reason: ComponentUpgradeReason },
+    #[display("failed: {reason}")]
+    Failed {
+        #[cfg_attr(any(test, feature = "test"), arbitrary(value = StrVariant::Static("reason")))]
+        reason: StrVariant,
+    },
 }
 
 impl ExecutionRequest {
@@ -551,8 +473,8 @@ impl ExecutionRequest {
         match self {
             ExecutionRequest::Created { .. } => "created",
             ExecutionRequest::Locked(_) => "locked",
-            ExecutionRequest::Unlocked { .. } => "unlocked",
-            ExecutionRequest::ComponentUpgraded { .. } => "component_upgraded",
+            ExecutionRequest::Unlocked(_) => "unlocked",
+            ExecutionRequest::ComponentUpgradeFinished { .. } => "component_upgrade_finished",
             ExecutionRequest::TemporarilyFailed { .. } => "temporarily_failed",
             ExecutionRequest::TemporarilyTimedOut { .. } => "temporarily_timed_out",
             ExecutionRequest::Finished { .. } => "finished",
@@ -1575,8 +1497,8 @@ pub trait DbExternalApi: DbConnection {
     ) -> Result<Vec<DeploymentRecord>, DbErrorRead>;
 
     /// Pause an execution. Only pending executions can be paused.
-    /// If the execution is currently locked, implementations must release the lock first
-    /// and then record the paused state.
+    /// If the execution is an activity and is currently in `PendingState::Locked`, implementations must
+    /// append `ExecutionRequest::Unlocked` to avoid affecting failed attempt count, before appending `ExecutionRequest::Paused`.
     async fn pause_execution(
         &self,
         execution_id: &ExecutionId,
@@ -2693,10 +2615,8 @@ mod tests {
     use super::PendingStateFinished;
     use super::PendingStateFinishedError;
     use super::PendingStateFinishedResultKind;
-    use super::UnlockedReason;
     use crate::ExecutionFailureKind;
     use crate::JoinSetId;
-    use crate::StrVariant;
     use crate::SupportedFunctionReturnValue;
     use chrono::DateTime;
     use chrono::Datelike;
@@ -2736,38 +2656,6 @@ mod tests {
         let ser = serde_json::to_string(&expected).unwrap();
         let actual: PendingStateFinished = serde_json::from_str(&ser).unwrap();
         assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn unlocked_reason_should_deserialize_legacy_string() {
-        let actual: UnlockedReason = serde_json::from_str(r#""executor closing""#).unwrap();
-        assert_eq!(
-            UnlockedReason::Other {
-                reason: StrVariant::Static("executor closing"),
-            },
-            actual
-        );
-    }
-
-    #[test]
-    fn unlocked_reason_other_should_serialize_current_tagged_shape() {
-        let actual = serde_json::to_string(&UnlockedReason::Other {
-            reason: StrVariant::Static("executor closing"),
-        })
-        .unwrap();
-        assert_eq!(r#"{"type":"other","reason":"executor closing"}"#, actual);
-    }
-
-    #[test]
-    fn unlocked_reason_should_deserialize_current_tagged_shape() {
-        let actual: UnlockedReason =
-            serde_json::from_str(r#"{"type":"other","reason":"executor closing"}"#).unwrap();
-        assert_eq!(
-            UnlockedReason::Other {
-                reason: StrVariant::Static("executor closing"),
-            },
-            actual
-        );
     }
 
     #[test]

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -9,12 +9,12 @@ use concepts::{
     storage::{
         AppendBatchResponse, AppendDelayResponseOutcome, AppendEventsToExecution, AppendRequest,
         AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo,
-        ComponentMetadataRecord, ComponentUpgradeReason, CreateRequest, DUMMY_CREATED,
-        DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout,
-        DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable, DbExecutor, DbExternalApi,
-        DbPool, DbPoolCloseable, DeploymentComponentDetail, DeploymentComponentRecord,
-        DeploymentRecord, DeploymentState, DeploymentStatus, ExecutionEvent,
-        ExecutionListPagination, ExecutionRequest, ExecutionWithState,
+        ComponentMetadataRecord, ComponentUpgradeOutcome, ComponentUpgradeReason, CreateRequest,
+        DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead,
+        DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
+        DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentComponentDetail,
+        DeploymentComponentRecord, DeploymentRecord, DeploymentState, DeploymentStatus,
+        ExecutionEvent, ExecutionListPagination, ExecutionRequest, ExecutionWithState,
         ExecutionWithStateRequestsResponses, ExpiredDelay, ExpiredLock, ExpiredTimer,
         HISTORY_EVENT_TYPE_JOIN_NEXT, HistoryEvent, JoinSetRequest, JoinSetResponse,
         JoinSetResponseEvent, JoinSetResponseEventOuter, ListExecutionEventsResponse,
@@ -23,7 +23,7 @@ use concepts::{
         LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
         PendingStateFinishedResultKind, PendingStateMergedPause, ResponseCursor,
         ResponseWithCursor, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED,
-        STATE_PENDING_AT, TimeoutOutcome, UnlockedReason, Version, VersionType, WasmBacktrace,
+        STATE_PENDING_AT, TimeoutOutcome, Unlocked, Version, VersionType, WasmBacktrace,
     },
 };
 use db_common::{
@@ -604,17 +604,10 @@ async fn update_state_pending_after_response_appended(
     })
 }
 
-struct PendingAfterEventUpdate<'a> {
+struct PendingAfterEventUpdate {
     scheduled_at: DateTime<Utc>,
     intermittent_failure: bool,
     component_input_digest: ComponentDigest,
-    incompatible_digest_update: IncompatibleDigestUpdate<'a>,
-}
-
-#[derive(Clone, Copy)]
-enum IncompatibleDigestUpdate<'a> {
-    LeaveUnchanged,
-    Set(&'a ComponentDigest),
 }
 
 #[instrument(level = Level::DEBUG, skip_all, fields(%execution_id, scheduled_at = %update.scheduled_at, %appending_version))]
@@ -622,28 +615,13 @@ async fn update_state_pending_after_event_appended(
     tx: &Transaction<'_>,
     execution_id: &ExecutionId,
     appending_version: &Version,
-    update: PendingAfterEventUpdate<'_>,
+    update: PendingAfterEventUpdate,
 ) -> Result<(AppendResponse, AppendNotifier), DbErrorWrite> {
     let scheduled_at = update.scheduled_at;
     debug!("Setting t_state to Pending(`{scheduled_at:?}`) after event appended");
 
     let intermittent_delta = i64::from(update.intermittent_failure); // 0 or 1
-    let mut params: Vec<Box<dyn ToSql + Send + Sync>> = vec![
-        Box::new(i64::from(appending_version.0)), // $1
-        Box::new(scheduled_at),                   // $2
-        Box::new(STATE_PENDING_AT),               // $3
-        Box::new(intermittent_delta),             // $4
-        Box::new(execution_id.to_string()),       // $5
-    ];
-    let incompatible_digest_assignment = match update.incompatible_digest_update {
-        IncompatibleDigestUpdate::LeaveUnchanged => String::new(),
-        IncompatibleDigestUpdate::Set(digest) => {
-            params.push(Box::new(digest.to_vec()));
-            format!("incompatible_digest = ${},", params.len())
-        }
-    };
-    let sql = format!(
-        r"
+    let sql = r"
             UPDATE t_state
             SET
                 corresponding_version = $1,
@@ -651,7 +629,6 @@ async fn update_state_pending_after_event_appended(
                 state = $3,
                 updated_at = CURRENT_TIMESTAMP,
                 intermittent_event_count = intermittent_event_count + $4,
-                {incompatible_digest_assignment}
 
                 max_retries = NULL,
                 retry_exp_backoff_millis = NULL,
@@ -662,10 +639,19 @@ async fn update_state_pending_after_event_appended(
 
                 result_kind = NULL
             WHERE execution_id = $5;
-            "
-    );
-    let params_refs: Vec<&(dyn ToSql + Sync)> = params.iter().map(|p| p.as_ref() as _).collect();
-    let updated = tx.execute(&sql, &params_refs).await?;
+            ";
+    let updated = tx
+        .execute(
+            sql,
+            &[
+                &i64::from(appending_version.0),
+                &scheduled_at,
+                &STATE_PENDING_AT,
+                &intermittent_delta,
+                &execution_id.to_string(),
+            ],
+        )
+        .await?;
 
     if updated != 1 {
         return Err(DbErrorWrite::NotFound);
@@ -685,7 +671,7 @@ async fn update_state_pending_after_event_appended(
     ))
 }
 
-async fn update_state_component_upgraded(
+async fn update_state_component_upgrade_finished_success(
     tx: &Transaction<'_>,
     execution_id: &ExecutionId,
     component_digest: &ComponentDigest,
@@ -718,6 +704,59 @@ async fn update_state_component_upgraded(
     if updated != 1 {
         return Err(DbErrorWrite::NotFound);
     }
+    Ok(appending_version.increment())
+}
+
+async fn update_state_unlocked_from_locked(
+    tx: &Transaction<'_>,
+    execution_id: &ExecutionId,
+    component_digest: ComponentDigest,
+    scheduled_at: DateTime<Utc>,
+    appending_version: &Version,
+) -> Result<(AppendResponse, AppendNotifier), DbErrorWrite> {
+    update_state_pending_after_event_appended(
+        tx,
+        execution_id,
+        appending_version,
+        PendingAfterEventUpdate {
+            scheduled_at,
+            intermittent_failure: false,
+            component_input_digest: component_digest,
+        },
+    )
+    .await
+}
+
+async fn update_state_component_upgrade_finished_failed(
+    tx: &Transaction<'_>,
+    execution_id: &ExecutionId,
+    target_digest: &ComponentDigest,
+    appending_version: &Version,
+) -> Result<AppendResponse, DbErrorWrite> {
+    debug!("Marking component {target_digest} incompatible after upgrade failure");
+
+    let updated = tx
+        .execute(
+            r"
+            UPDATE t_state
+            SET
+                corresponding_version = $1,
+                updated_at = CURRENT_TIMESTAMP,
+                incompatible_digest = $2
+            WHERE execution_id = $3;
+            ",
+            &[
+                &i64::from(appending_version.0),
+                &target_digest.as_slice(),
+                &execution_id.to_string(),
+            ],
+        )
+        .await?;
+
+    if updated != 1 {
+        return Err(DbErrorWrite::NotFound);
+    }
+
     Ok(appending_version.increment())
 }
 
@@ -2104,53 +2143,88 @@ async fn append(
                     scheduled_at: *backoff_expires_at,
                     intermittent_failure: true,
                     component_input_digest: combined_state.execution_with_state.component_digest,
-                    incompatible_digest_update: IncompatibleDigestUpdate::LeaveUnchanged,
                 },
             )
             .await?;
             return Ok((next_version, notifier));
         }
 
-        ExecutionRequest::Unlocked {
-            backoff_expires_at,
-            reason,
-        } => {
-            let incompatible_digest_update = match reason {
-                UnlockedReason::AutoUpgradeFailed { target_digest, .. } => {
-                    IncompatibleDigestUpdate::Set(target_digest)
+        ExecutionRequest::Unlocked(unlocked) => {
+            match &combined_state.execution_with_state.pending_state {
+                PendingState::PendingAt(_) => {
+                    return Err(DbErrorWrite::NonRetriable(
+                        DbErrorWriteNonRetriable::IllegalState {
+                            reason: "`Unlocked` cannot be appended to a pending execution".into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        },
+                    ));
                 }
-                UnlockedReason::Other { .. } => IncompatibleDigestUpdate::LeaveUnchanged,
-            };
-            let (next_version, notifier) = update_state_pending_after_event_appended(
-                tx,
-                execution_id,
-                &appending_version,
-                PendingAfterEventUpdate {
-                    scheduled_at: *backoff_expires_at,
-                    intermittent_failure: false,
-                    component_input_digest: combined_state.execution_with_state.component_digest,
-                    incompatible_digest_update,
-                },
-            )
-            .await?;
-            return Ok((next_version, notifier));
+                PendingState::Locked(_) => {
+                    let (next_version, notifier) = update_state_unlocked_from_locked(
+                        tx,
+                        execution_id,
+                        combined_state.execution_with_state.component_digest,
+                        unlocked.backoff_expires_at,
+                        &appending_version,
+                    )
+                    .await?;
+                    return Ok((next_version, notifier));
+                }
+                PendingState::BlockedByJoinSet(_) => {
+                    return Err(DbErrorWrite::NonRetriable(
+                        DbErrorWriteNonRetriable::IllegalState {
+                            reason: "`Unlocked` cannot be appended to a blocked execution".into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        },
+                    ));
+                }
+                PendingState::Paused(_) => {
+                    return Err(DbErrorWrite::NonRetriable(
+                        DbErrorWriteNonRetriable::IllegalState {
+                            reason: "`Unlocked` cannot be appended to a paused execution".into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        },
+                    ));
+                }
+                PendingState::Finished(_) => {
+                    unreachable!("handled above");
+                }
+            }
         }
 
-        ExecutionRequest::ComponentUpgraded {
+        ExecutionRequest::ComponentUpgradeFinished {
             component_digest,
             deployment_id,
-            ..
-        } => {
-            let next_version = update_state_component_upgraded(
-                tx,
-                execution_id,
-                component_digest,
-                *deployment_id,
-                &appending_version,
-            )
-            .await?;
-            return Ok((next_version, AppendNotifier::default()));
-        }
+            outcome,
+        } => match outcome {
+            ComponentUpgradeOutcome::Success { .. } => {
+                let next_version = update_state_component_upgrade_finished_success(
+                    tx,
+                    execution_id,
+                    component_digest,
+                    *deployment_id,
+                    &appending_version,
+                )
+                .await?;
+                return Ok((next_version, AppendNotifier::default()));
+            }
+            ComponentUpgradeOutcome::Failed { .. } => {
+                let next_version = update_state_component_upgrade_finished_failed(
+                    tx,
+                    execution_id,
+                    component_digest,
+                    &appending_version,
+                )
+                .await?;
+                return Ok((next_version, AppendNotifier::default()));
+            }
+        },
 
         ExecutionRequest::Paused => {
             match &combined_state.execution_with_state.pending_state {
@@ -2313,7 +2387,6 @@ async fn append(
                         component_input_digest: combined_state
                             .execution_with_state
                             .component_digest,
-                        incompatible_digest_update: IncompatibleDigestUpdate::LeaveUnchanged,
                     },
                 )
                 .await?;
@@ -3063,10 +3136,10 @@ async fn upgrade_execution_component(
         execution_id,
         AppendRequest {
             created_at: Utc::now(),
-            event: ExecutionRequest::ComponentUpgraded {
+            event: ExecutionRequest::ComponentUpgradeFinished {
                 component_digest: new.clone(),
                 deployment_id: combined_state.execution_with_state.deployment_id,
-                reason,
+                outcome: ComponentUpgradeOutcome::Success { reason },
             },
         },
         appending_version,
@@ -4780,10 +4853,10 @@ impl DbExternalApi for PostgresConnection {
                 execution_id,
                 AppendRequest {
                     created_at: paused_at,
-                    event: ExecutionRequest::Unlocked {
+                    event: ExecutionRequest::Unlocked(Unlocked {
                         backoff_expires_at: paused_at,
-                        reason: StrVariant::Static("paused").into(),
-                    },
+                        reason: "paused".into(),
+                    }),
                 },
                 appending_version,
             )

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -9,12 +9,12 @@ use concepts::{
     storage::{
         AppendBatchResponse, AppendDelayResponseOutcome, AppendEventsToExecution, AppendRequest,
         AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo,
-        ComponentMetadataRecord, ComponentUpgradeReason, CreateRequest, DUMMY_CREATED,
-        DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout,
-        DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable, DbExecutor, DbExternalApi,
-        DbPool, DbPoolCloseable, DeploymentComponentDetail, DeploymentComponentRecord,
-        DeploymentRecord, DeploymentState, DeploymentStatus, ExecutionEvent,
-        ExecutionListPagination, ExecutionRequest, ExecutionWithState,
+        ComponentMetadataRecord, ComponentUpgradeOutcome, ComponentUpgradeReason, CreateRequest,
+        DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead,
+        DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
+        DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentComponentDetail,
+        DeploymentComponentRecord, DeploymentRecord, DeploymentState, DeploymentStatus,
+        ExecutionEvent, ExecutionListPagination, ExecutionRequest, ExecutionWithState,
         ExecutionWithStateRequestsResponses, ExpiredDelay, ExpiredLock, ExpiredTimer,
         HISTORY_EVENT_TYPE_JOIN_NEXT, HistoryEvent, JoinSetRequest, JoinSetResponse,
         JoinSetResponseEvent, JoinSetResponseEventOuter, ListExecutionEventsResponse,
@@ -23,7 +23,7 @@ use concepts::{
         LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
         PendingStateFinishedResultKind, PendingStateMergedPause, ResponseCursor,
         ResponseWithCursor, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED,
-        STATE_PENDING_AT, TimeoutOutcome, UnlockedReason, Version, VersionType,
+        STATE_PENDING_AT, TimeoutOutcome, Unlocked, Version, VersionType,
     },
 };
 use conversions::{JsonWrapper, consistency_db_err, consistency_rusqlite, from_generic_error};
@@ -474,17 +474,10 @@ fn deployment_component_detail_from_row(
     })
 }
 
-struct PendingAfterEventUpdate<'a> {
+struct PendingAfterEventUpdate {
     scheduled_at: DateTime<Utc>,
     intermittent_failure: bool,
     component_input_digest: ComponentDigest,
-    incompatible_digest_update: IncompatibleDigestUpdate<'a>,
-}
-
-#[derive(Clone, Copy)]
-enum IncompatibleDigestUpdate<'a> {
-    LeaveUnchanged,
-    Set(&'a ComponentDigest),
 }
 
 impl SqlitePool {
@@ -1088,29 +1081,11 @@ impl SqlitePool {
         tx: &Transaction,
         execution_id: &ExecutionId,
         appending_version: &Version,
-        update: PendingAfterEventUpdate<'_>,
+        update: PendingAfterEventUpdate,
     ) -> Result<(AppendResponse, AppendNotifier), DbErrorWrite> {
         let scheduled_at = update.scheduled_at;
         debug!("Setting t_state to Pending(`{scheduled_at:?}`) after event appended");
-        let mut params: Vec<(&'static str, Box<dyn ToSql>)> = vec![
-            (":execution_id", Box::new(execution_id.to_string())),
-            (":appending_version", Box::new(appending_version.0)),
-            (":pending_expires_finished", Box::new(scheduled_at)),
-            (":state", Box::new(STATE_PENDING_AT)),
-            (
-                ":intermittent_delta",
-                Box::new(i32::from(update.intermittent_failure)),
-            ),
-        ];
-        let incompatible_digest_assignment = match update.incompatible_digest_update {
-            IncompatibleDigestUpdate::LeaveUnchanged => String::new(),
-            IncompatibleDigestUpdate::Set(digest) => {
-                params.push((":incompatible_digest", Box::new(digest.clone())));
-                "incompatible_digest = :incompatible_digest,".to_string()
-            }
-        };
-        let sql = format!(
-            r"
+        let sql = r"
                 UPDATE t_state
                 SET
                     corresponding_version = :appending_version,
@@ -1118,7 +1093,6 @@ impl SqlitePool {
                     state = :state,
                     updated_at = CURRENT_TIMESTAMP,
                     intermittent_event_count = intermittent_event_count + :intermittent_delta,
-                    {incompatible_digest_assignment}
 
                     max_retries = NULL,
                     retry_exp_backoff_millis = NULL,
@@ -1129,16 +1103,15 @@ impl SqlitePool {
 
                     result_kind = NULL
                 WHERE execution_id = :execution_id;
-            " // `executor_id` and `run_id` are preserved for lock extension.
-        );
-        let mut stmt = tx.prepare_cached(&sql)?;
-        let params_refs: Vec<(&str, &dyn ToSql)> = params
-            .iter()
-            .map(|(name, value)| (*name, value.as_ref() as &dyn ToSql))
-            .collect();
-        let updated = stmt
-            .execute(params_refs.as_slice())
-            .map_err(DbErrorWrite::from)?;
+            "; // `executor_id` and `run_id` are preserved for lock extension.
+        let mut stmt = tx.prepare_cached(sql)?;
+        let updated = stmt.execute(named_params! {
+            ":execution_id": execution_id.to_string(),
+            ":appending_version": appending_version.0,
+            ":pending_expires_finished": scheduled_at,
+            ":state": STATE_PENDING_AT,
+            ":intermittent_delta": i32::from(update.intermittent_failure),
+        })?;
         if updated != 1 {
             return Err(DbErrorWrite::NotFound);
         }
@@ -1156,7 +1129,7 @@ impl SqlitePool {
         ))
     }
 
-    fn update_state_component_upgraded(
+    fn update_state_component_upgrade_finished_success(
         tx: &Transaction,
         execution_id: &ExecutionId,
         component_digest: &ComponentDigest,
@@ -1181,6 +1154,34 @@ impl SqlitePool {
             ":appending_version": appending_version.0,
             ":component_digest": component_digest,
             ":deployment_id": deployment_id.to_string(),
+        })?;
+        if updated != 1 {
+            return Err(DbErrorWrite::NotFound);
+        }
+        Ok(appending_version.increment())
+    }
+
+    fn update_state_component_upgrade_finished_failed(
+        tx: &Transaction,
+        execution_id: &ExecutionId,
+        target_digest: &ComponentDigest,
+        appending_version: &Version,
+    ) -> Result<AppendResponse, DbErrorWrite> {
+        debug!("Marking component {target_digest} incompatible after upgrade failure");
+        let mut stmt = tx.prepare_cached(
+            r"
+                UPDATE t_state
+                SET
+                    corresponding_version = :appending_version,
+                    updated_at = CURRENT_TIMESTAMP,
+                    incompatible_digest = :target_digest
+                WHERE execution_id = :execution_id;
+            ",
+        )?;
+        let updated = stmt.execute(named_params! {
+            ":execution_id": execution_id.to_string(),
+            ":appending_version": appending_version.0,
+            ":target_digest": target_digest,
         })?;
         if updated != 1 {
             return Err(DbErrorWrite::NotFound);
@@ -2133,50 +2134,89 @@ impl SqlitePool {
                         component_input_digest: combined_state
                             .execution_with_state
                             .component_digest,
-                        incompatible_digest_update: IncompatibleDigestUpdate::LeaveUnchanged,
                     },
                 )?;
                 return Ok((next_version, notifier));
             }
 
-            ExecutionRequest::Unlocked {
-                backoff_expires_at,
-                reason,
-            } => {
-                let incompatible_digest_update = match reason {
-                    UnlockedReason::AutoUpgradeFailed { target_digest, .. } => {
-                        IncompatibleDigestUpdate::Set(target_digest)
-                    }
-                    UnlockedReason::Other { .. } => IncompatibleDigestUpdate::LeaveUnchanged,
-                };
-                let (next_version, notifier) = Self::update_state_pending_after_event_appended(
-                    tx,
-                    execution_id,
-                    &appending_version,
-                    PendingAfterEventUpdate {
-                        scheduled_at: *backoff_expires_at,
-                        intermittent_failure: false,
-                        component_input_digest: combined_state
-                            .execution_with_state
-                            .component_digest,
-                        incompatible_digest_update,
-                    },
-                )?;
-                return Ok((next_version, notifier));
-            }
+            ExecutionRequest::Unlocked(unlocked) => match &combined_state
+                .execution_with_state
+                .pending_state
+            {
+                PendingState::PendingAt(_) => {
+                    return Err(DbErrorWrite::NonRetriable(
+                        DbErrorWriteNonRetriable::IllegalState {
+                            reason: "`Unlocked` cannot be appended to a pending execution".into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        },
+                    ));
+                }
+                PendingState::Locked(_) => {
+                    let (next_version, notifier) = Self::update_state_pending_after_event_appended(
+                        tx,
+                        execution_id,
+                        &appending_version,
+                        PendingAfterEventUpdate {
+                            scheduled_at: unlocked.backoff_expires_at,
+                            intermittent_failure: false,
+                            component_input_digest: combined_state
+                                .execution_with_state
+                                .component_digest,
+                        },
+                    )?;
+                    return Ok((next_version, notifier));
+                }
+                PendingState::BlockedByJoinSet(_) => {
+                    return Err(DbErrorWrite::NonRetriable(
+                        DbErrorWriteNonRetriable::IllegalState {
+                            reason: "`Unlocked` cannot be appended to a blocked execution".into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        },
+                    ));
+                }
+                PendingState::Paused(_) => {
+                    return Err(DbErrorWrite::NonRetriable(
+                        DbErrorWriteNonRetriable::IllegalState {
+                            reason: "`Unlocked` cannot be appended to a paused execution".into(),
+                            context: SpanTrace::capture(),
+                            source: None,
+                            loc: Location::caller(),
+                        },
+                    ));
+                }
+                PendingState::Finished(_) => {
+                    unreachable!("handled above");
+                }
+            },
 
-            ExecutionRequest::ComponentUpgraded {
+            ExecutionRequest::ComponentUpgradeFinished {
                 component_digest,
                 deployment_id,
-                ..
+                outcome,
             } => {
-                let next_version = Self::update_state_component_upgraded(
-                    tx,
-                    execution_id,
-                    component_digest,
-                    *deployment_id,
-                    &appending_version,
-                )?;
+                let next_version = match outcome {
+                    ComponentUpgradeOutcome::Success { .. } => {
+                        Self::update_state_component_upgrade_finished_success(
+                            tx,
+                            execution_id,
+                            component_digest,
+                            *deployment_id,
+                            &appending_version,
+                        )?
+                    }
+                    ComponentUpgradeOutcome::Failed { .. } => {
+                        Self::update_state_component_upgrade_finished_failed(
+                            tx,
+                            execution_id,
+                            component_digest,
+                            &appending_version,
+                        )?
+                    }
+                };
                 return Ok((next_version, AppendNotifier::default()));
             }
 
@@ -2335,7 +2375,6 @@ impl SqlitePool {
                             component_input_digest: combined_state
                                 .execution_with_state
                                 .component_digest,
-                            incompatible_digest_update: IncompatibleDigestUpdate::LeaveUnchanged,
                         },
                     )?;
                     return Ok((next_version, notifier));
@@ -3060,10 +3099,10 @@ impl SqlitePool {
             execution_id,
             AppendRequest {
                 created_at: Utc::now(),
-                event: ExecutionRequest::ComponentUpgraded {
+                event: ExecutionRequest::ComponentUpgradeFinished {
                     component_digest: new.clone(),
                     deployment_id: combined_state.execution_with_state.deployment_id,
-                    reason,
+                    outcome: ComponentUpgradeOutcome::Success { reason },
                 },
             },
             appending_version,
@@ -3536,10 +3575,10 @@ impl SqlitePool {
                 execution_id,
                 AppendRequest {
                     created_at: paused_at,
-                    event: ExecutionRequest::Unlocked {
-                        backoff_expires_at: paused_at,
-                        reason: StrVariant::Static("paused").into(),
-                    },
+                    event: ExecutionRequest::Unlocked(Unlocked {
+                        backoff_expires_at: paused_at, // does not matter, about to append `Paused` in same tx.
+                        reason: "paused".into(),
+                    }),
                 },
                 appending_version,
             )?;

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, RunId};
 use concepts::storage::{
     AppendEventsToExecution, AppendRequest, AppendResponseToExecution, DbErrorGeneric,
-    DbErrorWrite, DbExecutor, DbPool, ExecutionLog, LockedExecution,
+    DbErrorWrite, DbExecutor, DbPool, ExecutionLog, LockedExecution, Unlocked,
 };
 use concepts::time::{ClockFn, Sleep};
 use concepts::{
@@ -669,10 +669,10 @@ impl ExecTask {
 
                 let (primary_event, child_finished, version) = match err {
                     WorkerError::ExecutorClosing(version) => {
-                        let primary_event = ExecutionRequest::Unlocked {
-                            backoff_expires_at: result_obtained_at, // continue right when new executor starts
+                        let primary_event = ExecutionRequest::Unlocked(Unlocked {
+                            backoff_expires_at: result_obtained_at,
                             reason: "executor closing".into(),
-                        };
+                        });
                         (primary_event, None, version)
                     }
                     WorkerError::TemporaryTimeout {
@@ -782,10 +782,10 @@ impl ExecTask {
                             "Limit reached: {reason}, unlocking after {unlock_expiry_on_limit_reached:?} at {expires_at}"
                         );
                         (
-                            ExecutionRequest::Unlocked {
+                            ExecutionRequest::Unlocked(Unlocked {
                                 backoff_expires_at: expires_at,
-                                reason: StrVariant::from(reason).into(),
-                            },
+                                reason: StrVariant::from(reason),
+                            }),
                             None,
                             new_version,
                         )

--- a/crates/executor/src/expired_timers_watcher.rs
+++ b/crates/executor/src/expired_timers_watcher.rs
@@ -11,7 +11,7 @@ use concepts::storage::DbErrorWrite;
 use concepts::storage::DbPool;
 use concepts::storage::ExecutionLog;
 use concepts::storage::ExpiredDelay;
-use concepts::storage::UnlockedReason;
+use concepts::storage::Unlocked;
 use concepts::time::ClockFn;
 use concepts::{
     FinishedExecutionFailure,
@@ -109,12 +109,10 @@ pub(crate) async fn tick(
                         created_at: executed_at,
                         primary_event: AppendRequest {
                             created_at: executed_at,
-                            event: ExecutionRequest::Unlocked {
+                            event: ExecutionRequest::Unlocked(Unlocked {
                                 backoff_expires_at: executed_at,
-                                reason: UnlockedReason::Other {
-                                    reason: "made progress".into(),
-                                },
-                            },
+                                reason: "made progress".into(),
+                            }),
                         },
                         execution_id: execution_id.clone(),
                         version: expired.next_version,

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -8,14 +8,15 @@ use concepts::{
     prefixed_ulid::{DelayId, DeploymentId, ExecutorId, RunId},
     storage::{
         AppendEventsToExecution, AppendRequest, AppendResponseToExecution, BacktraceInfo,
-        CancelOutcome, CapturedDbWrite, ChildExecutionRequestError, ComponentUpgradeReason,
-        CreateRequest, DbErrorGeneric, DbErrorRead, DbErrorWrite, ExecutionEvent,
-        ExecutionListPagination, ExecutionRequest, ExecutionWithState, HistoryEvent,
-        HistoryEventScheduleAt, JoinSetRequest, Locked, LockedBy, LogEntry, LogEntryRow, LogLevel,
-        LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
-        PendingStateFinished, PendingStateFinishedError, PendingStateFinishedResultKind,
-        PendingStateLocked, PendingStatePendingAt, PersistKind, ScheduleRequestError, StubError,
-        UnlockedReason, Version, VersionParseError, http_client_trace::HttpClientTrace,
+        CancelOutcome, CapturedDbWrite, ChildExecutionRequestError, ComponentUpgradeOutcome,
+        ComponentUpgradeReason, CreateRequest, DbErrorGeneric, DbErrorRead, DbErrorWrite,
+        ExecutionEvent, ExecutionListPagination, ExecutionRequest, ExecutionWithState,
+        HistoryEvent, HistoryEventScheduleAt, JoinSetRequest, Locked, LockedBy, LogEntry,
+        LogEntryRow, LogLevel, LogStreamType, Pagination, PendingState,
+        PendingStateBlockedByJoinSet, PendingStateFinished, PendingStateFinishedError,
+        PendingStateFinishedResultKind, PendingStateLocked, PendingStatePendingAt, PersistKind,
+        ScheduleRequestError, StubError, Unlocked, Version, VersionParseError,
+        http_client_trace::HttpClientTrace,
     },
 };
 use concepts::{JoinSetId, JoinSetKind};
@@ -959,30 +960,46 @@ pub fn from_execution_event_to_grpc(event: ExecutionEvent) -> grpc_gen::Executio
                 retry_config: Some(retry_config.into()),
                 lock_expires_at: Some(prost_wkt_types::Timestamp::from(lock_expires_at)),
             }),
-            ExecutionRequest::Unlocked {
-                backoff_expires_at,
-                reason,
-            } => grpc_gen::execution_event::Event::Unlocked(grpc_gen::execution_event::Unlocked {
-                backoff_expires_at: Some(prost_wkt_types::Timestamp::from(backoff_expires_at)),
-                reason: reason.to_string(),
-            }),
-            ExecutionRequest::ComponentUpgraded {
+            ExecutionRequest::Unlocked(unlocked) => grpc_gen::execution_event::Event::Unlocked(
+                grpc_gen::execution_event::Unlocked {
+                    reason: unlocked.reason.to_string(),
+                    backoff_expires_at: Some(prost_wkt_types::Timestamp::from(
+                        unlocked.backoff_expires_at,
+                    )),
+                },
+            ),
+            ExecutionRequest::ComponentUpgradeFinished {
                 component_digest,
                 deployment_id,
-                reason,
-            } => grpc_gen::execution_event::Event::ComponentUpgraded(
-                grpc_gen::execution_event::ComponentUpgraded {
+                outcome,
+            } => grpc_gen::execution_event::Event::ComponentUpgradeFinished(
+                grpc_gen::execution_event::ComponentUpgradeFinished {
                     component_digest: Some(component_digest.into()),
                     deployment_id: Some(deployment_id.into()),
-                    reason: Some(match reason {
-                        ComponentUpgradeReason::Auto => {
-                            grpc_gen::execution_event::component_upgraded::Reason::Auto(
-                                grpc_gen::execution_event::component_upgraded::Auto {},
+                    outcome: Some(match outcome {
+                        ComponentUpgradeOutcome::Success { reason } => {
+                            grpc_gen::execution_event::component_upgrade_finished::Outcome::Success(
+                                grpc_gen::execution_event::component_upgrade_finished::Success {
+                                    reason: Some(match reason {
+                                        ComponentUpgradeReason::Auto => {
+                                            grpc_gen::execution_event::component_upgrade_finished::success::Reason::Auto(
+                                                grpc_gen::execution_event::component_upgrade_finished::Auto {},
+                                            )
+                                        }
+                                        ComponentUpgradeReason::Manual { force } => {
+                                            grpc_gen::execution_event::component_upgrade_finished::success::Reason::Manual(
+                                                grpc_gen::execution_event::component_upgrade_finished::Manual { force },
+                                            )
+                                        }
+                                    }),
+                                },
                             )
                         }
-                        ComponentUpgradeReason::Manual { force } => {
-                            grpc_gen::execution_event::component_upgraded::Reason::Manual(
-                                grpc_gen::execution_event::component_upgraded::Manual { force },
+                        ComponentUpgradeOutcome::Failed { reason } => {
+                            grpc_gen::execution_event::component_upgrade_finished::Outcome::Failed(
+                                grpc_gen::execution_event::component_upgrade_finished::Failed {
+                                    reason: reason.to_string(),
+                                },
                             )
                         }
                     }),
@@ -1109,17 +1126,17 @@ impl TryFrom<grpc_gen::ExecutionEvent> for ExecutionEvent {
                     .argument_must_exist("retry_config")?
                     .try_into()?,
             }),
-            grpc_gen::execution_event::Event::Unlocked(unlocked) => ExecutionRequest::Unlocked {
-                backoff_expires_at: unlocked
-                    .backoff_expires_at
-                    .argument_must_exist("backoff_expires_at")?
-                    .into(),
-                reason: UnlockedReason::Other {
+            grpc_gen::execution_event::Event::Unlocked(unlocked) => {
+                ExecutionRequest::Unlocked(Unlocked {
+                    backoff_expires_at: unlocked
+                        .backoff_expires_at
+                        .argument_must_exist("backoff_expires_at")?
+                        .into(),
                     reason: StrVariant::from(unlocked.reason),
-                },
-            },
-            grpc_gen::execution_event::Event::ComponentUpgraded(upgraded) => {
-                ExecutionRequest::ComponentUpgraded {
+                })
+            }
+            grpc_gen::execution_event::Event::ComponentUpgradeFinished(upgraded) => {
+                ExecutionRequest::ComponentUpgradeFinished {
                     component_digest: upgraded
                         .component_digest
                         .argument_must_exist("component_digest")?
@@ -1128,13 +1145,22 @@ impl TryFrom<grpc_gen::ExecutionEvent> for ExecutionEvent {
                         .deployment_id
                         .argument_must_exist("deployment_id")?
                         .try_into()?,
-                    reason: match upgraded.reason.argument_must_exist("reason")? {
-                        grpc_gen::execution_event::component_upgraded::Reason::Auto(_) => {
-                            ComponentUpgradeReason::Auto
+                    outcome: match upgraded.outcome.argument_must_exist("outcome")? {
+                        grpc_gen::execution_event::component_upgrade_finished::Outcome::Success(success) => {
+                            ComponentUpgradeOutcome::Success {
+                                reason: match success.reason.argument_must_exist("reason")? {
+                                    grpc_gen::execution_event::component_upgrade_finished::success::Reason::Auto(_) => {
+                                        ComponentUpgradeReason::Auto
+                                    }
+                                    grpc_gen::execution_event::component_upgrade_finished::success::Reason::Manual(manual) => {
+                                        ComponentUpgradeReason::Manual { force: manual.force }
+                                    }
+                                },
+                            }
                         }
-                        grpc_gen::execution_event::component_upgraded::Reason::Manual(manual) => {
-                            ComponentUpgradeReason::Manual {
-                                force: manual.force,
+                        grpc_gen::execution_event::component_upgrade_finished::Outcome::Failed(failed) => {
+                            ComponentUpgradeOutcome::Failed {
+                                reason: StrVariant::from(failed.reason),
                             }
                         }
                     },

--- a/crates/testing/db-tests/tests/diff-tests.rs
+++ b/crates/testing/db-tests/tests/diff-tests.rs
@@ -171,11 +171,10 @@ fn normalize_timestamps(
         ExecutionRequest::Locked(locked) => {
             locked.lock_expires_at = arbitrary_valid_datetime(unstructured)?;
         }
-        ExecutionRequest::Unlocked {
-            backoff_expires_at,
-            reason: _,
+        ExecutionRequest::Unlocked(unlocked) => {
+            unlocked.backoff_expires_at = arbitrary_valid_datetime(unstructured)?;
         }
-        | ExecutionRequest::TemporarilyFailed {
+        ExecutionRequest::TemporarilyFailed {
             backoff_expires_at,
             reason: _,
             detail: _,
@@ -190,10 +189,10 @@ fn normalize_timestamps(
         ExecutionRequest::HistoryEvent { event } => {
             normalize_history_event_timestamps(event, unstructured)?;
         }
-        ExecutionRequest::ComponentUpgraded {
+        ExecutionRequest::ComponentUpgradeFinished {
             component_digest: _,
             deployment_id: _,
-            reason: _,
+            outcome: _,
         }
         | ExecutionRequest::Finished {
             retval: _,

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -8,7 +8,7 @@ use concepts::storage::{
     FrameSymbol, FunctionNameFilter, JoinSetRequest, JoinSetResponse, JoinSetResponseEventOuter,
     LockedBy, LockedExecution, Pagination, PendingState, PendingStateBlockedByJoinSet,
     PendingStateLocked, PendingStatePaused, PendingStatePendingAt, ResponseCursor, TimeoutOutcome,
-    Version, VersionType, WasmBacktrace,
+    Unlocked, Version, VersionType, WasmBacktrace,
 };
 use concepts::storage::{DbErrorWrite, DbPoolCloseable, DeploymentRecord, DeploymentStatus};
 use concepts::storage::{DbErrorWriteNonRetriable, HistoryEvent, ListExecutionsFilter};
@@ -350,10 +350,10 @@ async fn locking_in_unlock_backoff_should_not_be_possible(
         let created_at = sim_clock.now();
         info!(now = %created_at, "unlock");
         let req = AppendRequest {
-            event: ExecutionRequest::Unlocked {
+            event: ExecutionRequest::Unlocked(Unlocked {
                 backoff_expires_at,
-                reason: StrVariant::Static("reason").into(),
-            },
+                reason: StrVariant::Static("reason"),
+            }),
             created_at,
         };
         db_connection
@@ -1767,6 +1767,166 @@ async fn create_join_set(
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
+async fn cannot_append_unlocked_to_blocked_execution(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let db_connection = db_pool.connection().await.unwrap();
+
+    let execution_id = ExecutionId::generate();
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: execution_id.clone(),
+            ffqn: SOME_FFQN,
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_activity(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
+
+    let lock_expiry = Duration::from_millis(100);
+    let mut version = lock(
+        db_connection.as_ref(),
+        &execution_id,
+        &sim_clock,
+        ExecutorId::generate(),
+        sim_clock.now() + lock_expiry,
+        RunId::generate(),
+    )
+    .await;
+
+    let join_set_id = JoinSetId::new(JoinSetKind::Named, "blocked".into()).unwrap();
+    create_join_set(
+        &execution_id,
+        &mut version,
+        join_set_id.clone(),
+        sim_clock.now(),
+        db_connection.as_ref(),
+    )
+    .await;
+
+    version = db_connection
+        .append(
+            execution_id.clone(),
+            version,
+            AppendRequest {
+                created_at: sim_clock.now(),
+                event: ExecutionRequest::HistoryEvent {
+                    event: HistoryEvent::JoinNext {
+                        join_set_id,
+                        run_expires_at: sim_clock.now() + lock_expiry,
+                        closing: false,
+                        requested_ffqn: Some(SOME_FFQN),
+                    },
+                },
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = db_connection
+        .append(
+            execution_id,
+            version,
+            AppendRequest {
+                created_at: sim_clock.now(),
+                event: ExecutionRequest::Unlocked(Unlocked {
+                    backoff_expires_at: sim_clock.now(),
+                    reason: "should fail".into(),
+                }),
+            },
+        )
+        .await
+        .unwrap_err();
+    let reason = assert_matches!(
+        err,
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason
+    );
+    assert_eq!(
+        "`Unlocked` cannot be appended to a blocked execution",
+        reason.to_string()
+    );
+
+    drop(db_connection);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn cannot_append_unlocked_to_paused_execution(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let db_connection = db_pool.connection().await.unwrap();
+
+    let execution_id = ExecutionId::generate();
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: execution_id.clone(),
+            ffqn: SOME_FFQN,
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_activity(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
+
+    let version = db_connection
+        .append(
+            execution_id.clone(),
+            Version::new(1),
+            AppendRequest {
+                created_at: sim_clock.now(),
+                event: ExecutionRequest::Paused,
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = db_connection
+        .append(
+            execution_id,
+            version,
+            AppendRequest {
+                created_at: sim_clock.now(),
+                event: ExecutionRequest::Unlocked(Unlocked {
+                    backoff_expires_at: sim_clock.now(),
+                    reason: "should fail".into(),
+                }),
+            },
+        )
+        .await
+        .unwrap_err();
+    let reason = assert_matches!(
+        err,
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason
+    );
+    assert_eq!(
+        "`Unlocked` cannot be appended to a paused execution",
+        reason.to_string()
+    );
+
+    drop(db_connection);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
 async fn test_append_response_with_same_delay_id_twice_should_fail(database: Database) {
     set_up();
     let sim_clock = SimClock::default();
@@ -2241,14 +2401,13 @@ async fn pause_and_unpause_locked_execution_should_return_to_pending_at(
         PendingState::Paused(PendingStatePaused::PendingAt(PendingStatePendingAt { scheduled_at, last_lock })) => (scheduled_at, last_lock));
     assert_eq!(paused_at, paused_pending_at.0);
     assert_eq!(Some(found_locked_by.clone()), paused_pending_at.1);
-    let (backoff_expires_at, reason) = assert_matches!(
+    let reason = assert_matches!(
         &log.events[2].event,
-        ExecutionRequest::Unlocked {
-            backoff_expires_at,
-            reason,
-        } => (*backoff_expires_at, reason)
+        ExecutionRequest::Unlocked(Unlocked { backoff_expires_at, reason }) => {
+            assert_eq!(&paused_at, backoff_expires_at);
+            reason
+        }
     );
-    assert_eq!(paused_at, backoff_expires_at);
     assert_eq!("paused", reason.to_string());
     assert_matches!(log.events[3].event, ExecutionRequest::Paused);
 
@@ -2463,16 +2622,17 @@ async fn pause_then_join_next_then_unpause_should_restore_blocked_by_join_set(da
         .await
         .unwrap();
 
+    let created_at = sim_clock.now();
     version = db_connection
         .append(
             execution_id.clone(),
             version,
             AppendRequest {
-                created_at: sim_clock.now(),
-                event: ExecutionRequest::Unlocked {
-                    backoff_expires_at: sim_clock.now(),
-                    reason: StrVariant::Static("paused").into(),
-                },
+                created_at,
+                event: ExecutionRequest::Unlocked(Unlocked {
+                    backoff_expires_at: created_at,
+                    reason: "paused".into(),
+                }),
             },
         )
         .await

--- a/crates/testing/test-utils/src/lib.rs
+++ b/crates/testing/test-utils/src/lib.rs
@@ -150,7 +150,7 @@ impl From<ExecutionLog> for ExecutionLogSanitized {
                 | ExecutionRequest::Locked(Locked { component_id, .. }) => {
                     component_id.component_digest = COMPONENT_DIGEST_DUMMY;
                 }
-                ExecutionRequest::ComponentUpgraded {
+                ExecutionRequest::ComponentUpgradeFinished {
                     component_digest, ..
                 } => {
                     *component_digest = COMPONENT_DIGEST_DUMMY;

--- a/crates/wasm-workers/src/cron/cron_worker.rs
+++ b/crates/wasm-workers/src/cron/cron_worker.rs
@@ -2,12 +2,11 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::DeploymentId;
 use concepts::storage::{
-    AppendRequest, CreateRequest, ExecutionRequest, HistoryEvent, HistoryEventScheduleAt,
+    AppendRequest, CreateRequest, ExecutionRequest, HistoryEvent, HistoryEventScheduleAt, Unlocked,
 };
 use concepts::time::ClockFn;
 use concepts::{
     ComponentId, ExecutionId, ExecutionMetadata, FunctionFqn, FunctionMetadata, Name, Params,
-    StrVariant,
 };
 use executor::worker::{Worker, WorkerContext, WorkerResult, WorkerResultOk};
 use std::sync::Arc;
@@ -139,10 +138,10 @@ impl Worker for CronWorker {
                 debug!(next_fire = %next_fire, "Scheduling next tick");
                 AppendRequest {
                     created_at: now,
-                    event: ExecutionRequest::Unlocked {
+                    event: ExecutionRequest::Unlocked(Unlocked {
                         backoff_expires_at: next_fire,
-                        reason: StrVariant::Static("cron: waiting for next cron tick").into(),
-                    },
+                        reason: "cron".into(),
+                    }),
                 }
             }
         };
@@ -171,6 +170,7 @@ impl Worker for CronWorker {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use concepts::StrVariant;
     use concepts::component_id::COMPONENT_DIGEST_DUMMY;
     use concepts::prefixed_ulid::{DEPLOYMENT_ID_DUMMY, ExecutorId, RunId};
     use concepts::storage::{
@@ -433,7 +433,7 @@ mod tests {
         ));
         assert!(matches!(
             schedule_log.events[3].event,
-            ExecutionRequest::Unlocked { .. }
+            ExecutionRequest::Unlocked(_)
         ));
 
         // Verify the child execution was created with correct FFQN

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -104,7 +104,7 @@ pub(crate) enum ApplyError {
     #[error("executor closing")]
     ExecutorClosing,
     #[error("replay interrupt")]
-    ReplayWaitingForResponse, // TODO: Rename to ReplayInterrupt
+    ReplayWaitingForResponse, // TODO: Rename to ReplayStubDbFlush
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -199,21 +199,18 @@ fn normalize_execution_request_for_matching(req: ExecutionRequest) -> ExecutionR
             locked.lock_expires_at = DateTime::UNIX_EPOCH;
             ExecutionRequest::Locked(locked)
         }
-        ExecutionRequest::Unlocked {
-            backoff_expires_at: _,
-            reason,
-        } => ExecutionRequest::Unlocked {
-            backoff_expires_at: DateTime::UNIX_EPOCH,
-            reason,
-        },
-        ExecutionRequest::ComponentUpgraded {
+        ExecutionRequest::Unlocked(mut unlocked) => {
+            unlocked.backoff_expires_at = DateTime::UNIX_EPOCH;
+            ExecutionRequest::Unlocked(unlocked)
+        }
+        ExecutionRequest::ComponentUpgradeFinished {
             component_digest,
             deployment_id,
-            reason,
-        } => ExecutionRequest::ComponentUpgraded {
+            outcome,
+        } => ExecutionRequest::ComponentUpgradeFinished {
             component_digest,
             deployment_id,
-            reason,
+            outcome,
         },
         ExecutionRequest::TemporarilyFailed {
             backoff_expires_at: _,

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -593,11 +593,11 @@ mod tests {
     use concepts::component_id::{COMPONENT_DIGEST_DUMMY, ComponentDigest, Digest};
     use concepts::prefixed_ulid::{DEPLOYMENT_ID_DUMMY, DelayId, ExecutorId, RunId};
     use concepts::storage::{
-        CapturedDbWrite, ComponentUpgradeReason, CreateRequest, DbConnectionTest, DbPool,
-        DbPoolCloseable, ExecutionRequest, HistoryEvent, JoinSetRequest, JoinSetResponse, Locked,
-        LogEntry, LogInfoAppendRow, LogLevel, PendingState, PendingStateFinished,
-        PendingStateFinishedError, PendingStateFinishedResultKind, PendingStatePendingAt,
-        UnlockedReason, Version,
+        CapturedDbWrite, ComponentUpgradeOutcome, ComponentUpgradeReason, CreateRequest,
+        DbConnectionTest, DbPool, DbPoolCloseable, ExecutionRequest, HistoryEvent, JoinSetRequest,
+        JoinSetResponse, Locked, LogEntry, LogInfoAppendRow, LogLevel, PendingState,
+        PendingStateFinished, PendingStateFinishedError, PendingStateFinishedResultKind,
+        PendingStatePendingAt, Version,
     };
     use concepts::time::{ClockFn, Now, TokioSleep};
     use concepts::{
@@ -2102,7 +2102,7 @@ mod tests {
         let has_unlocked = log
             .events
             .iter()
-            .any(|e| matches!(e.event, ExecutionRequest::Unlocked { .. }));
+            .any(|e| matches!(e.event, ExecutionRequest::Unlocked(_)));
         assert!(
             has_unlocked,
             "expected Unlocked event in execution log, got: {:?}",
@@ -2452,17 +2452,31 @@ mod tests {
         );
         assert_matches!(
             upgraded_pending_state.pending_state,
-            PendingState::PendingAt(..)
+            PendingState::BlockedByJoinSet(..)
         );
         let first_upgrade_log = db_connection.get(&execution_id).await.unwrap();
-        assert_eq!(11, first_upgrade_log.events.len());
+        assert_eq!(10, first_upgrade_log.events.len());
+        assert!(
+            first_upgrade_log
+                .events
+                .iter()
+                .all(|event| !matches!(event.event, ExecutionRequest::Unlocked(_))),
+            "blocked auto-upgrade must not append Unlocked: {:?}",
+            first_upgrade_log.events
+        );
         assert_matches!(
             &first_upgrade_log.events[5].event,
             ExecutionRequest::Locked(_)
         );
         assert_matches!(
             &first_upgrade_log.events[6].event,
-            ExecutionRequest::ComponentUpgraded { component_digest, reason: ComponentUpgradeReason::Auto, .. } => {
+            ExecutionRequest::ComponentUpgradeFinished {
+                component_digest,
+                outcome: ComponentUpgradeOutcome::Success {
+                    reason: ComponentUpgradeReason::Auto,
+                },
+                ..
+            } => {
                 assert_eq!(&first_upgrade_component_id.component_digest, component_digest);
             }
         );
@@ -2487,16 +2501,6 @@ mod tests {
                 event: HistoryEvent::JoinNext { .. }
             }
         );
-        assert_matches!(
-            &first_upgrade_log.events[10].event,
-            ExecutionRequest::Unlocked {
-                reason: UnlockedReason::Other { reason },
-                ..
-            } => {
-                assert_eq!("auto-upgrade succeeded", reason.as_ref());
-            }
-        );
-
         sim_clock.move_time_forward(Duration::from_millis(10));
         assert_eq!(
             1,
@@ -2513,20 +2517,328 @@ mod tests {
                 .len()
         );
         let second_upgrade_log = db_connection.get(&execution_id).await.unwrap();
-        assert_eq!(14, second_upgrade_log.events.len());
+        assert_eq!(13, second_upgrade_log.events.len());
+        assert!(
+            second_upgrade_log
+                .events
+                .iter()
+                .all(|event| !matches!(event.event, ExecutionRequest::Unlocked(_))),
+            "finished auto-upgrade must not append Unlocked: {:?}",
+            second_upgrade_log.events
+        );
         assert_matches!(
-            &second_upgrade_log.events[11].event,
+            &second_upgrade_log.events[10].event,
             ExecutionRequest::Locked(_)
         );
         assert_matches!(
-            &second_upgrade_log.events[12].event,
-            ExecutionRequest::ComponentUpgraded { component_digest, reason: ComponentUpgradeReason::Auto, .. } => {
+            &second_upgrade_log.events[11].event,
+            ExecutionRequest::ComponentUpgradeFinished {
+                component_digest,
+                outcome: ComponentUpgradeOutcome::Success {
+                    reason: ComponentUpgradeReason::Auto,
+                },
+                ..
+            } => {
                 assert_eq!(&second_upgrade_component_id.component_digest, component_digest);
             }
         );
         assert_matches!(
-            &second_upgrade_log.events[13].event,
+            &second_upgrade_log.events[12].event,
             ExecutionRequest::Finished { .. }
+        );
+
+        drop(db_connection);
+        db_close.close().await;
+    }
+
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_auto_locking_upgrade_failure_records_failed_outcome(database: Database) {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+        let sim_clock = SimClock::epoch();
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "test-auto-locking-failure");
+        let original_js_source = r"
+        export default function test_auto_locking_failure(params) {
+            obelisk.sleep({ milliseconds: 10 });
+            return 'old';
+        }";
+        let failing_upgrade_js_source = r"
+        export default function test_auto_locking_failure(params) {
+            const js = obelisk.createJoinSet();
+            js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            return 'new';
+        }";
+
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+        let (original_worker, original_component_id, _original_runnable) =
+            compile_js_workflow_worker(
+                original_js_source,
+                &user_ffqn,
+                db_pool.clone(),
+                sim_clock.clone_box(),
+                fn_registry.clone(),
+                workflow_engine.clone(),
+            );
+        let (upgrade_worker, upgrade_component_id, _upgrade_runnable) = compile_js_workflow_worker(
+            failing_upgrade_js_source,
+            &user_ffqn,
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            fn_registry,
+            workflow_engine,
+        );
+        assert_ne!(
+            original_component_id.component_digest,
+            upgrade_component_id.component_digest
+        );
+
+        let original_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+            original_worker,
+            sim_clock.clone_box(),
+            db_pool.clone(),
+            LockingStrategy::Auto,
+            ExecutorId::from_parts(0, 9009),
+        );
+        let upgrade_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+            upgrade_worker,
+            sim_clock.clone_box(),
+            db_pool.clone(),
+            LockingStrategy::Auto,
+            ExecutorId::from_parts(0, 9010),
+        );
+
+        let execution_id = ExecutionId::from_parts(0, 9010);
+        let created_at = sim_clock.now();
+        let db_connection = db_pool.connection_test().await.unwrap();
+        db_connection
+            .create(CreateRequest {
+                created_at,
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: original_component_id,
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            1,
+            original_exec
+                .tick_test_await(sim_clock.now(), RunId::from_parts(0, 9009))
+                .await
+                .len()
+        );
+        sim_clock.move_time_forward(Duration::from_millis(10));
+        assert_eq!(
+            1,
+            expired_timers_watcher::tick_test(db_connection.as_ref(), sim_clock.now())
+                .await
+                .unwrap()
+                .expired_async_timers
+        );
+
+        assert_eq!(
+            1,
+            upgrade_exec
+                .tick_test_await(sim_clock.now(), RunId::from_parts(0, 9010))
+                .await
+                .len()
+        );
+
+        let log = db_connection.get(&execution_id).await.unwrap();
+        assert_eq!(8, log.events.len());
+        assert_matches!(&log.events[0].event, ExecutionRequest::Created { .. });
+        assert_matches!(&log.events[1].event, ExecutionRequest::Locked(_));
+        assert_matches!(&log.events[5].event, ExecutionRequest::Locked(_));
+        assert_matches!(
+            &log.events[6].event,
+            ExecutionRequest::ComponentUpgradeFinished {
+                component_digest,
+                outcome: ComponentUpgradeOutcome::Failed { reason },
+                ..
+            } => {
+                assert_eq!(&upgrade_component_id.component_digest, component_digest);
+                assert!(
+                    !reason.as_ref().is_empty(),
+                    "unexpected failure reason: {reason}"
+                );
+            }
+        );
+        assert_matches!(
+            &log.events[7].event,
+            ExecutionRequest::Unlocked(unlocked) => {
+                assert_eq!("auto-upgrade failed", unlocked.reason.as_ref());
+            }
+        );
+        assert_matches!(log.pending_state, PendingState::PendingAt(..));
+
+        drop(db_connection);
+        db_close.close().await;
+    }
+
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_auto_locking_upgrade_through_stub_write_appends_unlocked(
+        database: Database,
+    ) {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+        let sim_clock = SimClock::epoch();
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "test-auto-locking-stub");
+        let original_js_source = r"
+        export default function test_auto_locking_stub(params) {
+            return 'old';
+        }";
+        let stub_upgrade_js_source = r"
+        export default function test_auto_locking_stub(params) {
+            const js = obelisk.createJoinSet();
+            const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            obelisk.stub(execId, { 'ok': 'stubbed-by-upgrade' });
+            const response = js.joinNext();
+            if (!response.ok) throw 'stub failed';
+            return obelisk.getResult(execId);
+        }";
+
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+        let (_original_worker, original_component_id, _original_runnable) =
+            compile_js_workflow_worker(
+                original_js_source,
+                &user_ffqn,
+                db_pool.clone(),
+                sim_clock.clone_box(),
+                fn_registry.clone(),
+                workflow_engine.clone(),
+            );
+        let (upgrade_worker, upgrade_component_id, _upgrade_runnable) = compile_js_workflow_worker(
+            stub_upgrade_js_source,
+            &user_ffqn,
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            fn_registry,
+            workflow_engine,
+        );
+        assert_ne!(
+            original_component_id.component_digest,
+            upgrade_component_id.component_digest
+        );
+
+        let upgrade_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+            upgrade_worker,
+            sim_clock.clone_box(),
+            db_pool.clone(),
+            LockingStrategy::Auto,
+            ExecutorId::from_parts(0, 9011),
+        );
+
+        let execution_id = ExecutionId::from_parts(0, 9011);
+        let created_at = sim_clock.now();
+        let db_connection = db_pool.connection_test().await.unwrap();
+        db_connection
+            .create(CreateRequest {
+                created_at,
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: original_component_id,
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            1,
+            upgrade_exec
+                .tick_test_await(sim_clock.now(), RunId::from_parts(0, 9011))
+                .await
+                .len()
+        );
+
+        let pending_state = db_connection
+            .get_pending_state(&execution_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            upgrade_component_id.component_digest,
+            pending_state.component_digest
+        );
+        assert_matches!(pending_state.pending_state, PendingState::PendingAt(..));
+
+        let log = db_connection.get(&execution_id).await.unwrap();
+        assert_eq!(6, log.events.len());
+        assert_eq!(
+            1,
+            log.responses.len(),
+            "stub write should append a response"
+        );
+        assert_matches!(&log.events[0].event, ExecutionRequest::Created { .. });
+        assert_matches!(&log.events[1].event, ExecutionRequest::Locked(_));
+        assert_matches!(
+            &log.events[2].event,
+            ExecutionRequest::ComponentUpgradeFinished {
+                component_digest,
+                outcome: ComponentUpgradeOutcome::Success {
+                    reason: ComponentUpgradeReason::Auto,
+                },
+                ..
+            } => {
+                assert_eq!(&upgrade_component_id.component_digest, component_digest);
+            }
+        );
+        assert_matches!(
+            &log.events[3].event,
+            ExecutionRequest::HistoryEvent {
+                event: HistoryEvent::JoinSetCreate { .. }
+            }
+        );
+        assert_matches!(
+            &log.events[4].event,
+            ExecutionRequest::HistoryEvent {
+                event: HistoryEvent::JoinSetRequest {
+                    request: JoinSetRequest::ChildExecutionRequest { .. },
+                    ..
+                }
+            }
+        );
+        assert_matches!(
+            &log.events[5].event,
+            ExecutionRequest::Unlocked(unlocked) => {
+                assert_eq!("auto-upgrade succeeded", unlocked.reason.as_ref());
+            }
+        );
+        assert_matches!(
+            &log.responses[0].event.event.event,
+            JoinSetResponse::ChildExecutionFinished { result, .. } => {
+                let ok = assert_matches!(result, SupportedFunctionReturnValue::Ok(Some(ok)) => ok);
+                assert_eq!(WastVal::String("stubbed-by-upgrade".into()), ok.value);
+            }
         );
 
         drop(db_connection);

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -15,12 +15,13 @@ use crate::workflow::replay_db_proxy::{
 };
 use crate::workflow::workflow_ctx::{ImportedFnCall, ReplayKind, WorkerPartialResult};
 use crate::{RunnableComponent, WasmFileError};
+use assert_matches::assert_matches;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
 use concepts::storage::{
-    AppendRequest, CapturedDbWrite, ComponentUpgradeReason, DbConnection, DbErrorWrite, DbPool,
-    ExecutionLog, ExecutionRequest, Locked, UnlockedReason, Version,
+    AppendRequest, CapturedDbWrite, ComponentUpgradeOutcome, ComponentUpgradeReason, DbConnection,
+    DbErrorWrite, DbPool, ExecutionLog, ExecutionRequest, Locked, Unlocked, Version,
 };
 use concepts::time::{ClockFn, now_tokio_instant};
 use concepts::{
@@ -393,7 +394,7 @@ enum WorkerResultRefactored {
     DbError(DbErrorWrite),
     LockExpired(WorkflowCtx),
     ExecutorClosing(WorkflowCtx),
-    ReplayWaitingForResponse(WorkflowCtx),
+    ReplayWaitingForResponse(WorkflowCtx), // TODO: Rename to ReplayStubDbFlush
 }
 
 type CallFuncResult = Result<(SupportedFunctionReturnValue, WorkflowCtx), RunError>;
@@ -465,7 +466,7 @@ struct PrepareFuncFinished {
     params: Arc<[Val]>,
 }
 
-struct ReplayWaitingForResponse;
+struct ReplayWaitingForResponse; // TODO: Rename to ReplayStubDbFlush
 
 impl WorkflowWorker {
     pub(crate) async fn capture_replay_writes_from_log(
@@ -518,6 +519,15 @@ impl WorkflowWorker {
 
         self.replay_internal(ctx, replay_db_connection, replay_kind)
             .await
+            .map(|(writes, replay_end)| {
+                (
+                    writes,
+                    match replay_end {
+                        ReplayPendingState::FinishedWithFailure(fatal_error) => Some(fatal_error),
+                        _ => None,
+                    },
+                )
+            })
     }
 
     pub(crate) async fn advance_from_log(
@@ -973,26 +983,36 @@ impl WorkflowWorker {
     /// It can assume it is the only writer to its own and its children's execution log.
     /// In the worst case, e.g. on a race with an external stub response writer, the advance will
     /// fail, and the new replay will have to be issued.
-    pub(crate) async fn replay_internal(
+    async fn replay_internal(
         &self,
         ctx: WorkerContext,
         replay_db_connection: ReplayWorkflowDbConnection,
         replay_kind: ReplayKind,
-    ) -> Result<(Vec<InternalCapturedWrite>, Option<FatalError>), ReplayInternalError> {
-        let (retval, replay_db_connection, fatal_error) = match self
+    ) -> Result<(Vec<InternalCapturedWrite>, ReplayPendingState), ReplayInternalError> {
+        let (retval, replay_db_connection, replay_outcome) = match self
             .run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind))
             .await
         {
             Ok((Either::Left(WorkerResultOk::RunFinished(RunFinished { retval, .. })), db)) => {
-                Ok((Some(retval), db, None))
+                Ok((Some(retval), db, ReplayPendingState::Finished))
             }
-            Ok((_, db)) => Ok((None, db, None)), // replay interrupted or db updated (both have writes) or execution is waiting
+            Ok((Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher), db)) => {
+                Ok((None, db, ReplayPendingState::Blocked))
+            }
+            Ok((Either::Right(ReplayWaitingForResponse), db)) => {
+                // Only first phase of stubbing leaves the execution in `PendingState::Locked`
+                Ok((None, db, ReplayPendingState::Locked))
+            }
             Err(WorkflowError::FatalError { err, db_connection }) => {
                 debug!("Replay finished with fatal error: {err:?}");
                 let retval = SupportedFunctionReturnValue::ExecutionFailure(
                     FinishedExecutionFailure::from(&err),
                 );
-                Ok((Some(retval), db_connection, Some(err)))
+                Ok((
+                    Some(retval),
+                    db_connection,
+                    ReplayPendingState::FinishedWithFailure(err),
+                ))
             }
             Err(WorkflowError::LimitReached { reason, version }) => {
                 Err(ReplayInternalError::LimitReached { reason, version })
@@ -1018,6 +1038,10 @@ impl WorkflowWorker {
         if replay_kind == ReplayKind::Unfinished
             && let Some(retval) = retval
         {
+            assert_matches!(
+                replay_outcome,
+                ReplayPendingState::Finished | ReplayPendingState::FinishedWithFailure(_)
+            );
             debug!("Replay finished returning a value: {retval:?}");
             // Capture the Finished event that the executor would write.
             let version = replay_db_connection.version().clone();
@@ -1031,7 +1055,7 @@ impl WorkflowWorker {
                 parent,
             });
         }
-        Ok((replay_db_connection.into_writes(), fatal_error))
+        Ok((replay_db_connection.into_writes(), replay_outcome))
     }
 
     // Returns the same `db_connection` it was supplied.
@@ -1403,7 +1427,7 @@ impl WorkflowWorker {
             ..ctx
         };
 
-        let (mut fresh_replay, fatal_error) = self
+        let (mut fresh_replay, replay_pending_state) = self
             .replay_internal(replay_ctx, replay_db_connection, ReplayKind::Unfinished)
             .await
             .map_err(|err| match err {
@@ -1420,27 +1444,73 @@ impl WorkflowWorker {
                 }
             })?;
 
-        // Although not all fatal errors are caused by nondeterminism detected, auto upgrade will not persist any of them.
-        if let Some(fatal_error) = fatal_error {
+        // Explicit replay/advance may persist this fatal replay outcome as `Finished`.
+        // Auto-upgrade is implicit, so it only marks this component digest incompatible
+        // and leaves the execution available for manual replay/advance later.
+        if let ReplayPendingState::FinishedWithFailure(fatal_error) = replay_pending_state {
             // Set ignore_component_digest to avoid needless locks in the future.
+            let created_at = self.clock_fn.now();
             db_conn
-                .append(
-                    execution_id,
-                    version,
-                    AppendRequest {
-                        created_at: self.clock_fn.now(),
-                        event: ExecutionRequest::Unlocked {
-                            backoff_expires_at: self.clock_fn.now(),
-                            reason: UnlockedReason::AutoUpgradeFailed {
-                                target_digest: self.config.component_id.component_digest.clone(),
-                                reason: StrVariant::from(fatal_error.to_string()),
+                .append_batch(
+                    created_at,
+                    vec![
+                        AppendRequest {
+                            created_at,
+                            event: ExecutionRequest::ComponentUpgradeFinished {
+                                component_digest: self.config.component_id.component_digest.clone(),
+                                deployment_id: self.deployment_id,
+                                outcome: ComponentUpgradeOutcome::Failed {
+                                    reason: StrVariant::from(fatal_error.to_string()),
+                                },
                             },
                         },
-                    },
+                        AppendRequest {
+                            created_at,
+                            event: ExecutionRequest::Unlocked(Unlocked {
+                                backoff_expires_at: created_at,
+                                reason: "auto-upgrade failed".into(),
+                            }),
+                        },
+                    ],
+                    execution_id,
+                    version,
                 )
                 .await
                 .map_err(WorkerError::DbError)?;
             return Ok(()); // NOK but db already updated
+        }
+
+        if fresh_replay.is_empty() {
+            warn!("Auto upgrade failed - empty writes returned by replay"); // Unsure what the next pending state would be.
+            let created_at = self.clock_fn.now();
+            db_conn
+                .append_batch(
+                    created_at,
+                    vec![
+                        AppendRequest {
+                            created_at,
+                            event: ExecutionRequest::ComponentUpgradeFinished {
+                                component_digest: self.config.component_id.component_digest.clone(),
+                                deployment_id: self.deployment_id,
+                                outcome: ComponentUpgradeOutcome::Failed {
+                                    reason: "auto-upgrade replay produced no writes".into(),
+                                },
+                            },
+                        },
+                        AppendRequest {
+                            created_at,
+                            event: ExecutionRequest::Unlocked(Unlocked {
+                                backoff_expires_at: created_at,
+                                reason: "auto-upgrade failed".into(),
+                            }),
+                        },
+                    ],
+                    execution_id,
+                    version,
+                )
+                .await
+                .map_err(WorkerError::DbError)?;
+            return Ok(());
         }
 
         let version = db_conn
@@ -1449,59 +1519,56 @@ impl WorkflowWorker {
                 version,
                 AppendRequest {
                     created_at: self.clock_fn.now(),
-                    event: ExecutionRequest::ComponentUpgraded {
+                    event: ExecutionRequest::ComponentUpgradeFinished {
                         component_digest: new_digest,
                         deployment_id: self.deployment_id,
-                        reason: ComponentUpgradeReason::Auto,
+                        outcome: ComponentUpgradeOutcome::Success {
+                            reason: ComponentUpgradeReason::Auto,
+                        },
                     },
                 },
             )
             .await
             .map_err(WorkerError::DbError)?;
 
-        let unlock_version = {
-            if let Some(last) = fresh_replay.last() {
-                let finished = matches!(last.write, CapturedDbWrite::AppendFinished { .. });
-                bump_versions_for_execution(&mut fresh_replay, &execution_id);
-                let version = apply_writes(
-                    db_conn.as_ref(),
-                    &self.cancel_registry,
-                    self.logs_storage_config
-                        .as_ref()
-                        .map(|config| &config.log_sender),
-                    fresh_replay,
-                    version,
-                )
-                .await
-                .map_err(WorkerError::DbError)?;
-                if finished {
-                    None // Do not send Unlocked evend if execution is going to be finished.
-                } else {
-                    Some(version)
-                }
-            } else {
-                // No captured events = blocked
-                Some(version)
+        // accomodate for already appended `ExecutionRequest::ComponentUpgradeFinished`
+        bump_versions_for_execution(&mut fresh_replay, &execution_id);
+        let version = apply_writes(
+            db_conn.as_ref(),
+            &self.cancel_registry,
+            self.logs_storage_config
+                .as_ref()
+                .map(|config| &config.log_sender),
+            fresh_replay,
+            version,
+        )
+        .await
+        .map_err(WorkerError::DbError)?;
+        match replay_pending_state {
+            ReplayPendingState::Finished => {
+                debug!("Auto upgrade replay finished the execution");
             }
-        };
-
-        if let Some(unlock_version) = unlock_version {
-            db_conn
-                .append(
-                    execution_id,
-                    unlock_version,
-                    AppendRequest {
-                        created_at: self.clock_fn.now(),
-                        event: ExecutionRequest::Unlocked {
-                            backoff_expires_at: self.clock_fn.now(),
-                            reason: UnlockedReason::Other {
+            ReplayPendingState::Blocked => {
+                debug!("Auto upgrade replay blocked the execution");
+            }
+            ReplayPendingState::Locked => {
+                let created_at = self.clock_fn.now();
+                db_conn
+                    .append(
+                        execution_id,
+                        version,
+                        AppendRequest {
+                            created_at,
+                            event: ExecutionRequest::Unlocked(Unlocked {
+                                backoff_expires_at: created_at,
                                 reason: "auto-upgrade succeeded".into(),
-                            },
+                            }),
                         },
-                    },
-                )
-                .await
-                .map_err(WorkerError::DbError)?;
+                    )
+                    .await
+                    .map_err(WorkerError::DbError)?;
+            }
+            ReplayPendingState::FinishedWithFailure(_) => unreachable!("handled above"),
         }
         info!("Execution auto-upgraded");
         Ok(())
@@ -1549,6 +1616,14 @@ impl Worker for WorkflowWorker {
             }
         })
     }
+}
+
+#[derive(Debug)]
+enum ReplayPendingState {
+    Locked,
+    Blocked,
+    Finished,
+    FinishedWithFailure(FatalError),
 }
 
 #[cfg(any(test, feature = "test"))]

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -406,16 +406,25 @@ message ExecutionEvent {
     message Unpaused {
     }
 
-    message ComponentUpgraded {
+    message ComponentUpgradeFinished {
         message Auto {
         }
         message Manual {
             bool force = 1;
         }
+        message Success {
+            oneof reason {
+                Auto auto = 1;
+                Manual manual = 2;
+            }
+        }
+        message Failed {
+            string reason = 1;
+        }
         ContentDigest component_digest = 1;
-        oneof reason {
-            Auto auto = 2;
-            Manual manual = 3;
+        oneof outcome {
+            Success success = 2;
+            Failed failed = 3;
         }
         DeploymentId deployment_id = 4;
     }
@@ -608,7 +617,7 @@ message ExecutionEvent {
         HistoryEvent history_variant = 9;
         Paused paused = 11;
         Unpaused unpaused = 12;
-        ComponentUpgraded component_upgraded = 13;
+        ComponentUpgradeFinished component_upgrade_finished = 13;
     }
 
     optional uint32 backtrace_id = 10;


### PR DESCRIPTION
Replace the success-only `ComponentUpgraded` event with
`ComponentUpgradeFinished` so both successful and failed auto-upgrades are
recorded in the execution log. Failed upgrades mark the new digest as
incompatible through the log instead of updating t_state directly.

Tighten `Unlocked` so it only releases a locked execution back to `PendingAt`,
while keeping the previous `backoff_expires_at` wire shape for JSON/proto
compatibility. Auto-upgrade appends `Unlocked` only when replay stops during
a stub-response flush and would otherwise leave the execution locked, leading
to a timeout.

This fixes the case where auto-upgrade unconditionally moved executions to
`PendingAt` (via `ComponentUpgraded`, allowing a blocked workflow to be
picked up immediately and panic on the next execution run if the response
had not arrived yet.

Add tests for blocked upgrades, failed upgrades, and the stub-write path
that still needs Unlocked.
