### PR TITLE
build: Set Wstd version back to 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7484,9 +7484,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wstd"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f743611ee524c2416bc1513157eb3235ca24f4270d1b3ab19f93676fcff21398"
+checksum = "0903606f1acdecad11576768ecc61ce215d6848652ac16c0e4592bb265e4200e"
 dependencies = [
  "anyhow",
  "async-task",
@@ -7506,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "wstd-macro"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5db5d13d6e3f2b180b04be8ff8d5c35b37d5621d3e2d0aa85ab99adf817a780"
+checksum = "d6a9df01a7fb39fbe7e9b5ef76f586f06425dd6f2be350de4781936f72f9899d"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,7 +387,7 @@ boa_runtime = { package="obeli-sk-boa-runtime" , version="1.0.0-obeli-sk.7", def
 wasip2 = "1.0.4"
 wit-bindgen = "0.57.1"
 wit-bindgen-rust = "0.57.1"
-wstd = "0.6.5"
+wstd = "0.6.6"
 
 # otlp
 opentelemetry = "0.31.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
 authors = ["Project Developers"]
 edition = "2024"
-rust-version = "1.91.0"
+rust-version = "1.96.0"
 
 [workspace.dependencies]
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }

--- a/dev-deps.txt
+++ b/dev-deps.txt
@@ -6,6 +6,7 @@ nixpkgs-fmt 1.3.0
 pkg-config 0.29.2
 libprotoc 34.1
 rustc 1.96.0 (ac68faa20 2026-05-25)
+rust-version 1.96.0
 wasm-tools 1.251.0
 cargo-zigbuild 0.22.3
 litestream v0.5.12

--- a/scripts/dev-deps.sh
+++ b/scripts/dev-deps.sh
@@ -31,6 +31,9 @@ echo "pkg-config $(pkg-config --version)" >> dev-deps.txt
 # protobuf
 protoc --version >> dev-deps.txt
 rustc --version >> dev-deps.txt
+cargo metadata --no-deps --format-version 1 \
+    | jq -r '.workspace_root as $root | .packages[] | select(.manifest_path == ($root + "/Cargo.toml")) | "rust-version " + .rust_version' \
+    >> dev-deps.txt
 wasm-tools --version >> dev-deps.txt
 nix develop .#cargo-zigbuild --command cargo-zigbuild --version >> dev-deps.txt
 
@@ -39,5 +42,4 @@ echo "litestream $(get_litestream_version)" >> dev-deps.txt
 
 # libc
 ldd --version | head -n 1 >> dev-deps.txt
-
 


### PR DESCRIPTION
Previous `cargo upgrade` downgraded it in the lockfile to buggy 0.6.5.
