### PR TITLE
js runtimes refactor

### DIFF
--- a/assets/activity-js-runtime-version.txt
+++ b/assets/activity-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/activity-js-runtime:2026-03-28@sha256:e17d896c29f92fed302829d629b4354d0e9404885e68ede9eb19fae9dc65f7d7
+oci://docker.io/getobelisk/activity-js-runtime:2026-06-09@sha256:5e4fe38ee3238707686079f1c83683042117f33db2455dc705fc912bf553c46c

--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-05-23-1@sha256:835684028f3098feb8cfa7fcadda6c1ebd7d73cf7323f9fdd3efa5f364a47cfa
+oci://docker.io/getobelisk/webhook-js-runtime:2026-06-09@sha256:66fadb55c49ad97d4ad58cb7b66c6469d672f2e905c8e36b1c7ae1bad8cafa22

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-05-23-1@sha256:6f36e25794bc5d02170a3eecf773757595afb64e189fca48cce702764b5f3167
+oci://docker.io/getobelisk/workflow-js-runtime:2026-06-09@sha256:27d8b82f6457cede0448da30e977392e919e4abc17d93181d7f86901f30d42dc

--- a/crates/activity-js-runtime/src/activity_js_runtime.rs
+++ b/crates/activity-js-runtime/src/activity_js_runtime.rs
@@ -98,24 +98,17 @@ async fn execute_async(
     // Get the default export function from the ES module
     let default_fn = match get_default_export(js_code, &context, executor).await {
         Ok(func) => func,
-        Err(EsmError::ParseError(msg)) => {
-            host_fn_error(&format!("module parse error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmError::LoadError(msg)) => {
-            host_fn_error(&format!("module load error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmError::LinkError(msg)) => {
-            host_fn_error(&format!("module link error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmError::EvalError(msg)) => {
-            host_fn_error(&format!("module eval error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmError::NoDefaultExport | EsmError::DefaultNotCallable) => {
-            return Err(JsRuntimeError::NoDefaultExport);
+        Err(err) => {
+            let msg = match err {
+                EsmError::ParseError(msg) => format!("module parse error: {msg}"),
+                EsmError::LoadError(msg) => format!("module load error: {msg}"),
+                EsmError::LinkError(msg) => format!("module link error: {msg}"),
+                EsmError::EvalError(msg) => format!("module eval error: {msg}"),
+                EsmError::NoDefaultExport => "no default export".to_string(),
+                EsmError::DefaultNotCallable => "default export is not callable".to_string(),
+            };
+            host_fn_error(&msg);
+            return Err(JsRuntimeError::CannotInstantiate(msg));
         }
     };
 

--- a/crates/activity-js-runtime/wit/obelisk_js-runtime/execute.wit
+++ b/crates/activity-js-runtime/wit/obelisk_js-runtime/execute.wit
@@ -3,14 +3,14 @@ package obelisk-activity:activity-js-runtime;
 interface execute {
 
     variant js-runtime-error {
-        execution-failed, // Must exist to satisfy Obelisk contract
-        /// Error when `js-code` could not be parsed as an ES module.
-        module-parse-error(string),
-        /// `js-code` was parsed, but does not have a callable default export.
-        no-default-export,
-        // Function was executed and succeeded, but did not type check.
+        /// Must exist to satisfy Obelisk contract.
+        execution-failed,
+        /// JS source could not be loaded — parse error, missing default
+        /// export, etc. String is a human-readable description.
+        cannot-instantiate(string),
+        /// Function was executed and succeeded, but did not type check.
         wrong-return-type(string),
-        // Function was executed and threw an error, but it did not type check.
+        /// Function was executed and threw an error, but it did not type check.
         wrong-thrown-type(string),
     }
 

--- a/crates/boa-common/src/imports.rs
+++ b/crates/boa-common/src/imports.rs
@@ -84,9 +84,13 @@ pub fn register_import_modules(
         // SyntheticModuleInitializer to retrieve during evaluation.
         let exports_obj = JsObject::with_null_proto();
         for (js_name, wit_name) in funcs {
+            // The host has already verified every `wit_name` against the
+            // package suffix in `wasm-workers::js_imports`, so the strip /
+            // suffix-match calls below are infallible by construction.
             let proxy = if let Some(base_specifier) = &schedule_base {
-                // Schedule proxy: strip `-schedule` from wit_name to get base function name
-                let base_fn = wit_name.strip_suffix("-schedule").unwrap_or(wit_name);
+                let base_fn = wit_name.strip_suffix("-schedule").unwrap_or_else(|| {
+                    unreachable!("host-resolved schedule import `{wit_name}` must end with `-schedule`")
+                });
                 create_proxy(
                     ProxyKind::Schedule {
                         interface_name: base_specifier,
@@ -95,7 +99,6 @@ pub fn register_import_modules(
                     context,
                 )
             } else if let Some(base_specifier) = &ext_base {
-                // Extension proxy: determine type from wit_name suffix
                 if let Some(base_fn) = wit_name.strip_suffix("-submit") {
                     create_proxy(
                         ProxyKind::ExtSubmit {
@@ -109,18 +112,15 @@ pub fn register_import_modules(
                 } else if wit_name.ends_with("-get") {
                     create_proxy(ProxyKind::ExtGet, context)
                 } else {
-                    // Unknown ext suffix — fall back to direct call on base specifier
-                    create_proxy(
-                        ProxyKind::DirectCall {
-                            interface_name: base_specifier,
-                            function_name: wit_name,
-                        },
-                        context,
+                    unreachable!(
+                        "host-resolved ext import `{wit_name}` must end with \
+                         `-submit`, `-await-next`, or `-get`"
                     )
                 }
             } else if let Some(base_specifier) = &stub_base {
-                // Stub proxy: strip `-stub` from wit_name to get base function name
-                let base_fn = wit_name.strip_suffix("-stub").unwrap_or(wit_name);
+                let base_fn = wit_name.strip_suffix("-stub").unwrap_or_else(|| {
+                    unreachable!("host-resolved stub import `{wit_name}` must end with `-stub`")
+                });
                 create_proxy(
                     ProxyKind::Stub {
                         interface_name: base_specifier,

--- a/crates/boa-common/src/imports.rs
+++ b/crates/boa-common/src/imports.rs
@@ -89,7 +89,9 @@ pub fn register_import_modules(
             // suffix-match calls below are infallible by construction.
             let proxy = if let Some(base_specifier) = &schedule_base {
                 let base_fn = wit_name.strip_suffix("-schedule").unwrap_or_else(|| {
-                    unreachable!("host-resolved schedule import `{wit_name}` must end with `-schedule`")
+                    unreachable!(
+                        "host-resolved schedule import `{wit_name}` must end with `-schedule`"
+                    )
                 });
                 create_proxy(
                     ProxyKind::Schedule {

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -251,18 +251,18 @@ impl Worker for ActivityJsWorker {
                             version,
                         ))
                     }
-                    "module_parse_error" | "no_default_export" => {
-                        let detail = payload.as_ref().and_then(|p| {
-                            if let WastVal::String(s) = p.as_ref() {
-                                Some(s.clone())
-                            } else {
-                                None
-                            }
-                        });
+                    "cannot_instantiate" => {
+                        let reason = if let Some(payload) = payload
+                            && let WastVal::String(s) = payload.as_ref()
+                        {
+                            s.clone()
+                        } else {
+                            unreachable!("cannot-instantiate carries a string payload")
+                        };
                         Err(WorkerError::FatalError(
                             FatalError::CannotInstantiate {
-                                reason: format!("js-runtime-error: {name}"),
-                                detail,
+                                reason,
+                                detail: None,
                             },
                             version,
                         ))
@@ -746,7 +746,7 @@ mod tests {
                 FatalError::CannotInstantiate { reason, detail: _ },
                 _version,
             ) => {
-                assert!(reason.contains("no_default_export"), "reason: {reason}");
+                assert!(reason.contains("no default export"), "reason: {reason}");
             }
         );
     }
@@ -771,7 +771,7 @@ mod tests {
                 FatalError::CannotInstantiate { reason, detail: _ },
                 _version,
             ) => {
-                assert!(reason.contains("module_parse_error"), "reason: {reason}");
+                assert!(reason.contains("module parse error"), "reason: {reason}");
             }
         );
     }

--- a/crates/wasm-workers/src/js_imports.rs
+++ b/crates/wasm-workers/src/js_imports.rs
@@ -105,9 +105,7 @@ fn extract_and_verify<'a>(
             let js_name = interner
                 .resolve_expect(sym)
                 .utf8()
-                .ok_or_else(|| {
-                    format!("imported name from `{specifier}` is not valid UTF-8")
-                })?;
+                .ok_or_else(|| format!("imported name from `{specifier}` is not valid UTF-8"))?;
             verify_named_import(js_name, ifc)?;
         }
 

--- a/crates/wasm-workers/src/js_imports.rs
+++ b/crates/wasm-workers/src/js_imports.rs
@@ -1,31 +1,14 @@
 //! Shared JS import extraction and resolution for Boa-based runtimes.
 //!
 //! Used by both `workflow_js_worker` and `webhook_trigger` to parse JS source,
-//! extract ES module imports, and resolve them against the function registry.
+//! extract ES module imports, validate them against the function registry,
+//! and expand each referenced interface into the full set of function bindings
+//! the synthetic module needs to expose.
 
 use boa_engine::ast::declaration::ImportName;
-use concepts::FunctionRegistry;
+use concepts::{FunctionRegistry, IfcFqnName, PackageIfcFns};
 use std::collections::HashMap;
-
-/// Suffix appended to WIT package names for schedule imports.
-const SCHEDULE_SUFFIX: &str = "-obelisk-schedule";
-/// Suffix appended to WIT package names for extension imports (submit/awaitNext/get).
-const EXT_SUFFIX: &str = "-obelisk-ext";
-/// Suffix appended to WIT package names for stub imports.
-const STUB_SUFFIX: &str = "-obelisk-stub";
-
-/// Strip an obelisk suffix from a WIT specifier's package name.
-///
-/// Specifier format: `"ns:pkg-obelisk-schedule/ifc"` → `"ns:pkg/ifc"`.
-/// Returns `Some(base_specifier)` if the suffix was found, `None` otherwise.
-fn strip_specifier_suffix(specifier: &str, suffix: &str) -> Option<String> {
-    let slash_pos = specifier.find('/')?;
-    let pkg_part = &specifier[..slash_pos];
-    let ifc_part = &specifier[slash_pos..];
-    pkg_part
-        .strip_suffix(suffix)
-        .map(|base_pkg| format!("{base_pkg}{ifc_part}"))
-}
+use std::str::FromStr;
 
 /// Convert a JS camelCase name to WIT kebab-case.
 fn camel_to_kebab(s: &str) -> String {
@@ -45,18 +28,18 @@ fn camel_to_kebab(s: &str) -> String {
     result
 }
 
-/// Import kind extracted from JS source.
+/// A function imported via `import { ... } from 'ns:pkg/ifc'`, with both its
+/// JS-side camelCase name and the resolved WIT kebab-case name.
 #[derive(Debug)]
-enum JsImportKind {
-    /// `import { a, b } from 'spec'` — list of (`js_name`, `wit_name`) pairs.
-    Named(Vec<(String, String)>),
-    /// `import * as ns from 'spec'`.
-    Namespace,
+pub(crate) struct NamedFnImport {
+    pub js_name: String,
+    pub wit_name: String,
 }
 
 /// Convert a WIT kebab-case name to JS camelCase.
 ///
-/// Examples: `"account-info"` → `"accountInfo"`, `"add"` → `"add"`.
+/// Examples: `"account-info"` → `"accountInfo"`, `"add"` → `"add"`,
+/// `"add-submit"` → `"addSubmit"`.
 fn kebab_to_camel(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut capitalize_next = false;
@@ -75,11 +58,19 @@ fn kebab_to_camel(s: &str) -> String {
     result
 }
 
-/// Extract import specifiers and their imported names from JS source code.
+/// Parse JS source, validate every non-`obelisk:` import against the function
+/// registry, and return the deduped map of referenced interfaces with their
+/// resolved `PackageIfcFns` entry from the registry. The registry already
+/// lists `-obelisk-*` extension interfaces separately with their suffixed
+/// function names, so an `import` from `pkg-obelisk-ext/ifc` resolves to the
+/// extension entry directly — no per-flavor synthesis on this side.
 ///
-/// Returns a map from specifier to `JsImportKind`.
-/// Imports from the `obelisk:` namespace are skipped (those are host-provided APIs).
-fn extract_js_imports(js_code: &str) -> Result<HashMap<String, JsImportKind>, String> {
+/// Named imports are checked function-by-function so typos surface at link
+/// time. Namespace imports (`import * as`) just contribute their interface.
+fn extract_and_verify<'a>(
+    js_code: &str,
+    all_exports: &'a [PackageIfcFns],
+) -> Result<HashMap<IfcFqnName, &'a PackageIfcFns>, String> {
     let mut interner = boa_engine::interner::Interner::new();
     let mut parser = boa_engine::parser::Parser::new(boa_engine::Source::from_bytes(js_code));
     let scope = boa_engine::ast::scope::Scope::new_global();
@@ -87,173 +78,91 @@ fn extract_js_imports(js_code: &str) -> Result<HashMap<String, JsImportKind>, St
         .parse_module(&scope, &mut interner)
         .map_err(|e| format!("import extraction parse error: {e}"))?;
 
-    let mut imports: HashMap<String, JsImportKind> = HashMap::new();
+    let mut referenced: HashMap<IfcFqnName, &PackageIfcFns> = HashMap::new();
 
     for entry in module.items().import_entries() {
         let specifier = interner
             .resolve_expect(entry.module_request())
             .utf8()
-            .unwrap_or("")
-            .to_string();
+            .ok_or_else(|| "import specifier is not valid UTF-8".to_string())?;
 
-        // Skip obelisk: namespace (host-provided)
-        if specifier.starts_with("obelisk:") {
+        let ifc_fqn = IfcFqnName::from_str(specifier).map_err(|e| {
+            format!(
+                "import specifier `{specifier}` is not a WIT interface FQN \
+                 (`ns:pkg/ifc` or `ns:pkg/ifc@ver`): {e}"
+            )
+        })?;
+        if ifc_fqn.is_namespace_obelisk() {
             continue;
         }
 
-        match entry.import_name() {
-            ImportName::Name(sym) => {
-                let js_name = interner
-                    .resolve_expect(sym)
-                    .utf8()
-                    .unwrap_or("")
-                    .to_string();
-                let wit_name = camel_to_kebab(&js_name);
-                match imports.entry(specifier) {
-                    std::collections::hash_map::Entry::Occupied(mut e) => {
-                        if let JsImportKind::Named(funcs) = e.get_mut() {
-                            funcs.push((js_name, wit_name));
-                        }
-                    }
-                    std::collections::hash_map::Entry::Vacant(e) => {
-                        e.insert(JsImportKind::Named(vec![(js_name, wit_name)]));
-                    }
-                }
-            }
-            ImportName::Namespace => {
-                imports.insert(specifier, JsImportKind::Namespace);
-            }
+        let ifc = all_exports
+            .iter()
+            .find(|pkg| pkg.ifc_fqn == ifc_fqn)
+            .ok_or_else(|| format!("interface `{ifc_fqn}` not found for import"))?;
+
+        if let ImportName::Name(sym) = entry.import_name() {
+            let js_name = interner
+                .resolve_expect(sym)
+                .utf8()
+                .ok_or_else(|| {
+                    format!("imported name from `{specifier}` is not valid UTF-8")
+                })?;
+            verify_named_import(js_name, ifc)?;
         }
+
+        referenced.entry(ifc_fqn).or_insert(ifc);
     }
-    Ok(imports)
+    Ok(referenced)
+}
+
+/// Verify that a JS-side named import resolves to a real function on the
+/// interface. The registry's extension entries already carry suffixed
+/// function names (e.g. `add-submit`), so we just kebab-case the JS name and
+/// look it up directly.
+fn verify_named_import(js_name: &str, ifc: &PackageIfcFns) -> Result<(), String> {
+    let wit_name = camel_to_kebab(js_name);
+    if !ifc.fns.contains_key(wit_name.as_str()) {
+        return Err(format!(
+            "function `{ifc_fqn}.{wit_name}` (imported as `{js_name}`) not found",
+            ifc_fqn = ifc.ifc_fqn,
+        ));
+    }
+    Ok(())
 }
 
 /// Resolve JS imports against the function registry.
 ///
-/// Parses JS source to extract imports, then validates each import against the
-/// registry. For namespace imports (`import *`), resolves all functions for the
-/// interface. Handles `-obelisk-schedule` suffix by stripping it for lookup and
-/// adjusting function names.
+/// Returns one entry per referenced interface, with every function the
+/// synthetic module needs to expose so both `import { x }` and `import * as
+/// ns` from the same specifier work uniformly.
 ///
-/// Returns the fully resolved imports map: specifier → [(`js_name`, `wit_name`)].
-pub fn resolve_js_imports(
+/// The key preserves the original specifier (including any `-obelisk-*`
+/// package suffix) so the runtime can register the module under the same
+/// name JS uses.
+pub(crate) fn resolve_js_imports(
     js_code: &str,
     fn_registry: &dyn FunctionRegistry,
-) -> Result<HashMap<String, Vec<(String, String)>>, String> {
-    let raw_imports = extract_js_imports(js_code)?;
-    if raw_imports.is_empty() {
-        return Ok(HashMap::new());
-    }
-
+) -> Result<HashMap<IfcFqnName, Vec<NamedFnImport>>, String> {
     let all_exports = fn_registry.all_exports();
-    let mut resolved: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    let referenced = extract_and_verify(js_code, all_exports)?;
+    Ok(referenced
+        .into_iter()
+        .map(|(ifc_fqn, ifc)| (ifc_fqn, expand_interface(ifc)))
+        .collect())
+}
 
-    for (specifier, kind) in raw_imports {
-        // Check for obelisk suffixes that change the proxy type.
-        // For suffixed specifiers, look up the base interface for validation.
-        let schedule_base = strip_specifier_suffix(&specifier, SCHEDULE_SUFFIX);
-        let ext_base = strip_specifier_suffix(&specifier, EXT_SUFFIX);
-        let stub_base = strip_specifier_suffix(&specifier, STUB_SUFFIX);
-        let is_schedule = schedule_base.is_some();
-        let is_ext = ext_base.is_some();
-        let is_stub = stub_base.is_some();
-        let lookup_specifier = schedule_base
-            .as_deref()
-            .or(ext_base.as_deref())
-            .or(stub_base.as_deref())
-            .unwrap_or(&specifier);
-
-        // Find the interface in the registry using the base specifier
-        let ifc = all_exports
-            .iter()
-            .find(|pkg| &*pkg.ifc_fqn == lookup_specifier);
-
-        // Interface must exist at link time for all import kinds.
-        let ifc =
-            ifc.ok_or_else(|| format!("interface '{lookup_specifier}' not found for import"))?;
-
-        match kind {
-            JsImportKind::Named(funcs) => {
-                if is_schedule {
-                    // For schedule imports, strip the `-schedule` suffix from
-                    // wit_name before validating against the base interface.
-                    for (js_name, wit_name) in &funcs {
-                        let base_wit = wit_name.strip_suffix("-schedule").unwrap_or(wit_name);
-                        if !ifc.fns.keys().any(|k| &**k == base_wit) {
-                            return Err(format!(
-                                "function '{js_name}' (base '{base_wit}') not found in interface '{lookup_specifier}'"
-                            ));
-                        }
-                    }
-                } else if is_ext {
-                    // For ext imports, strip `-submit`, `-await-next`, or `-get`
-                    // suffix from wit_name before validating against the base interface.
-                    for (js_name, wit_name) in &funcs {
-                        let base_wit = wit_name
-                            .strip_suffix("-submit")
-                            .or_else(|| wit_name.strip_suffix("-await-next"))
-                            .or_else(|| wit_name.strip_suffix("-get"))
-                            .ok_or_else(|| {
-                                format!(
-                                    "ext import '{js_name}' ('{wit_name}') must end with \
-                                     Submit, AwaitNext, or Get"
-                                )
-                            })?;
-                        if !ifc.fns.keys().any(|k| &**k == base_wit) {
-                            return Err(format!(
-                                "function '{js_name}' (base '{base_wit}') not found in interface '{lookup_specifier}'"
-                            ));
-                        }
-                    }
-                } else if is_stub {
-                    // For stub imports, strip the `-stub` suffix from
-                    // wit_name before validating against the base interface.
-                    for (js_name, wit_name) in &funcs {
-                        let base_wit = wit_name.strip_suffix("-stub").unwrap_or(wit_name);
-                        if !ifc.fns.keys().any(|k| &**k == base_wit) {
-                            return Err(format!(
-                                "function '{js_name}' (base '{base_wit}') not found in interface '{lookup_specifier}'"
-                            ));
-                        }
-                    }
-                } else {
-                    // For direct call imports, validate each function exists
-                    for (js_name, wit_name) in &funcs {
-                        if !ifc.fns.keys().any(|k| &**k == wit_name) {
-                            return Err(format!(
-                                "function '{js_name}' ('{wit_name}') not found in interface '{specifier}'"
-                            ));
-                        }
-                    }
-                }
-                resolved.insert(specifier, funcs);
-            }
-            JsImportKind::Namespace => {
-                let mut funcs: Vec<(String, String)> = Vec::new();
-                for fn_name in ifc.fns.keys() {
-                    let wit_name = fn_name.to_string();
-                    let js_name = kebab_to_camel(&wit_name);
-                    if is_schedule {
-                        // Add Schedule suffix: "fibo" → "fiboSchedule" / "fibo-schedule"
-                        funcs.push((format!("{js_name}Schedule"), format!("{wit_name}-schedule")));
-                    } else if is_ext {
-                        // Generate three functions per base function
-                        funcs.push((format!("{js_name}Submit"), format!("{wit_name}-submit")));
-                        funcs.push((
-                            format!("{js_name}AwaitNext"),
-                            format!("{wit_name}-await-next"),
-                        ));
-                        funcs.push((format!("{js_name}Get"), format!("{wit_name}-get")));
-                    } else if is_stub {
-                        // Add Stub suffix: "myFunc" → "myFuncStub" / "my-func-stub"
-                        funcs.push((format!("{js_name}Stub"), format!("{wit_name}-stub")));
-                    } else {
-                        funcs.push((js_name, wit_name));
-                    }
-                }
-                resolved.insert(specifier, funcs);
-            }
-        }
-    }
-    Ok(resolved)
+/// Build the full list of `NamedFnImport` entries the synthetic module for
+/// this interface should expose. Extension interfaces already carry their
+/// suffixed function names in `ifc.fns`, so a straight kebab→camel mapping
+/// is all that's needed.
+fn expand_interface(ifc: &PackageIfcFns) -> Vec<NamedFnImport> {
+    ifc.fns
+        .keys()
+        .map(|fn_name| {
+            let wit_name = fn_name.to_string();
+            let js_name = kebab_to_camel(&wit_name);
+            NamedFnImport { js_name, wit_name }
+        })
+        .collect()
 }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -34,7 +34,6 @@ use hyper::{Method, StatusCode, Uri};
 use hyper_util::rt::TokioIo;
 use log_activities::obelisk::log::log::Host;
 use route_recognizer::{Match, Router};
-use std::collections::HashMap;
 use std::ops::Deref;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -306,13 +305,22 @@ impl WebhookEndpointCompiled {
             }
         }
 
-        // Resolve JS imports against the function registry before linking.
-        let mut config = self.config;
-        if let Some(js_config) = &mut config.js_config {
-            js_config.resolved_imports =
-                crate::js_imports::resolve_js_imports(&js_config.source, fn_registry)
-                    .map_err(|e| crate::WasmFileError::linking_error("JS import resolution", e))?;
-        }
+        // Resolve JS imports against the function registry before linking and
+        // serialize the result once — the runtime reads it from an env var, so
+        // there's no point doing the work per request.
+        let resolved_imports_json = if let Some(js_config) = &self.config.js_config {
+            let resolved = crate::js_imports::resolve_js_imports(&js_config.source, fn_registry)
+                .map_err(|e| crate::WasmFileError::linking_error("JS import resolution", e))?;
+            if resolved.is_empty() {
+                None
+            } else {
+                let json =
+                    serde_json::to_string(&resolved).expect("resolved imports must be serializable");
+                Some(Arc::from(json))
+            }
+        } else {
+            None
+        };
 
         // Pre-instantiate to catch missing imports
         let proxy_pre = linker
@@ -325,8 +333,9 @@ impl WebhookEndpointCompiled {
         })?);
 
         Ok(WebhookEndpointInstanceLinked {
-            config: Arc::new(config),
+            config: Arc::new(self.config),
             proxy_pre,
+            resolved_imports_json,
         })
     }
 }
@@ -336,6 +345,9 @@ pub struct WebhookEndpointInstanceLinked {
     #[debug(skip)]
     proxy_pre: Arc<ProxyPre<WebhookEndpointCtx>>,
     config: Arc<WebhookEndpointConfig>,
+    /// Set on JS webhooks; serialized `HashMap<String, Vec<(String, String)>>` passed
+    /// to the runtime via the `__OBELISK_RESOLVED_IMPORTS__` env var.
+    resolved_imports_json: Option<Arc<str>>,
 }
 impl WebhookEndpointInstanceLinked {
     #[must_use]
@@ -548,9 +560,6 @@ pub struct WebhookEndpointConfig {
 pub struct WebhookEndpointJsConfig {
     pub source: String,
     pub file_name: String,
-    /// Resolved imports: specifier → [(`js_name`, `wit_name`)].
-    /// Serialized as JSON and passed to the runtime via `__OBELISK_RESOLVED_IMPORTS__`.
-    pub resolved_imports: HashMap<String, Vec<(String, String)>>,
 }
 
 struct WebhookEndpointCtx {
@@ -1585,6 +1594,7 @@ impl WebhookEndpointCtx {
     fn new<'a>(
         deployment_id: DeploymentId,
         config: &Arc<WebhookEndpointConfig>,
+        resolved_imports_json: Option<&'a str>,
         engine: &Engine,
         clock_fn: Box<dyn ClockFn>,
         sleep: Arc<dyn Sleep>,
@@ -1627,10 +1637,8 @@ impl WebhookEndpointCtx {
         if let Some(js_config) = &config.js_config {
             wasi_ctx.env("__OBELISK_JS_SOURCE__", &js_config.source);
             wasi_ctx.env("__OBELISK_JS_FILE_NAME__", &js_config.file_name);
-            if !js_config.resolved_imports.is_empty() {
-                let imports_json = serde_json::to_string(&js_config.resolved_imports)
-                    .expect("resolved imports must be serializable");
-                wasi_ctx.env("__OBELISK_RESOLVED_IMPORTS__", &imports_json);
+            if let Some(resolved_imports_json) = resolved_imports_json {
+                wasi_ctx.env("__OBELISK_RESOLVED_IMPORTS__", resolved_imports_json);
             }
         }
 
@@ -1926,6 +1934,7 @@ impl RequestHandler {
             let mut store = WebhookEndpointCtx::new(
                 self.deployment_id,
                 &found_instance.config,
+                instance_match.handler().resolved_imports_json.as_deref(),
                 &self.engine,
                 self.clock_fn,
                 self.sleep,
@@ -2700,7 +2709,6 @@ pub(crate) mod tests {
         use concepts::prefixed_ulid::DEPLOYMENT_ID_DUMMY;
         use concepts::time::{ClockFn, TokioSleep};
         use concepts::{ComponentId, ComponentType, StrVariant};
-        use std::collections::HashMap;
         use std::net::SocketAddr;
         use std::sync::Arc;
         use test_utils::sim_clock::SimClock;
@@ -2752,7 +2760,6 @@ pub(crate) mod tests {
                         js_config: Some(WebhookEndpointJsConfig {
                             source: source.to_string(),
                             file_name: String::new(),
-                            resolved_imports: HashMap::new(),
                         }),
                         config_section_hint:
                             crate::http_hooks::ConfigSectionHint::WebhookEndpointJs,
@@ -2903,7 +2910,6 @@ pub(crate) mod tests {
                         js_config: Some(WebhookEndpointJsConfig {
                             source: source.to_string(),
                             file_name: String::new(),
-                            resolved_imports: HashMap::new(),
                         }),
                         config_section_hint:
                             crate::http_hooks::ConfigSectionHint::WebhookEndpointJs,
@@ -3279,7 +3285,6 @@ pub(crate) mod tests {
                             js_config: Some(WebhookEndpointJsConfig {
                                 source: js_source.to_string(),
                                 file_name: String::new(),
-                                resolved_imports: HashMap::new(),
                             }),
                             config_section_hint:
                                 crate::http_hooks::ConfigSectionHint::WebhookEndpointJs,

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -328,8 +328,8 @@ impl WebhookEndpointCompiled {
                         )
                     })
                     .collect();
-                let json = serde_json::to_string(&tupled)
-                    .expect("resolved imports must be serializable");
+                let json =
+                    serde_json::to_string(&tupled).expect("resolved imports must be serializable");
                 Some(Arc::from(json))
             }
         } else {

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -307,15 +307,29 @@ impl WebhookEndpointCompiled {
 
         // Resolve JS imports against the function registry before linking and
         // serialize the result once — the runtime reads it from an env var, so
-        // there's no point doing the work per request.
+        // there's no point doing the work per request. The webhook runtime
+        // currently consumes pairs as `[js_name, wit_name]` tuples, so we
+        // flatten `NamedFnImport` to that shape at the boundary.
         let resolved_imports_json = if let Some(js_config) = &self.config.js_config {
             let resolved = crate::js_imports::resolve_js_imports(&js_config.source, fn_registry)
                 .map_err(|e| crate::WasmFileError::linking_error("JS import resolution", e))?;
             if resolved.is_empty() {
                 None
             } else {
-                let json =
-                    serde_json::to_string(&resolved).expect("resolved imports must be serializable");
+                let tupled: std::collections::HashMap<&IfcFqnName, Vec<(&str, &str)>> = resolved
+                    .iter()
+                    .map(|(ifc_fqn, funcs)| {
+                        (
+                            ifc_fqn,
+                            funcs
+                                .iter()
+                                .map(|f| (f.js_name.as_str(), f.wit_name.as_str()))
+                                .collect(),
+                        )
+                    })
+                    .collect();
+                let json = serde_json::to_string(&tupled)
+                    .expect("resolved imports must be serializable");
                 Some(Arc::from(json))
             }
         } else {

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info};
 use utils::wasm_tools::WasmComponent;
-use val_json::type_wrapper::TypeWrapper;
+use val_json::type_wrapper::{TypeKey, TypeWrapper, indexmap::IndexMap};
 use val_json::wast_val::{WastVal, WastValWithType};
 
 /// Compiled JS workflow. Holds the compiled Boa WASM component + JS source + user FFQN.
@@ -183,23 +183,24 @@ impl WorkflowJsWorker {
             })
             .collect();
 
-        // Serialize resolved imports as list<tuple<string, list<tuple<string, string>>>>
+        // Serialize resolved imports as list<resolved-interface-imports>, where
+        // each entry is a record { ifc-fqn, functions: list<named-fn-import> }.
         let imports_json: Vec<serde_json::Value> = resolved_imports
             .iter()
-            .map(|(specifier, funcs)| {
+            .map(|(ifc_fqn, funcs)| {
                 let funcs_json: Vec<serde_json::Value> = funcs
                     .iter()
                     .map(|(js_name, wit_name)| {
-                        serde_json::Value::Array(vec![
-                            serde_json::Value::String(js_name.clone()),
-                            serde_json::Value::String(wit_name.clone()),
-                        ])
+                        serde_json::json!({
+                            "js_name": js_name,
+                            "wit_name": wit_name,
+                        })
                     })
                     .collect();
-                serde_json::Value::Array(vec![
-                    serde_json::Value::String(specifier.clone()),
-                    serde_json::Value::Array(funcs_json),
-                ])
+                serde_json::json!({
+                    "ifc_fqn": ifc_fqn,
+                    "functions": funcs_json,
+                })
             })
             .collect();
 
@@ -211,19 +212,24 @@ impl WorkflowJsWorker {
             js_file_name.map_or(serde_json::Value::Null, serde_json::Value::String),
             serde_json::Value::Array(imports_json),
         ]);
+        let named_fn_import_ty = TypeWrapper::Record(IndexMap::from([
+            (TypeKey::new_kebab("js-name"), TypeWrapper::String),
+            (TypeKey::new_kebab("wit-name"), TypeWrapper::String),
+        ]));
+        let resolved_interface_imports_ty = TypeWrapper::Record(IndexMap::from([
+            (TypeKey::new_kebab("ifc-fqn"), TypeWrapper::String),
+            (
+                TypeKey::new_kebab("functions"),
+                TypeWrapper::List(Box::new(named_fn_import_ty)),
+            ),
+        ]));
         let params = Params::from_json_values(
             boa_params,
             [
                 &TypeWrapper::String,
                 &TypeWrapper::List(Box::new(TypeWrapper::String)),
                 &TypeWrapper::Option(Box::new(TypeWrapper::String)),
-                &TypeWrapper::List(Box::new(TypeWrapper::Tuple(Box::new([
-                    TypeWrapper::String,
-                    TypeWrapper::List(Box::new(TypeWrapper::Tuple(Box::new([
-                        TypeWrapper::String,
-                        TypeWrapper::String,
-                    ])))),
-                ])))),
+                &TypeWrapper::List(Box::new(resolved_interface_imports_ty)),
             ]
             .into_iter(),
         )
@@ -365,18 +371,18 @@ fn transform_to_outer_result(
                         version,
                     ))
                 }
-                "module_parse_error" | "no_default_export" => {
-                    let detail = payload.as_ref().and_then(|p| {
-                        if let WastVal::String(s) = p.as_ref() {
-                            Some(s.clone())
-                        } else {
-                            None
-                        }
-                    });
+                "cannot_instantiate" => {
+                    let reason = if let Some(payload) = payload
+                        && let WastVal::String(s) = payload.as_ref()
+                    {
+                        s.clone()
+                    } else {
+                        unreachable!("cannot-instantiate carries a string payload")
+                    };
                     Err((
                         FatalError::CannotInstantiate {
-                            reason: format!("js-runtime-error: {name}"),
-                            detail,
+                            reason,
+                            detail: None,
                         },
                         version,
                     ))
@@ -1034,7 +1040,7 @@ mod tests {
                 FatalError::CannotInstantiate { reason, detail: _ },
                 _version,
             ) => {
-                assert!(reason.contains("no_default_export"), "reason: {reason}");
+                assert!(reason.contains("no default export"), "reason: {reason}");
             }
         );
     }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -17,8 +17,8 @@ use concepts::storage::http_client_trace::HttpClientTrace;
 use concepts::storage::{CapturedDbWrite, DbPool, Version};
 use concepts::{
     ComponentType, ExecutionFailureKind, ExecutionId, FinishedExecutionFailure, FunctionFqn,
-    FunctionMetadata, FunctionRegistry, PackageIfcFns, ParameterType, Params, ResultParsingError,
-    ResultParsingErrorFromVal, ReturnTypeExtendable, SupportedFunctionReturnValue,
+    FunctionMetadata, FunctionRegistry, IfcFqnName, PackageIfcFns, ParameterType, Params,
+    ResultParsingError, ResultParsingErrorFromVal, ReturnTypeExtendable, SupportedFunctionReturnValue,
 };
 use executor::worker::{
     FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
@@ -119,8 +119,8 @@ pub struct WorkflowJsWorkerLinked {
     user_params: Vec<ParameterType>,
     user_return_type: ReturnTypeExtendable,
     user_exports_noext: Vec<FunctionMetadata>,
-    /// Resolved imports: specifier → [(`js_name`, `wit_name`)].
-    resolved_imports: HashMap<String, Vec<(String, String)>>,
+    /// Resolved imports: interface FQN → imported functions.
+    resolved_imports: HashMap<IfcFqnName, Vec<NamedFnImport>>,
 }
 
 impl WorkflowJsWorkerLinked {
@@ -158,18 +158,18 @@ pub struct WorkflowJsWorker {
     user_params: Vec<ParameterType>,
     user_return_type: ReturnTypeExtendable,
     user_exports_noext: Vec<FunctionMetadata>,
-    /// Resolved imports: specifier → [(`js_name`, `wit_name`)].
-    resolved_imports: HashMap<String, Vec<(String, String)>>,
+    /// Resolved imports: interface FQN → imported functions.
+    resolved_imports: HashMap<IfcFqnName, Vec<NamedFnImport>>,
 }
 
-use crate::js_imports::resolve_js_imports;
+use crate::js_imports::{NamedFnImport, resolve_js_imports};
 
 impl WorkflowJsWorker {
     fn boa_invocation(
         params: &Params,
         js_source: String,
         js_file_name: Option<String>,
-        resolved_imports: &HashMap<String, Vec<(String, String)>>,
+        resolved_imports: &HashMap<IfcFqnName, Vec<NamedFnImport>>,
     ) -> (FunctionFqn, Params) {
         let json_params = params
             .as_json_values()
@@ -190,7 +190,7 @@ impl WorkflowJsWorker {
             .map(|(ifc_fqn, funcs)| {
                 let funcs_json: Vec<serde_json::Value> = funcs
                     .iter()
-                    .map(|(js_name, wit_name)| {
+                    .map(|NamedFnImport { js_name, wit_name }| {
                         serde_json::json!({
                             "js_name": js_name,
                             "wit_name": wit_name,
@@ -198,7 +198,7 @@ impl WorkflowJsWorker {
                     })
                     .collect();
                 serde_json::json!({
-                    "ifc_fqn": ifc_fqn,
+                    "ifc_fqn": ifc_fqn.to_string(),
                     "functions": funcs_json,
                 })
             })

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -18,7 +18,8 @@ use concepts::storage::{CapturedDbWrite, DbPool, Version};
 use concepts::{
     ComponentType, ExecutionFailureKind, ExecutionId, FinishedExecutionFailure, FunctionFqn,
     FunctionMetadata, FunctionRegistry, IfcFqnName, PackageIfcFns, ParameterType, Params,
-    ResultParsingError, ResultParsingErrorFromVal, ReturnTypeExtendable, SupportedFunctionReturnValue,
+    ResultParsingError, ResultParsingErrorFromVal, ReturnTypeExtendable,
+    SupportedFunctionReturnValue,
 };
 use executor::worker::{
     FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,

--- a/crates/workflow-js-runtime/src/lib.rs
+++ b/crates/workflow-js-runtime/src/lib.rs
@@ -25,7 +25,9 @@ mod deterministic_executor;
 mod workflow_js_runtime;
 
 use generated::export;
-use generated::exports::obelisk_workflow::workflow_js_runtime::execute::{Guest, JsRuntimeError};
+use generated::exports::obelisk_workflow::workflow_js_runtime::execute::{
+    Guest, JsRuntimeError, ResolvedInterfaceImports,
+};
 
 pub struct Component;
 export!(Component with_types_in generated);
@@ -35,7 +37,7 @@ impl Guest for Component {
         js_code: String,
         params_json: Vec<String>,
         js_file_name: Option<String>,
-        resolved_imports: Vec<(String, Vec<(String, String)>)>,
+        resolved_imports: Vec<ResolvedInterfaceImports>,
     ) -> Result<Result<String, String>, JsRuntimeError> {
         workflow_js_runtime::execute(&js_code, &params_json, js_file_name, resolved_imports)
     }

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -120,7 +120,9 @@
 //! ```
 
 use crate::deterministic_executor::DeterministicJobExecutor;
-use crate::generated::exports::obelisk_workflow::workflow_js_runtime::execute::JsRuntimeError;
+use crate::generated::exports::obelisk_workflow::workflow_js_runtime::execute::{
+    JsRuntimeError, ResolvedInterfaceImports,
+};
 use crate::generated::obelisk::log::log as obelisk_log;
 use crate::generated::obelisk::types::backtrace::{FrameInfo, FrameSymbol, WasmBacktrace};
 use crate::generated::obelisk::types::execution::{ExecutionId, Function, ResponseId};
@@ -572,14 +574,26 @@ pub fn execute(
     js_code: &str,
     params_json: &[String],
     js_file_name: Option<String>,
-    resolved_imports: Vec<(String, Vec<(String, String)>)>,
+    resolved_imports: Vec<ResolvedInterfaceImports>,
 ) -> Result<Result<String, String>, JsRuntimeError> {
     if let Some(js_file_name) = js_file_name {
         JS_FILE_NAME.with(|s| *s.borrow_mut() = js_file_name);
     }
 
-    // Convert resolved imports from host into the HashMap format expected by register_import_modules.
-    let imports: HashMap<String, Vec<(String, String)>> = resolved_imports.into_iter().collect();
+    // Flatten typed records into the (specifier → [(js_name, wit_name)]) map
+    // that `register_import_modules` expects.
+    let imports: HashMap<String, Vec<(String, String)>> = resolved_imports
+        .into_iter()
+        .map(|ifc| {
+            (
+                ifc.ifc_fqn,
+                ifc.functions
+                    .into_iter()
+                    .map(|f| (f.js_name, f.wit_name))
+                    .collect(),
+            )
+        })
+        .collect();
     let executor = Rc::new(DeterministicJobExecutor::default());
     let loader = Rc::new(MapModuleLoader::new());
     let mut context = Context::builder()
@@ -612,24 +626,19 @@ pub fn execute(
     // Get the default export function from the ES module
     let default_fn = match get_default_export_workflow(js_code, &mut context) {
         Ok(func) => func,
-        Err(EsmErrorWorkflow::ParseError(msg)) => {
-            obelisk_log::error(&format!("module parse error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmErrorWorkflow::LoadError(msg)) => {
-            obelisk_log::error(&format!("module load error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmErrorWorkflow::LinkError(msg)) => {
-            obelisk_log::error(&format!("module link error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmErrorWorkflow::EvalError(msg)) => {
-            obelisk_log::error(&format!("module eval error: {msg}"));
-            return Err(JsRuntimeError::ModuleParseError(msg));
-        }
-        Err(EsmErrorWorkflow::NoDefaultExport | EsmErrorWorkflow::DefaultNotCallable) => {
-            return Err(JsRuntimeError::NoDefaultExport);
+        Err(err) => {
+            let msg = match err {
+                EsmErrorWorkflow::ParseError(msg) => format!("module parse error: {msg}"),
+                EsmErrorWorkflow::LoadError(msg) => format!("module load error: {msg}"),
+                EsmErrorWorkflow::LinkError(msg) => format!("module link error: {msg}"),
+                EsmErrorWorkflow::EvalError(msg) => format!("module eval error: {msg}"),
+                EsmErrorWorkflow::NoDefaultExport => "no default export".to_string(),
+                EsmErrorWorkflow::DefaultNotCallable => {
+                    "default export is not callable".to_string()
+                }
+            };
+            obelisk_log::error(&msg);
+            return Err(JsRuntimeError::CannotInstantiate(msg));
         }
     };
 

--- a/crates/workflow-js-runtime/wit/obelisk_workflow-js-runtime/execute.wit
+++ b/crates/workflow-js-runtime/wit/obelisk_workflow-js-runtime/execute.wit
@@ -5,14 +5,26 @@ interface execute {
     variant js-runtime-error {
         /// Must exist to satisfy Obelisk contract.
         execution-failed,
-        /// Error when `js-code` could not be parsed as an ES module.
-        module-parse-error(string),
-        /// `js-code` was parsed, but does not have a callable default export.
-        no-default-export,
+        /// JS source could not be loaded — parse error, missing default
+        /// export, etc. String is a human-readable description.
+        cannot-instantiate(string),
         /// Function was executed and succeeded, but result did not type check.
         wrong-return-type(string),
         /// Function was executed and threw an error, but it did not type check.
         wrong-thrown-type(string),
+    }
+
+    /// One ES-module-style imported function within an interface.
+    record named-fn-import {
+        js-name: string,
+        wit-name: string,
+    }
+
+    /// Functions imported from a single interface, resolved by the host
+    /// against the function registry.
+    record resolved-interface-imports {
+        ifc-fqn: string,
+        functions: list<named-fn-import>,
     }
 
     /// Execute JavaScript code as a workflow.
@@ -21,14 +33,19 @@ interface execute {
     /// The default export receives params as positional arguments
     /// (each element is one JSON-serialized parameter value) and returns a string.
     ///
-    /// `resolved-imports` maps ES module import specifiers to their functions, resolved
-    /// by the host against the function registry. Each entry is:
-    ///   (interface-name, list of (js-camel-case-name, wit-kebab-case-name))
-    /// For example: ("testing:integration/activity", [("accountInfo", "account-info")])
+    /// `resolved-imports` lists the JS module imports the host has resolved
+    /// against the function registry, grouped by interface. For example:
+    ///   { ifc-fqn: "testing:integration/activity",
+    ///     functions: [{ js-name: "accountInfo", wit-name: "account-info" }] }
     /// This enables `import * as ns` (host resolves all functions for the interface)
     /// and validates named imports before entering the JS runtime.
     ///
     /// Returns Ok(Ok(result)) on success, Ok(Err(error_message)) on user error,
     /// or Err(js-runtime-error) on runtime error.
-    run: func(js-code: string, params-json: list<string>, js-file-name: option<string>, resolved-imports: list<tuple<string, list<tuple<string, string>>>>) -> result<result<string, string>, js-runtime-error>;
+    run: func(
+        js-code: string,
+        params-json: list<string>,
+        js-file-name: option<string>,
+        resolved-imports: list<resolved-interface-imports>,
+    ) -> result<result<string, string>, js-runtime-error>;
 }

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2817,7 +2817,6 @@ async fn compile_and_link(
                                 js_config: Some(WebhookEndpointJsConfig {
                                     source: webhook_js.js_source,
                                     file_name: webhook_js.js_file_name.clone(),
-                                    resolved_imports: std::collections::HashMap::new(),
                                 }),
                                 config_section_hint: webhook_js.config_section_hint,
                             };


### PR DESCRIPTION
- **refactor(js): Unify JS runtime errors, serialize `resolved_imports_json` once**
- **refactor(js): Use `NamedFnImport`, verify mixed imports in linking phase**
- **style: Fix clippy**
- **build: Push JS runtimes**
