### PR TITLE
refactor: Always set locking strategy to `Interrupt` for replays

### DIFF
--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -916,6 +916,8 @@ pub enum DbErrorWriteNonRetriable {
         source: Option<Arc<dyn std::error::Error + Send + Sync>>,
         loc: &'static Location<'static>,
     },
+    #[error("illegal state: `Unlocked` cannot be appended in state {0}")]
+    UnlockedCannotBeAppended(&'static str),
     #[error("version conflict: expected: {expected}, got: {requested}")]
     VersionConflict {
         expected: Version,

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2153,12 +2153,7 @@ async fn append(
             match &combined_state.execution_with_state.pending_state {
                 PendingState::PendingAt(_) => {
                     return Err(DbErrorWrite::NonRetriable(
-                        DbErrorWriteNonRetriable::IllegalState {
-                            reason: "`Unlocked` cannot be appended to a pending execution".into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        },
+                        DbErrorWriteNonRetriable::UnlockedCannotBeAppended("pending"),
                     ));
                 }
                 PendingState::Locked(_) => {
@@ -2174,22 +2169,12 @@ async fn append(
                 }
                 PendingState::BlockedByJoinSet(_) => {
                     return Err(DbErrorWrite::NonRetriable(
-                        DbErrorWriteNonRetriable::IllegalState {
-                            reason: "`Unlocked` cannot be appended to a blocked execution".into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        },
+                        DbErrorWriteNonRetriable::UnlockedCannotBeAppended("blocked"),
                     ));
                 }
                 PendingState::Paused(_) => {
                     return Err(DbErrorWrite::NonRetriable(
-                        DbErrorWriteNonRetriable::IllegalState {
-                            reason: "`Unlocked` cannot be appended to a paused execution".into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        },
+                        DbErrorWriteNonRetriable::UnlockedCannotBeAppended("paused"),
                     ));
                 }
                 PendingState::Finished(_) => {

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2139,59 +2139,44 @@ impl SqlitePool {
                 return Ok((next_version, notifier));
             }
 
-            ExecutionRequest::Unlocked(unlocked) => match &combined_state
-                .execution_with_state
-                .pending_state
-            {
-                PendingState::PendingAt(_) => {
-                    return Err(DbErrorWrite::NonRetriable(
-                        DbErrorWriteNonRetriable::IllegalState {
-                            reason: "`Unlocked` cannot be appended to a pending execution".into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        },
-                    ));
+            ExecutionRequest::Unlocked(unlocked) => {
+                match &combined_state.execution_with_state.pending_state {
+                    PendingState::PendingAt(_) => {
+                        return Err(DbErrorWrite::NonRetriable(
+                            DbErrorWriteNonRetriable::UnlockedCannotBeAppended("pending"),
+                        ));
+                    }
+                    PendingState::Locked(_) => {
+                        let (next_version, notifier) =
+                            Self::update_state_pending_after_event_appended(
+                                tx,
+                                execution_id,
+                                &appending_version,
+                                PendingAfterEventUpdate {
+                                    scheduled_at: unlocked.backoff_expires_at,
+                                    intermittent_failure: false,
+                                    component_input_digest: combined_state
+                                        .execution_with_state
+                                        .component_digest,
+                                },
+                            )?;
+                        return Ok((next_version, notifier));
+                    }
+                    PendingState::BlockedByJoinSet(_) => {
+                        return Err(DbErrorWrite::NonRetriable(
+                            DbErrorWriteNonRetriable::UnlockedCannotBeAppended("blocked"),
+                        ));
+                    }
+                    PendingState::Paused(_) => {
+                        return Err(DbErrorWrite::NonRetriable(
+                            DbErrorWriteNonRetriable::UnlockedCannotBeAppended("paused"),
+                        ));
+                    }
+                    PendingState::Finished(_) => {
+                        unreachable!("handled above");
+                    }
                 }
-                PendingState::Locked(_) => {
-                    let (next_version, notifier) = Self::update_state_pending_after_event_appended(
-                        tx,
-                        execution_id,
-                        &appending_version,
-                        PendingAfterEventUpdate {
-                            scheduled_at: unlocked.backoff_expires_at,
-                            intermittent_failure: false,
-                            component_input_digest: combined_state
-                                .execution_with_state
-                                .component_digest,
-                        },
-                    )?;
-                    return Ok((next_version, notifier));
-                }
-                PendingState::BlockedByJoinSet(_) => {
-                    return Err(DbErrorWrite::NonRetriable(
-                        DbErrorWriteNonRetriable::IllegalState {
-                            reason: "`Unlocked` cannot be appended to a blocked execution".into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        },
-                    ));
-                }
-                PendingState::Paused(_) => {
-                    return Err(DbErrorWrite::NonRetriable(
-                        DbErrorWriteNonRetriable::IllegalState {
-                            reason: "`Unlocked` cannot be appended to a paused execution".into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        },
-                    ));
-                }
-                PendingState::Finished(_) => {
-                    unreachable!("handled above");
-                }
-            },
+            }
 
             ExecutionRequest::ComponentUpgradeFinished {
                 component_digest,

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -6,7 +6,8 @@ use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, RunId};
 use concepts::storage::{
     AppendEventsToExecution, AppendRequest, AppendResponseToExecution, DbErrorGeneric,
-    DbErrorWrite, DbExecutor, DbPool, ExecutionLog, LockedExecution, Unlocked,
+    DbErrorWrite, DbErrorWriteNonRetriable, DbExecutor, DbPool, ExecutionLog, LockedExecution,
+    Unlocked,
 };
 use concepts::time::{ClockFn, Sleep};
 use concepts::{
@@ -878,9 +879,18 @@ impl Append {
                 .append_batch_respond_to_parent(events, response, self.created_at)
                 .await?;
         } else {
-            db_exec
+            let res = db_exec
                 .append(self.execution_id, self.version, self.primary_event)
-                .await?;
+                .await;
+            match res {
+                Ok(_)
+                | Err(DbErrorWrite::NonRetriable(
+                    DbErrorWriteNonRetriable::UnlockedCannotBeAppended(_),
+                )) => {
+                    // Ignore unsuccessful `Unlocked`
+                }
+                Err(err) => return Err(err),
+            }
         }
         Ok(())
     }

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -1845,13 +1845,9 @@ async fn cannot_append_unlocked_to_blocked_execution(database: Database) {
         )
         .await
         .unwrap_err();
-    let reason = assert_matches!(
+    assert_matches!(
         err,
-        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason
-    );
-    assert_eq!(
-        "`Unlocked` cannot be appended to a blocked execution",
-        reason.to_string()
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::UnlockedCannotBeAppended(_))
     );
 
     drop(db_connection);
@@ -1911,13 +1907,9 @@ async fn cannot_append_unlocked_to_paused_execution(database: Database) {
         )
         .await
         .unwrap_err();
-    let reason = assert_matches!(
+    assert_matches!(
         err,
-        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason
-    );
-    assert_eq!(
-        "`Unlocked` cannot be appended to a paused execution",
-        reason.to_string()
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::UnlockedCannotBeAppended(_))
     );
 
     drop(db_connection);

--- a/crates/wasm-workers/src/cron/cron_worker.rs
+++ b/crates/wasm-workers/src/cron/cron_worker.rs
@@ -136,6 +136,7 @@ impl Worker for CronWorker {
             },
             Some(next_fire) => {
                 debug!(next_fire = %next_fire, "Scheduling next tick");
+                // Unlocked transition must be valid - execution was just locked
                 AppendRequest {
                     created_at: now,
                     event: ExecutionRequest::Unlocked(Unlocked {

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -470,6 +470,19 @@ struct PrepareFuncFinished {
 
 struct ReplayInterrupt;
 
+struct WorkflowWorkerView<'a> {
+    deployment_id: DeploymentId,
+    config: &'a WorkflowConfig,
+    engine: &'a Engine,
+    clock_fn: Box<dyn ClockFn>,
+    exported_ffqn_to_index: &'a hashbrown::HashMap<FunctionFqn, ComponentExportIndex>,
+    instance_pre: &'a InstancePre<WorkflowCtx>,
+    fn_registry: Arc<dyn FunctionRegistry>,
+    cancel_registry: CancelRegistry,
+    deadline_factory: &'a dyn DeadlineTrackerFactory,
+    logs_storage_config: Option<LogStrageConfig>,
+}
+
 impl WorkflowWorker {
     pub(crate) async fn capture_replay_writes_from_log(
         &self,
@@ -477,7 +490,7 @@ impl WorkflowWorker {
         log: ExecutionLog,
         ffqn: FunctionFqn,
         params: Params,
-        real_connection: Box<dyn DbConnection>,
+        db_conn: Box<dyn DbConnection>,
     ) -> Result<
         (
             Vec<InternalCapturedWrite>,
@@ -524,7 +537,7 @@ impl WorkflowWorker {
             replay_kind,
             execution_id,
             log.next_version,
-            real_connection,
+            db_conn,
             parent,
         )
         .await
@@ -592,14 +605,13 @@ impl WorkflowWorker {
     }
 
     async fn prepare_func(
-        &self,
         ctx: WorkerContext,
         db_connection: Box<dyn WorkflowDbConnection>,
         is_replay: Option<ReplayKind>,
+        view: WorkflowWorkerView<'_>,
     ) -> Result<PrepareFuncFinished, WorkflowError> {
-        assert_eq!(self.config.component_id, ctx.locked_event.component_id);
-
-        let deadline_tracker = match self
+        assert_eq!(view.config.component_id, ctx.locked_event.component_id);
+        let deadline_tracker = match view
             .deadline_factory
             .create(ctx.locked_event.lock_expires_at, ctx.executor_close_watcher)
         {
@@ -615,29 +627,29 @@ impl WorkflowWorker {
 
         let seed = ctx.execution_id.random_seed();
         let workflow_ctx = WorkflowCtx::new(
-            self.deployment_id,
+            view.deployment_id,
             db_connection,
             ctx.event_history,
             ctx.responses,
             seed,
-            self.clock_fn.clone_box(),
-            self.config.join_next_blocking_strategy,
+            view.clock_fn,
+            view.config.join_next_blocking_strategy,
             ctx.worker_span,
-            self.config.backtrace_persist,
+            view.config.backtrace_persist,
             deadline_tracker,
-            self.fn_registry.clone(),
-            self.cancel_registry.clone(),
+            view.fn_registry,
+            view.cancel_registry,
             ctx.locked_event,
-            self.config.lock_extension,
-            self.config.subscription_interruption,
-            self.logs_storage_config.clone(),
+            view.config.lock_extension,
+            view.config.subscription_interruption,
+            view.logs_storage_config,
             is_replay,
         );
 
-        let mut store = Store::new(&self.engine, workflow_ctx);
+        let mut store = Store::new(view.engine, workflow_ctx);
 
         // Set fuel.
-        if let Some(fuel) = self.config.fuel {
+        if let Some(fuel) = view.config.fuel {
             store
                 .set_fuel(fuel)
                 .expect("engine must have `consume_fuel` enabled");
@@ -664,7 +676,7 @@ impl WorkflowWorker {
             }
         });
 
-        let instance = match self.instance_pre.instantiate_async(&mut store).await {
+        let instance = match view.instance_pre.instantiate_async(&mut store).await {
             Ok(instance) => instance,
             Err(err) => {
                 let reason = err.to_string();
@@ -684,13 +696,13 @@ impl WorkflowWorker {
         };
 
         let func = {
-            let Some(fn_export_index) = self.exported_ffqn_to_index.get(&ctx.ffqn) else {
+            let Some(fn_export_index) = view.exported_ffqn_to_index.get(&ctx.ffqn) else {
                 let db_connection = store.into_data().db_connection;
                 return Err(WorkflowError::FatalError {
                     err: FatalError::CannotInstantiate {
                         reason: format!(
                             "function {} not found in exports of {}",
-                            ctx.ffqn, self.config.component_id
+                            ctx.ffqn, view.config.component_id
                         ),
                         detail: None,
                     },
@@ -1006,46 +1018,60 @@ impl WorkflowWorker {
         ),
         ReplayInternalError,
     > {
+        let mut replay_config = self.config.clone();
+        replay_config.join_next_blocking_strategy = JoinNextBlockingStrategy::Interrupt;
+        let view = WorkflowWorkerView {
+            deployment_id: self.deployment_id,
+            config: &replay_config,
+            engine: &self.engine,
+            clock_fn: self.clock_fn.clone_box(),
+            exported_ffqn_to_index: &self.exported_ffqn_to_index,
+            instance_pre: &self.instance_pre,
+            fn_registry: self.fn_registry.clone(),
+            cancel_registry: self.cancel_registry.clone(),
+            deadline_factory: self.deadline_factory.as_ref(),
+            logs_storage_config: self.logs_storage_config.clone(),
+        };
         let replay_db_connection =
             ReplayWorkflowDbConnection::new(execution_id, version, real_connection, parent);
-        let (retval, replay_db_connection, replay_outcome) = match self
-            .run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind))
-            .await
-        {
-            Ok((Either::Left(WorkerResultOk::RunFinished(RunFinished { retval, .. })), db)) => {
-                Ok((Some(retval), db, ReplayPendingState::Finished))
-            }
-            Ok((Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher), db)) => {
-                Ok((None, db, ReplayPendingState::Blocked))
-            }
-            Ok((Either::Right(ReplayInterrupt), db)) => {
-                // Only first phase of stubbing leaves the execution in `PendingState::Locked`
-                Ok((None, db, ReplayPendingState::Locked))
-            }
-            Err(WorkflowError::FatalError { err, db_connection }) => {
-                debug!("Replay finished with fatal error: {err:?}");
-                let retval = SupportedFunctionReturnValue::ExecutionFailure(
-                    FinishedExecutionFailure::from(&err),
-                );
-                Ok((
-                    Some(retval),
-                    db_connection,
-                    ReplayPendingState::FinishedWithFailure(err),
-                ))
-            }
-            Err(WorkflowError::LimitReached { reason, version }) => {
-                Err(ReplayInternalError::LimitReached { reason, version })
-            }
-            Err(WorkflowError::DbError(db_error_write)) => {
-                Err(ReplayInternalError::DbError(db_error_write))
-            }
-            Err(WorkflowError::LockExpired(version)) => {
-                Err(ReplayInternalError::LockExpired(version))
-            }
-            Err(WorkflowError::ExecutorClosing(version)) => {
-                Err(ReplayInternalError::ExecutorClosing(version))
-            }
-        }?;
+        let (retval, replay_db_connection, replay_outcome) =
+            match Self::run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind), view)
+                .await
+            {
+                Ok((Either::Left(WorkerResultOk::RunFinished(RunFinished { retval, .. })), db)) => {
+                    Ok((Some(retval), db, ReplayPendingState::Finished))
+                }
+                Ok((Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher), db)) => {
+                    Ok((None, db, ReplayPendingState::Blocked))
+                }
+                Ok((Either::Right(ReplayInterrupt), db)) => {
+                    // Only first phase of stubbing leaves the execution in `PendingState::Locked`
+                    Ok((None, db, ReplayPendingState::Locked))
+                }
+                Err(WorkflowError::FatalError { err, db_connection }) => {
+                    debug!("Replay finished with fatal error: {err:?}");
+                    let retval = SupportedFunctionReturnValue::ExecutionFailure(
+                        FinishedExecutionFailure::from(&err),
+                    );
+                    Ok((
+                        Some(retval),
+                        db_connection,
+                        ReplayPendingState::FinishedWithFailure(err),
+                    ))
+                }
+                Err(WorkflowError::LimitReached { reason, version }) => {
+                    Err(ReplayInternalError::LimitReached { reason, version })
+                }
+                Err(WorkflowError::DbError(db_error_write)) => {
+                    Err(ReplayInternalError::DbError(db_error_write))
+                }
+                Err(WorkflowError::LockExpired(version)) => {
+                    Err(ReplayInternalError::LockExpired(version))
+                }
+                Err(WorkflowError::ExecutorClosing(version)) => {
+                    Err(ReplayInternalError::ExecutorClosing(version))
+                }
+            }?;
 
         let Ok(mut replay_db_connection) = replay_db_connection
             .as_any()
@@ -1080,10 +1106,10 @@ impl WorkflowWorker {
 
     // Returns the same `db_connection` it was supplied.
     async fn run_internal(
-        &self,
         ctx: WorkerContext,
         db_connection: Box<dyn WorkflowDbConnection>,
         is_replay: Option<ReplayKind>,
+        view: WorkflowWorkerView<'_>,
     ) -> Result<
         (
             Either<WorkerResultOk, ReplayInterrupt>,
@@ -1098,7 +1124,8 @@ impl WorkflowWorker {
         }
         let worker_span = ctx.worker_span.clone();
         let execution_deadline = ctx.locked_event.lock_expires_at;
-        let prepare_finished = self.prepare_func(ctx, db_connection, is_replay).await?;
+        let fuel = view.config.fuel;
+        let prepare_finished = Self::prepare_func(ctx, db_connection, is_replay, view).await?;
         Self::call_func_convert_result(
             prepare_finished.store,
             prepare_finished.func,
@@ -1106,7 +1133,7 @@ impl WorkflowWorker {
             prepare_finished.params,
             &worker_span,
             execution_deadline,
-            self.config.fuel,
+            fuel,
         )
         .await
     }
@@ -1230,15 +1257,15 @@ enum CloseJoinSetOk {
 
 impl WorkflowWorker {
     async fn auto_upgrade_locked(&self, ctx: WorkerContext) -> Result<(), WorkerError> {
+        info!("Auto-upgrading execution");
         let new_digest = self.config.component_id.component_digest.clone();
         let execution_id = ctx.execution_id.clone();
         let version = ctx.version.clone();
         let parent = ctx.parent.clone();
         let replay_ctx = WorkerContext {
-            can_be_retried: true,
+            can_be_retried: true, // avoid a warning in log
             ..ctx
         };
-
         let (mut fresh_replay, replay_pending_state, db_conn) = self
             .replay_internal(
                 replay_ctx,
@@ -1419,13 +1446,25 @@ impl Worker for WorkflowWorker {
         worker_span.in_scope(|| {
             info!("Execution run started",);
         });
-        let res = self
-            .run_internal(
-                ctx,
-                db_connection,
-                None, // is_replay
-            )
-            .await;
+        let view = WorkflowWorkerView {
+            deployment_id: self.deployment_id,
+            config: &self.config,
+            engine: &self.engine,
+            clock_fn: self.clock_fn.clone_box(),
+            exported_ffqn_to_index: &self.exported_ffqn_to_index,
+            instance_pre: &self.instance_pre,
+            fn_registry: self.fn_registry.clone(),
+            cancel_registry: self.cancel_registry.clone(),
+            deadline_factory: self.deadline_factory.as_ref(),
+            logs_storage_config: self.logs_storage_config.clone(),
+        };
+        let res = Self::run_internal(
+            ctx,
+            db_connection,
+            None, // is_replay
+            view,
+        )
+        .await;
         worker_span.in_scope(|| match res {
             Ok((Either::Left(ok), _)) => {
                 info!("Execution run finished");

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1313,6 +1313,7 @@ impl WorkflowWorker {
                                 },
                             },
                         },
+                        // Unlocked transition must be valid - execution was just locked
                         AppendRequest {
                             created_at,
                             event: ExecutionRequest::Unlocked(Unlocked {
@@ -1346,6 +1347,7 @@ impl WorkflowWorker {
                                 },
                             },
                         },
+                        // Unlocked transition must be valid - execution was just locked
                         AppendRequest {
                             created_at,
                             event: ExecutionRequest::Unlocked(Unlocked {


### PR DESCRIPTION
- **refactor: Always set locking strategy to `Interrupt` for replays**
- **refactor(db): Add `UnlockedCannotBeAppended` error, ignored by executor**
