### PR TITLE
refactor(webhook): Persist execution id on first app log

### DIFF
--- a/crates/wasm-workers/src/activity/activity_ctx.rs
+++ b/crates/wasm-workers/src/activity/activity_ctx.rs
@@ -115,23 +115,23 @@ pub(crate) fn store(
 }
 
 impl log_activities::obelisk::log::log::Host for ActivityCtx {
-    fn trace(&mut self, message: String) {
+    async fn trace(&mut self, message: String) {
         self.component_logger.log(LogLevel::Trace, message);
     }
 
-    fn debug(&mut self, message: String) {
+    async fn debug(&mut self, message: String) {
         self.component_logger.log(LogLevel::Debug, message);
     }
 
-    fn info(&mut self, message: String) {
+    async fn info(&mut self, message: String) {
         self.component_logger.log(LogLevel::Info, message);
     }
 
-    fn warn(&mut self, message: String) {
+    async fn warn(&mut self, message: String) {
         self.component_logger.log(LogLevel::Warn, message);
     }
 
-    fn error(&mut self, message: String) {
+    async fn error(&mut self, message: String) {
         self.component_logger.log(LogLevel::Error, message);
     }
 }

--- a/crates/wasm-workers/src/component_logger.rs
+++ b/crates/wasm-workers/src/component_logger.rs
@@ -64,5 +64,9 @@ pub(crate) mod log_activities {
                         import obelisk:log/log@1.0.0;
                     }",
         world: "any:any/bindings",
+        imports: {
+            // Async so webhook impl can lazily create its execution row before appending the log.
+            "obelisk:log/log@1.0.0": async,
+        },
     });
 }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -709,7 +709,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(id) => id,
             Err(err) => {
                 let msg = format!("schedule-json: invalid execution ID: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::FfqnParsingError(msg).into());
             }
         };
@@ -720,7 +720,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
                 Ok(ffqn) => ffqn,
                 Err(err) => {
                     let msg = format!("schedule-json: invalid function name: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Err(ScheduleJsonError::FfqnParsingError(msg).into());
                 }
             };
@@ -728,7 +728,8 @@ impl WebhookSupportHost for WebhookEndpointCtx {
         // Look up function in registry
         let Some((fn_metadata, component_id)) = self.fn_registry.get_by_exported_function(&ffqn)
         else {
-            self.error("schedule-json: function not found".to_string());
+            self.error("schedule-json: function not found".to_string())
+                .await;
             return Err(ScheduleJsonError::FunctionNotFound.into());
         };
 
@@ -737,12 +738,12 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(serde_json::Value::Array(arr)) => arr,
             Ok(_) => {
                 let msg = "schedule-json: params must be a JSON array".to_string();
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
             Err(err) => {
                 let msg = format!("schedule-json: cannot parse params as JSON: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
         };
@@ -758,7 +759,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(params) => params,
             Err(err) => {
                 let msg = format!("schedule-json: params type checking failed: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
         };
@@ -770,7 +771,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(dt) => dt,
             Err(err) => {
                 let msg = format!("schedule-json: invalid schedule-at: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
         };
@@ -860,7 +861,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
                 Ok(ffqn) => ffqn,
                 Err(err) => {
                     let msg = format!("call-json: invalid function name: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Err(ScheduleJsonError::FfqnParsingError(msg).into());
                 }
             };
@@ -868,7 +869,8 @@ impl WebhookSupportHost for WebhookEndpointCtx {
         // Look up function in registry
         let Some((fn_metadata, component_id)) = self.fn_registry.get_by_exported_function(&ffqn)
         else {
-            self.error("call-json: function not found".to_string());
+            self.error("call-json: function not found".to_string())
+                .await;
             return Err(ScheduleJsonError::FunctionNotFound.into());
         };
 
@@ -877,12 +879,12 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(serde_json::Value::Array(arr)) => arr,
             Ok(_) => {
                 let msg = "call-json: params must be a JSON array".to_string();
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
             Err(err) => {
                 let msg = format!("call-json: cannot parse params as JSON: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
         };
@@ -898,7 +900,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(params) => params,
             Err(err) => {
                 let msg = format!("call-json: params type checking failed: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(ScheduleJsonError::TypeCheckError(msg).into());
             }
         };
@@ -1043,7 +1045,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             Ok(id) => id,
             Err(err) => {
                 let msg = format!("get-status: cannot parse execution ID: {err}");
-                self.error(msg.clone());
+                self.error(msg.clone()).await;
                 return Err(GetStatusError::ExecutionIdParsingError(msg).into());
             }
         };
@@ -1110,7 +1112,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
                 Ok(id) => id,
                 Err(err) => {
                     let msg = format!("get: cannot parse execution ID: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Err(GetError::ExecutionIdParsingError(msg).into());
                 }
             };
@@ -1161,7 +1163,7 @@ impl WebhookSupportHost for WebhookEndpointCtx {
                 Ok(id) => id,
                 Err(err) => {
                     let msg = format!("try-get: cannot parse execution ID: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Err(TryGetError::ExecutionIdParsingError(msg).into());
                 }
             };
@@ -1181,7 +1183,8 @@ impl WebhookSupportHost for WebhookEndpointCtx {
         {
             Ok(state) => state,
             Err(DbErrorRead::NotFound) => {
-                self.error(format!("try-get: execution not found: {}", execution_id.id));
+                self.error(format!("try-get: execution not found: {}", execution_id.id))
+                    .await;
                 return Err(TryGetError::NotFound.into());
             }
             Err(err) => {
@@ -1256,6 +1259,21 @@ impl WebhookEndpointCtx {
         let version = conn.create(create_request).await?;
         self.version = Some(version.clone());
         Ok(version)
+    }
+
+    // Best-effort: ensure the top-level execution row exists so `t_log` rows aren't orphaned.
+    // Failures are tracing-only. Skips the DB roundtrip when the log level is below the
+    // configured min_level (no row would be appended anyway).
+    async fn ensure_execution_row_for_log(&mut self, level: LogLevel) {
+        if self.version.is_none()
+            && let Some(config) = &self.component_logger.logs_storage_config
+            && (level as u8) >= (config.min_level as u8)
+        {
+            let res = self.get_version_or_create().await;
+            if let Err(err) = res {
+                debug!("Cannot persist log: failed to create execution row: {err:?}");
+            }
+        }
     }
 
     /// Create a new `OneOff` join set and return its ID along with a child execution ID.
@@ -1754,23 +1772,28 @@ impl WebhookEndpointCtx {
 }
 
 impl log_activities::obelisk::log::log::Host for WebhookEndpointCtx {
-    fn trace(&mut self, message: String) {
+    async fn trace(&mut self, message: String) {
+        self.ensure_execution_row_for_log(LogLevel::Trace).await;
         self.component_logger.log(LogLevel::Trace, message);
     }
 
-    fn debug(&mut self, message: String) {
+    async fn debug(&mut self, message: String) {
+        self.ensure_execution_row_for_log(LogLevel::Debug).await;
         self.component_logger.log(LogLevel::Debug, message);
     }
 
-    fn info(&mut self, message: String) {
+    async fn info(&mut self, message: String) {
+        self.ensure_execution_row_for_log(LogLevel::Info).await;
         self.component_logger.log(LogLevel::Info, message);
     }
 
-    fn warn(&mut self, message: String) {
+    async fn warn(&mut self, message: String) {
+        self.ensure_execution_row_for_log(LogLevel::Warn).await;
         self.component_logger.log(LogLevel::Warn, message);
     }
 
-    fn error(&mut self, message: String) {
+    async fn error(&mut self, message: String) {
+        self.ensure_execution_row_for_log(LogLevel::Error).await;
         self.component_logger.log(LogLevel::Error, message);
     }
 }

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -1407,7 +1407,7 @@ impl WorkflowCtx {
                             Ok(id) => id,
                             Err(err) => {
                                 let msg = format!("schedule-json: invalid execution ID: {err}");
-                                host.error(msg.clone());
+                                host.error(msg.clone()).await;
                                 return Ok((Err(ScheduleJsonError::FfqnParsingError(msg)),));
                             }
                         };
@@ -1418,7 +1418,7 @@ impl WorkflowCtx {
                             Ok(ffqn) => ffqn,
                             Err(err) => {
                                 let msg = format!("schedule-json: invalid function name: {err}");
-                                host.error(msg.clone());
+                                host.error(msg.clone()).await;
                                 return Ok((Err(ScheduleJsonError::FfqnParsingError(msg)),));
                             }
                         };
@@ -1453,7 +1453,7 @@ impl WorkflowCtx {
                             Err(err) => {
                                 use latest::obelisk::workflow::workflow_support::ScheduleJsonError;
                                 let msg = format!("call-json: invalid function name: {err}");
-                                host.error(msg.clone());
+                                host.error(msg.clone()).await;
                                 return Ok((Err(ScheduleJsonError::FfqnParsingError(msg)),));
                             }
                         };
@@ -2368,12 +2368,12 @@ pub(crate) mod workflow_support {
                 Ok(serde_json::Value::Array(params)) => params,
                 Ok(_other) => {
                     let msg = "schedule-json: params must be a json array".to_string();
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Ok(Err(ScheduleJsonError::TypeCheckError(msg)));
                 }
                 Err(err) => {
                     let msg = format!("schedule-json: cannot parse params as JSON array: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Ok(Err(ScheduleJsonError::TypeCheckError(msg)));
                 }
             };
@@ -2396,11 +2396,13 @@ pub(crate) mod workflow_support {
             match result {
                 Ok(()) => Ok(Ok(())),
                 Err(ScheduleRequestError::FunctionNotFound) => {
-                    self.error("schedule-json: function not found".to_string());
+                    self.error("schedule-json: function not found".to_string())
+                        .await;
                     Ok(Err(ScheduleJsonError::FunctionNotFound))
                 }
                 Err(ScheduleRequestError::TypeCheckError(msg)) => {
-                    self.error(format!("schedule-json: type check error: {msg}"));
+                    self.error(format!("schedule-json: type check error: {msg}"))
+                        .await;
                     Ok(Err(ScheduleJsonError::TypeCheckError(msg)))
                 }
             }
@@ -2581,12 +2583,12 @@ pub(crate) mod workflow_support {
                 Ok(ExecutionId::TopLevel(_)) => {
                     let msg = "stub-json: execution-id must be a derived (child) execution ID, not a top-level one"
                         .to_string();
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Ok(Err(StubJsonError::ExecutionIdParsingError(msg)));
                 }
                 Err(err) => {
                     let msg = format!("stub-json: cannot parse execution-id: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Ok(Err(StubJsonError::ExecutionIdParsingError(msg)));
                 }
             };
@@ -2635,12 +2637,12 @@ pub(crate) mod workflow_support {
                 Ok(serde_json::Value::Array(params)) => params,
                 Ok(_other) => {
                     let msg = "call-json: params must be a json array".to_string();
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Ok(Err(ScheduleJsonError::TypeCheckError(msg)));
                 }
                 Err(err) => {
                     let msg = format!("call-json: cannot parse params as JSON array: {err}");
-                    self.error(msg.clone());
+                    self.error(msg.clone()).await;
                     return Ok(Err(ScheduleJsonError::TypeCheckError(msg)));
                 }
             };
@@ -2653,11 +2655,13 @@ pub(crate) mod workflow_support {
                     params,
                 } => (fn_component_id, params),
                 SubmitChildIntent::Err(ChildExecutionRequestError::FunctionNotFound) => {
-                    self.error(format!("call-json: function not found: {target_ffqn}"));
+                    self.error(format!("call-json: function not found: {target_ffqn}"))
+                        .await;
                     return Ok(Err(ScheduleJsonError::FunctionNotFound));
                 }
                 SubmitChildIntent::Err(ChildExecutionRequestError::TypeCheckError(msg)) => {
-                    self.error(format!("call-json: type check error: {msg}"));
+                    self.error(format!("call-json: type check error: {msg}"))
+                        .await;
                     return Ok(Err(ScheduleJsonError::TypeCheckError(msg)));
                 }
             };
@@ -2757,7 +2761,7 @@ fn capture_replay_application_log(ctx: &mut WorkflowCtx, level: LogLevel, messag
 }
 
 impl log_activities::obelisk::log::log::Host for WorkflowCtx {
-    fn trace(&mut self, message: String) {
+    async fn trace(&mut self, message: String) {
         if capture_replay_application_log(self, LogLevel::Trace, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Trace, &message);
         } else {
@@ -2765,7 +2769,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
         }
     }
 
-    fn debug(&mut self, message: String) {
+    async fn debug(&mut self, message: String) {
         if capture_replay_application_log(self, LogLevel::Debug, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Debug, &message);
         } else {
@@ -2773,7 +2777,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
         }
     }
 
-    fn info(&mut self, message: String) {
+    async fn info(&mut self, message: String) {
         if capture_replay_application_log(self, LogLevel::Info, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Info, &message);
         } else {
@@ -2781,7 +2785,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
         }
     }
 
-    fn warn(&mut self, message: String) {
+    async fn warn(&mut self, message: String) {
         if capture_replay_application_log(self, LogLevel::Warn, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Warn, &message);
         } else {
@@ -2789,7 +2793,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
         }
     }
 
-    fn error(&mut self, message: String) {
+    async fn error(&mut self, message: String) {
         if capture_replay_application_log(self, LogLevel::Error, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Error, &message);
         } else {


### PR DESCRIPTION
Avoid orphaned messages in `t_log` without corresponding execution in `t_execution_log`.
