### PR TITLE
Merge file upload into deployment submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -2741,6 +2742,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +2776,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -4366,6 +4394,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -4966,6 +4995,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 arbitrary = { version = "1.4.2", features = ["derive"] }
 assert_matches = "1.5.0"
 async-trait = "0.1"
-axum = { version = "0.8.9", features = ["http2"] }
+axum = { version = "0.8.9", features = ["http2", "multipart"] }
 axum-accept = "0.0.5"
 axum-extra = { version = "0.12.6", features = ["query"] }
 base64 = "0.22.1"
@@ -298,6 +298,7 @@ rand = "0.9"
 refinery = { version = "0.9.2", default-features = false, features = ["rusqlite", "tokio-postgres-rustls"] }
 reqwest = { version = "0.13", default-features = false, features = [
     "json",
+    "multipart",
     "rustls-no-provider",
 ] }
 rustls = { version = "0.23", default-features = false, features = [

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -738,6 +738,17 @@
           ]
         },
         {
+          "name": "gc",
+          "about": "Delete content-addressed file blobs not referenced by any stored deployment",
+          "options": [
+            {
+              "name": "--api-url",
+              "short": "a",
+              "help": "Address of the obelisk server"
+            }
+          ]
+        },
+        {
           "name": "active",
           "about": "Print the ID of the currently active deployment",
           "options": [

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -637,8 +637,8 @@
               "help": "Submit an empty deployment with no components"
             },
             {
-              "name": "--verify",
-              "help": "Deprecated for submit: verification happens when the deployment is activated"
+              "name": "--allow-missing-runtime-config",
+              "help": "Tolerate missing environment variables / secrets while verifying the deployment before persisting it (default: missing config fails)"
             },
             {
               "name": "--description",
@@ -673,8 +673,8 @@
               "help": "Enqueue an empty deployment with no components"
             },
             {
-              "name": "--verify",
-              "help": "Verify all environment variables before enqueuing"
+              "name": "--allow-missing-runtime-config",
+              "help": "Tolerate missing environment variables / secrets while verifying the deployment before enqueuing it (default: missing config fails)"
             },
             {
               "name": "--description",

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -638,7 +638,7 @@
             },
             {
               "name": "--verify",
-              "help": "Verify all environment variables before persisting"
+              "help": "Deprecated for submit: verification happens when the deployment is activated"
             },
             {
               "name": "--description",

--- a/assets/schemas/deployment-canonical.json
+++ b/assets/schemas/deployment-canonical.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "DeploymentCanonical",
-  "description": "Canonical deployment configuration — no local file paths.\nUsed for hash computation, wire format, and DB storage.",
+  "title": "DeploymentResolved",
+  "description": "Resolved deployment configuration after resolving deployment-owned text sources.\n\nThis is a runtime/verification shape derived from the stored manifest plus a file\nprovider. It is not the stored deployment source of truth. Deployment-owned scripts\nand backtrace sources are inlined as content; deployment-owned WASM locations remain\nrelative path + content digest until `DeploymentRunnable` materializes them from the\nCAS into a runnable cache path. OCI references remain external references.",
   "type": "object",
   "properties": {
     "activities_wasm": {
@@ -13,49 +13,49 @@
     "activities_stub": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ActivityStubComponentConfigCanonical"
+        "$ref": "#/$defs/ActivityStubComponentConfigResolved"
       }
     },
     "activities_external": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ActivityExternalComponentConfigCanonical"
+        "$ref": "#/$defs/ActivityExternalComponentConfigResolved"
       }
     },
     "activities_js": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ActivityJsComponentConfigCanonical"
+        "$ref": "#/$defs/ActivityJsComponentConfigResolved"
       }
     },
     "activities_exec": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ActivityExecComponentConfigCanonical"
+        "$ref": "#/$defs/ActivityExecComponentConfigResolved"
       }
     },
     "workflows_wasm": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/WorkflowWasmComponentConfigCanonical"
+        "$ref": "#/$defs/WorkflowWasmComponentConfigResolved"
       }
     },
     "workflows_js": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/WorkflowJsComponentConfigCanonical"
+        "$ref": "#/$defs/WorkflowJsComponentConfigResolved"
       }
     },
     "webhooks_wasm": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/WebhookWasmComponentConfigCanonical"
+        "$ref": "#/$defs/WebhookWasmComponentConfigResolved"
       }
     },
     "webhooks_js": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/WebhookJsComponentConfigCanonical"
+        "$ref": "#/$defs/WebhookJsComponentConfigResolved"
       }
     },
     "crons": {
@@ -440,13 +440,13 @@
         "params"
       ]
     },
-    "ActivityStubComponentConfigCanonical": {
+    "ActivityStubComponentConfigResolved": {
       "anyOf": [
         {
           "$ref": "#/$defs/ActivityStubFileConfigToml"
         },
         {
-          "$ref": "#/$defs/ActivityStubExtInlineConfigCanonical"
+          "$ref": "#/$defs/ActivityStubExtInlineConfigResolved"
         }
       ]
     },
@@ -473,7 +473,7 @@
         "location"
       ]
     },
-    "ActivityStubExtInlineConfigCanonical": {
+    "ActivityStubExtInlineConfigResolved": {
       "type": "object",
       "properties": {
         "name": {
@@ -525,13 +525,13 @@
         "type"
       ]
     },
-    "ActivityExternalComponentConfigCanonical": {
+    "ActivityExternalComponentConfigResolved": {
       "anyOf": [
         {
           "$ref": "#/$defs/ActivityExternalFileConfigToml"
         },
         {
-          "$ref": "#/$defs/ActivityStubExtInlineConfigCanonical"
+          "$ref": "#/$defs/ActivityStubExtInlineConfigResolved"
         }
       ]
     },
@@ -566,15 +566,15 @@
         "location"
       ]
     },
-    "ActivityJsComponentConfigCanonical": {
-      "description": "Canonical form of `ActivityJsComponentConfigToml`.",
+    "ActivityJsComponentConfigResolved": {
+      "description": "Resolved form of `ActivityJsComponentConfigToml`.",
       "type": "object",
       "properties": {
         "name": {
           "$ref": "#/$defs/ConfigName"
         },
         "location": {
-          "$ref": "#/$defs/ScriptLocationCanonical"
+          "$ref": "#/$defs/ScriptLocationResolved"
         },
         "content_digest": {
           "type": [
@@ -652,8 +652,8 @@
         "allowed_hosts"
       ]
     },
-    "ScriptLocationCanonical": {
-      "description": "Canonical location of a script source (JS or exec) — no deployment-relative paths.\nUsed for hash computation, wire format in deployment submission, and DB storage.\n\n- `Content` is owned by the deployment (inline content, or a file that lived under\n  the deployment directory); `file_name` is the deployment-relative path (which may\n  include subfolders), used to recreate the file on filesystem export.\n- `Path` is an external local file that the deployment merely references; it is read\n  at runtime and is not recreated on export.\n- `Oci` is an external registry reference.",
+    "ScriptLocationResolved": {
+      "description": "Resolved location of a script source (JS or exec) after file-provider resolution.\n\n- `Content` is owned by the deployment (inline content, or a file that lived under\n  the deployment directory and was read from disk/CAS); `file_name` is the\n  deployment-relative path (which may include subfolders), used for source names and\n  backtraces.\n- `Path` is an external local file that the deployment merely references; it is read\n  at runtime.\n- `Oci` is an external registry reference.",
       "oneOf": [
         {
           "type": "object",
@@ -695,15 +695,15 @@
         }
       ]
     },
-    "ActivityExecComponentConfigCanonical": {
-      "description": "Canonical form of `ActivityExecComponentConfigToml`.",
+    "ActivityExecComponentConfigResolved": {
+      "description": "Resolved form of `ActivityExecComponentConfigToml`.",
       "type": "object",
       "properties": {
         "name": {
           "$ref": "#/$defs/ConfigName"
         },
         "location": {
-          "$ref": "#/$defs/ScriptLocationCanonical"
+          "$ref": "#/$defs/ScriptLocationResolved"
         },
         "content_digest": {
           "type": [
@@ -824,8 +824,8 @@
         "name"
       ]
     },
-    "WorkflowWasmComponentConfigCanonical": {
-      "description": "Canonical form of `WorkflowWasmComponentConfigToml`.",
+    "WorkflowWasmComponentConfigResolved": {
+      "description": "Resolved form of `WorkflowWasmComponentConfigToml`.",
       "type": "object",
       "properties": {
         "common": {
@@ -853,7 +853,7 @@
           "$ref": "#/$defs/BlockingStrategyConfigToml"
         },
         "backtrace": {
-          "$ref": "#/$defs/ComponentBacktraceConfigCanonical"
+          "$ref": "#/$defs/ComponentBacktraceConfigResolved"
         },
         "stub_wasi": {
           "type": "boolean"
@@ -933,13 +933,13 @@
         "await"
       ]
     },
-    "ComponentBacktraceConfigCanonical": {
+    "ComponentBacktraceConfigResolved": {
       "type": "object",
       "properties": {
         "frame_files_to_sources": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/BacktraceSourceCanonical"
+            "$ref": "#/$defs/BacktraceSourceResolved"
           }
         }
       },
@@ -947,8 +947,8 @@
         "frame_files_to_sources"
       ]
     },
-    "BacktraceSourceCanonical": {
-      "description": "Canonical backtrace source: the inlined source `content` plus the deployment-relative\n`file_name` it was read from (used to recreate the file, mirroring subfolders, on export).",
+    "BacktraceSourceResolved": {
+      "description": "Resolved backtrace source: the inlined source `content` plus the deployment-relative\n`file_name` it was read from (used to recreate the file, mirroring subfolders, on export).",
       "type": "object",
       "properties": {
         "content": {
@@ -964,15 +964,15 @@
         "file_name"
       ]
     },
-    "WorkflowJsComponentConfigCanonical": {
-      "description": "Canonical form of `WorkflowJsComponentConfigToml`.",
+    "WorkflowJsComponentConfigResolved": {
+      "description": "Resolved form of `WorkflowJsComponentConfigToml`.",
       "type": "object",
       "properties": {
         "name": {
           "$ref": "#/$defs/ConfigName"
         },
         "location": {
-          "$ref": "#/$defs/ScriptLocationCanonical"
+          "$ref": "#/$defs/ScriptLocationResolved"
         },
         "content_digest": {
           "type": [
@@ -1030,8 +1030,8 @@
         "lock_extension"
       ]
     },
-    "WebhookWasmComponentConfigCanonical": {
-      "description": "Canonical form of `WebhookWasmComponentConfigToml`.",
+    "WebhookWasmComponentConfigResolved": {
+      "description": "Resolved form of `WebhookWasmComponentConfigToml`.",
       "type": "object",
       "properties": {
         "name": {
@@ -1072,7 +1072,7 @@
           "default": []
         },
         "backtrace": {
-          "$ref": "#/$defs/ComponentBacktraceConfigCanonical",
+          "$ref": "#/$defs/ComponentBacktraceConfigResolved",
           "default": {
             "frame_files_to_sources": {}
           }
@@ -1125,15 +1125,15 @@
         "route"
       ]
     },
-    "WebhookJsComponentConfigCanonical": {
-      "description": "Canonical form of `WebhookJsComponentConfigToml`.",
+    "WebhookJsComponentConfigResolved": {
+      "description": "Resolved form of `WebhookJsComponentConfigToml`.",
       "type": "object",
       "properties": {
         "name": {
           "$ref": "#/$defs/ConfigName"
         },
         "location": {
-          "$ref": "#/$defs/ScriptLocationCanonical"
+          "$ref": "#/$defs/ScriptLocationResolved"
         },
         "content_digest": {
           "type": [

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -2198,18 +2198,11 @@
       "DeploymentSubmitResponse": {
         "type": "object",
         "required": [
-          "deployment_id",
-          "missing_digests"
+          "deployment_id"
         ],
         "properties": {
           "deployment_id": {
             "type": "string"
-          },
-          "missing_digests": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           }
         }
       },

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -2171,6 +2171,10 @@
           "deployment_toml"
         ],
         "properties": {
+          "allow_missing_runtime_config": {
+            "type": "boolean",
+            "description": "Tolerate missing environment variables / secrets while verifying the\ndeployment before persisting it. Defaults to strict (missing config fails)."
+          },
           "deployment_id": {
             "type": [
               "string",
@@ -2188,10 +2192,6 @@
               "null"
             ],
             "description": "Optional human-readable deployment description"
-          },
-          "verify": {
-            "type": "boolean",
-            "description": "Deprecated for submit: verification happens when the deployment is activated."
           }
         }
       },
@@ -2210,13 +2210,13 @@
         "type": "object",
         "description": "Request payload for switching deployment",
         "properties": {
+          "allow_missing_runtime_config": {
+            "type": "boolean",
+            "description": "Tolerate missing environment variables / secrets while verifying. Rejected\nfor a hot redeploy, which requires all runtime config to be available."
+          },
           "hot_redeploy": {
             "type": "boolean",
             "description": "Hot redeploy without restart"
-          },
-          "verify": {
-            "type": "boolean",
-            "description": "Verify config before switching"
           }
         }
       },

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -339,7 +339,8 @@
         "tags": [
           "deployments"
         ],
-        "summary": "Submit a new deployment",
+        "summary": "Submit a new deployment.",
+        "description": "Accepts either an `application/json` body (no attached file blobs; referenced\nfiles must already exist in the CAS) or a `multipart/form-data` package whose\nparts carry the manifest and the deployment-owned file blobs. On an incomplete\npackage the server stores nothing and returns a `409` `SubmitPackageErrorBody`\nlisting the missing files to attach and retry.",
         "operationId": "submit_deployment",
         "requestBody": {
           "content": {
@@ -366,7 +367,14 @@
             "description": "Invalid config"
           },
           "409": {
-            "description": "Validation failed"
+            "description": "Incomplete or invalid package",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmitPackageErrorBody"
+                }
+              }
+            }
           }
         }
       }
@@ -412,6 +420,7 @@
           "deployments"
         ],
         "summary": "Upload a deployment file blob to the content-addressed store. The request body is the\nraw file content; the response is the server-computed content digest. The digest must be\nreferenced by the deployment.",
+        "description": "Deprecated: attach file blobs to a `multipart/form-data` `POST /v1/deployments`\npackage instead. Retained as admin CAS tooling.",
         "operationId": "upload_file",
         "parameters": [
           {
@@ -2220,6 +2229,25 @@
           }
         }
       },
+      "DigestMismatch": {
+        "type": "object",
+        "required": [
+          "file",
+          "supplied_digest",
+          "actual_digest"
+        ],
+        "properties": {
+          "actual_digest": {
+            "type": "string"
+          },
+          "file": {
+            "$ref": "#/components/schemas/FileIssue"
+          },
+          "supplied_digest": {
+            "type": "string"
+          }
+        }
+      },
       "ExecutionEventsResponse": {
         "type": "object",
         "description": "Response containing execution events",
@@ -2365,6 +2393,44 @@
           "pending_state": {
             "type": "object",
             "description": "Current pending state of the execution"
+          }
+        }
+      },
+      "FileIssue": {
+        "type": "object",
+        "description": "A single file-set problem found while validating a submit package.",
+        "required": [
+          "section",
+          "field_path",
+          "message"
+        ],
+        "properties": {
+          "component_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "digest": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "field_path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "section": {
+            "type": "string"
           }
         }
       },
@@ -2747,6 +2813,49 @@
           },
           "result": {
             "type": "object"
+          }
+        }
+      },
+      "SubmitPackageErrorBody": {
+        "type": "object",
+        "description": "Structured `409` body describing why a submit package was rejected. No\ndeployment is stored when this is returned. A client retries the same submit\nwith the `missing_files` blobs attached.",
+        "required": [
+          "missing_digest_fields",
+          "missing_files",
+          "unexpected_files",
+          "digest_mismatches",
+          "oversized_files"
+        ],
+        "properties": {
+          "digest_mismatches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DigestMismatch"
+            }
+          },
+          "missing_digest_fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileIssue"
+            }
+          },
+          "missing_files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileIssue"
+            }
+          },
+          "oversized_files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileIssue"
+            }
+          },
+          "unexpected_files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileIssue"
+            }
           }
         }
       }

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -414,54 +414,6 @@
         }
       }
     },
-    "/v1/deployments/{deployment_id}/files": {
-      "post": {
-        "tags": [
-          "deployments"
-        ],
-        "summary": "Upload a deployment file blob to the content-addressed store. The request body is the\nraw file content; the response is the server-computed content digest. The digest must be\nreferenced by the deployment.",
-        "description": "Deprecated: attach file blobs to a `multipart/form-data` `POST /v1/deployments`\npackage instead. Retained as admin CAS tooling.",
-        "operationId": "upload_file",
-        "parameters": [
-          {
-            "name": "deployment_id",
-            "in": "path",
-            "description": "Deployment ID that references the file",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/octet-stream": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Stored; returns the content digest",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/deployments/{deployment_id}/switch": {
       "put": {
         "tags": [

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -355,9 +355,9 @@
           "200": {
             "description": "Deployment submitted",
             "content": {
-              "text/plain": {
+              "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/DeploymentSubmitResponse"
                 }
               }
             }
@@ -402,6 +402,53 @@
           },
           "404": {
             "description": "Deployment not found"
+          }
+        }
+      }
+    },
+    "/v1/deployments/{deployment_id}/files": {
+      "post": {
+        "tags": [
+          "deployments"
+        ],
+        "summary": "Upload a deployment file blob to the content-addressed store. The request body is the\nraw file content; the response is the server-computed content digest. The digest must be\nreferenced by the deployment.",
+        "operationId": "upload_file",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "description": "Deployment ID that references the file",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Stored; returns the content digest",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -1415,42 +1462,6 @@
         }
       }
     },
-    "/v1/files": {
-      "post": {
-        "tags": [
-          "deployments"
-        ],
-        "summary": "Upload a deployment file blob to the content-addressed store. The request body is the\nraw file content; the response is the server-computed content digest.",
-        "operationId": "upload_file",
-        "requestBody": {
-          "content": {
-            "application/octet-stream": {
-              "schema": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32",
-                  "minimum": 0
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Stored; returns the content digest",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/files/{digest}": {
       "get": {
         "tags": [
@@ -2169,7 +2180,7 @@
           },
           "deployment_toml": {
             "type": "string",
-            "description": "Verbatim deployment manifest (`deployment.toml`). Referenced file blobs must\nalready be uploaded to the content-addressed store."
+            "description": "Verbatim deployment manifest (`deployment.toml`). Referenced file blobs must\nbe uploaded separately after the server returns `missing_digests`."
           },
           "description": {
             "type": [
@@ -2180,7 +2191,25 @@
           },
           "verify": {
             "type": "boolean",
-            "description": "Verify all environment variables before persisting"
+            "description": "Deprecated for submit: verification happens when the deployment is activated."
+          }
+        }
+      },
+      "DeploymentSubmitResponse": {
+        "type": "object",
+        "required": [
+          "deployment_id",
+          "missing_digests"
+        ],
+        "properties": {
+          "deployment_id": {
+            "type": "string"
+          },
+          "missing_digests": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -702,7 +702,7 @@
       ]
     },
     "JsLocationToml": {
-      "description": "Location of a JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).\nOn-disk format only; replaced by [`ScriptLocationCanonical`] before transmission and hash computation.",
+      "description": "Location of a JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).\nOn-disk format only; replaced by [`ScriptLocationResolved`] before transmission and hash computation.",
       "type": "string"
     },
     "ActivityExecComponentConfigToml": {
@@ -996,7 +996,7 @@
       "type": "object",
       "properties": {
         "sources": {
-          "description": "Maps a frame-symbol key to a backtrace source file path. On-disk format only;\nresolved to `ComponentBacktraceConfigCanonical` before transmission and hash\ncomputation. A relative path is deployment-dir-relative (a leading\n`${DEPLOYMENT_DIR}/` is accepted for backcompat); an absolute path is out-of-tree.",
+          "description": "Maps a frame-symbol key to a backtrace source file path. On-disk format only;\nresolved to `ComponentBacktraceConfigResolved` before transmission and hash\ncomputation. A relative path is deployment-dir-relative (a leading\n`${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/BacktraceSourceToml"

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1522,6 +1522,11 @@ pub trait DbExternalApi: DbConnection {
         deployment_id: DeploymentId,
     ) -> Result<Vec<DeploymentFileRecord>, DbErrorRead>;
 
+    /// Delete content-addressed file blobs not referenced by any stored deployment,
+    /// returning the number deleted. Such orphans are left behind when a submit writes
+    /// blobs to the store and then fails verification before persisting the deployment.
+    async fn gc_orphan_files(&self) -> Result<u64, DbErrorWrite>;
+
     async fn activate_deployment(
         &self,
         deployment_id: DeploymentId,

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -4819,6 +4819,21 @@ impl DbExternalApi for PostgresConnection {
     }
 
     #[instrument(skip(self))]
+    async fn gc_orphan_files(&self) -> Result<u64, DbErrorWrite> {
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+        let deleted = tx
+            .execute(
+                "DELETE FROM t_file WHERE digest NOT IN \
+                 (SELECT digest FROM t_deployment_file)",
+                &[],
+            )
+            .await?;
+        tx.commit().await?;
+        Ok(deleted)
+    }
+
+    #[instrument(skip(self))]
     async fn activate_deployment(
         &self,
         deployment_id: DeploymentId,

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -4792,6 +4792,25 @@ impl DbExternalApi for SqlitePool {
     }
 
     #[instrument(skip(self))]
+    async fn gc_orphan_files(&self) -> Result<u64, DbErrorWrite> {
+        self.transaction(
+            move |tx| {
+                let deleted = tx
+                    .execute(
+                        "DELETE FROM t_file WHERE digest NOT IN \
+                         (SELECT digest FROM t_deployment_file)",
+                        [],
+                    )
+                    .map_err(RusqliteError::from)?;
+                Ok(deleted as u64)
+            },
+            TxType::MultipleWrites,
+            "gc_orphan_files",
+        )
+        .await
+    }
+
+    #[instrument(skip(self))]
     async fn activate_deployment(
         &self,
         deployment_id: DeploymentId,

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -762,8 +762,7 @@ pub mod cron {
 /// provider. It is not the stored deployment source of truth. Deployment-owned scripts
 /// and backtrace sources are inlined as content; deployment-owned WASM locations remain
 /// relative path + content digest until `DeploymentResolved` materializes them from the
-/// CAS into a runnable cache path. External absolute paths and OCI references remain
-/// external references.
+/// CAS into a runnable cache path. OCI references remain external references.
 #[derive(Debug, Deserialize, Serialize, Default, Clone, JsonSchema)]
 pub struct DeploymentCanonical {
     pub activities_wasm: Vec<ActivityWasmComponentConfigToml>,

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -1,6 +1,6 @@
 //! Deployment configuration data model shared between the obelisk server and the webui.
 //!
-//! Contains the canonical deployment configuration ([`DeploymentCanonical`]), the wire
+//! Contains the canonical deployment configuration ([`DeploymentResolved`]), the wire
 //! format used for hash computation, deployment submission and DB storage (`config_json`),
 //! plus the data types it is composed of. Some of these types double as the TOML
 //! representation (their original `*Toml` names are kept).
@@ -416,7 +416,7 @@ pub struct ActivityExternalFileConfigToml {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct ActivityStubExtInlineConfigCanonical {
+pub struct ActivityStubExtInlineConfigResolved {
     pub name: ConfigName,
     #[schemars(with = "String")]
     pub ffqn: FunctionFqn,
@@ -428,12 +428,12 @@ pub struct ActivityStubExtInlineConfigCanonical {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
-pub enum ActivityStubComponentConfigCanonical {
+pub enum ActivityStubComponentConfigResolved {
     File(ActivityStubFileConfigToml),
-    Inline(ActivityStubExtInlineConfigCanonical),
+    Inline(ActivityStubExtInlineConfigResolved),
 }
 
-impl ActivityStubComponentConfigCanonical {
+impl ActivityStubComponentConfigResolved {
     #[must_use]
     pub fn name_str(&self) -> &str {
         match self {
@@ -445,12 +445,12 @@ impl ActivityStubComponentConfigCanonical {
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
 #[serde(untagged)]
-pub enum ActivityExternalComponentConfigCanonical {
+pub enum ActivityExternalComponentConfigResolved {
     File(ActivityExternalFileConfigToml),
-    Inline(ActivityStubExtInlineConfigCanonical),
+    Inline(ActivityStubExtInlineConfigResolved),
 }
 
-impl ActivityExternalComponentConfigCanonical {
+impl ActivityExternalComponentConfigResolved {
     #[must_use]
     pub fn name_str(&self) -> &str {
         match self {
@@ -460,7 +460,7 @@ impl ActivityExternalComponentConfigCanonical {
     }
 }
 
-/// Canonical location of a script source (JS or exec) after file-provider resolution.
+/// Resolved location of a script source (JS or exec) after file-provider resolution.
 ///
 /// - `Content` is owned by the deployment (inline content, or a file that lived under
 ///   the deployment directory and was read from disk/CAS); `file_name` is the
@@ -471,7 +471,7 @@ impl ActivityExternalComponentConfigCanonical {
 /// - `Oci` is an external registry reference.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ScriptLocationCanonical {
+pub enum ScriptLocationResolved {
     #[schemars(with = "String")]
     Content { content: String, file_name: String },
     /// External local file, read at runtime, not recreated on export.
@@ -482,22 +482,22 @@ pub enum ScriptLocationCanonical {
     Oci { image: String },
 }
 
-/// Canonical backtrace source: the inlined source `content` plus the deployment-relative
+/// Resolved backtrace source: the inlined source `content` plus the deployment-relative
 /// `file_name` it was read from (used to recreate the file, mirroring subfolders, on export).
 #[derive(JsonSchema, Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct BacktraceSourceCanonical {
+pub struct BacktraceSourceResolved {
     pub content: String,
     pub file_name: String,
 }
 
 #[derive(JsonSchema, Debug, Default, Clone, Serialize, Deserialize)]
-pub struct ComponentBacktraceConfigCanonical {
-    #[schemars(with = "std::collections::HashMap<String, BacktraceSourceCanonical>")]
-    pub frame_files_to_sources: HashMap<String, BacktraceSourceCanonical>,
+pub struct ComponentBacktraceConfigResolved {
+    #[schemars(with = "std::collections::HashMap<String, BacktraceSourceResolved>")]
+    pub frame_files_to_sources: HashMap<String, BacktraceSourceResolved>,
 }
 
-impl ComponentBacktraceConfigCanonical {
+impl ComponentBacktraceConfigResolved {
     /// Map each frame-symbol key to its source content (dropping the recreate path),
     /// as needed by the runtime backtrace lookup.
     #[must_use]
@@ -509,12 +509,12 @@ impl ComponentBacktraceConfigCanonical {
     }
 }
 
-/// Canonical form of `ActivityJsComponentConfigToml`.
+/// Resolved form of `ActivityJsComponentConfigToml`.
 #[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct ActivityJsComponentConfigCanonical {
+pub struct ActivityJsComponentConfigResolved {
     pub name: ConfigName,
-    pub location: ScriptLocationCanonical,
+    pub location: ScriptLocationResolved,
     pub content_digest: Option<ContentDigest>,
     pub component_digest: Option<ComponentDigest>,
     pub ffqn: FunctionFqn,
@@ -550,12 +550,12 @@ pub struct ExecSecretsToml {
     pub env_vars: Vec<SecretEnvVarToml>,
 }
 
-/// Canonical form of `ActivityExecComponentConfigToml`.
+/// Resolved form of `ActivityExecComponentConfigToml`.
 #[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct ActivityExecComponentConfigCanonical {
+pub struct ActivityExecComponentConfigResolved {
     pub name: ConfigName,
-    pub location: ScriptLocationCanonical,
+    pub location: ScriptLocationResolved,
     pub content_digest: Option<ContentDigest>,
     pub ffqn: FunctionFqn,
     pub params: Vec<JsParamToml>,
@@ -606,10 +606,10 @@ pub enum BlockingStrategyConfigSimple {
     Await,
 }
 
-/// Canonical form of `WorkflowWasmComponentConfigToml`.
+/// Resolved form of `WorkflowWasmComponentConfigToml`.
 #[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct WorkflowWasmComponentConfigCanonical {
+pub struct WorkflowWasmComponentConfigResolved {
     pub common: ComponentCommon,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_digest: Option<ContentDigest>,
@@ -617,18 +617,18 @@ pub struct WorkflowWasmComponentConfigCanonical {
     pub exec: ExecConfigToml,
     pub retry_exp_backoff: DurationConfig,
     pub blocking_strategy: BlockingStrategyConfigToml,
-    pub backtrace: ComponentBacktraceConfigCanonical,
+    pub backtrace: ComponentBacktraceConfigResolved,
     pub stub_wasi: bool,
     pub lock_extension: bool,
     pub logs_store_min_level: LogLevelToml,
 }
 
-/// Canonical form of `WorkflowJsComponentConfigToml`.
+/// Resolved form of `WorkflowJsComponentConfigToml`.
 #[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct WorkflowJsComponentConfigCanonical {
+pub struct WorkflowJsComponentConfigResolved {
     pub name: ConfigName,
-    pub location: ScriptLocationCanonical,
+    pub location: ScriptLocationResolved,
     pub content_digest: Option<ContentDigest>,
     pub component_digest: Option<ComponentDigest>,
     pub ffqn: FunctionFqn,
@@ -643,8 +643,8 @@ pub struct WorkflowJsComponentConfigCanonical {
 
 pub mod webhook {
     use super::{
-        AllowedHostToml, ComponentBacktraceConfigCanonical, ComponentCommon,
-        ComponentStdOutputToml, ConfigName, LogLevelToml, ScriptLocationCanonical,
+        AllowedHostToml, ComponentBacktraceConfigResolved, ComponentCommon, ComponentStdOutputToml,
+        ConfigName, LogLevelToml, ScriptLocationResolved,
     };
     use crate::component_id::ContentDigest;
     use crate::env_var::EnvVarConfig;
@@ -679,10 +679,10 @@ pub mod webhook {
         pub route: String,
     }
 
-    /// Canonical form of `WebhookWasmComponentConfigToml`.
+    /// Resolved form of `WebhookWasmComponentConfigToml`.
     #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
     #[serde(deny_unknown_fields)]
-    pub struct WebhookWasmComponentConfigCanonical {
+    pub struct WebhookWasmComponentConfigResolved {
         #[serde(flatten)]
         pub common: ComponentCommon,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -697,19 +697,19 @@ pub mod webhook {
         #[serde(default)]
         pub env_vars: Vec<EnvVarConfig>,
         #[serde(default)]
-        pub backtrace: ComponentBacktraceConfigCanonical,
+        pub backtrace: ComponentBacktraceConfigResolved,
         #[serde(default)]
         pub logs_store_min_level: LogLevelToml,
         #[serde(default, rename = "allowed_host")]
         pub allowed_hosts: Vec<AllowedHostToml>,
     }
 
-    /// Canonical form of `WebhookJsComponentConfigToml`.
+    /// Resolved form of `WebhookJsComponentConfigToml`.
     #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
     #[serde(deny_unknown_fields)]
-    pub struct WebhookJsComponentConfigCanonical {
+    pub struct WebhookJsComponentConfigResolved {
         pub name: ConfigName,
-        pub location: ScriptLocationCanonical,
+        pub location: ScriptLocationResolved,
         #[serde(default)]
         pub content_digest: Option<ContentDigest>,
         #[serde(default = "default_external_server_name")]
@@ -756,24 +756,24 @@ pub mod cron {
     }
 }
 
-/// Canonical deployment configuration after resolving deployment-owned text sources.
+/// Resolved deployment configuration after resolving deployment-owned text sources.
 ///
 /// This is a runtime/verification shape derived from the stored manifest plus a file
 /// provider. It is not the stored deployment source of truth. Deployment-owned scripts
 /// and backtrace sources are inlined as content; deployment-owned WASM locations remain
-/// relative path + content digest until `DeploymentResolved` materializes them from the
+/// relative path + content digest until `DeploymentRunnable` materializes them from the
 /// CAS into a runnable cache path. OCI references remain external references.
 #[derive(Debug, Deserialize, Serialize, Default, Clone, JsonSchema)]
-pub struct DeploymentCanonical {
+pub struct DeploymentResolved {
     pub activities_wasm: Vec<ActivityWasmComponentConfigToml>,
-    pub activities_stub: Vec<ActivityStubComponentConfigCanonical>,
-    pub activities_external: Vec<ActivityExternalComponentConfigCanonical>,
-    pub activities_js: Vec<ActivityJsComponentConfigCanonical>,
-    pub activities_exec: Vec<ActivityExecComponentConfigCanonical>,
-    pub workflows_wasm: Vec<WorkflowWasmComponentConfigCanonical>,
-    pub workflows_js: Vec<WorkflowJsComponentConfigCanonical>,
-    pub webhooks_wasm: Vec<webhook::WebhookWasmComponentConfigCanonical>,
-    pub webhooks_js: Vec<webhook::WebhookJsComponentConfigCanonical>,
+    pub activities_stub: Vec<ActivityStubComponentConfigResolved>,
+    pub activities_external: Vec<ActivityExternalComponentConfigResolved>,
+    pub activities_js: Vec<ActivityJsComponentConfigResolved>,
+    pub activities_exec: Vec<ActivityExecComponentConfigResolved>,
+    pub workflows_wasm: Vec<WorkflowWasmComponentConfigResolved>,
+    pub workflows_js: Vec<WorkflowJsComponentConfigResolved>,
+    pub webhooks_wasm: Vec<webhook::WebhookWasmComponentConfigResolved>,
+    pub webhooks_js: Vec<webhook::WebhookJsComponentConfigResolved>,
     #[serde(default)]
     pub crons: Vec<cron::CronComponentConfigToml>,
 }

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -460,14 +460,14 @@ impl ActivityExternalComponentConfigCanonical {
     }
 }
 
-/// Canonical location of a script source (JS or exec) — no deployment-relative paths.
-/// Used for hash computation, wire format in deployment submission, and DB storage.
+/// Canonical location of a script source (JS or exec) after file-provider resolution.
 ///
 /// - `Content` is owned by the deployment (inline content, or a file that lived under
-///   the deployment directory); `file_name` is the deployment-relative path (which may
-///   include subfolders), used to recreate the file on filesystem export.
+///   the deployment directory and was read from disk/CAS); `file_name` is the
+///   deployment-relative path (which may include subfolders), used for source names and
+///   backtraces.
 /// - `Path` is an external local file that the deployment merely references; it is read
-///   at runtime and is not recreated on export.
+///   at runtime.
 /// - `Oci` is an external registry reference.
 #[derive(Debug, Clone, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -756,8 +756,14 @@ pub mod cron {
     }
 }
 
-/// Canonical deployment configuration — no local file paths.
-/// Used for hash computation, wire format, and DB storage.
+/// Canonical deployment configuration after resolving deployment-owned text sources.
+///
+/// This is a runtime/verification shape derived from the stored manifest plus a file
+/// provider. It is not the stored deployment source of truth. Deployment-owned scripts
+/// and backtrace sources are inlined as content; deployment-owned WASM locations remain
+/// relative path + content digest until `DeploymentResolved` materializes them from the
+/// CAS into a runnable cache path. External absolute paths and OCI references remain
+/// external references.
 #[derive(Debug, Deserialize, Serialize, Default, Clone, JsonSchema)]
 pub struct DeploymentCanonical {
     pub activities_wasm: Vec<ActivityWasmComponentConfigToml>,

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -46,8 +46,9 @@ service DeploymentRepository {
     rpc SwitchDeployment(SwitchDeploymentRequest) returns (SwitchDeploymentResponse);
     rpc SubmitDeployment(SubmitDeploymentRequest) returns (SubmitDeploymentResponse);
     rpc GetDeployment(GetDeploymentRequest) returns (GetDeploymentResponse);
-    // Upload a deployment file blob to the content-addressed store. Scoped to a
-    // deployment: the server rejects a digest not in that deployment's missing set.
+    // Deprecated: deployment file blobs are attached to `SubmitDeployment` via
+    // `DeploymentFileContent`. Retained as admin-only CAS tooling; not used by the
+    // normal deployment submit flow.
     rpc UploadFile(UploadFileRequest) returns (UploadFileResponse);
     // Fetch a deployment file blob by content digest.
     rpc GetFile(GetFileRequest) returns (GetFileResponse);
@@ -1112,8 +1113,7 @@ message SwitchDeploymentResponse {
 
 message SubmitDeploymentRequest {
     // Verbatim deployment manifest (`deployment.toml`), stored byte-for-byte.
-    // Every relative `location =` carries a `content_digest`; the referenced
-    // blobs are uploaded separately via `UploadFile`.
+    // Every deployment-owned relative `location =` must carry a `content_digest`.
     string deployment_toml = 1;
     optional string created_by = 2;
     // Deprecated for submit: verification happens when the deployment is activated.
@@ -1124,12 +1124,62 @@ message SubmitDeploymentRequest {
     // the submitted manifest, the submission is a no-op and returns this ID.
     // A digest mismatch is rejected. When unset, a fresh ID is generated.
     optional DeploymentId deployment_id = 5;
+    // Deployment-owned file blobs referenced by the manifest. A blob may be
+    // omitted when its digest already exists in the CAS; if a referenced digest
+    // is neither attached here nor present in the CAS, submit fails with
+    // `SubmitDeploymentErrorDetail.missing_files` and no deployment is stored.
+    repeated DeploymentFileContent files = 6;
 }
+
+message DeploymentFileContent {
+    // Deployment-relative path as it appears after normalizing the manifest
+    // reference. Used to attach bytes to a specific manifest reference and to
+    // make validation errors actionable.
+    string path = 1;
+    // Optional client-computed digest for clearer errors and deduplication; the
+    // server always recomputes it from `content` and uses the recomputed value.
+    optional string digest = 2;
+    bytes content = 3;
+}
+
 message SubmitDeploymentResponse {
     DeploymentId deployment_id = 1;
-    // Digests the manifest references that the server does not yet have; the
-    // client must `UploadFile` each before the deployment can be activated.
-    repeated string missing_digests = 2;
+}
+
+// Structured detail attached (prost-encoded) to a FAILED_PRECONDITION /
+// INVALID_ARGUMENT submit status. Each list points at the offending manifest
+// reference so callers can act without guessing.
+message SubmitDeploymentErrorDetail {
+    // Deployment-owned references whose `content_digest` field is absent.
+    repeated FileIssue missing_digest_fields = 1;
+    // Referenced digests neither attached in the request nor present in CAS.
+    repeated FileIssue missing_files = 2;
+    // Attached blobs whose digest is not referenced by the manifest.
+    repeated FileIssue unexpected_files = 3;
+    // Attached blobs whose recomputed digest disagrees with the supplied one.
+    repeated DigestMismatch digest_mismatches = 4;
+    // Attached blobs exceeding the per-file size limit.
+    repeated FileIssue oversized_files = 5;
+}
+
+message FileIssue {
+    // Example: "activity_js", "workflow_wasm.backtrace.sources".
+    string section = 1;
+    // Component name after name derivation, when available.
+    optional string component_name = 2;
+    // Stable field path, e.g. "activity_js[name=send-email].location".
+    string field_path = 3;
+    // Deployment-relative file path, when the issue is tied to a path.
+    optional string path = 4;
+    // Expected digest, when known. Absent for `missing_digest_fields`.
+    optional string digest = 5;
+    string message = 6;
+}
+
+message DigestMismatch {
+    FileIssue file = 1;
+    string supplied_digest = 2;
+    string actual_digest = 3;
 }
 
 message UploadFileRequest {

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -1093,10 +1093,24 @@ message GetCurrentDeploymentIdResponse {
     DeploymentId deployment_id = 1;
 }
 
+// Policy for runtime configuration (environment variables and secrets) that a
+// deployment references but that may be absent from the server's environment.
+// Structural, file, compile, and link validation are always performed regardless
+// of this value.
+enum RuntimeConfigCheck {
+    // Unset; treated as RUNTIME_CONFIG_CHECK_STRICT.
+    RUNTIME_CONFIG_CHECK_UNSPECIFIED = 0;
+    // Missing environment variables or secrets fail the operation.
+    RUNTIME_CONFIG_CHECK_STRICT = 1;
+    // Missing environment variables or secrets are tolerated.
+    RUNTIME_CONFIG_CHECK_ALLOW_MISSING = 2;
+}
+
 message SwitchDeploymentRequest {
     DeploymentId deployment_id = 1;
-    // Run `obelisk server verify` on the deployment config before switching.
-    bool verify = 2;
+    // Runtime config availability policy applied while verifying the deployment.
+    // A hot redeploy rejects RUNTIME_CONFIG_CHECK_ALLOW_MISSING.
+    RuntimeConfigCheck runtime_config_check = 2;
     // Perform a hot redeployment (reload running components without restart).
     bool hot_redeploy = 3;
 }
@@ -1116,8 +1130,9 @@ message SubmitDeploymentRequest {
     // Every deployment-owned relative `location =` must carry a `content_digest`.
     string deployment_toml = 1;
     optional string created_by = 2;
-    // Deprecated for submit: verification happens when the deployment is activated.
-    bool verify = 3;
+    // Runtime config availability policy applied while verifying the deployment
+    // before it is persisted. Defaults to RUNTIME_CONFIG_CHECK_STRICT.
+    RuntimeConfigCheck runtime_config_check = 3;
     optional string description = 4;
     // Optional client-supplied deployment ID for idempotent submission.
     // If a deployment with this ID already exists and its content digest matches

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -1116,8 +1116,7 @@ message SubmitDeploymentRequest {
     // blobs are uploaded separately via `UploadFile`.
     string deployment_toml = 1;
     optional string created_by = 2;
-    // Verify env vars / secrets exist. Resolution itself happens at activation in
-    // the server's environment; this only decides whether a missing one errors now.
+    // Deprecated for submit: verification happens when the deployment is activated.
     bool verify = 3;
     optional string description = 4;
     // Optional client-supplied deployment ID for idempotent submission.

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -46,12 +46,11 @@ service DeploymentRepository {
     rpc SwitchDeployment(SwitchDeploymentRequest) returns (SwitchDeploymentResponse);
     rpc SubmitDeployment(SubmitDeploymentRequest) returns (SubmitDeploymentResponse);
     rpc GetDeployment(GetDeploymentRequest) returns (GetDeploymentResponse);
-    // Deprecated: deployment file blobs are attached to `SubmitDeployment` via
-    // `DeploymentFileContent`. Retained as admin-only CAS tooling; not used by the
-    // normal deployment submit flow.
-    rpc UploadFile(UploadFileRequest) returns (UploadFileResponse);
     // Fetch a deployment file blob by content digest.
     rpc GetFile(GetFileRequest) returns (GetFileResponse);
+    // Delete content-addressed file blobs not referenced by any stored deployment
+    // (e.g. orphans left by a submit that failed verification after writing blobs).
+    rpc GcOrphanFiles(GcOrphanFilesRequest) returns (GcOrphanFilesResponse);
 }
 
 message GenerateExecutionIdRequest {
@@ -1197,20 +1196,18 @@ message DigestMismatch {
     string actual_digest = 3;
 }
 
-message UploadFileRequest {
-    DeploymentId deployment_id = 1;
-    bytes content = 2;
-}
-message UploadFileResponse {
-    // Server-computed digest of the uploaded content, for confirmation.
-    string digest = 1;
-}
-
 message GetFileRequest {
     string digest = 1;
 }
 message GetFileResponse {
     bytes content = 1;
+}
+
+message GcOrphanFilesRequest {
+}
+message GcOrphanFilesResponse {
+    // Number of orphan file blobs deleted from the content-addressed store.
+    uint64 deleted_count = 1;
 }
 
 message GetDeploymentRequest {

--- a/src/args.rs
+++ b/src/args.rs
@@ -182,6 +182,15 @@ pub(crate) enum Deployment {
         #[arg(short, long, default_value = "http://127.0.0.1:5005")]
         api_url: String,
     },
+    /// Delete content-addressed file blobs not referenced by any stored deployment.
+    ///
+    /// Such orphans are left behind when a submit writes blobs to the store and then
+    /// fails verification before persisting the deployment.
+    Gc {
+        /// Address of the obelisk server
+        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        api_url: String,
+    },
     /// Print the ID of the currently active deployment.
     Active {
         /// Output as JSON instead of plain text.

--- a/src/args.rs
+++ b/src/args.rs
@@ -102,7 +102,7 @@ pub(crate) enum Deployment {
         /// Submit an empty deployment with no components.
         #[arg(long)]
         empty: bool,
-        /// Verify all environment variables before persisting.
+        /// Deprecated for submit: verification happens when the deployment is activated.
         #[arg(long)]
         verify: bool,
         /// Optional human-readable description.

--- a/src/args.rs
+++ b/src/args.rs
@@ -102,9 +102,10 @@ pub(crate) enum Deployment {
         /// Submit an empty deployment with no components.
         #[arg(long)]
         empty: bool,
-        /// Deprecated for submit: verification happens when the deployment is activated.
+        /// Tolerate missing environment variables / secrets while verifying the
+        /// deployment before persisting it (default: missing config fails).
         #[arg(long)]
-        verify: bool,
+        allow_missing_runtime_config: bool,
         /// Optional human-readable description.
         #[arg(long)]
         description: Option<String>,
@@ -131,9 +132,10 @@ pub(crate) enum Deployment {
         /// Enqueue an empty deployment with no components.
         #[arg(long)]
         empty: bool,
-        /// Verify all environment variables before enqueuing.
+        /// Tolerate missing environment variables / secrets while verifying the
+        /// deployment before enqueuing it (default: missing config fails).
         #[arg(long)]
-        verify: bool,
+        allow_missing_runtime_config: bool,
         /// Optional human-readable description for a newly submitted deployment.
         #[arg(long)]
         description: Option<String>,

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -154,6 +154,17 @@ impl args::Deployment {
                 Ok(())
             }
 
+            args::Deployment::Gc { api_url } => {
+                let channel = to_channel(&api_url).await?;
+                let mut client = get_deployment_repository_client(channel).await?;
+                let resp = client
+                    .gc_orphan_files(grpc_gen::GcOrphanFilesRequest {})
+                    .await?
+                    .into_inner();
+                println!("Deleted {} orphan file blob(s).", resp.deleted_count);
+                Ok(())
+            }
+
             args::Deployment::Active { api_url, json } => {
                 let channel = to_channel(&api_url).await?;
                 let mut client = get_deployment_repository_client(channel).await?;

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -315,9 +315,8 @@ async fn submit_deployment(
     Ok(id)
 }
 
-/// Upload the manifest's referenced file blobs to the content-addressed store, then submit the
-/// verbatim manifest. The server is content-addressed and idempotent, so re-uploading a blob it
-/// already has is a no-op.
+/// Submit the verbatim manifest, upload the blobs the server reports missing, then re-submit with
+/// the same deployment ID to confirm the deployment is complete.
 async fn upload_and_submit_manifest(
     client: &mut DeploymentClient,
     prepared: PreparedDeploymentManifest,
@@ -325,22 +324,43 @@ async fn upload_and_submit_manifest(
     description: Option<String>,
     deployment_id: Option<DeploymentId>,
 ) -> anyhow::Result<DeploymentId> {
-    for file in &prepared.files {
+    let resp = client
+        .submit_deployment(grpc_gen::SubmitDeploymentRequest {
+            deployment_toml: prepared.deployment_toml.clone(),
+            created_by: Some("cli".to_string()),
+            verify,
+            description: description.clone(),
+            deployment_id: deployment_id.map(grpc_gen::DeploymentId::from),
+        })
+        .await?
+        .into_inner();
+    let submitted_id =
+        DeploymentId::try_from(resp.deployment_id.context("missing deployment_id")?)?;
+
+    for missing in &resp.missing_digests {
+        let file = prepared
+            .files
+            .iter()
+            .find(|file| file.digest.to_string() == *missing)
+            .with_context(|| {
+                format!("server requested unknown deployment file digest `{missing}`")
+            })?;
         client
             .upload_file(grpc_gen::UploadFileRequest {
-                deployment_id: deployment_id.map(grpc_gen::DeploymentId::from),
+                deployment_id: Some(grpc_gen::DeploymentId::from(submitted_id)),
                 content: file.bytes.clone(),
             })
             .await
             .with_context(|| format!("cannot upload deployment file `{}`", file.path))?;
     }
+
     let resp = client
         .submit_deployment(grpc_gen::SubmitDeploymentRequest {
             deployment_toml: prepared.deployment_toml,
             created_by: Some("cli".to_string()),
             verify,
             description,
-            deployment_id: deployment_id.map(grpc_gen::DeploymentId::from),
+            deployment_id: Some(grpc_gen::DeploymentId::from(submitted_id)),
         })
         .await?
         .into_inner();

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -315,8 +315,9 @@ async fn submit_deployment(
     Ok(id)
 }
 
-/// Submit the verbatim manifest, upload the blobs the server reports missing, then re-submit with
-/// the same deployment ID to confirm the deployment is complete.
+/// Submit the enriched manifest as a CAS-efficient package: first without file
+/// blobs, and if the server reports missing files, retry the same submit with only
+/// those blobs attached. The requested TOML is identical on both attempts.
 async fn upload_and_submit_manifest(
     client: &mut DeploymentClient,
     prepared: PreparedDeploymentManifest,
@@ -324,54 +325,147 @@ async fn upload_and_submit_manifest(
     description: Option<String>,
     deployment_id: Option<DeploymentId>,
 ) -> anyhow::Result<DeploymentId> {
+    // Preflight: no blobs, so digests already in the CAS are not re-uploaded.
+    let missing = match submit_attempt(
+        client,
+        &prepared,
+        verify,
+        description.as_deref(),
+        deployment_id,
+        Vec::new(),
+    )
+    .await?
+    {
+        SubmitAttempt::Stored(id) => return Ok(id),
+        SubmitAttempt::Missing(digests) => digests,
+    };
+
+    // Retry with only the blobs the server is missing.
+    let files = prepared
+        .files
+        .iter()
+        .filter(|file| missing.contains(&file.digest.to_string()))
+        .map(|file| grpc_gen::DeploymentFileContent {
+            path: file.path.clone(),
+            digest: Some(file.digest.to_string()),
+            content: file.bytes.clone(),
+        })
+        .collect();
+    match submit_attempt(
+        client,
+        &prepared,
+        verify,
+        description.as_deref(),
+        deployment_id,
+        files,
+    )
+    .await?
+    {
+        SubmitAttempt::Stored(id) => Ok(id),
+        SubmitAttempt::Missing(digests) => bail!(
+            "server is still missing {} file blob(s) after upload: {}",
+            digests.len(),
+            digests.join(", ")
+        ),
+    }
+}
+
+enum SubmitAttempt {
+    Stored(DeploymentId),
+    /// Digests the server is missing; the deployment was not stored.
+    Missing(Vec<String>),
+}
+
+/// One submit request. A `FAILED_PRECONDITION` carrying only `missing_files`
+/// becomes `Missing`; any other structured issue or status is a hard error.
+async fn submit_attempt(
+    client: &mut DeploymentClient,
+    prepared: &PreparedDeploymentManifest,
+    verify: bool,
+    description: Option<&str>,
+    deployment_id: Option<DeploymentId>,
+    files: Vec<grpc_gen::DeploymentFileContent>,
+) -> anyhow::Result<SubmitAttempt> {
     let resp = client
         .submit_deployment(grpc_gen::SubmitDeploymentRequest {
             deployment_toml: prepared.deployment_toml.clone(),
             created_by: Some("cli".to_string()),
             verify,
-            description: description.clone(),
+            description: description.map(str::to_string),
             deployment_id: deployment_id.map(grpc_gen::DeploymentId::from),
+            files,
         })
-        .await?
-        .into_inner();
-    let submitted_id =
-        DeploymentId::try_from(resp.deployment_id.context("missing deployment_id")?)?;
-
-    for missing in &resp.missing_digests {
-        let file = prepared
-            .files
-            .iter()
-            .find(|file| file.digest.to_string() == *missing)
-            .with_context(|| {
-                format!("server requested unknown deployment file digest `{missing}`")
-            })?;
-        client
-            .upload_file(grpc_gen::UploadFileRequest {
-                deployment_id: Some(grpc_gen::DeploymentId::from(submitted_id)),
-                content: file.bytes.clone(),
-            })
-            .await
-            .with_context(|| format!("cannot upload deployment file `{}`", file.path))?;
+        .await;
+    match resp {
+        Ok(resp) => {
+            let resp = resp.into_inner();
+            Ok(SubmitAttempt::Stored(DeploymentId::try_from(
+                resp.deployment_id.context("missing deployment_id")?,
+            )?))
+        }
+        Err(status) => {
+            if let Some(detail) = decode_submit_error_detail(&status) {
+                let only_missing = detail.unexpected_files.is_empty()
+                    && detail.digest_mismatches.is_empty()
+                    && detail.oversized_files.is_empty()
+                    && detail.missing_digest_fields.is_empty()
+                    && !detail.missing_files.is_empty();
+                if only_missing {
+                    let digests = detail
+                        .missing_files
+                        .iter()
+                        .filter_map(|issue| issue.digest.clone())
+                        .collect();
+                    return Ok(SubmitAttempt::Missing(digests));
+                }
+                bail!(
+                    "deployment submit rejected: {}",
+                    format_submit_detail(&detail)
+                );
+            }
+            Err(status.into())
+        }
     }
+}
 
-    let resp = client
-        .submit_deployment(grpc_gen::SubmitDeploymentRequest {
-            deployment_toml: prepared.deployment_toml,
-            created_by: Some("cli".to_string()),
-            verify,
-            description,
-            deployment_id: Some(grpc_gen::DeploymentId::from(submitted_id)),
-        })
-        .await?
-        .into_inner();
-    if !resp.missing_digests.is_empty() {
-        bail!(
-            "server is still missing {} file blob(s) after upload: {}",
-            resp.missing_digests.len(),
-            resp.missing_digests.join(", ")
-        );
+/// Decode the `SubmitDeploymentErrorDetail` attached to a submit status, if present.
+fn decode_submit_error_detail(
+    status: &tonic::Status,
+) -> Option<grpc_gen::SubmitDeploymentErrorDetail> {
+    use prost::Message as _;
+    let details = status.details();
+    if details.is_empty() {
+        return None;
     }
-    DeploymentId::try_from(resp.deployment_id.context("missing deployment_id")?).map_err(Into::into)
+    grpc_gen::SubmitDeploymentErrorDetail::decode(details).ok()
+}
+
+fn format_submit_detail(detail: &grpc_gen::SubmitDeploymentErrorDetail) -> String {
+    let mut lines = Vec::new();
+    for issue in &detail.missing_digest_fields {
+        lines.push(format!("missing content_digest at {}", issue.field_path));
+    }
+    for issue in &detail.missing_files {
+        lines.push(format!(
+            "missing file at {} ({})",
+            issue.field_path, issue.message
+        ));
+    }
+    for issue in &detail.unexpected_files {
+        lines.push(format!("unexpected file {}", issue.field_path));
+    }
+    for mismatch in &detail.digest_mismatches {
+        lines.push(format!(
+            "digest mismatch for {}: supplied {}, actual {}",
+            mismatch.file.as_ref().map_or("", |file| &file.field_path),
+            mismatch.supplied_digest,
+            mismatch.actual_digest
+        ));
+    }
+    for issue in &detail.oversized_files {
+        lines.push(format!("oversized file {}", issue.field_path));
+    }
+    lines.join("; ")
 }
 
 /// Fetch a deployment file blob from the server's content-addressed store.

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -12,13 +12,22 @@ use grpc::to_channel;
 use std::path::PathBuf;
 use tonic::transport::Channel;
 
+/// Map the CLI `--allow-missing-runtime-config` flag to the wire enum.
+fn runtime_config_check_from_bool(allow_missing: bool) -> grpc_gen::RuntimeConfigCheck {
+    if allow_missing {
+        grpc_gen::RuntimeConfigCheck::AllowMissing
+    } else {
+        grpc_gen::RuntimeConfigCheck::Strict
+    }
+}
+
 impl args::Deployment {
     pub(crate) async fn run(self) -> Result<(), anyhow::Error> {
         match self {
             args::Deployment::Submit {
                 file,
                 empty,
-                verify,
+                allow_missing_runtime_config,
                 description,
                 deployment_id,
                 api_url,
@@ -29,7 +38,7 @@ impl args::Deployment {
                 let id = upload_and_submit_manifest(
                     &mut client,
                     prepared,
-                    verify,
+                    runtime_config_check_from_bool(allow_missing_runtime_config),
                     description,
                     deployment_id,
                 )
@@ -41,18 +50,20 @@ impl args::Deployment {
             args::Deployment::Enqueue {
                 source,
                 empty,
-                verify,
+                allow_missing_runtime_config,
                 description,
                 deployment_id,
                 api_url,
             } => {
+                let runtime_config_check =
+                    runtime_config_check_from_bool(allow_missing_runtime_config);
                 let channel = to_channel(&api_url).await?;
                 let mut client = get_deployment_repository_client(channel).await?;
                 let id = submit_deployment(
                     &mut client,
                     source,
                     empty,
-                    false, // will be verified in switch
+                    runtime_config_check,
                     description,
                     deployment_id,
                 )
@@ -60,7 +71,7 @@ impl args::Deployment {
                 switch_deployment(
                     &mut client,
                     id,
-                    verify,
+                    runtime_config_check,
                     false, // hot
                 )
                 .await
@@ -73,13 +84,15 @@ impl args::Deployment {
                 deployment_id,
                 api_url,
             } => {
+                // A hot redeploy always requires runtime config to be available.
+                let runtime_config_check = grpc_gen::RuntimeConfigCheck::Strict;
                 let channel = to_channel(&api_url).await?;
                 let mut client = get_deployment_repository_client(channel).await?;
                 let id = submit_deployment(
                     &mut client,
                     source,
                     empty,
-                    false, // will be verified in switch
+                    runtime_config_check,
                     description,
                     deployment_id,
                 )
@@ -87,7 +100,7 @@ impl args::Deployment {
                 switch_deployment(
                     &mut client,
                     id,
-                    true, // does not matter, will be verified in any case
+                    runtime_config_check,
                     true, // hot
                 )
                 .await
@@ -291,7 +304,7 @@ async fn submit_deployment(
     client: &mut DeploymentClient,
     source: Option<DeploymentSource>,
     empty: bool,
-    verify: bool,
+    runtime_config_check: grpc_gen::RuntimeConfigCheck,
     description: Option<String>,
     deployment_id: Option<DeploymentId>,
 ) -> anyhow::Result<DeploymentId> {
@@ -309,8 +322,14 @@ async fn submit_deployment(
         Some(DeploymentSource::File(path)) => prepare_deployment_manifest_from_disk(&path).await?,
         None => prepare_manifest_from_file_or_empty(None, empty).await?,
     };
-    let id =
-        upload_and_submit_manifest(client, prepared, verify, description, deployment_id).await?;
+    let id = upload_and_submit_manifest(
+        client,
+        prepared,
+        runtime_config_check,
+        description,
+        deployment_id,
+    )
+    .await?;
     println!("Submitted as {id}");
     Ok(id)
 }
@@ -321,7 +340,7 @@ async fn submit_deployment(
 async fn upload_and_submit_manifest(
     client: &mut DeploymentClient,
     prepared: PreparedDeploymentManifest,
-    verify: bool,
+    runtime_config_check: grpc_gen::RuntimeConfigCheck,
     description: Option<String>,
     deployment_id: Option<DeploymentId>,
 ) -> anyhow::Result<DeploymentId> {
@@ -329,7 +348,7 @@ async fn upload_and_submit_manifest(
     let missing = match submit_attempt(
         client,
         &prepared,
-        verify,
+        runtime_config_check,
         description.as_deref(),
         deployment_id,
         Vec::new(),
@@ -354,7 +373,7 @@ async fn upload_and_submit_manifest(
     match submit_attempt(
         client,
         &prepared,
-        verify,
+        runtime_config_check,
         description.as_deref(),
         deployment_id,
         files,
@@ -381,7 +400,7 @@ enum SubmitAttempt {
 async fn submit_attempt(
     client: &mut DeploymentClient,
     prepared: &PreparedDeploymentManifest,
-    verify: bool,
+    runtime_config_check: grpc_gen::RuntimeConfigCheck,
     description: Option<&str>,
     deployment_id: Option<DeploymentId>,
     files: Vec<grpc_gen::DeploymentFileContent>,
@@ -390,7 +409,7 @@ async fn submit_attempt(
         .submit_deployment(grpc_gen::SubmitDeploymentRequest {
             deployment_toml: prepared.deployment_toml.clone(),
             created_by: Some("cli".to_string()),
-            verify,
+            runtime_config_check: runtime_config_check.into(),
             description: description.map(str::to_string),
             deployment_id: deployment_id.map(grpc_gen::DeploymentId::from),
             files,
@@ -483,13 +502,13 @@ async fn fetch_file(client: &mut DeploymentClient, digest: &str) -> anyhow::Resu
 async fn switch_deployment(
     client: &mut DeploymentClient,
     id: DeploymentId,
-    verify: bool,
+    runtime_config_check: grpc_gen::RuntimeConfigCheck,
     hot: bool,
 ) -> anyhow::Result<()> {
     let resp = client
         .switch_deployment(grpc_gen::SwitchDeploymentRequest {
             deployment_id: Some(grpc_gen::DeploymentId::from(id)),
-            verify,
+            runtime_config_check: runtime_config_check.into(),
             hot_redeploy: hot,
         })
         .await?

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -209,7 +209,7 @@ pub(crate) fn generate_deployment_schema(output: Option<PathBuf>) -> Result<(), 
 pub(crate) fn generate_deployment_canonical_schema(
     output: Option<PathBuf>,
 ) -> Result<(), anyhow::Error> {
-    write_schema::<crate::config::toml::DeploymentCanonical>(output)
+    write_schema::<crate::config::toml::DeploymentResolved>(output)
 }
 
 #[cfg(debug_assertions)]

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -935,9 +935,9 @@ impl TestServer {
             resp.status()
         );
         let body: Value = resp.json().await.unwrap();
-        body["ok"]
+        body["deployment_id"]
             .as_str()
-            .expect("webapi submit deployment: missing ok field")
+            .expect("webapi submit deployment: missing deployment_id field")
             .parse()
             .expect("webapi submit deployment: invalid deployment id")
     }
@@ -962,8 +962,8 @@ impl TestServer {
             .expect("webapi submit deployment request failed")
     }
 
-    /// Upload a manifest's referenced file blobs over gRPC, then submit it, mirroring the
-    /// CLI `deployment apply` upload-then-submit flow. Returns the new deployment ID.
+    /// Submit a manifest over gRPC, upload the missing file blobs, then confirm completeness.
+    /// Returns the new deployment ID.
     async fn grpc_upload_and_submit_manifest(
         &self,
         deployment_toml_path: &std::path::Path,
@@ -976,10 +976,30 @@ impl TestServer {
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
                 .unwrap();
-        for file in &prepared.files {
+        let resp = grpc_client
+            .submit_deployment(SubmitDeploymentRequest {
+                deployment_toml: prepared.deployment_toml.clone(),
+                created_by: Some("test".to_string()),
+                verify: true,
+                description: None,
+                deployment_id: None,
+            })
+            .await
+            .expect("submit_deployment failed")
+            .into_inner();
+        let deployment_id = resp
+            .deployment_id
+            .clone()
+            .expect("submit_deployment: missing deployment_id");
+        for missing in &resp.missing_digests {
+            let file = prepared
+                .files
+                .iter()
+                .find(|file| file.digest.to_string() == *missing)
+                .unwrap_or_else(|| panic!("server requested unknown digest `{missing}`"));
             grpc_client
                 .upload_file(UploadFileRequest {
-                    deployment_id: None,
+                    deployment_id: Some(deployment_id.clone()),
                     content: file.bytes.clone(),
                 })
                 .await
@@ -991,10 +1011,10 @@ impl TestServer {
                 created_by: Some("test".to_string()),
                 verify: true,
                 description: None,
-                deployment_id: None,
+                deployment_id: Some(deployment_id),
             })
             .await
-            .expect("submit_deployment failed")
+            .expect("resubmit_deployment failed")
             .into_inner();
         assert!(
             resp.missing_digests.is_empty(),
@@ -1827,7 +1847,7 @@ async fn submit_deployment_is_idempotent_by_id_and_digest_webapi() {
         resp1.status()
     );
     let body1: Value = resp1.json().await.unwrap();
-    let returned1: DeploymentId = body1["ok"].as_str().unwrap().parse().unwrap();
+    let returned1: DeploymentId = body1["deployment_id"].as_str().unwrap().parse().unwrap();
     assert_eq!(deployment_id, returned1, "explicit ID must be honored");
 
     // Resubmitting the identical manifest under the same ID is an idempotent no-op.
@@ -1840,7 +1860,7 @@ async fn submit_deployment_is_idempotent_by_id_and_digest_webapi() {
         resp2.status()
     );
     let body2: Value = resp2.json().await.unwrap();
-    let returned2: DeploymentId = body2["ok"].as_str().unwrap().parse().unwrap();
+    let returned2: DeploymentId = body2["deployment_id"].as_str().unwrap().parse().unwrap();
     assert_eq!(
         deployment_id, returned2,
         "no-op resubmit must return same ID"
@@ -1862,6 +1882,97 @@ async fn submit_deployment_is_idempotent_by_id_and_digest_webapi() {
         reqwest::StatusCode::BAD_REQUEST,
         "different config under same ID must be rejected as a digest conflict"
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn submit_deployment_defers_missing_file_upload_and_upload_is_scoped_grpc() {
+    let server = TestServer::start(test_addr!(62)).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join("deferred.js"),
+        "export function run() { return 'ok'; }",
+    )
+    .await
+    .unwrap();
+    let deployment_toml_path = dir.path().join("deployment.toml");
+    tokio::fs::write(
+        &deployment_toml_path,
+        r#"
+[[activity_js]]
+name = "deferred"
+location = "deferred.js"
+ffqn = "testing:integration/deferred.run"
+"#,
+    )
+    .await
+    .unwrap();
+    let prepared =
+        crate::config::manifest::prepare_deployment_manifest_from_disk(&deployment_toml_path)
+            .await
+            .unwrap();
+    let expected_digest = prepared.files[0].digest.to_string();
+
+    let mut grpc_client =
+        DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+            .await
+            .unwrap();
+    let submit_resp = grpc_client
+        .submit_deployment(SubmitDeploymentRequest {
+            deployment_toml: prepared.deployment_toml.clone(),
+            created_by: Some("test".to_string()),
+            verify: true,
+            description: None,
+            deployment_id: None,
+        })
+        .await
+        .expect("submit_deployment failed")
+        .into_inner();
+    assert_eq!(submit_resp.missing_digests, vec![expected_digest]);
+    let deployment_id = submit_resp
+        .deployment_id
+        .clone()
+        .expect("submit_deployment: missing deployment_id");
+
+    grpc_client
+        .upload_file(UploadFileRequest {
+            deployment_id: Some(deployment_id.clone()),
+            content: b"unexpected".to_vec(),
+        })
+        .await
+        .expect_err("unexpected digest must be rejected");
+
+    grpc_client
+        .switch_deployment(SwitchDeploymentRequest {
+            deployment_id: Some(deployment_id.clone()),
+            verify: true,
+            hot_redeploy: true,
+        })
+        .await
+        .expect_err("incomplete deployment must not activate");
+
+    grpc_client
+        .upload_file(UploadFileRequest {
+            deployment_id: Some(deployment_id.clone()),
+            content: prepared.files[0].bytes.clone(),
+        })
+        .await
+        .expect("expected upload must succeed");
+
+    let submit_resp = grpc_client
+        .submit_deployment(SubmitDeploymentRequest {
+            deployment_toml: prepared.deployment_toml,
+            created_by: Some("test".to_string()),
+            verify: true,
+            description: None,
+            deployment_id: Some(deployment_id),
+        })
+        .await
+        .expect("idempotent resubmit failed")
+        .into_inner();
+    assert!(submit_resp.missing_digests.is_empty());
 
     server.shutdown().await;
 }

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -70,8 +70,8 @@ use db_sqlite::sqlite_dao::{SqliteConfig, SqlitePool};
 use directories::BaseDirs;
 use grpc::grpc_gen::{
     AdvanceExecutionRequest, DeploymentId as GrpcDeploymentId, ExecutionId as GrpcExecutionId,
-    GetStatusRequest, ListComponentsRequest, ReplayExecutionRequest, SubmitDeploymentRequest,
-    SubmitRequest, SwitchDeploymentRequest, UploadFileRequest,
+    GetDeploymentRequest, GetStatusRequest, ListComponentsRequest, ReplayExecutionRequest,
+    SubmitDeploymentRequest, SubmitRequest, SwitchDeploymentRequest,
     deployment_repository_client::DeploymentRepositoryClient,
     execution_repository_client::ExecutionRepositoryClient,
     function_repository_client::FunctionRepositoryClient, switch_deployment_response::Outcome,
@@ -984,65 +984,67 @@ impl TestServer {
             .expect("webapi submit deployment request failed")
     }
 
-    /// Submit a manifest over gRPC, upload the missing file blobs, then confirm completeness.
+    /// Submit a manifest over gRPC as a CAS-efficient package: preflight without
+    /// blobs, then retry attaching only the files the server reports missing.
     /// Returns the new deployment ID.
     async fn grpc_upload_and_submit_manifest(
         &self,
         deployment_toml_path: &std::path::Path,
     ) -> DeploymentId {
+        use prost::Message as _;
+
         let prepared =
             crate::config::manifest::prepare_deployment_manifest_from_disk(deployment_toml_path)
                 .await
                 .expect("cannot prepare deployment manifest");
-        let mut grpc_client =
+        let grpc_client =
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
                 .unwrap();
-        let resp = grpc_client
-            .submit_deployment(SubmitDeploymentRequest {
-                deployment_toml: prepared.deployment_toml.clone(),
-                created_by: Some("test".to_string()),
-                verify: true,
-                description: None,
-                deployment_id: None,
-            })
-            .await
-            .expect("submit_deployment failed")
-            .into_inner();
-        let deployment_id = resp
-            .deployment_id
-            .clone()
-            .expect("submit_deployment: missing deployment_id");
-        for missing in &resp.missing_digests {
-            let file = prepared
-                .files
-                .iter()
-                .find(|file| file.digest.to_string() == *missing)
-                .unwrap_or_else(|| panic!("server requested unknown digest `{missing}`"));
+
+        let submit = async |files| {
             grpc_client
-                .upload_file(UploadFileRequest {
-                    deployment_id: Some(deployment_id.clone()),
-                    content: file.bytes.clone(),
+                .clone()
+                .submit_deployment(SubmitDeploymentRequest {
+                    deployment_toml: prepared.deployment_toml.clone(),
+                    created_by: Some("test".to_string()),
+                    verify: true,
+                    description: None,
+                    deployment_id: None,
+                    files,
                 })
                 .await
-                .unwrap_or_else(|e| panic!("cannot upload deployment file `{}`: {e}", file.path));
-        }
-        let resp = grpc_client
-            .submit_deployment(SubmitDeploymentRequest {
-                deployment_toml: prepared.deployment_toml,
-                created_by: Some("test".to_string()),
-                verify: true,
-                description: None,
-                deployment_id: Some(deployment_id),
-            })
-            .await
-            .expect("resubmit_deployment failed")
-            .into_inner();
-        assert!(
-            resp.missing_digests.is_empty(),
-            "server still missing blobs after upload: {:?}",
-            resp.missing_digests
-        );
+        };
+
+        // Preflight: no blobs attached. Succeeds outright when every referenced
+        // digest is already in the CAS.
+        let resp = match submit(Vec::new()).await {
+            Ok(resp) => resp.into_inner(),
+            Err(status) => {
+                let detail = grpc::grpc_gen::SubmitDeploymentErrorDetail::decode(status.details())
+                    .expect("submit error must carry SubmitDeploymentErrorDetail");
+                let missing: Vec<String> = detail
+                    .missing_files
+                    .iter()
+                    .filter_map(|issue| issue.digest.clone())
+                    .collect();
+                // Retry with only the missing blobs.
+                let files = prepared
+                    .files
+                    .iter()
+                    .filter(|file| missing.contains(&file.digest.to_string()))
+                    .map(|file| grpc::grpc_gen::DeploymentFileContent {
+                        path: file.path.clone(),
+                        digest: Some(file.digest.to_string()),
+                        content: file.bytes.clone(),
+                    })
+                    .collect();
+                submit(files)
+                    .await
+                    .expect("resubmit with blobs failed")
+                    .into_inner()
+            }
+        };
         resp.deployment_id
             .expect("submit_deployment: missing deployment_id")
             .id
@@ -1164,6 +1166,8 @@ impl TestDeployClient {
                         verify: false,
                         description: None,
                         deployment_id: None,
+                        // The mutated active manifest references only blobs already in the CAS.
+                        files: Vec::new(),
                     })
                     .await
                     .unwrap()
@@ -1909,7 +1913,9 @@ async fn submit_deployment_is_idempotent_by_id_and_digest_webapi() {
 }
 
 #[tokio::test]
-async fn submit_deployment_defers_missing_file_upload_and_upload_is_scoped_grpc() {
+async fn submit_deployment_package_validates_before_persisting_grpc() {
+    use prost::Message as _;
+
     let server = TestServer::start(test_addr!(62)).await;
 
     let dir = tempfile::tempdir().unwrap();
@@ -1936,65 +1942,107 @@ ffqn = "testing:integration/deferred.run"
             .await
             .unwrap();
     let expected_digest = prepared.files[0].digest.to_string();
+    let deployment_id = DeploymentId::generate();
+    let grpc_id = GrpcDeploymentId {
+        id: deployment_id.to_string(),
+    };
 
     let mut grpc_client =
         DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
             .await
             .unwrap();
-    let submit_resp = grpc_client
-        .submit_deployment(SubmitDeploymentRequest {
-            deployment_toml: prepared.deployment_toml.clone(),
-            created_by: Some("test".to_string()),
-            verify: true,
-            description: None,
-            deployment_id: None,
-        })
+    let submit = |files, id| {
+        let mut client = grpc_client.clone();
+        let toml = prepared.deployment_toml.clone();
+        async move {
+            client
+                .submit_deployment(SubmitDeploymentRequest {
+                    deployment_toml: toml,
+                    created_by: Some("test".to_string()),
+                    verify: true,
+                    description: None,
+                    deployment_id: Some(id),
+                    files,
+                })
+                .await
+        }
+    };
+
+    // Preflight with no blobs reports the missing file and stores nothing.
+    let status = submit(Vec::new(), grpc_id.clone())
         .await
-        .expect("submit_deployment failed")
-        .into_inner();
-    assert_eq!(submit_resp.missing_digests, vec![expected_digest]);
-    let deployment_id = submit_resp
-        .deployment_id
+        .expect_err("preflight must report the missing file");
+    let detail = grpc::grpc_gen::SubmitDeploymentErrorDetail::decode(status.details())
+        .expect("must carry SubmitDeploymentErrorDetail");
+    assert_eq!(detail.missing_files.len(), 1);
+    assert_eq!(
+        detail.missing_files[0].digest.as_deref(),
+        Some(expected_digest.as_str())
+    );
+    assert_eq!(detail.missing_files[0].section, "activity_js");
+    grpc_client
         .clone()
-        .expect("submit_deployment: missing deployment_id");
+        .get_deployment(GetDeploymentRequest {
+            deployment_id: Some(grpc_id.clone()),
+        })
+        .await
+        .expect_err("failed preflight must not persist a deployment");
 
-    grpc_client
-        .upload_file(UploadFileRequest {
-            deployment_id: Some(deployment_id.clone()),
+    // An attached blob not referenced by the manifest is rejected as unexpected.
+    let status = submit(
+        vec![grpc::grpc_gen::DeploymentFileContent {
+            path: "deferred.js".to_string(),
+            digest: None,
             content: b"unexpected".to_vec(),
-        })
-        .await
-        .expect_err("unexpected digest must be rejected");
+        }],
+        grpc_id.clone(),
+    )
+    .await
+    .expect_err("unexpected blob must be rejected");
+    let detail = grpc::grpc_gen::SubmitDeploymentErrorDetail::decode(status.details()).unwrap();
+    assert_eq!(detail.unexpected_files.len(), 1);
 
-    grpc_client
-        .switch_deployment(SwitchDeploymentRequest {
-            deployment_id: Some(deployment_id.clone()),
-            verify: true,
-            hot_redeploy: true,
-        })
-        .await
-        .expect_err("incomplete deployment must not activate");
-
-    grpc_client
-        .upload_file(UploadFileRequest {
-            deployment_id: Some(deployment_id.clone()),
+    // A client-supplied digest that disagrees with the bytes is rejected.
+    let status = submit(
+        vec![grpc::grpc_gen::DeploymentFileContent {
+            path: "deferred.js".to_string(),
+            digest: Some(
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+            ),
             content: prepared.files[0].bytes.clone(),
-        })
-        .await
-        .expect("expected upload must succeed");
+        }],
+        grpc_id.clone(),
+    )
+    .await
+    .expect_err("digest mismatch must be rejected");
+    let detail = grpc::grpc_gen::SubmitDeploymentErrorDetail::decode(status.details()).unwrap();
+    assert_eq!(detail.digest_mismatches.len(), 1);
 
-    let submit_resp = grpc_client
-        .submit_deployment(SubmitDeploymentRequest {
-            deployment_toml: prepared.deployment_toml,
-            created_by: Some("test".to_string()),
-            verify: true,
-            description: None,
-            deployment_id: Some(deployment_id),
+    // Retry with the correct blob persists the complete deployment.
+    let resp = submit(
+        vec![grpc::grpc_gen::DeploymentFileContent {
+            path: "deferred.js".to_string(),
+            digest: Some(expected_digest.clone()),
+            content: prepared.files[0].bytes.clone(),
+        }],
+        grpc_id.clone(),
+    )
+    .await
+    .expect("submit with correct blob must succeed")
+    .into_inner();
+    assert_eq!(
+        resp.deployment_id.expect("deployment_id").id,
+        deployment_id.to_string()
+    );
+
+    // The stored deployment is complete and now exists.
+    grpc_client
+        .get_deployment(GetDeploymentRequest {
+            deployment_id: Some(grpc_id),
         })
         .await
-        .expect("idempotent resubmit failed")
-        .into_inner();
-    assert!(submit_resp.missing_digests.is_empty());
+        .expect("stored deployment must exist");
 
     server.shutdown().await;
 }

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -70,8 +70,9 @@ use db_sqlite::sqlite_dao::{SqliteConfig, SqlitePool};
 use directories::BaseDirs;
 use grpc::grpc_gen::{
     AdvanceExecutionRequest, DeploymentId as GrpcDeploymentId, ExecutionId as GrpcExecutionId,
-    GetDeploymentRequest, GetStatusRequest, ListComponentsRequest, ReplayExecutionRequest,
-    RuntimeConfigCheck, SubmitDeploymentRequest, SubmitRequest, SwitchDeploymentRequest,
+    GcOrphanFilesRequest, GetDeploymentRequest, GetFileRequest, GetStatusRequest,
+    ListComponentsRequest, ReplayExecutionRequest, RuntimeConfigCheck, SubmitDeploymentRequest,
+    SubmitRequest, SwitchDeploymentRequest,
     deployment_repository_client::DeploymentRepositoryClient,
     execution_repository_client::ExecutionRepositoryClient,
     function_repository_client::FunctionRepositoryClient, switch_deployment_response::Outcome,
@@ -2071,12 +2072,11 @@ ffqn = "testing:integration/needs-env.run"
 env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
 "#;
 
-    let mut grpc_client =
-        DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
-            .await
-            .unwrap()
-            .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-            .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+    let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap()
+        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
 
     let submit = |check: RuntimeConfigCheck, id: Option<GrpcDeploymentId>| {
         let mut client = grpc_client.clone();
@@ -2264,6 +2264,143 @@ ffqn = "testing:integration/pkg.run"
         .await
         .expect("get deployment failed");
     assert_eq!(resp.status().as_u16(), 200, "stored deployment must exist");
+
+    server.shutdown().await;
+}
+
+/// Phase 8: a submit that writes file blobs and then fails verification leaves orphan
+/// blobs in the CAS. `GcOrphanFiles` deletes blobs not referenced by any stored
+/// deployment while keeping those a valid deployment still references.
+#[tokio::test]
+async fn gc_orphan_files_grpc() {
+    let server = TestServer::start(test_addr!(81)).await;
+
+    let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap()
+        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+
+    // Prepare a deployment-owned JS file (digest-enriched) from disk. `section` selects
+    // `activity_js` or `workflow_js` (a JS workflow validates its source at link time, so
+    // a syntax error there fails submit verification).
+    async fn prepare(
+        section: &str,
+        source: &str,
+    ) -> (
+        tempfile::TempDir,
+        crate::config::manifest::PreparedDeploymentManifest,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join("a.js"), source)
+            .await
+            .unwrap();
+        let toml_path = dir.path().join("deployment.toml");
+        tokio::fs::write(
+            &toml_path,
+            format!(
+                r#"
+[[{section}]]
+name = "a"
+location = "a.js"
+ffqn = "testing:integration/a.run"
+"#
+            ),
+        )
+        .await
+        .unwrap();
+        let prepared = crate::config::manifest::prepare_deployment_manifest_from_disk(&toml_path)
+            .await
+            .unwrap();
+        (dir, prepared)
+    }
+
+    let submit_request =
+        |prepared: &crate::config::manifest::PreparedDeploymentManifest| SubmitDeploymentRequest {
+            deployment_toml: prepared.deployment_toml.clone(),
+            created_by: Some("test".to_string()),
+            runtime_config_check: RuntimeConfigCheck::Strict as i32,
+            description: None,
+            deployment_id: Some(GrpcDeploymentId {
+                id: DeploymentId::generate().to_string(),
+            }),
+            files: vec![grpc::grpc_gen::DeploymentFileContent {
+                path: "a.js".to_string(),
+                digest: Some(prepared.files[0].digest.to_string()),
+                content: prepared.files[0].bytes.clone(),
+            }],
+        };
+
+    // A valid deployment: its blob is referenced and must survive GC.
+    let (_good_dir, good) = prepare("activity_js", "export function run() { return 'ok'; }").await;
+    let good_digest = good.files[0].digest.to_string();
+    grpc_client
+        .clone()
+        .submit_deployment(submit_request(&good))
+        .await
+        .expect("valid deployment must persist");
+
+    // An invalid deployment: the blob is written, then verification fails, so no
+    // deployment row references it. It becomes an orphan. A JS workflow validates its
+    // source at link time, so a syntax error fails submit.
+    let (_bad_dir, bad) = prepare("workflow_js", "this is @@@ not valid javascript {{{").await;
+    let bad_digest = bad.files[0].digest.to_string();
+    grpc_client
+        .clone()
+        .submit_deployment(submit_request(&bad))
+        .await
+        .expect_err("invalid deployment must fail verification");
+
+    // Before GC: both blobs are present in the CAS.
+    grpc_client
+        .clone()
+        .get_file(GetFileRequest {
+            digest: good_digest.clone(),
+        })
+        .await
+        .expect("referenced blob present before gc");
+    grpc_client
+        .clone()
+        .get_file(GetFileRequest {
+            digest: bad_digest.clone(),
+        })
+        .await
+        .expect("orphan blob present before gc");
+
+    // GC deletes exactly the orphan.
+    let deleted = grpc_client
+        .clone()
+        .gc_orphan_files(GcOrphanFilesRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .deleted_count;
+    assert_eq!(deleted, 1, "exactly one orphan blob must be deleted");
+
+    // After GC: the orphan is gone, the referenced blob remains.
+    grpc_client
+        .clone()
+        .get_file(GetFileRequest {
+            digest: good_digest,
+        })
+        .await
+        .expect("referenced blob must survive gc");
+    let status = grpc_client
+        .clone()
+        .get_file(GetFileRequest { digest: bad_digest })
+        .await
+        .expect_err("orphan blob must be gone after gc");
+    assert_eq!(status.code(), tonic::Code::NotFound);
+
+    // A second GC is a no-op.
+    let deleted = grpc_client
+        .clone()
+        .gc_orphan_files(GcOrphanFilesRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .deleted_count;
+    assert_eq!(deleted, 0, "second gc must delete nothing");
 
     server.shutdown().await;
 }

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -71,7 +71,7 @@ use directories::BaseDirs;
 use grpc::grpc_gen::{
     AdvanceExecutionRequest, DeploymentId as GrpcDeploymentId, ExecutionId as GrpcExecutionId,
     GetDeploymentRequest, GetStatusRequest, ListComponentsRequest, ReplayExecutionRequest,
-    SubmitDeploymentRequest, SubmitRequest, SwitchDeploymentRequest,
+    RuntimeConfigCheck, SubmitDeploymentRequest, SubmitRequest, SwitchDeploymentRequest,
     deployment_repository_client::DeploymentRepositoryClient,
     execution_repository_client::ExecutionRepositoryClient,
     function_repository_client::FunctionRepositoryClient, switch_deployment_response::Outcome,
@@ -947,7 +947,7 @@ impl TestServer {
             .client
             .post(format!("{}/v1/deployments", self.base_url))
             .header("Accept", "application/json")
-            .json(&json!({ "deployment_toml": deployment_toml, "verify": false }))
+            .json(&json!({ "deployment_toml": deployment_toml }))
             .send()
             .await
             .expect("webapi submit deployment request failed");
@@ -976,7 +976,6 @@ impl TestServer {
             .header("Accept", "application/json")
             .json(&json!({
                 "deployment_toml": deployment_toml,
-                "verify": false,
                 "deployment_id": deployment_id.to_string(),
             }))
             .send()
@@ -1010,7 +1009,7 @@ impl TestServer {
                 .submit_deployment(SubmitDeploymentRequest {
                     deployment_toml: prepared.deployment_toml.clone(),
                     created_by: Some("test".to_string()),
-                    verify: true,
+                    runtime_config_check: RuntimeConfigCheck::Strict as i32,
                     description: None,
                     deployment_id: None,
                     files,
@@ -1067,7 +1066,7 @@ impl TestServer {
                 deployment_id: Some(GrpcDeploymentId {
                     id: deployment_id.to_string(),
                 }),
-                verify: true,
+                runtime_config_check: RuntimeConfigCheck::Strict as i32,
                 hot_redeploy: true,
             })
             .await
@@ -1085,7 +1084,7 @@ impl TestServer {
                 self.base_url
             ))
             .header("Accept", "application/json")
-            .json(&json!({ "verify": false, "hot_redeploy": true }))
+            .json(&json!({ "hot_redeploy": true }))
             .send()
             .await
             .expect("webapi switch deployment request failed");
@@ -1169,7 +1168,7 @@ impl TestDeployClient {
                     .submit_deployment(SubmitDeploymentRequest {
                         deployment_toml: new_deployment_toml,
                         created_by: Some("test".to_string()),
-                        verify: false,
+                        runtime_config_check: RuntimeConfigCheck::Strict as i32,
                         description: None,
                         deployment_id: None,
                         // The mutated active manifest references only blobs already in the CAS.
@@ -1182,7 +1181,7 @@ impl TestDeployClient {
                 let switch_resp = grpc_client
                     .switch_deployment(SwitchDeploymentRequest {
                         deployment_id: Some(GrpcDeploymentId { id: second_id }),
-                        verify: false,
+                        runtime_config_check: RuntimeConfigCheck::Strict as i32,
                         hot_redeploy: true,
                     })
                     .await
@@ -1967,7 +1966,7 @@ ffqn = "testing:integration/deferred.run"
                 .submit_deployment(SubmitDeploymentRequest {
                     deployment_toml: toml,
                     created_by: Some("test".to_string()),
-                    verify: true,
+                    runtime_config_check: RuntimeConfigCheck::Strict as i32,
                     description: None,
                     deployment_id: Some(id),
                     files,
@@ -2051,6 +2050,105 @@ ffqn = "testing:integration/deferred.run"
         })
         .await
         .expect("stored deployment must exist");
+
+    server.shutdown().await;
+}
+
+/// Phase 5: `RuntimeConfigCheck` governs whether missing env vars / secrets fail
+/// verification. Submit is strict by default and tolerant under `ALLOW_MISSING`; a
+/// hot redeploy is always strict and rejects `ALLOW_MISSING` outright.
+#[tokio::test]
+async fn submit_runtime_config_check_grpc() {
+    let server = TestServer::start(test_addr!(79)).await;
+
+    // A JS activity referencing a bare-name env var guaranteed absent from the server
+    // environment. Inline content needs no attached file blobs.
+    let deployment_toml = r#"
+[[activity_js]]
+name = "needs_env"
+content = "export function run() { return 'ok'; }"
+ffqn = "testing:integration/needs-env.run"
+env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
+"#;
+
+    let mut grpc_client =
+        DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+            .await
+            .unwrap()
+            .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+
+    let submit = |check: RuntimeConfigCheck, id: Option<GrpcDeploymentId>| {
+        let mut client = grpc_client.clone();
+        async move {
+            client
+                .submit_deployment(SubmitDeploymentRequest {
+                    deployment_toml: deployment_toml.to_string(),
+                    created_by: Some("test".to_string()),
+                    runtime_config_check: check as i32,
+                    description: None,
+                    deployment_id: id,
+                    files: Vec::new(),
+                })
+                .await
+        }
+    };
+
+    // Strict submit fails on the missing env var and stores nothing.
+    let status = submit(RuntimeConfigCheck::Strict, None)
+        .await
+        .expect_err("strict submit must reject a missing env var");
+    assert!(
+        status
+            .message()
+            .contains("OBELISK_PHASE5_DEFINITELY_MISSING_VAR"),
+        "error must name the missing env var, got: {}",
+        status.message()
+    );
+
+    // ALLOW_MISSING submit tolerates the missing env var and persists.
+    let stored_id = submit(RuntimeConfigCheck::AllowMissing, None)
+        .await
+        .expect("allow-missing submit must persist")
+        .into_inner()
+        .deployment_id
+        .expect("deployment_id")
+        .id;
+    let stored_grpc_id = GrpcDeploymentId { id: stored_id };
+
+    // A hot redeploy with ALLOW_MISSING is rejected outright.
+    let status = grpc_client
+        .clone()
+        .switch_deployment(SwitchDeploymentRequest {
+            deployment_id: Some(stored_grpc_id.clone()),
+            runtime_config_check: RuntimeConfigCheck::AllowMissing as i32,
+            hot_redeploy: true,
+        })
+        .await
+        .expect_err("hot redeploy must reject allow-missing-runtime-config");
+    assert!(
+        status.message().contains("allow-missing-runtime-config"),
+        "error must explain the rejection, got: {}",
+        status.message()
+    );
+
+    // A strict hot redeploy of the same deployment fails because the env var is missing.
+    let status = grpc_client
+        .clone()
+        .switch_deployment(SwitchDeploymentRequest {
+            deployment_id: Some(stored_grpc_id),
+            runtime_config_check: RuntimeConfigCheck::Strict as i32,
+            hot_redeploy: true,
+        })
+        .await
+        .expect_err("strict hot redeploy must fail on the missing env var");
+    assert!(
+        status
+            .message()
+            .contains("OBELISK_PHASE5_DEFINITELY_MISSING_VAR"),
+        "error must name the missing env var, got: {}",
+        status.message()
+    );
 
     server.shutdown().await;
 }

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1000,7 +1000,9 @@ impl TestServer {
         let grpc_client =
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
-                .unwrap();
+                .unwrap()
+                .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+                .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
 
         let submit = async |files| {
             grpc_client
@@ -1057,7 +1059,9 @@ impl TestServer {
         let mut grpc_client =
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
-                .unwrap();
+                .unwrap()
+                .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+                .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
         let resp = grpc_client
             .switch_deployment(SwitchDeploymentRequest {
                 deployment_id: Some(GrpcDeploymentId {
@@ -1158,7 +1162,9 @@ impl TestDeployClient {
                 let mut grpc_client =
                     DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
                         .await
-                        .unwrap();
+                        .unwrap()
+                        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+                        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
                 let submit_resp = grpc_client
                     .submit_deployment(SubmitDeploymentRequest {
                         deployment_toml: new_deployment_toml,
@@ -1950,7 +1956,9 @@ ffqn = "testing:integration/deferred.run"
     let mut grpc_client =
         DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
             .await
-            .unwrap();
+            .unwrap()
+            .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
     let submit = |files, id| {
         let mut client = grpc_client.clone();
         let toml = prepared.deployment_toml.clone();

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -81,7 +81,10 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::Sha256;
 use std::fmt::Write as _;
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 use test_utils::sanitize_json;
 use tokio::{sync::watch, task::JoinHandle};
 use tokio_stream::StreamExt;
@@ -102,6 +105,21 @@ mod populate_js_codegen_cache {
 
 fn get_workspace_dir() -> PathBuf {
     PathBuf::from(std::env::var("CARGO_WORKSPACE_DIR").unwrap())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry.file_type().unwrap();
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path);
+        } else if file_type.is_file() {
+            std::fs::copy(&src_path, &dst_path).unwrap();
+        }
+    }
 }
 
 /// Fixed ports used by all integration tests.
@@ -133,6 +151,10 @@ pub(crate) use test_addr;
 fn write_test_configs(ip: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
     let workspace = get_workspace_dir();
     let db_dir = tempfile::tempdir().unwrap();
+    let fixture_src = workspace.join("crates/testing/test-programs");
+    let fixture_dst = db_dir.path().join("crates/testing/test-programs");
+    copy_dir_recursive(&fixture_src.join("js"), &fixture_dst.join("js"));
+    copy_dir_recursive(&fixture_src.join("exec"), &fixture_dst.join("exec"));
     let server_contents = format!(
         r#"api.listening_addr = "{ip}:{API_PORT}"
 webui.enabled = false
@@ -152,7 +174,7 @@ directory = "{db_dir}"
     let server_path = db_dir.path().join("obelisk-test-server.toml");
     std::fs::write(&server_path, server_contents).unwrap();
 
-    let ws = workspace.display();
+    let ws = ".";
     let deployment_contents = format!(
         r#"
 [[activity_js]]

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -15,7 +15,7 @@ use crate::{
 use toml_edit::{DocumentMut, value};
 
 /// Append an inline `[[activity_stub]]` to a deployment manifest, mirroring the canonical
-/// `ActivityStubExtInlineConfigCanonical` the tests used to construct in-memory.
+/// `ActivityStubExtInlineConfigResolved` the tests used to construct in-memory.
 fn append_inline_stub(doc: &mut DocumentMut, name: &str, ffqn: &str) {
     let mut table = toml_edit::Table::new();
     table["name"] = value(name);

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2153,6 +2153,121 @@ env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
     server.shutdown().await;
 }
 
+/// Phase 6: the REST `POST /v1/deployments` accepts a `multipart/form-data` package
+/// and reports an incomplete package as a structured `409` so the client retries with
+/// the missing blobs attached.
+#[tokio::test]
+async fn submit_deployment_multipart_package_webapi() {
+    let server = TestServer::start(test_addr!(80)).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join("pkg.js"),
+        "export function run() { return 'ok'; }",
+    )
+    .await
+    .unwrap();
+    let deployment_toml_path = dir.path().join("deployment.toml");
+    tokio::fs::write(
+        &deployment_toml_path,
+        r#"
+[[activity_js]]
+name = "pkg"
+location = "pkg.js"
+ffqn = "testing:integration/pkg.run"
+"#,
+    )
+    .await
+    .unwrap();
+    let prepared =
+        crate::config::manifest::prepare_deployment_manifest_from_disk(&deployment_toml_path)
+            .await
+            .unwrap();
+    let toml = prepared.deployment_toml.clone();
+    let expected_digest = prepared.files[0].digest.to_string();
+    let content = prepared.files[0].bytes.clone();
+    let url = format!("{}/v1/deployments", server.base_url);
+
+    // Preflight with no file parts: incomplete package, stored nothing, lists the missing file.
+    let resp = server
+        .client
+        .post(&url)
+        .header("Accept", "application/json")
+        .multipart(reqwest::multipart::Form::new().text("deployment_toml", toml.clone()))
+        .send()
+        .await
+        .expect("multipart preflight failed");
+    assert_eq!(
+        resp.status().as_u16(),
+        409,
+        "incomplete package must be 409"
+    );
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["missing_files"].as_array().unwrap().len(), 1);
+    assert_eq!(body["missing_files"][0]["digest"], json!(expected_digest));
+    assert_eq!(body["missing_files"][0]["section"], json!("activity_js"));
+
+    // A blob whose supplied digest disagrees with its bytes is reported as a mismatch.
+    let mismatch_part = reqwest::multipart::Part::bytes(content.clone())
+        .file_name("pkg.js")
+        .mime_str("application/octet-stream")
+        .unwrap();
+    let resp = server
+        .client
+        .post(&url)
+        .header("Accept", "application/json")
+        .multipart(
+            reqwest::multipart::Form::new()
+                .text("deployment_toml", toml.clone())
+                .part(
+                    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                    mismatch_part,
+                ),
+        )
+        .send()
+        .await
+        .expect("multipart mismatch submit failed");
+    assert_eq!(resp.status().as_u16(), 409, "digest mismatch must be 409");
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["digest_mismatches"].as_array().unwrap().len(), 1);
+
+    // Retry with the correct blob (field name carries the digest): the package is complete.
+    let part = reqwest::multipart::Part::bytes(content)
+        .file_name("pkg.js")
+        .mime_str("application/octet-stream")
+        .unwrap();
+    let resp = server
+        .client
+        .post(&url)
+        .header("Accept", "application/json")
+        .multipart(
+            reqwest::multipart::Form::new()
+                .text("deployment_toml", toml)
+                .part(expected_digest.clone(), part),
+        )
+        .send()
+        .await
+        .expect("multipart retry failed");
+    assert_eq!(resp.status().as_u16(), 200, "complete package must succeed");
+    let body: Value = resp.json().await.unwrap();
+    let deployment_id = body["deployment_id"].as_str().expect("deployment_id");
+
+    // The stored deployment now exists and is retrievable.
+    let resp = server
+        .client
+        .get(format!(
+            "{}/v1/deployments/{deployment_id}",
+            server.base_url
+        ))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("get deployment failed");
+    assert_eq!(resp.status().as_u16(), 200, "stored deployment must exist");
+
+    server.shutdown().await;
+}
+
 // ---- Activity: submit + result ----
 
 #[tokio::test]

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1371,7 +1371,11 @@ pub(crate) async fn run_internal(
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)
         .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip),
+        .accept_compressed(CompressionEncoding::Gzip)
+        // Submit requests inline deployment-owned blobs; raise the decode limit
+        // well above tonic's 4 MiB default. `GetFile` responses are likewise large.
+        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE),
     )
     .add_service(
         tonic_reflection::server::Builder::configure()
@@ -1958,16 +1962,16 @@ fn validate_submit_package(
 #[instrument(skip_all)]
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn submit_deployment(
-    _server_verified: ServerVerified,
+    server_verified: ServerVerified,
     deployment_toml: &str,
     _verify: bool,
     created_by: Option<String>,
     description: Option<String>,
     requested_deployment_id: Option<DeploymentId>,
-    _prepared_dirs: &PreparedDirs,
+    prepared_dirs: &PreparedDirs,
     supplied_files: Vec<SuppliedFile>,
     db_pool: Arc<dyn DbPool>,
-    _termination_watcher: &mut watch::Receiver<()>,
+    termination_watcher: &mut watch::Receiver<()>,
 ) -> Result<DeploymentId, SubmitDeploymentError> {
     info!("Submitting deployment");
     // The deployment digest is the hash of the verbatim manifest; it transitively covers
@@ -2041,6 +2045,39 @@ pub(crate) async fn submit_deployment(
             )));
         }
     }
+
+    // Fully validate the deployment before persisting it, so a stored deployment is
+    // already known-good: canonicalize from the CAS (resolving env vars/secrets),
+    // parse JS, validate WIT/WASM, and compile + link every component. Activation no
+    // longer performs first-time package validation. Blobs already written to the CAS
+    // when verification fails are acceptable GC input; no deployment row is inserted.
+    let canonical = canonical_from_manifest(&*db_pool, deployment_toml)
+        .await
+        .map_err(SubmitDeploymentError::Other)?;
+    let cas_arc: Arc<dyn concepts::cas::Cas> = db_pool
+        .cas_conn()
+        .await
+        .map_err(anyhow::Error::from)?
+        .into();
+    deployment_verify_config_compile_link(
+        server_verified,
+        prepared_dirs,
+        canonical,
+        Some(cas_arc),
+        DeploymentId::generate(),
+        VerifyParams {
+            dir_params: PrepareDirsParams {
+                clean_cache: false,
+                clean_codegen_cache: false,
+            },
+            ignore_missing_env_vars: false,
+            suppress_type_checking_errors: false,
+            suppress_linking_errors: false,
+        },
+        termination_watcher,
+    )
+    .await
+    .map_err(SubmitDeploymentError::Other)?;
 
     let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
     let now = chrono::Utc::now();

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2059,12 +2059,13 @@ pub(crate) async fn submit_deployment(
         .await
         .map_err(anyhow::Error::from)?
         .into();
-    deployment_verify_config_compile_link(
+    let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
+    let compiled_linked = deployment_verify_config_compile_link(
         server_verified,
         prepared_dirs,
         canonical,
         Some(cas_arc),
-        DeploymentId::generate(),
+        deployment_id,
         VerifyParams {
             dir_params: PrepareDirsParams {
                 clean_cache: false,
@@ -2079,7 +2080,6 @@ pub(crate) async fn submit_deployment(
     .await
     .map_err(SubmitDeploymentError::Other)?;
 
-    let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
     let now = chrono::Utc::now();
 
     conn.insert_deployment(DeploymentRecord {
@@ -2096,6 +2096,18 @@ pub(crate) async fn submit_deployment(
     })
     .await
     .map_err(anyhow::Error::from)?;
+
+    // Persist the verified component metadata and backtrace sources so the DB-backed
+    // ListComponents / GetBacktraceSource see this deployment without waiting for a
+    // server restart. Verification above already compiled and linked every component.
+    persist_deployment_component_metadata(
+        conn.as_ref(),
+        deployment_id,
+        &compiled_linked.component_registry_ro,
+    )
+    .await
+    .map_err(SubmitDeploymentError::Other)?;
+    upsert_backtrace_sources(conn.as_ref(), &compiled_linked).await;
 
     info!(%deployment_id, "Deployment submitted");
     Ok(deployment_id)

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -6,15 +6,15 @@ use crate::config::config_holder::PathPrefixes;
 use crate::config::config_holder::load_deployment_canonical;
 use crate::config::content_digest_to_wasm_file;
 use crate::config::env_var::EnvVarConfig;
-use crate::config::toml::ActivityExecComponentConfigCanonicalExt as _;
+use crate::config::toml::ActivityExecComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityExecConfigVerified;
-use crate::config::toml::ActivityExternalComponentConfigCanonical;
-use crate::config::toml::ActivityExternalComponentConfigCanonicalExt as _;
+use crate::config::toml::ActivityExternalComponentConfigResolved;
+use crate::config::toml::ActivityExternalComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityExternalConfigVerified;
-use crate::config::toml::ActivityJsComponentConfigCanonicalExt as _;
+use crate::config::toml::ActivityJsComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityJsConfigVerified;
-use crate::config::toml::ActivityStubComponentConfigCanonical;
-use crate::config::toml::ActivityStubComponentConfigCanonicalExt as _;
+use crate::config::toml::ActivityStubComponentConfigResolved;
+use crate::config::toml::ActivityStubComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityStubConfigVerified;
 use crate::config::toml::ActivityStubExtConfigVerified;
 use crate::config::toml::ActivityStubExtInlineConfigVerified;
@@ -27,7 +27,7 @@ use crate::config::toml::ComponentLocationToml;
 use crate::config::toml::ComponentStdOutputToml;
 use crate::config::toml::ConfigName;
 use crate::config::toml::DatabaseConfigToml;
-use crate::config::toml::DeploymentCanonical;
+use crate::config::toml::DeploymentResolved;
 use crate::config::toml::InflightSemaphoreExt as _;
 use crate::config::toml::LogLevelToml;
 use crate::config::toml::SQLITE_FILE_NAME;
@@ -35,18 +35,18 @@ use crate::config::toml::ServerConfigToml;
 use crate::config::toml::TimersWatcherTomlConfig;
 use crate::config::toml::WasmtimeAllocatorConfig;
 use crate::config::toml::WorkflowConfigVerified;
-use crate::config::toml::WorkflowJsComponentConfigCanonicalExt as _;
+use crate::config::toml::WorkflowJsComponentConfigResolvedExt as _;
 use crate::config::toml::WorkflowJsConfigVerified;
-use crate::config::toml::WorkflowWasmComponentConfigCanonicalExt as _;
+use crate::config::toml::WorkflowWasmComponentConfigResolvedExt as _;
 use crate::config::toml::cron::CronComponentConfigTomlExt as _;
 use crate::config::toml::cron::CronConfigVerified;
 use crate::config::toml::webhook;
 use crate::config::toml::webhook::HttpServer;
-use crate::config::toml::webhook::WebhookJsComponentConfigCanonicalExt as _;
+use crate::config::toml::webhook::WebhookJsComponentConfigResolvedExt as _;
 use crate::config::toml::webhook::WebhookJsConfigVerified;
 use crate::config::toml::webhook::WebhookRoute;
 use crate::config::toml::webhook::WebhookRouteVerified;
-use crate::config::toml::webhook::WebhookWasmComponentConfigCanonicalExt as _;
+use crate::config::toml::webhook::WebhookWasmComponentConfigResolvedExt as _;
 use crate::config::toml::webhook::WebhookWasmComponentConfigVerified;
 use crate::config::toml::{AllowedHostToml, MethodsInput, MethodsInputStar};
 use crate::config::wasm_cache_metadata_dir;
@@ -678,7 +678,7 @@ pub(crate) async fn server_verify(
 pub(crate) async fn deployment_verify_config_compile_link(
     server_verified: ServerVerified,
     prepared_dirs: &PreparedDirs,
-    deployment: DeploymentCanonical,
+    deployment: DeploymentResolved,
     cas: Option<Arc<dyn concepts::cas::Cas>>,
     deployment_id: DeploymentId,
     params: VerifyParams,
@@ -733,14 +733,14 @@ pub(crate) async fn deployment_compile_link(
 pub(crate) async fn deployment_verify_config(
     server_verified: &ServerVerified,
     prepared_dirs: &PreparedDirs,
-    deployment: DeploymentCanonical,
+    deployment: DeploymentResolved,
     cas: Option<Arc<dyn concepts::cas::Cas>>,
     params: VerifyParams,
     termination_watcher: &mut watch::Receiver<()>,
 ) -> Result<DeploymentVerified, anyhow::Error> {
     // Materialize deployment-owned WASM blobs from the CAS onto disk before compiling.
     let deployment =
-        DeploymentResolved::resolve(deployment, cas.as_deref(), &prepared_dirs.wasm_cache_dir)
+        DeploymentRunnable::resolve(deployment, cas.as_deref(), &prepared_dirs.wasm_cache_dir)
             .await?;
     let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(
         deployment,
@@ -766,7 +766,7 @@ async fn get_deployment_canonical_from_db(
     database: &DatabaseConfigToml,
     path_prefixes: &PathPrefixes,
     db_pool_container: &mut DbPoolCloseableContainer,
-) -> anyhow::Result<(DeploymentCanonical, DeploymentId)> {
+) -> anyhow::Result<(DeploymentResolved, DeploymentId)> {
     let conn = if let Some((pool, _)) = db_pool_container.as_ref() {
         pool.external_api_conn()
             .await
@@ -846,7 +846,7 @@ async fn get_deployment_canonical_from_db(
 /// already-canonicalized form used to compile/link this run.
 pub(crate) struct LocalDeployment {
     deployment_toml: String,
-    canonical: DeploymentCanonical,
+    canonical: DeploymentResolved,
     files: Vec<crate::config::manifest::DeploymentManifestFile>,
 }
 
@@ -865,7 +865,7 @@ impl LocalDeployment {
     pub(crate) fn empty() -> Self {
         Self {
             deployment_toml: String::new(),
-            canonical: DeploymentCanonical::default(),
+            canonical: DeploymentResolved::default(),
             files: Vec::new(),
         }
     }
@@ -876,9 +876,9 @@ impl LocalDeployment {
 /// Empty on purpose: a stored manifest has no submitter host to anchor relative paths to.
 /// Deployment-owned references are addressed by content digest in the CAS, so joining a
 /// `${DEPLOYMENT_DIR}` / relative path against an empty root leaves it relative. That keeps
-/// deployment-owned WASM locations relative in the resulting `DeploymentCanonical` (no
+/// deployment-owned WASM locations relative in the resulting `DeploymentResolved` (no
 /// fabricated host paths); they become concrete on-disk paths only later, in
-/// [`DeploymentResolved::resolve`], which materializes their blobs from the CAS.
+/// [`DeploymentRunnable::resolve`], which materializes their blobs from the CAS.
 fn cas_deployment_dir() -> std::path::PathBuf {
     std::path::PathBuf::new()
 }
@@ -915,7 +915,7 @@ async fn canonical_and_files_from_manifest(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_toml: &str,
 ) -> anyhow::Result<(
-    DeploymentCanonical,
+    DeploymentResolved,
     Vec<concepts::storage::DeploymentFileRecord>,
 )> {
     let cas: std::sync::Arc<dyn concepts::cas::Cas> = db_pool
@@ -945,16 +945,16 @@ async fn canonical_and_files_from_manifest(
 async fn canonical_from_manifest(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_toml: &str,
-) -> anyhow::Result<DeploymentCanonical> {
+) -> anyhow::Result<DeploymentResolved> {
     Ok(canonical_and_files_from_manifest(db_pool, deployment_toml)
         .await?
         .0)
 }
 
-/// A [`DeploymentCanonical`] whose every WASM component location is a concrete, runnable
+/// A [`DeploymentResolved`] whose every WASM component location is a concrete, runnable
 /// reference: an absolute on-disk path or an OCI image.
 ///
-/// `DeploymentCanonical` is host-independent: a deployment-owned WASM is a *relative* path
+/// `DeploymentResolved` is host-independent: a deployment-owned WASM is a *relative* path
 /// addressed by content digest in the CAS (a stored manifest carries no submitter host).
 /// Compiling/linking needs real files, so [`Self::resolve`] materializes each deployment-owned
 /// blob from the CAS into the wasm cache and rewrites its location to that path. OCI
@@ -964,11 +964,11 @@ async fn canonical_from_manifest(
 ///
 /// The inner value is private so the only way to obtain one is `resolve`; that makes it
 /// impossible to feed an unresolved (relative-path) canonical into compilation.
-pub(crate) struct DeploymentResolved {
-    deployment: DeploymentCanonical,
+pub(crate) struct DeploymentRunnable {
+    deployment: DeploymentResolved,
 }
 
-impl DeploymentResolved {
+impl DeploymentRunnable {
     /// Resolve every deployment-owned WASM location against the CAS.
     ///
     /// `cas` may be `None` for disk/offline flows (e.g. `obelisk server verify <toml>` with
@@ -976,7 +976,7 @@ impl DeploymentResolved {
     /// encountering a deployment-owned (relative) WASM there is an error because there is no
     /// store to read it.
     pub(crate) async fn resolve(
-        mut deployment: DeploymentCanonical,
+        mut deployment: DeploymentResolved,
         cas: Option<&dyn concepts::cas::Cas>,
         wasm_cache_dir: &Path,
     ) -> anyhow::Result<Self> {
@@ -990,7 +990,7 @@ impl DeploymentResolved {
             .await?;
         }
         for c in &mut deployment.activities_stub {
-            if let ActivityStubComponentConfigCanonical::File(f) = c {
+            if let ActivityStubComponentConfigResolved::File(f) = c {
                 materialize_wasm_location(
                     &mut f.common.location,
                     f.content_digest.as_ref(),
@@ -1001,7 +1001,7 @@ impl DeploymentResolved {
             }
         }
         for c in &mut deployment.activities_external {
-            if let ActivityExternalComponentConfigCanonical::File(f) = c {
+            if let ActivityExternalComponentConfigResolved::File(f) = c {
                 materialize_wasm_location(
                     &mut f.common.location,
                     f.content_digest.as_ref(),
@@ -1032,7 +1032,7 @@ impl DeploymentResolved {
         Ok(Self { deployment })
     }
 
-    fn into_canonical(self) -> DeploymentCanonical {
+    fn into_canonical(self) -> DeploymentResolved {
         self.deployment
     }
 }
@@ -1278,7 +1278,7 @@ pub(crate) async fn run_internal(
             )
             .await?;
 
-            (new_deployment_id, DeploymentCanonical::default())
+            (new_deployment_id, DeploymentResolved::default())
         }
     };
     let engines = create_engines(&config, &prepared_dirs)?;
@@ -2811,7 +2811,7 @@ impl DeploymentVerified {
     }
 
     fn verify_no_webui_server_bindings(
-        deployment: &DeploymentCanonical,
+        deployment: &DeploymentResolved,
     ) -> Result<(), anyhow::Error> {
         let mut offending_webhooks = deployment
             .webhooks_wasm
@@ -2839,7 +2839,7 @@ impl DeploymentVerified {
     #[instrument(skip_all)]
     #[expect(clippy::too_many_arguments)]
     async fn fetch_and_verify_all(
-        deployment: DeploymentResolved,
+        deployment: DeploymentRunnable,
         http_servers: Vec<webhook::HttpServer>,
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
@@ -2869,7 +2869,7 @@ impl DeploymentVerified {
             let target_url = format!("http://{api_listening_addr}");
             deployment
                 .webhooks_wasm
-                .push(webhook::WebhookWasmComponentConfigCanonical {
+                .push(webhook::WebhookWasmComponentConfigResolved {
                     common: ComponentCommon {
                         name: ConfigName::new(StrVariant::Static("obelisk_webui")).unwrap(),
                         location: WEBUI_LOCATION
@@ -2885,7 +2885,7 @@ impl DeploymentVerified {
                         key: "TARGET_URL".to_string(),
                         value: target_url.clone(),
                     }],
-                    backtrace: crate::config::toml::ComponentBacktraceConfigCanonical::default(),
+                    backtrace: crate::config::toml::ComponentBacktraceConfigResolved::default(),
                     logs_store_min_level: LogLevelToml::Off,
                     allowed_hosts: vec![AllowedHostToml {
                         pattern: target_url,
@@ -4474,7 +4474,7 @@ pub(crate) fn gen_trace_id() -> String {
 mod tests {
     use crate::{
         command::server::{
-            DeploymentResolved, DeploymentVerified, PrepareDirsParams, ServerCompiledLinked,
+            DeploymentRunnable, DeploymentVerified, PrepareDirsParams, ServerCompiledLinked,
             ServerVerified, VerifyParams, compile_activity_inline, create_engines,
             deployment_verify_config, prepare_dirs,
         },
@@ -4560,7 +4560,7 @@ mod tests {
         // Verify deployment. The current disk-authored canonical holds internal absolute
         // paths, so it resolves to itself without a CAS.
         let deployment =
-            DeploymentResolved::resolve(deployment, None, &prepared_dirs.wasm_cache_dir).await?;
+            DeploymentRunnable::resolve(deployment, None, &prepared_dirs.wasm_cache_dir).await?;
         let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(
             deployment,
             server_verified.http_servers,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -957,9 +957,10 @@ async fn canonical_from_manifest(
 /// `DeploymentCanonical` is host-independent: a deployment-owned WASM is a *relative* path
 /// addressed by content digest in the CAS (a stored manifest carries no submitter host).
 /// Compiling/linking needs real files, so [`Self::resolve`] materializes each deployment-owned
-/// blob from the CAS into the wasm cache and rewrites its location to that path. External
-/// (absolute) paths and OCI references already are concrete and pass through unchanged. The
-/// disk-authored local-run canonical is already all-absolute, so it resolves to itself.
+/// blob from the CAS into the wasm cache and rewrites its location to that path. OCI
+/// references already are concrete and pass through unchanged. The current disk-authored
+/// local-run canonical expands valid relative WASM paths to absolute internal paths, so it
+/// resolves to itself.
 ///
 /// The inner value is private so the only way to obtain one is `resolve`; that makes it
 /// impossible to feed an unresolved (relative-path) canonical into compilation.
@@ -971,8 +972,9 @@ impl DeploymentResolved {
     /// Resolve every deployment-owned WASM location against the CAS.
     ///
     /// `cas` may be `None` for disk/offline flows (e.g. `obelisk server verify <toml>` with
-    /// `--skip-db`), whose canonical holds only absolute paths and OCI refs; encountering a
-    /// deployment-owned (relative) WASM there is an error because there is no store to read it.
+    /// `--skip-db`), whose current canonical holds internal absolute paths and OCI refs;
+    /// encountering a deployment-owned (relative) WASM there is an error because there is no
+    /// store to read it.
     pub(crate) async fn resolve(
         mut deployment: DeploymentCanonical,
         cas: Option<&dyn concepts::cas::Cas>,
@@ -1037,7 +1039,7 @@ impl DeploymentResolved {
 
 /// Turn a single WASM component location into a concrete on-disk path.
 ///
-/// - `Oci` and absolute `Path`s are already concrete and left untouched.
+/// - `Oci` and already-materialized absolute `Path`s are concrete and left untouched.
 /// - A relative `Path` is deployment-owned: its bytes live in the CAS under `content_digest`.
 ///   Materialize them into `wasm_cache_dir` (keyed by digest, mirroring the OCI pull cache)
 ///   and rewrite the location to that absolute path.
@@ -4270,8 +4272,8 @@ mod tests {
         let params = VerifyParams::default();
         let webui_enabled = None;
 
-        // Verify deployment. The disk-authored canonical holds only absolute paths, so it
-        // resolves to itself without a CAS.
+        // Verify deployment. The current disk-authored canonical holds internal absolute
+        // paths, so it resolves to itself without a CAS.
         let deployment =
             DeploymentResolved::resolve(deployment, None, &prepared_dirs.wasm_cache_dir).await?;
         let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1784,9 +1784,177 @@ pub(crate) async fn persist_deployment_component_metadata(
     Ok(())
 }
 
+/// Per-file size limit for deployment-owned blobs attached to a submit request.
+const MAX_DEPLOYMENT_FILE_BYTES: usize = 512 * 1024 * 1024;
+
+/// A deployment-owned blob attached to a submit request.
+pub(crate) struct SuppliedFile {
+    pub(crate) path: String,
+    /// Optional client-computed digest; the server recomputes and uses its own value.
+    pub(crate) supplied_digest: Option<String>,
+    pub(crate) content: Vec<u8>,
+}
+
+/// A single file-set problem found while validating a submit package. Mirrors the
+/// proto `FileIssue` but keeps the command layer free of grpc types.
+#[derive(Debug, Clone)]
+pub(crate) struct SubmitFileIssue {
+    pub(crate) section: String,
+    pub(crate) component_name: Option<String>,
+    pub(crate) field_path: String,
+    pub(crate) path: Option<String>,
+    pub(crate) digest: Option<String>,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SubmitDigestMismatch {
+    pub(crate) file: SubmitFileIssue,
+    pub(crate) supplied_digest: String,
+    pub(crate) actual_digest: String,
+}
+
+/// Structured file-set validation failure. No deployment is stored when returned.
+#[derive(Debug, Default)]
+pub(crate) struct SubmitPackageError {
+    pub(crate) missing_digest_fields: Vec<SubmitFileIssue>,
+    pub(crate) missing_files: Vec<SubmitFileIssue>,
+    pub(crate) unexpected_files: Vec<SubmitFileIssue>,
+    pub(crate) digest_mismatches: Vec<SubmitDigestMismatch>,
+    pub(crate) oversized_files: Vec<SubmitFileIssue>,
+}
+
+impl SubmitPackageError {
+    fn is_empty(&self) -> bool {
+        self.missing_digest_fields.is_empty()
+            && self.missing_files.is_empty()
+            && self.unexpected_files.is_empty()
+            && self.digest_mismatches.is_empty()
+            && self.oversized_files.is_empty()
+    }
+}
+
+/// Submit failure: either a structured file-set error (no deployment stored) or any
+/// other error (parse/idempotency/storage).
+pub(crate) enum SubmitDeploymentError {
+    Package(SubmitPackageError),
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for SubmitDeploymentError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err)
+    }
+}
+
+fn issue_from_ref(
+    file: &crate::config::manifest::DeploymentFileRef,
+    message: &str,
+) -> SubmitFileIssue {
+    SubmitFileIssue {
+        section: file.field.section.clone(),
+        component_name: file.field.component_name.clone(),
+        field_path: file.field.field_path.clone(),
+        path: Some(file.path.clone()),
+        digest: Some(file.digest.to_string()),
+        message: message.to_string(),
+    }
+}
+
+fn supplied_issue(path: &str, digest: &ContentDigest, message: &str) -> SubmitFileIssue {
+    SubmitFileIssue {
+        section: "files".to_string(),
+        component_name: None,
+        field_path: format!("files[path={path}]"),
+        path: Some(path.to_string()),
+        digest: Some(digest.to_string()),
+        message: message.to_string(),
+    }
+}
+
+/// Match attached blobs to the manifest's deployment-owned file refs. Returns the
+/// blobs that must be written to the CAS (referenced, not already present, attached),
+/// or a structured error pointing at each offending reference. Pure: no I/O.
+fn validate_submit_package(
+    expected: &[crate::config::manifest::DeploymentFileRef],
+    supplied: Vec<SuppliedFile>,
+    cas_present: &hashbrown::HashSet<ContentDigest>,
+    max_bytes: usize,
+) -> Result<Vec<crate::config::manifest::DeploymentManifestFile>, SubmitPackageError> {
+    use crate::config::manifest::DeploymentManifestFile;
+
+    let mut err = SubmitPackageError::default();
+    // `expected` is already deduplicated by digest in `DeploymentManifest`.
+    let expected_by_digest: HashMap<ContentDigest, ()> = expected
+        .iter()
+        .map(|file| (file.digest.clone(), ()))
+        .collect();
+
+    let mut provided: HashMap<ContentDigest, Vec<u8>> = HashMap::new();
+    for file in supplied {
+        let actual = compute_content_digest(&file.content);
+        if let Some(supplied_digest) = &file.supplied_digest
+            && supplied_digest.parse::<ContentDigest>().ok().as_ref() != Some(&actual)
+        {
+            err.digest_mismatches.push(SubmitDigestMismatch {
+                file: supplied_issue(
+                    &file.path,
+                    &actual,
+                    "attached blob digest does not match the supplied digest",
+                ),
+                supplied_digest: supplied_digest.clone(),
+                actual_digest: actual.to_string(),
+            });
+            continue;
+        }
+        if file.content.len() > max_bytes {
+            err.oversized_files.push(supplied_issue(
+                &file.path,
+                &actual,
+                &format!("attached blob exceeds the {max_bytes}-byte per-file limit"),
+            ));
+            continue;
+        }
+        if expected_by_digest.contains_key(&actual) {
+            provided.insert(actual, file.content);
+        } else {
+            err.unexpected_files.push(supplied_issue(
+                &file.path,
+                &actual,
+                "attached blob is not referenced by the manifest",
+            ));
+        }
+    }
+
+    let mut to_write = Vec::new();
+    for file in expected {
+        if cas_present.contains(&file.digest) {
+            continue;
+        }
+        if let Some(bytes) = provided.remove(&file.digest) {
+            to_write.push(DeploymentManifestFile {
+                path: file.path.clone(),
+                digest: file.digest.clone(),
+                bytes,
+            });
+        } else {
+            err.missing_files.push(issue_from_ref(
+                file,
+                "referenced file is neither attached nor present in the store",
+            ));
+        }
+    }
+
+    if err.is_empty() {
+        Ok(to_write)
+    } else {
+        Err(err)
+    }
+}
+
 /// Shared logic for submitting a deployment (used by both gRPC and web API).
-/// Parses and stores the verbatim manifest plus the file refs it names. File bytes may be
-/// uploaded later; compile/link verification happens when the deployment is activated.
+/// Validates the manifest and its file set as a package; persists only a complete
+/// deployment. Compile/link verification still happens when the deployment is activated.
 #[instrument(skip_all)]
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn submit_deployment(
@@ -1797,37 +1965,82 @@ pub(crate) async fn submit_deployment(
     description: Option<String>,
     requested_deployment_id: Option<DeploymentId>,
     _prepared_dirs: &PreparedDirs,
+    supplied_files: Vec<SuppliedFile>,
     db_pool: Arc<dyn DbPool>,
     _termination_watcher: &mut watch::Receiver<()>,
-) -> anyhow::Result<(DeploymentId, Vec<ContentDigest>)> {
+) -> Result<DeploymentId, SubmitDeploymentError> {
     info!("Submitting deployment");
     // The deployment digest is the hash of the verbatim manifest; it transitively covers
-    // every referenced file because the manifest embeds each file's content digest.
+    // every referenced file because the manifest embeds each file's content digest. It is
+    // used only for idempotency, not returned (the client already has the manifest).
     let digest = DeploymentRecord::compute_digest(deployment_toml);
 
-    let conn = db_pool.external_api_conn().await?;
+    let conn = db_pool
+        .external_api_conn()
+        .await
+        .map_err(anyhow::Error::from)?;
 
     // Idempotent submission: if the caller supplied a deployment ID that already
-    // exists, return it as a no-op when the content digest matches (skipping the
-    // expensive verify/compile/link), and reject a digest mismatch as a conflict.
+    // exists, return it as a no-op when the content digest matches, and reject a
+    // digest mismatch as a conflict. A stored deployment is always complete.
     if let Some(requested_deployment_id) = requested_deployment_id
-        && let Some(existing) = conn.get_deployment(requested_deployment_id).await?
+        && let Some(existing) = conn
+            .get_deployment(requested_deployment_id)
+            .await
+            .map_err(anyhow::Error::from)?
     {
         if existing.digest == digest {
             info!(%requested_deployment_id, "Deployment already exists with matching digest, returning existing ID");
-            let missing = conn.missing_digests(requested_deployment_id).await?;
-            return Ok((requested_deployment_id, missing));
+            return Ok(requested_deployment_id);
         }
-        bail!(
+        return Err(SubmitDeploymentError::Other(anyhow::anyhow!(
             "deployment {requested_deployment_id} already exists with a different content digest \
              (existing {}, submitted {digest}); use a fresh deployment ID",
             existing.digest
-        );
+        )));
     }
 
-    let file_records =
-        crate::config::manifest::file_records_from_manifest(deployment_toml, &cas_deployment_dir())
-            .context("cannot read deployment file references from manifest")?;
+    let manifest = crate::config::manifest::DeploymentManifest::try_from_toml(
+        deployment_toml,
+        &cas_deployment_dir(),
+    )
+    .context("cannot read deployment file references from manifest")?;
+
+    // A referenced digest already in the CAS need not be attached to the request.
+    let cas = db_pool.cas_conn().await.map_err(anyhow::Error::from)?;
+    let mut cas_present = hashbrown::HashSet::new();
+    for file in &manifest.files {
+        if cas
+            .contains_blob(&file.digest)
+            .await
+            .map_err(|err| anyhow::anyhow!("cannot query CAS for {}: {err}", file.digest))?
+        {
+            cas_present.insert(file.digest.clone());
+        }
+    }
+
+    let to_write = validate_submit_package(
+        &manifest.files,
+        supplied_files,
+        &cas_present,
+        MAX_DEPLOYMENT_FILE_BYTES,
+    )
+    .map_err(SubmitDeploymentError::Package)?;
+
+    // Write missing blobs to the CAS before inserting the deployment row, so the
+    // stored deployment never references absent blobs. Orphan blobs from a later
+    // failed insert are acceptable GC input.
+    for file in &to_write {
+        let stored = cas.write_blob(&file.bytes).await.map_err(|err| {
+            anyhow::anyhow!("cannot store deployment file {}: {err}", file.digest)
+        })?;
+        if stored != file.digest {
+            return Err(SubmitDeploymentError::Other(anyhow::anyhow!(
+                "stored deployment file digest mismatch: expected {}, got {stored}",
+                file.digest
+            )));
+        }
+    }
 
     let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
     let now = chrono::Utc::now();
@@ -1842,13 +2055,13 @@ pub(crate) async fn submit_deployment(
         obelisk_version: crate::args::shadow::PKG_VERSION.to_string(),
         created_by,
         deployment_toml: deployment_toml.to_string(),
-        files: file_records,
+        files: manifest.file_records(),
     })
-    .await?;
+    .await
+    .map_err(anyhow::Error::from)?;
 
-    let missing = conn.missing_digests(deployment_id).await?;
     info!(%deployment_id, "Deployment submitted");
-    Ok((deployment_id, missing))
+    Ok(deployment_id)
 }
 
 fn compute_content_digest(content: &[u8]) -> ContentDigest {
@@ -4351,5 +4564,140 @@ mod tests {
 
         assert!(err.to_string().contains("shared between component types"));
         Ok(())
+    }
+
+    mod submit_package {
+        use crate::command::server::{
+            MAX_DEPLOYMENT_FILE_BYTES, SuppliedFile, compute_content_digest,
+            validate_submit_package,
+        };
+        use crate::config::manifest::{DeploymentFileRef, ManifestFieldRef};
+        use concepts::ContentDigest;
+        use hashbrown::HashSet;
+
+        fn file_ref(path: &str, content: &[u8]) -> (DeploymentFileRef, ContentDigest) {
+            let digest = compute_content_digest(content);
+            (
+                DeploymentFileRef {
+                    path: path.to_string(),
+                    digest: digest.clone(),
+                    field: ManifestFieldRef {
+                        section: "activity_wasm".to_string(),
+                        component_name: Some("c".to_string()),
+                        field_path: "activity_wasm[name=c].location".to_string(),
+                    },
+                },
+                digest,
+            )
+        }
+
+        #[test]
+        fn attached_blob_is_scheduled_for_write() {
+            let (expected, _digest) = file_ref("a.wasm", b"\0asm-bytes");
+            let supplied = vec![SuppliedFile {
+                path: "a.wasm".to_string(),
+                supplied_digest: None,
+                content: b"\0asm-bytes".to_vec(),
+            }];
+            let to_write = validate_submit_package(
+                &[expected],
+                supplied,
+                &HashSet::new(),
+                MAX_DEPLOYMENT_FILE_BYTES,
+            )
+            .expect("complete package");
+            assert_eq!(to_write.len(), 1);
+            assert_eq!(to_write[0].path, "a.wasm");
+        }
+
+        #[test]
+        fn cas_hit_needs_no_attached_blob_and_no_write() {
+            let (expected, digest) = file_ref("a.wasm", b"\0asm-bytes");
+            let cas_present = HashSet::from_iter([digest]);
+            let to_write = validate_submit_package(
+                &[expected],
+                Vec::new(),
+                &cas_present,
+                MAX_DEPLOYMENT_FILE_BYTES,
+            )
+            .expect("CAS hit is complete");
+            assert!(to_write.is_empty());
+        }
+
+        #[test]
+        fn missing_blob_reports_field_context() {
+            let (expected, digest) = file_ref("a.wasm", b"\0asm-bytes");
+            let err = validate_submit_package(
+                &[expected],
+                Vec::new(),
+                &HashSet::new(),
+                MAX_DEPLOYMENT_FILE_BYTES,
+            )
+            .expect_err("missing blob");
+            assert_eq!(err.missing_files.len(), 1);
+            assert_eq!(err.missing_files[0].section, "activity_wasm");
+            assert_eq!(
+                err.missing_files[0].digest.as_deref(),
+                Some(digest.to_string().as_str())
+            );
+        }
+
+        #[test]
+        fn unexpected_blob_is_rejected() {
+            let (expected, _digest) = file_ref("a.wasm", b"\0asm-bytes");
+            let supplied = vec![SuppliedFile {
+                path: "stray.wasm".to_string(),
+                supplied_digest: None,
+                content: b"unexpected".to_vec(),
+            }];
+            // The expected file is missing too, but the unexpected blob is still reported.
+            let err = validate_submit_package(
+                &[expected],
+                supplied,
+                &HashSet::new(),
+                MAX_DEPLOYMENT_FILE_BYTES,
+            )
+            .expect_err("unexpected blob");
+            assert_eq!(err.unexpected_files.len(), 1);
+            assert_eq!(err.unexpected_files[0].path.as_deref(), Some("stray.wasm"));
+        }
+
+        #[test]
+        fn digest_mismatch_is_rejected() {
+            let (expected, _digest) = file_ref("a.wasm", b"\0asm-bytes");
+            let supplied = vec![SuppliedFile {
+                path: "a.wasm".to_string(),
+                supplied_digest: Some(
+                    "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                        .to_string(),
+                ),
+                content: b"\0asm-bytes".to_vec(),
+            }];
+            let err = validate_submit_package(
+                &[expected],
+                supplied,
+                &HashSet::new(),
+                MAX_DEPLOYMENT_FILE_BYTES,
+            )
+            .expect_err("digest mismatch");
+            assert_eq!(err.digest_mismatches.len(), 1);
+            assert_eq!(
+                err.digest_mismatches[0].actual_digest,
+                compute_content_digest(b"\0asm-bytes").to_string()
+            );
+        }
+
+        #[test]
+        fn oversized_blob_is_rejected() {
+            let (expected, _digest) = file_ref("a.wasm", b"\0asm-bytes");
+            let supplied = vec![SuppliedFile {
+                path: "a.wasm".to_string(),
+                supplied_digest: None,
+                content: b"\0asm-bytes".to_vec(),
+            }];
+            let err = validate_submit_package(&[expected], supplied, &HashSet::new(), 1)
+                .expect_err("oversized blob");
+            assert_eq!(err.oversized_files.len(), 1);
+        }
     }
 }

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -58,6 +58,7 @@ use crate::server::web_api_server::WebApiState;
 use crate::server::web_api_server::app_router;
 use anyhow::Context;
 use anyhow::bail;
+use anyhow::ensure;
 use concepts::ComponentId;
 use concepts::ComponentType;
 use concepts::ContentDigest;
@@ -73,6 +74,7 @@ use concepts::ReturnTypeExtendable;
 use concepts::SUFFIX_FN_SCHEDULE;
 use concepts::StrVariant;
 use concepts::component_id::ComponentDigest;
+use concepts::component_id::Digest;
 use concepts::prefixed_ulid::DeploymentId;
 use concepts::storage::CreateRequest;
 use concepts::storage::DbErrorWrite;
@@ -104,6 +106,7 @@ use hashbrown::HashMap;
 use indexmap::IndexMap;
 use secrecy::SecretString;
 use serde_json::json;
+use sha2::{Digest as _, Sha256};
 use std::fmt::Debug;
 use std::future::Future;
 use std::path::Path;
@@ -1780,19 +1783,20 @@ pub(crate) async fn persist_deployment_component_metadata(
 }
 
 /// Shared logic for submitting a deployment (used by both gRPC and web API).
-/// Parses, verifies, and inserts the deployment record.
+/// Parses and stores the verbatim manifest plus the file refs it names. File bytes may be
+/// uploaded later; compile/link verification happens when the deployment is activated.
 #[instrument(skip_all)]
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn submit_deployment(
-    server_verified: ServerVerified,
+    _server_verified: ServerVerified,
     deployment_toml: &str,
-    verify: bool,
+    _verify: bool,
     created_by: Option<String>,
     description: Option<String>,
     requested_deployment_id: Option<DeploymentId>,
-    prepared_dirs: &PreparedDirs,
+    _prepared_dirs: &PreparedDirs,
     db_pool: Arc<dyn DbPool>,
-    termination_watcher: &mut watch::Receiver<()>,
+    _termination_watcher: &mut watch::Receiver<()>,
 ) -> anyhow::Result<(DeploymentId, Vec<ContentDigest>)> {
     info!("Submitting deployment");
     // The deployment digest is the hash of the verbatim manifest; it transitively covers
@@ -1819,31 +1823,9 @@ pub(crate) async fn submit_deployment(
         );
     }
 
-    // Canonicalize by reading the referenced blobs from the CAS (the client uploads them
-    // before submit). `${...}` env vars and secrets resolve here, in the server's environment.
-    let (deployment, file_records) =
-        canonical_and_files_from_manifest(&*db_pool, deployment_toml).await?;
-
-    let cas: Arc<dyn concepts::cas::Cas> = db_pool.cas_conn().await?.into();
-    let verify_deployment_id = DeploymentId::generate();
-    let server_compiled = deployment_verify_config_compile_link(
-        server_verified,
-        prepared_dirs,
-        deployment,
-        Some(cas),
-        verify_deployment_id,
-        VerifyParams {
-            dir_params: PrepareDirsParams {
-                clean_cache: false,
-                clean_codegen_cache: false,
-            },
-            ignore_missing_env_vars: !verify,
-            suppress_type_checking_errors: false,
-            suppress_linking_errors: false,
-        },
-        termination_watcher,
-    )
-    .await?;
+    let file_records =
+        crate::config::manifest::file_records_from_manifest(deployment_toml, &cas_deployment_dir())
+            .context("cannot read deployment file references from manifest")?;
 
     let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
     let now = chrono::Utc::now();
@@ -1862,18 +1844,48 @@ pub(crate) async fn submit_deployment(
     })
     .await?;
 
-    persist_deployment_component_metadata(
-        conn.as_ref(),
-        deployment_id,
-        &server_compiled.component_registry_ro,
-    )
-    .await?;
-
-    upsert_backtrace_sources(conn.as_ref(), &server_compiled).await;
-
     let missing = conn.missing_digests(deployment_id).await?;
     info!(%deployment_id, "Deployment submitted");
     Ok((deployment_id, missing))
+}
+
+fn compute_content_digest(content: &[u8]) -> ContentDigest {
+    let hash: [u8; 32] = Sha256::digest(content).into();
+    ContentDigest(Digest(hash))
+}
+
+pub(crate) async fn upload_deployment_file(
+    db_pool: Arc<dyn DbPool>,
+    deployment_id: DeploymentId,
+    content: &[u8],
+) -> anyhow::Result<ContentDigest> {
+    let digest = compute_content_digest(content);
+    let conn = db_pool
+        .external_api_conn()
+        .await
+        .context("cannot get external api connection for deployment file upload")?;
+    let deployment = conn
+        .get_deployment(deployment_id)
+        .await?
+        .with_context(|| format!("deployment {deployment_id} not found"))?;
+    ensure!(
+        deployment.files.iter().any(|file| file.digest == digest),
+        "uploaded file digest {digest} is not referenced by deployment {deployment_id}"
+    );
+
+    let cas = db_pool
+        .cas_conn()
+        .await
+        .context("cannot get CAS connection for deployment file upload")?;
+    let stored = cas
+        .write_blob(content)
+        .await
+        .with_context(|| format!("cannot store deployment file {digest}"))?;
+    ensure!(
+        stored == digest,
+        "stored deployment file digest mismatch: expected {digest}, got {stored}"
+    );
+    Ok(stored)
 }
 
 /// Outcome of switching a deployment.
@@ -1941,6 +1953,22 @@ pub(crate) async fn switch_deployment(
         .await
         .map_err(|e| SwitchError::Other(e.into()))?
         .ok_or(SwitchError::NotFound)?;
+
+    let missing = db_conn
+        .missing_digests(deployment_id)
+        .await
+        .map_err(|e| SwitchError::Other(e.into()))?;
+    if !missing.is_empty() {
+        return Err(SwitchError::Other(anyhow::anyhow!(
+            "deployment {deployment_id} is missing {} referenced file blob(s): {}",
+            missing.len(),
+            missing
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
 
     let target_deployment = canonical_from_manifest(&*db_pool, &deployment_record.deployment_toml)
         .await

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1964,7 +1964,7 @@ fn validate_submit_package(
 pub(crate) async fn submit_deployment(
     server_verified: ServerVerified,
     deployment_toml: &str,
-    _verify: bool,
+    runtime_config_check: RuntimeConfigCheck,
     created_by: Option<String>,
     description: Option<String>,
     requested_deployment_id: Option<DeploymentId>,
@@ -2071,7 +2071,7 @@ pub(crate) async fn submit_deployment(
                 clean_cache: false,
                 clean_codegen_cache: false,
             },
-            ignore_missing_env_vars: false,
+            ignore_missing_env_vars: runtime_config_check.ignore_missing_env_vars(),
             suppress_type_checking_errors: false,
             suppress_linking_errors: false,
         },
@@ -2175,20 +2175,36 @@ impl From<anyhow::Error> for SwitchError {
     }
 }
 
+/// Policy for runtime configuration (environment variables and secrets) that a
+/// deployment references but that may be absent from the server's environment.
+/// Structural, file, compile, and link validation always runs regardless.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum RuntimeConfigCheck {
+    /// Missing environment variables or secrets fail the operation.
+    #[default]
+    Strict,
+    /// Missing environment variables or secrets are tolerated.
+    AllowMissing,
+}
+
+impl RuntimeConfigCheck {
+    /// Whether verification should tolerate missing env vars / secrets.
+    pub(crate) fn ignore_missing_env_vars(self) -> bool {
+        matches!(self, RuntimeConfigCheck::AllowMissing)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SwitchDeploymentAction {
     HotRedeploy,
     VerifyAndStore,
-    Store,
 }
 impl SwitchDeploymentAction {
-    pub(crate) fn new(hot_redeploy: bool, verify: bool) -> SwitchDeploymentAction {
+    pub(crate) fn new(hot_redeploy: bool) -> SwitchDeploymentAction {
         if hot_redeploy {
             SwitchDeploymentAction::HotRedeploy
-        } else if verify {
-            SwitchDeploymentAction::VerifyAndStore
         } else {
-            SwitchDeploymentAction::Store
+            SwitchDeploymentAction::VerifyAndStore
         }
     }
 }
@@ -2199,6 +2215,7 @@ pub(crate) async fn switch_deployment(
     server_verified: ServerVerified,
     deployment_id: DeploymentId,
     action: SwitchDeploymentAction,
+    runtime_config_check: RuntimeConfigCheck,
     prepared_dirs: &PreparedDirs,
     db_pool: Arc<dyn DbPool>,
     termination_watcher: &mut watch::Receiver<()>,
@@ -2207,6 +2224,18 @@ pub(crate) async fn switch_deployment(
     cancel_registry: CancelRegistry,
     log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
 ) -> Result<SwitchOutcome, SwitchError> {
+    // A hot redeploy makes the deployment immediately live, so its runtime config must be
+    // fully available; tolerating missing env vars / secrets here would yield broken
+    // running components.
+    if action == SwitchDeploymentAction::HotRedeploy
+        && runtime_config_check == RuntimeConfigCheck::AllowMissing
+    {
+        return Err(SwitchError::Other(anyhow::anyhow!(
+            "a hot redeploy requires all runtime configuration to be available; \
+             `allow-missing-runtime-config` is not permitted"
+        )));
+    }
+
     let db_conn = db_pool
         .external_api_conn()
         .await
@@ -2244,6 +2273,16 @@ pub(crate) async fn switch_deployment(
         .map_err(|e| SwitchError::Other(e.into()))?
         .into();
 
+    let verify_params = VerifyParams {
+        dir_params: PrepareDirsParams {
+            clean_cache: false,
+            clean_codegen_cache: false,
+        },
+        ignore_missing_env_vars: runtime_config_check.ignore_missing_env_vars(),
+        suppress_type_checking_errors: false,
+        suppress_linking_errors: false,
+    };
+
     if action == SwitchDeploymentAction::HotRedeploy {
         let server_compiled_linked = deployment_verify_config_compile_link(
             server_verified,
@@ -2251,15 +2290,7 @@ pub(crate) async fn switch_deployment(
             target_deployment,
             Some(cas),
             DeploymentId::generate(),
-            VerifyParams {
-                dir_params: PrepareDirsParams {
-                    clean_cache: false,
-                    clean_codegen_cache: false,
-                },
-                ignore_missing_env_vars: false,
-                suppress_type_checking_errors: false,
-                suppress_linking_errors: false,
-            },
+            verify_params,
             termination_watcher,
         )
         .await?;
@@ -2275,26 +2306,18 @@ pub(crate) async fn switch_deployment(
         )
         .await
     } else {
-        if action == SwitchDeploymentAction::VerifyAndStore {
-            deployment_verify_config_compile_link(
-                server_verified,
-                prepared_dirs,
-                target_deployment,
-                Some(cas),
-                DeploymentId::generate(),
-                VerifyParams {
-                    dir_params: PrepareDirsParams {
-                        clean_cache: false,
-                        clean_codegen_cache: false,
-                    },
-                    ignore_missing_env_vars: false,
-                    suppress_type_checking_errors: false,
-                    suppress_linking_errors: false,
-                },
-                termination_watcher,
-            )
-            .await?;
-        }
+        // Cold switch: validation (compile + link) always runs before enqueuing, so a
+        // deployment queued for the next restart is known-good against the current host.
+        deployment_verify_config_compile_link(
+            server_verified,
+            prepared_dirs,
+            target_deployment,
+            Some(cas),
+            DeploymentId::generate(),
+            verify_params,
+            termination_watcher,
+        )
+        .await?;
         db_conn
             .enqueue_deployment(deployment_id)
             .await

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -58,7 +58,6 @@ use crate::server::web_api_server::WebApiState;
 use crate::server::web_api_server::app_router;
 use anyhow::Context;
 use anyhow::bail;
-use anyhow::ensure;
 use concepts::ComponentId;
 use concepts::ComponentType;
 use concepts::ContentDigest;
@@ -2116,40 +2115,6 @@ pub(crate) async fn submit_deployment(
 fn compute_content_digest(content: &[u8]) -> ContentDigest {
     let hash: [u8; 32] = Sha256::digest(content).into();
     ContentDigest(Digest(hash))
-}
-
-pub(crate) async fn upload_deployment_file(
-    db_pool: Arc<dyn DbPool>,
-    deployment_id: DeploymentId,
-    content: &[u8],
-) -> anyhow::Result<ContentDigest> {
-    let digest = compute_content_digest(content);
-    let conn = db_pool
-        .external_api_conn()
-        .await
-        .context("cannot get external api connection for deployment file upload")?;
-    let deployment = conn
-        .get_deployment(deployment_id)
-        .await?
-        .with_context(|| format!("deployment {deployment_id} not found"))?;
-    ensure!(
-        deployment.files.iter().any(|file| file.digest == digest),
-        "uploaded file digest {digest} is not referenced by deployment {deployment_id}"
-    );
-
-    let cas = db_pool
-        .cas_conn()
-        .await
-        .context("cannot get CAS connection for deployment file upload")?;
-    let stored = cas
-        .write_blob(content)
-        .await
-        .with_context(|| format!("cannot store deployment file {digest}"))?;
-    ensure!(
-        stored == digest,
-        "stored deployment file digest mismatch: expected {digest}, got {stored}"
-    );
-    Ok(stored)
 }
 
 /// Outcome of switching a deployment.

--- a/src/config/config_holder.rs
+++ b/src/config/config_holder.rs
@@ -1,4 +1,4 @@
-use crate::config::toml::DeploymentCanonical;
+use crate::config::toml::DeploymentResolved;
 use crate::config::toml::DeploymentTomlValidated;
 
 use super::toml::{DeploymentToml, ServerConfigToml};
@@ -177,7 +177,7 @@ pub(crate) async fn load_deployment_validated(
 
 pub(crate) async fn load_deployment_canonical(
     deployment_toml: &Path,
-) -> Result<DeploymentCanonical, anyhow::Error> {
+) -> Result<DeploymentResolved, anyhow::Error> {
     load_deployment_validated(deployment_toml)
         .await?
         .canonicalize()

--- a/src/config/file_provider.rs
+++ b/src/config/file_provider.rs
@@ -10,8 +10,7 @@ use std::sync::Arc;
 ///
 /// Canonicalization inlines every deployment-owned script/source into the
 /// `DeploymentCanonical`; where the bytes come from depends on context.
-/// External absolute-path refs are not deployment-owned and are not read
-/// through a provider.
+/// OCI refs are not deployment-owned and are not read through a provider.
 #[async_trait::async_trait]
 pub(crate) trait FileProvider: Send + Sync {
     /// Read the bytes of a deployment-owned file.

--- a/src/config/file_provider.rs
+++ b/src/config/file_provider.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// Source of deployment-owned file bytes during canonicalization.
 ///
 /// Canonicalization inlines every deployment-owned script/source into the
-/// `DeploymentCanonical`; where the bytes come from depends on context.
+/// `DeploymentResolved`; where the bytes come from depends on context.
 /// OCI refs are not deployment-owned and are not read through a provider.
 #[async_trait::async_trait]
 pub(crate) trait FileProvider: Send + Sync {

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -1,6 +1,6 @@
 use crate::config::file_provider::{DiskProvider, FileProvider};
 use crate::config::toml::{
-    DeploymentCanonical, DeploymentToml, OCI_SCHEMA_PREFIX, sanitize_deployment_relative_path,
+    DeploymentResolved, DeploymentToml, OCI_SCHEMA_PREFIX, sanitize_deployment_relative_path,
     strip_deployment_dir_prefix,
 };
 use anyhow::{Context, bail, ensure};
@@ -46,7 +46,7 @@ pub(crate) async fn manifest_to_canonical(
     deployment_toml: &str,
     deployment_dir: &Path,
     provider: &dyn FileProvider,
-) -> anyhow::Result<DeploymentCanonical> {
+) -> anyhow::Result<DeploymentResolved> {
     parse_manifest(deployment_toml, deployment_dir)?
         .canonicalize_with_provider(provider)
         .await
@@ -588,7 +588,7 @@ async fn read_deployment_file(
 )]
 pub(crate) async fn manifest_file_to_canonical(
     deployment_toml_path: &Path,
-) -> anyhow::Result<DeploymentCanonical> {
+) -> anyhow::Result<DeploymentResolved> {
     let deployment_toml = tokio::fs::read_to_string(deployment_toml_path)
         .await
         .with_context(|| format!("cannot read deployment manifest {deployment_toml_path:?}"))?;

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -117,32 +117,131 @@ pub(crate) fn compute_manifest_digest(deployment_toml: &str) -> ContentDigest {
     ContentDigest(Digest(hash))
 }
 
+/// A validated, digest-bearing projection of a stored deployment manifest.
+///
+/// This stage carries no file bytes. It proves the manifest is structurally valid
+/// and classifies every component location, so the requested TOML is storeable
+/// as-is. The deployment-owned file references it collects are the CAS objects the
+/// stored TOML depends on. See `meta/designs/deployment-submit-package-state-pipeline.md`.
+#[derive(Debug, Clone)]
+pub(crate) struct DeploymentManifest {
+    #[allow(dead_code)] // consumed by submit/storage paths in later phases
+    pub(crate) deployment_toml: String,
+    pub(crate) files: Vec<DeploymentFileRef>,
+}
+
+/// A deployment-owned file reference: a deployment-relative path and its required
+/// digest, plus field context for contextual submit errors.
+#[derive(Debug, Clone)]
+pub(crate) struct DeploymentFileRef {
+    pub(crate) path: String,
+    pub(crate) digest: ContentDigest,
+    #[allow(dead_code)] // surfaced in structured submit errors in later phases
+    pub(crate) field: ManifestFieldRef,
+}
+
+/// Locates a file reference within the manifest for contextual error reporting.
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // fields surfaced in structured submit errors in later phases
+pub(crate) struct ManifestFieldRef {
+    /// TOML section, e.g. `activity_wasm` or `workflow_wasm.backtrace.sources`.
+    pub(crate) section: String,
+    /// Component `name`, when present.
+    pub(crate) component_name: Option<String>,
+    /// Stable field path, e.g. `activity_wasm[name=a].location` or
+    /// `workflow_wasm[name=w].backtrace.sources[.../src/lib.rs]`.
+    pub(crate) field_path: String,
+}
+
+/// Classification of a script (JS/exec) component `location` / `content`.
+enum ManifestScriptLocation {
+    /// Inline `content`, no deployment-owned file.
+    Inline,
+    DeploymentFile { path: String, digest: ContentDigest },
+    Oci,
+}
+
+/// Classification of a WASM component `location`. WASM has no inline form, so a
+/// deployment-owned file cannot be disguised as a generic path.
+enum ManifestWasmLocation {
+    DeploymentFile { path: String, digest: ContentDigest },
+    Oci,
+}
+
+const WASM_SECTIONS: &[&str] = &[
+    "activity_wasm",
+    "activity_stub",
+    "activity_external",
+    "workflow_wasm",
+    "webhook_endpoint_wasm",
+];
+const BACKTRACE_SECTIONS: &[&str] = &["workflow_wasm", "webhook_endpoint_wasm"];
+const SCRIPT_SECTIONS: &[&str] = &[
+    "activity_js",
+    "workflow_js",
+    "webhook_endpoint_js",
+    "activity_exec",
+];
+
+impl DeploymentManifest {
+    /// Parse and structurally validate `deployment_toml`, then classify every
+    /// component location into a digest-bearing, deployment-relative file set.
+    /// No file I/O happens here. Absolute local paths are rejected.
+    pub(crate) fn try_from_toml(
+        deployment_toml: &str,
+        deployment_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        parse_manifest(deployment_toml, deployment_dir)?;
+
+        let doc = deployment_toml
+            .parse::<DocumentMut>()
+            .context("cannot parse deployment manifest as TOML")?;
+
+        // Section order matches the historical record collection so digest
+        // deduplication keeps the same first-seen path for colliding contents.
+        let mut files = Vec::new();
+        collect_wasm_section(&doc, "activity_wasm", &mut files)?;
+        collect_wasm_section(&doc, "activity_stub", &mut files)?;
+        collect_wasm_section(&doc, "activity_external", &mut files)?;
+        collect_wasm_section(&doc, "workflow_wasm", &mut files)?;
+        collect_backtrace_section(&doc, "workflow_wasm", &mut files)?;
+        collect_wasm_section(&doc, "webhook_endpoint_wasm", &mut files)?;
+        collect_backtrace_section(&doc, "webhook_endpoint_wasm", &mut files)?;
+        collect_script_section(&doc, "activity_js", &mut files)?;
+        collect_script_section(&doc, "workflow_js", &mut files)?;
+        collect_script_section(&doc, "webhook_endpoint_js", &mut files)?;
+        collect_script_section(&doc, "activity_exec", &mut files)?;
+
+        debug_assert!(
+            WASM_SECTIONS.len() + SCRIPT_SECTIONS.len() + BACKTRACE_SECTIONS.len() == 11,
+            "section lists drifted from collection order"
+        );
+
+        let mut seen = HashSet::new();
+        files.retain(|file| seen.insert(file.digest.clone()));
+        Ok(Self {
+            deployment_toml: deployment_toml.to_string(),
+            files,
+        })
+    }
+
+    /// Indexed projection of deployment-owned files for `t_deployment_file`.
+    pub(crate) fn file_records(&self) -> Vec<DeploymentFileRecord> {
+        self.files
+            .iter()
+            .map(|file| DeploymentFileRecord {
+                path: file.path.clone(),
+                digest: file.digest.clone(),
+            })
+            .collect()
+    }
+}
+
 pub(crate) fn file_records_from_manifest(
     deployment_toml: &str,
     deployment_dir: &Path,
 ) -> anyhow::Result<Vec<DeploymentFileRecord>> {
-    parse_manifest(deployment_toml, deployment_dir)?;
-
-    let doc = deployment_toml
-        .parse::<DocumentMut>()
-        .context("cannot parse deployment manifest as TOML")?;
-
-    let mut files = Vec::new();
-    collect_wasm_ref_records(&doc, "activity_wasm", &mut files)?;
-    collect_wasm_ref_records(&doc, "activity_stub", &mut files)?;
-    collect_wasm_ref_records(&doc, "activity_external", &mut files)?;
-    collect_wasm_ref_records(&doc, "workflow_wasm", &mut files)?;
-    collect_backtrace_ref_records(&doc, "workflow_wasm", &mut files)?;
-    collect_wasm_ref_records(&doc, "webhook_endpoint_wasm", &mut files)?;
-    collect_backtrace_ref_records(&doc, "webhook_endpoint_wasm", &mut files)?;
-    collect_script_ref_records(&doc, "activity_js", &mut files)?;
-    collect_script_ref_records(&doc, "workflow_js", &mut files)?;
-    collect_script_ref_records(&doc, "webhook_endpoint_js", &mut files)?;
-    collect_script_ref_records(&doc, "activity_exec", &mut files)?;
-
-    let mut seen = HashSet::new();
-    files.retain(|file| seen.insert(file.digest.clone()));
-    Ok(files)
+    Ok(DeploymentManifest::try_from_toml(deployment_toml, deployment_dir)?.file_records())
 }
 
 fn parse_manifest(
@@ -156,72 +255,92 @@ fn parse_manifest(
         .context("cannot validate deployment manifest")
 }
 
-fn collect_script_ref_records(
+fn component_name(table: &toml_edit::Table) -> Option<String> {
+    table.get("name").and_then(Item::as_str).map(str::to_string)
+}
+
+fn collect_script_section(
     doc: &DocumentMut,
     section: &str,
-    files: &mut Vec<DeploymentFileRecord>,
+    files: &mut Vec<DeploymentFileRef>,
 ) -> anyhow::Result<()> {
     let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
         return Ok(());
     };
 
-    for table in components.iter() {
-        let has_inline_content = table.get("content").and_then(Item::as_str).is_some();
-        let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
-            continue;
-        };
-        ensure!(
-            !has_inline_content,
-            "exactly one of `location` or `content` must be set for script components"
-        );
-        collect_file_ref_record(table, raw_location, files)?;
+    for table in components {
+        let name = component_name(table);
+        match classify_script_location(table)? {
+            ManifestScriptLocation::DeploymentFile { path, digest } => {
+                let field_path = format!(
+                    "{section}[name={}].location",
+                    name.as_deref().unwrap_or("")
+                );
+                files.push(DeploymentFileRef {
+                    path,
+                    digest,
+                    field: ManifestFieldRef {
+                        section: section.to_string(),
+                        component_name: name,
+                        field_path,
+                    },
+                });
+            }
+            ManifestScriptLocation::Inline | ManifestScriptLocation::Oci => {}
+        }
     }
 
     Ok(())
 }
 
-fn collect_wasm_ref_records(
+fn collect_wasm_section(
     doc: &DocumentMut,
     section: &str,
-    files: &mut Vec<DeploymentFileRecord>,
+    files: &mut Vec<DeploymentFileRef>,
 ) -> anyhow::Result<()> {
     let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
         return Ok(());
     };
 
-    for table in components.iter() {
+    for table in components {
+        let name = component_name(table);
         let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
             continue;
         };
-        collect_file_ref_record(table, raw_location, files)?;
+        match classify_wasm_location(raw_location, table.get("content_digest"))? {
+            ManifestWasmLocation::DeploymentFile { path, digest } => {
+                let field_path = format!(
+                    "{section}[name={}].location",
+                    name.as_deref().unwrap_or("")
+                );
+                files.push(DeploymentFileRef {
+                    path,
+                    digest,
+                    field: ManifestFieldRef {
+                        section: section.to_string(),
+                        component_name: name,
+                        field_path,
+                    },
+                });
+            }
+            ManifestWasmLocation::Oci => {}
+        }
     }
 
     Ok(())
 }
 
-fn collect_file_ref_record(
-    table: &toml_edit::Table,
-    raw_location: &str,
-    files: &mut Vec<DeploymentFileRecord>,
-) -> anyhow::Result<()> {
-    let Some(path) = deployment_owned_path(raw_location)? else {
-        return Ok(());
-    };
-    let digest = required_content_digest(table.get("content_digest"), &path)?;
-    files.push(DeploymentFileRecord { path, digest });
-    Ok(())
-}
-
-fn collect_backtrace_ref_records(
+fn collect_backtrace_section(
     doc: &DocumentMut,
     section: &str,
-    files: &mut Vec<DeploymentFileRecord>,
+    files: &mut Vec<DeploymentFileRef>,
 ) -> anyhow::Result<()> {
     let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
         return Ok(());
     };
 
-    for table in components.iter() {
+    for table in components {
+        let name = component_name(table);
         let Some(sources) = table
             .get("backtrace")
             .and_then(Item::as_table_like)
@@ -231,7 +350,7 @@ fn collect_backtrace_ref_records(
             continue;
         };
 
-        for (_, source) in sources.iter() {
+        for (key, source) in sources.iter() {
             let Some(raw_path) = backtrace_source_path(source) else {
                 continue;
             };
@@ -244,11 +363,52 @@ fn collect_backtrace_ref_records(
                     .and_then(|table| table.get("content_digest")),
                 &path,
             )?;
-            files.push(DeploymentFileRecord { path, digest });
+            files.push(DeploymentFileRef {
+                path,
+                digest,
+                field: ManifestFieldRef {
+                    section: format!("{section}.backtrace.sources"),
+                    component_name: name.clone(),
+                    field_path: format!(
+                        "{section}[name={}].backtrace.sources[{key}]",
+                        name.as_deref().unwrap_or("")
+                    ),
+                },
+            });
         }
     }
 
     Ok(())
+}
+
+fn classify_script_location(
+    table: &toml_edit::Table,
+) -> anyhow::Result<ManifestScriptLocation> {
+    let has_inline_content = table.get("content").and_then(Item::as_str).is_some();
+    let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
+        // No `location`: inline content (or neither, already rejected by validation).
+        return Ok(ManifestScriptLocation::Inline);
+    };
+    ensure!(
+        !has_inline_content,
+        "exactly one of `location` or `content` must be set for script components"
+    );
+    let Some(path) = deployment_owned_path(raw_location)? else {
+        return Ok(ManifestScriptLocation::Oci);
+    };
+    let digest = required_content_digest(table.get("content_digest"), &path)?;
+    Ok(ManifestScriptLocation::DeploymentFile { path, digest })
+}
+
+fn classify_wasm_location(
+    raw_location: &str,
+    content_digest: Option<&Item>,
+) -> anyhow::Result<ManifestWasmLocation> {
+    let Some(path) = deployment_owned_path(raw_location)? else {
+        return Ok(ManifestWasmLocation::Oci);
+    };
+    let digest = required_content_digest(content_digest, &path)?;
+    Ok(ManifestWasmLocation::DeploymentFile { path, digest })
 }
 
 fn required_content_digest(item: Option<&Item>, path: &str) -> anyhow::Result<ContentDigest> {
@@ -639,6 +799,58 @@ ffqn = "ns:pkg/ifc.external"
 
         assert!(
             err.contains("absolute local paths are not allowed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn manifest_classifies_files_with_field_context() {
+        let manifest = r#"
+[[activity_wasm]]
+name = "act"
+location = "components/a.wasm"
+content_digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+[[workflow_wasm]]
+name = "wf"
+location = "components/w.wasm"
+content_digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+[workflow_wasm.backtrace.sources]
+".../src/lib.rs" = { path = "src/lib.rs", content_digest = "sha256:3333333333333333333333333333333333333333333333333333333333333333" }
+"#;
+
+        let deployment_dir = Path::new("/does-not-matter");
+        let manifest = DeploymentManifest::try_from_toml(manifest, deployment_dir).unwrap();
+
+        assert_eq!(manifest.files.len(), 3);
+        let act = &manifest.files[0];
+        assert_eq!(act.path, "components/a.wasm");
+        assert_eq!(act.field.section, "activity_wasm");
+        assert_eq!(act.field.component_name.as_deref(), Some("act"));
+        assert_eq!(act.field.field_path, "activity_wasm[name=act].location");
+
+        let backtrace = &manifest.files[2];
+        assert_eq!(backtrace.path, "src/lib.rs");
+        assert_eq!(backtrace.field.section, "workflow_wasm.backtrace.sources");
+        assert_eq!(
+            backtrace.field.field_path,
+            "workflow_wasm[name=wf].backtrace.sources[.../src/lib.rs]"
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_deployment_owned_wasm_without_digest() {
+        let manifest = r#"
+[[activity_wasm]]
+name = "act"
+location = "components/a.wasm"
+"#;
+        let err = DeploymentManifest::try_from_toml(manifest, Path::new("/x"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("must set `content_digest`"),
             "unexpected error: {err}"
         );
     }

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -6,6 +6,8 @@ use crate::config::toml::{
 use anyhow::{Context, ensure};
 use concepts::ContentDigest;
 use concepts::component_id::Digest;
+use concepts::storage::DeploymentFileRecord;
+use hashbrown::HashSet;
 use sha2::{Digest as _, Sha256};
 use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
@@ -112,6 +114,34 @@ pub(crate) fn compute_manifest_digest(deployment_toml: &str) -> ContentDigest {
     ContentDigest(Digest(hash))
 }
 
+pub(crate) fn file_records_from_manifest(
+    deployment_toml: &str,
+    deployment_dir: &Path,
+) -> anyhow::Result<Vec<DeploymentFileRecord>> {
+    parse_manifest(deployment_toml, deployment_dir)?;
+
+    let doc = deployment_toml
+        .parse::<DocumentMut>()
+        .context("cannot parse deployment manifest as TOML")?;
+
+    let mut files = Vec::new();
+    collect_wasm_ref_records(&doc, "activity_wasm", &mut files)?;
+    collect_wasm_ref_records(&doc, "activity_stub", &mut files)?;
+    collect_wasm_ref_records(&doc, "activity_external", &mut files)?;
+    collect_wasm_ref_records(&doc, "workflow_wasm", &mut files)?;
+    collect_backtrace_ref_records(&doc, "workflow_wasm", &mut files)?;
+    collect_wasm_ref_records(&doc, "webhook_endpoint_wasm", &mut files)?;
+    collect_backtrace_ref_records(&doc, "webhook_endpoint_wasm", &mut files)?;
+    collect_script_ref_records(&doc, "activity_js", &mut files)?;
+    collect_script_ref_records(&doc, "workflow_js", &mut files)?;
+    collect_script_ref_records(&doc, "webhook_endpoint_js", &mut files)?;
+    collect_script_ref_records(&doc, "activity_exec", &mut files)?;
+
+    let mut seen = HashSet::new();
+    files.retain(|file| seen.insert(file.digest.clone()));
+    Ok(files)
+}
+
 fn parse_manifest(
     deployment_toml: &str,
     deployment_dir: &Path,
@@ -121,6 +151,108 @@ fn parse_manifest(
     deployment
         .validate(deployment_dir)
         .context("cannot validate deployment manifest")
+}
+
+fn collect_script_ref_records(
+    doc: &DocumentMut,
+    section: &str,
+    files: &mut Vec<DeploymentFileRecord>,
+) -> anyhow::Result<()> {
+    let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
+        return Ok(());
+    };
+
+    for table in components.iter() {
+        let has_inline_content = table.get("content").and_then(Item::as_str).is_some();
+        let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
+            continue;
+        };
+        ensure!(
+            !has_inline_content,
+            "exactly one of `location` or `content` must be set for script components"
+        );
+        collect_file_ref_record(table, raw_location, files)?;
+    }
+
+    Ok(())
+}
+
+fn collect_wasm_ref_records(
+    doc: &DocumentMut,
+    section: &str,
+    files: &mut Vec<DeploymentFileRecord>,
+) -> anyhow::Result<()> {
+    let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
+        return Ok(());
+    };
+
+    for table in components.iter() {
+        let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
+            continue;
+        };
+        collect_file_ref_record(table, raw_location, files)?;
+    }
+
+    Ok(())
+}
+
+fn collect_file_ref_record(
+    table: &toml_edit::Table,
+    raw_location: &str,
+    files: &mut Vec<DeploymentFileRecord>,
+) -> anyhow::Result<()> {
+    let Some(path) = deployment_owned_path(raw_location)? else {
+        return Ok(());
+    };
+    let digest = required_content_digest(table.get("content_digest"), &path)?;
+    files.push(DeploymentFileRecord { path, digest });
+    Ok(())
+}
+
+fn collect_backtrace_ref_records(
+    doc: &DocumentMut,
+    section: &str,
+    files: &mut Vec<DeploymentFileRecord>,
+) -> anyhow::Result<()> {
+    let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
+        return Ok(());
+    };
+
+    for table in components.iter() {
+        let Some(sources) = table
+            .get("backtrace")
+            .and_then(Item::as_table_like)
+            .and_then(|backtrace| backtrace.get("sources"))
+            .and_then(Item::as_table_like)
+        else {
+            continue;
+        };
+
+        for (_, source) in sources.iter() {
+            let Some(raw_path) = backtrace_source_path(source) else {
+                continue;
+            };
+            let Some(path) = deployment_owned_path(&raw_path)? else {
+                continue;
+            };
+            let digest = required_content_digest(
+                source
+                    .as_table_like()
+                    .and_then(|table| table.get("content_digest")),
+                &path,
+            )?;
+            files.push(DeploymentFileRecord { path, digest });
+        }
+    }
+
+    Ok(())
+}
+
+fn required_content_digest(item: Option<&Item>, path: &str) -> anyhow::Result<ContentDigest> {
+    item.and_then(Item::as_str)
+        .with_context(|| format!("deployment-owned file `{path}` must set `content_digest`"))?
+        .parse()
+        .with_context(|| format!("invalid content_digest for deployment-owned file `{path}`"))
 }
 
 async fn collect_script_refs(

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -3,7 +3,7 @@ use crate::config::toml::{
     DeploymentCanonical, DeploymentToml, OCI_SCHEMA_PREFIX, sanitize_deployment_relative_path,
     strip_deployment_dir_prefix,
 };
-use anyhow::{Context, ensure};
+use anyhow::{Context, bail, ensure};
 use concepts::ContentDigest;
 use concepts::component_id::Digest;
 use concepts::storage::DeploymentFileRecord;
@@ -99,6 +99,9 @@ pub(crate) async fn prepare_deployment_manifest(
     collect_script_refs(&mut doc, "workflow_js", deployment_dir, &mut files).await?;
     collect_script_refs(&mut doc, "webhook_endpoint_js", deployment_dir, &mut files).await?;
     collect_script_refs(&mut doc, "activity_exec", deployment_dir, &mut files).await?;
+
+    let mut seen = HashSet::new();
+    files.retain(|file| seen.insert(file.digest.clone()));
 
     let deployment_toml = doc.to_string();
     let digest = compute_manifest_digest(&deployment_toml);
@@ -395,8 +398,11 @@ fn write_backtrace_source_digest(source: &mut Item, path: String, digest: &Conte
 }
 
 fn deployment_owned_path(raw: &str) -> anyhow::Result<Option<String>> {
-    if raw.starts_with(OCI_SCHEMA_PREFIX) || Path::new(raw).is_absolute() {
+    if raw.starts_with(OCI_SCHEMA_PREFIX) {
         return Ok(None);
+    }
+    if Path::new(raw).is_absolute() {
+        bail!("absolute local paths are not allowed in deployment manifests: `{raw}`");
     }
     let path = strip_deployment_dir_prefix(raw).unwrap_or(raw);
     sanitize_deployment_relative_path(path).map(Some)
@@ -594,7 +600,25 @@ location = "components/w.wasm"
     }
 
     #[tokio::test]
-    async fn prepare_skips_absolute_and_oci_script_locations() {
+    async fn prepare_skips_oci_script_locations() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = r#"
+[[workflow_js]]
+name = "oci"
+location = "oci://docker.io/library/example:latest"
+ffqn = "ns:pkg/ifc.oci"
+"#;
+
+        let prepared = prepare_deployment_manifest(manifest, dir.path())
+            .await
+            .unwrap();
+
+        assert!(prepared.files.is_empty());
+        assert!(!prepared.deployment_toml.contains("content_digest"));
+    }
+
+    #[tokio::test]
+    async fn prepare_rejects_absolute_script_locations() {
         let dir = tempfile::tempdir().unwrap();
         let abs = dir.path().join("external.js");
         tokio::fs::write(&abs, "external").await.unwrap();
@@ -604,21 +628,19 @@ location = "components/w.wasm"
 name = "external"
 location = "{}"
 ffqn = "ns:pkg/ifc.external"
-
-[[workflow_js]]
-name = "oci"
-location = "oci://docker.io/library/example:latest"
-ffqn = "ns:pkg/ifc.oci"
 "#,
             abs.display()
         );
 
-        let prepared = prepare_deployment_manifest(&manifest, dir.path())
+        let err = prepare_deployment_manifest(&manifest, dir.path())
             .await
-            .unwrap();
+            .unwrap_err()
+            .to_string();
 
-        assert!(prepared.files.is_empty());
-        assert!(!prepared.deployment_toml.contains("content_digest"));
+        assert!(
+            err.contains("absolute local paths are not allowed"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -136,13 +136,11 @@ pub(crate) struct DeploymentManifest {
 pub(crate) struct DeploymentFileRef {
     pub(crate) path: String,
     pub(crate) digest: ContentDigest,
-    #[allow(dead_code)] // surfaced in structured submit errors in later phases
     pub(crate) field: ManifestFieldRef,
 }
 
 /// Locates a file reference within the manifest for contextual error reporting.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // fields surfaced in structured submit errors in later phases
 pub(crate) struct ManifestFieldRef {
     /// TOML section, e.g. `activity_wasm` or `workflow_wasm.backtrace.sources`.
     pub(crate) section: String,
@@ -157,7 +155,10 @@ pub(crate) struct ManifestFieldRef {
 enum ManifestScriptLocation {
     /// Inline `content`, no deployment-owned file.
     Inline,
-    DeploymentFile { path: String, digest: ContentDigest },
+    DeploymentFile {
+        path: String,
+        digest: ContentDigest,
+    },
     Oci,
 }
 
@@ -237,13 +238,6 @@ impl DeploymentManifest {
     }
 }
 
-pub(crate) fn file_records_from_manifest(
-    deployment_toml: &str,
-    deployment_dir: &Path,
-) -> anyhow::Result<Vec<DeploymentFileRecord>> {
-    Ok(DeploymentManifest::try_from_toml(deployment_toml, deployment_dir)?.file_records())
-}
-
 fn parse_manifest(
     deployment_toml: &str,
     deployment_dir: &Path,
@@ -272,10 +266,8 @@ fn collect_script_section(
         let name = component_name(table);
         match classify_script_location(table)? {
             ManifestScriptLocation::DeploymentFile { path, digest } => {
-                let field_path = format!(
-                    "{section}[name={}].location",
-                    name.as_deref().unwrap_or("")
-                );
+                let field_path =
+                    format!("{section}[name={}].location", name.as_deref().unwrap_or(""));
                 files.push(DeploymentFileRef {
                     path,
                     digest,
@@ -309,10 +301,8 @@ fn collect_wasm_section(
         };
         match classify_wasm_location(raw_location, table.get("content_digest"))? {
             ManifestWasmLocation::DeploymentFile { path, digest } => {
-                let field_path = format!(
-                    "{section}[name={}].location",
-                    name.as_deref().unwrap_or("")
-                );
+                let field_path =
+                    format!("{section}[name={}].location", name.as_deref().unwrap_or(""));
                 files.push(DeploymentFileRef {
                     path,
                     digest,
@@ -381,9 +371,7 @@ fn collect_backtrace_section(
     Ok(())
 }
 
-fn classify_script_location(
-    table: &toml_edit::Table,
-) -> anyhow::Result<ManifestScriptLocation> {
+fn classify_script_location(table: &toml_edit::Table) -> anyhow::Result<ManifestScriptLocation> {
     let has_inline_content = table.get("content").and_then(Item::as_str).is_some();
     let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
         // No `location`: inline content (or neither, already rejected by validation).

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -318,17 +318,16 @@ impl DeploymentToml {
 
     /// Resolve a WASM component file path to an absolute path. A `${DEPLOYMENT_DIR}/<suffix>`
     /// path and a bare relative path are both anchored to the deployment directory and must
-    /// stay within it (no `..` escape); an absolute path is left untouched (out-of-tree
-    /// reference). This makes every relative path in a deployment.toml deployment-relative.
+    /// stay within it (no `..` escape); authored absolute paths are rejected. This makes every
+    /// path in a deployment.toml deployment-relative.
     fn expand_deployment_dir(
         s: &mut String,
         deployment_dir: &std::path::Path,
     ) -> anyhow::Result<()> {
-        // A `${DEPLOYMENT_DIR}/x` path and a bare relative `x` are equivalent; only an
-        // absolute path is left untouched (out-of-tree reference).
+        // A `${DEPLOYMENT_DIR}/x` path and a bare relative `x` are equivalent.
         let candidate = strip_deployment_dir_prefix(s).unwrap_or(s.as_str());
         if std::path::Path::new(candidate).is_absolute() {
-            return Ok(());
+            bail!("absolute local paths are not allowed in deployment manifests: `{s}`");
         }
         let rel = sanitize_deployment_relative_path(candidate)
             .with_context(|| format!("invalid deployment-relative path `{s}`"))?;
@@ -399,10 +398,9 @@ impl DeploymentToml {
             }
         }
         // Script (JS/exec) locations and backtrace sources are NOT expanded here. Their
-        // `${DEPLOYMENT_DIR}` prefix and relative-vs-absolute classification are handled
-        // when resolving to canonical (`resolve_script_toml_to_canonical` /
-        // `resolve_backtrace_to_canonical`), so deployment-owned files (relative, mirrored)
-        // are distinguished from external references (absolute).
+        // `${DEPLOYMENT_DIR}` prefix is handled when resolving to canonical
+        // (`resolve_script_toml_to_canonical` / `resolve_backtrace_to_canonical`), so
+        // deployment-owned files preserve deployment-relative names.
         for c in &mut self.workflows_wasm {
             expand_loc(&mut c.common.location, deployment_dir)?;
         }
@@ -1563,6 +1561,7 @@ impl ActivityExecComponentConfigCanonicalExt for ActivityExecComponentConfigCano
                     source_bytes: content.as_bytes().to_vec(),
                 })
             }
+            // Legacy/internal canonical form; new deployment TOML cannot author absolute paths.
             ScriptLocationCanonical::ExternalPath { path } => {
                 let full_path = PathBuf::from(path);
                 let content = tokio::fs::read_to_string(&full_path)
@@ -1876,7 +1875,7 @@ pub(crate) struct ComponentBacktraceConfig {
     /// Maps a frame-symbol key to a backtrace source file path. On-disk format only;
     /// resolved to `ComponentBacktraceConfigCanonical` before transmission and hash
     /// computation. A relative path is deployment-dir-relative (a leading
-    /// `${DEPLOYMENT_DIR}/` is accepted for backcompat); an absolute path is out-of-tree.
+    /// `${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.
     #[serde(rename = "sources")]
     #[schemars(with = "std::collections::HashMap<String, BacktraceSourceToml>")]
     pub(crate) frame_files_to_sources: HashMap<String, BacktraceSourceToml>,
@@ -1930,7 +1929,7 @@ pub(crate) trait JsLocationCanonicalExt {
 impl JsLocationCanonicalExt for ScriptLocationCanonical {
     /// Return the JS source content and file name.
     /// For `Content`, returns them directly (validating digest if provided).
-    /// For `Path`, reads the external file at runtime (validating digest if provided).
+    /// For legacy/internal `ExternalPath`, reads the file at runtime (validating digest if provided).
     /// For `Oci`, pulls from the registry (or cache) under `wasm_cache_dir/js/`.
     async fn get_content(
         &self,
@@ -2608,39 +2607,16 @@ pub(crate) fn sanitize_deployment_relative_path(rel: &str) -> anyhow::Result<Str
     Ok(parts.join("/"))
 }
 
-/// Mirror an absolute path into a safe relative subpath by dropping the root/drive prefix
-/// and keeping the remaining components (e.g. `/home/u/p/src/lib.rs` → `home/u/p/src/lib.rs`).
-/// Rejects `..`. Used to recreate absolute-sourced backtrace files self-contained under the
-/// output directory (their content is captured in the canonical, so this round-trips).
-fn mirror_path_as_relative(path: &str) -> anyhow::Result<String> {
-    use std::path::Component;
-    let mut parts: Vec<&str> = Vec::new();
-    for comp in std::path::Path::new(path).components() {
-        match comp {
-            Component::Normal(s) => parts.push(
-                s.to_str()
-                    .with_context(|| format!("non-UTF8 path component in `{path}`"))?,
-            ),
-            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
-            Component::ParentDir => {
-                bail!("backtrace source path must not contain `..`: `{path}`")
-            }
-        }
-    }
-    ensure!(!parts.is_empty(), "empty backtrace source path: `{path}`");
-    Ok(parts.join("/"))
-}
-
 /// Resolve a script source (JS or exec) TOML location to its canonical form.
 ///
 /// - inline `content` → `Content { content, file_name: default_file_name }` (owned).
 /// - a **relative** `Path` (bare, or `${DEPLOYMENT_DIR}/…`) → read + inline as `Content`,
 ///   with `file_name` preserving the deployment-relative subpath (owned). `..` escapes error.
-/// - an **absolute** `Path` → `Path { path }` (external; read at runtime, not recreated).
+/// - an **absolute** `Path` → rejected.
 /// - an `Oci` reference → `Oci { image }`.
 ///
 /// When `content_digest` is set it is verified here against the relevant bytes (inline
-/// content, the owned file, or the external file). `Oci` digests are verified at runtime.
+/// content or the owned file). `Oci` digests are verified at runtime.
 async fn resolve_script_toml_to_canonical(
     location: Option<JsLocationToml>,
     content: Option<String>,
@@ -2659,14 +2635,7 @@ async fn resolve_script_toml_to_canonical(
         }
         (Some(JsLocationToml::Path(path)), None) => {
             if std::path::Path::new(&path).is_absolute() {
-                // External reference: verify digest against its bytes if set.
-                if content_digest.is_some() {
-                    let bytes = tokio::fs::read(&path)
-                        .await
-                        .with_context(|| format!("cannot read external script file {path:?}"))?;
-                    verify_content_digest(&bytes, content_digest, &path)?;
-                }
-                Ok(ScriptLocationCanonical::ExternalPath { path })
+                bail!("absolute local paths are not allowed in deployment manifests: `{path}`")
             } else {
                 let path = strip_deployment_dir_prefix(&path).unwrap_or(&path);
                 let path = sanitize_deployment_relative_path(path)?;
@@ -2690,7 +2659,7 @@ async fn resolve_script_toml_to_canonical(
 
 async fn resolve_backtrace_to_canonical(
     backtrace: &ComponentBacktraceConfig,
-    deployment_dir: &Path,
+    _deployment_dir: &Path,
     provider: &dyn FileProvider,
 ) -> anyhow::Result<ComponentBacktraceConfigCanonical> {
     let mut frame_files_to_sources = HashMap::new();
@@ -2698,47 +2667,28 @@ async fn resolve_backtrace_to_canonical(
         let path = source.path();
         let content_digest = source.content_digest();
         // Classify the source path like a script: a relative path (bare or
-        // `${DEPLOYMENT_DIR}/…`) is deployment-relative and its subpath is mirrored on
-        // export; an absolute path is recreated self-contained under a root-stripped mirror.
-        let (full_path, file_name, owned_rel_path) =
-            if let Some(rest) = strip_deployment_dir_prefix(path) {
-                let rel = sanitize_deployment_relative_path(rest)?;
-                (deployment_dir.join(&rel), rel.clone(), Some(rel))
-            } else if std::path::Path::new(path).is_absolute() {
-                // Captured content is recreated self-contained under a root-stripped mirror.
-                (PathBuf::from(path), mirror_path_as_relative(path)?, None)
-            } else {
-                let rel = sanitize_deployment_relative_path(path)?;
-                (deployment_dir.join(&rel), rel.clone(), Some(rel))
-            };
-        let content = if let Some(rel) = owned_rel_path {
-            provider.read(&rel, content_digest).await.and_then(|bytes| {
-                String::from_utf8(bytes)
-                    .with_context(|| format!("backtrace source {rel:?} is not valid UTF-8"))
-            })
+        // `${DEPLOYMENT_DIR}/…`) is deployment-relative and its subpath is mirrored on export.
+        let file_name = if let Some(rest) = strip_deployment_dir_prefix(path) {
+            sanitize_deployment_relative_path(rest)?
+        } else if std::path::Path::new(path).is_absolute() {
+            bail!("absolute local paths are not allowed in deployment manifests: `{path}`")
         } else {
-            if !full_path.exists() {
-                warn!("Ignoring missing backtrace source - file does not exist: {full_path:?}");
-                continue;
-            }
-            match tokio::fs::read(&full_path).await {
-                Ok(bytes) => verify_content_digest(&bytes, content_digest, path).and_then(|()| {
-                    String::from_utf8(bytes).with_context(|| {
-                        format!("backtrace source {full_path:?} is not valid UTF-8")
-                    })
-                }),
-                Err(err) => {
-                    Err(err).with_context(|| format!("cannot read backtrace source {full_path:?}"))
-                }
-            }
+            sanitize_deployment_relative_path(path)?
         };
+        let content = provider
+            .read(&file_name, content_digest)
+            .await
+            .and_then(|bytes| {
+                String::from_utf8(bytes)
+                    .with_context(|| format!("backtrace source {file_name:?} is not valid UTF-8"))
+            });
         match content {
             Ok(content) => {
                 frame_files_to_sources
                     .insert(key.clone(), BacktraceSourceCanonical { content, file_name });
             }
             Err(err) => {
-                warn!("Cannot read backtrace source {full_path:?} - {err:?}");
+                warn!("Cannot read backtrace source {file_name:?} - {err:?}");
             }
         }
     }
@@ -4164,14 +4114,14 @@ name = "my_stub"
         }
 
         #[tokio::test]
-        async fn absolute_path_is_external() {
+        async fn absolute_path_is_rejected() {
             let root = tempfile::tempdir().unwrap();
             let provider = disk_provider(root.path());
             let outside = root.path().join("outside.js");
             std::fs::write(&outside, "external content").unwrap();
             let abs = outside.to_string_lossy().into_owned();
 
-            let location = resolve_script_toml_to_canonical(
+            let err = resolve_script_toml_to_canonical(
                 Some(JsLocationToml::Path(abs.clone())),
                 None,
                 "ignored.js".to_string(),
@@ -4180,10 +4130,11 @@ name = "my_stub"
                 None,
             )
             .await
-            .unwrap();
-            assert_matches::assert_matches!(
-                location,
-                ScriptLocationCanonical::ExternalPath { path } if path == abs
+            .unwrap_err()
+            .to_string();
+            assert!(
+                err.contains("absolute local paths are not allowed"),
+                "unexpected error: {err}"
             );
         }
 
@@ -4268,20 +4219,17 @@ name = "my_stub"
         }
 
         #[tokio::test]
-        async fn external_file_content_digest_verified_at_submit() {
-            let root = tempfile::tempdir().unwrap();
-            let inner = root.path().join("inner");
-            std::fs::create_dir_all(&inner).unwrap();
-            let provider = disk_provider(&inner);
-            let outside = root.path().join("outside.js");
-            std::fs::write(&outside, "external content").unwrap();
+        async fn relative_file_content_digest_verified_at_submit() {
+            let dir = tempfile::tempdir().unwrap();
+            let provider = disk_provider(dir.path());
+            std::fs::write(dir.path().join("script.js"), "owned content").unwrap();
 
             let wrong = digest_of(b"nope");
             let err = resolve_script_toml_to_canonical(
-                Some(JsLocationToml::Path(outside.to_string_lossy().into_owned())),
+                Some(JsLocationToml::Path("script.js".to_string())),
                 None,
                 "ignored.js".to_string(),
-                &inner,
+                dir.path(),
                 &provider,
                 Some(&wrong),
             )
@@ -4396,10 +4344,16 @@ name = "my_stub"
             );
             assert!(err.contains("`..`"), "unexpected error: {err}");
 
-            // Absolute paths are left untouched (out-of-tree reference).
+            // Author-provided absolute paths are rejected.
             let mut abs = "/other/a.wasm".to_string();
-            DeploymentToml::expand_deployment_dir(&mut abs, dir).unwrap();
-            assert_eq!(abs, "/other/a.wasm");
+            let err = format!(
+                "{:#}",
+                DeploymentToml::expand_deployment_dir(&mut abs, dir).unwrap_err()
+            );
+            assert!(
+                err.contains("absolute local paths are not allowed"),
+                "unexpected error: {err}"
+            );
         }
 
         #[tokio::test]
@@ -4471,9 +4425,7 @@ name = "my_stub"
         }
 
         #[tokio::test]
-        async fn absolute_source_is_mirrored_root_stripped() {
-            // An absolute backtrace source path is recreated self-contained under a
-            // root-stripped relative mirror, so it never escapes the output directory.
+        async fn absolute_source_is_rejected() {
             let dir = tempfile::tempdir().unwrap();
             let abs = dir.path().join("nested/lib.rs");
             std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
@@ -4489,16 +4441,14 @@ name = "my_stub"
             let provider = DiskProvider {
                 deployment_dir: other_dir.path().to_path_buf(),
             };
-            let canon = resolve_backtrace_to_canonical(&bt, other_dir.path(), &provider)
+            let err = resolve_backtrace_to_canonical(&bt, other_dir.path(), &provider)
                 .await
-                .unwrap();
-            let src = canon.frame_files_to_sources.get(".../src/lib.rs").unwrap();
-            assert_eq!(src.content, "SRC");
-            // Root/drive stripped, remaining components preserved, no leading separator.
-            let expected = mirror_path_as_relative(&abs.to_string_lossy()).unwrap();
-            assert_eq!(src.file_name, expected);
-            assert!(!src.file_name.starts_with('/'));
-            assert!(src.file_name.ends_with("nested/lib.rs"));
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("absolute local paths are not allowed"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -53,18 +53,17 @@ use wasm_workers::{
 use webhook::{HttpServer, WebhookJsComponentConfigToml, WebhookWasmComponentConfigToml};
 
 pub(crate) use deployment_config::config::{
-    ActivityExecComponentConfigCanonical, ActivityExternalComponentConfigCanonical,
-    ActivityExternalFileConfigToml, ActivityJsComponentConfigCanonical,
-    ActivityStubComponentConfigCanonical, ActivityStubExtInlineConfigCanonical,
+    ActivityExecComponentConfigResolved, ActivityExternalComponentConfigResolved,
+    ActivityExternalFileConfigToml, ActivityJsComponentConfigResolved,
+    ActivityStubComponentConfigResolved, ActivityStubExtInlineConfigResolved,
     ActivityStubFileConfigToml, ActivityWasmComponentConfigToml, AllowedHostToml,
-    BacktraceSourceCanonical, BlockingStrategyConfigToml, ComponentBacktraceConfigCanonical,
-    ComponentCommon, ComponentLocationToml, ComponentStdOutputToml, ConfigName,
-    DeploymentCanonical, DurationConfig, DurationConfigOptional, ExecConfigToml, ExecSecretsToml,
-    InflightSemaphore, JsParamToml, LockingStrategy, LogLevelToml, MethodsInput, MethodsInputStar,
-    OCI_SCHEMA_PREFIX, ReplaceIn, ScriptLocationCanonical, Unlimited,
-    WorkflowJsComponentConfigCanonical, WorkflowWasmComponentConfigCanonical,
-    default_lock_extension, default_max_output_bytes, default_max_retries,
-    default_retry_exp_backoff,
+    BacktraceSourceResolved, BlockingStrategyConfigToml, ComponentBacktraceConfigResolved,
+    ComponentCommon, ComponentLocationToml, ComponentStdOutputToml, ConfigName, DeploymentResolved,
+    DurationConfig, DurationConfigOptional, ExecConfigToml, ExecSecretsToml, InflightSemaphore,
+    JsParamToml, LockingStrategy, LogLevelToml, MethodsInput, MethodsInputStar, OCI_SCHEMA_PREFIX,
+    ReplaceIn, ScriptLocationResolved, Unlimited, WorkflowJsComponentConfigResolved,
+    WorkflowWasmComponentConfigResolved, default_lock_extension, default_max_output_bytes,
+    default_max_retries, default_retry_exp_backoff,
 };
 
 const DEFAULT_SQLITE_DIR_IF_PROJECT_DIRS: &str =
@@ -131,7 +130,7 @@ pub(crate) struct DeploymentTomlValidated {
     pub(crate) deployment_dir: PathBuf,
 }
 impl DeploymentTomlValidated {
-    pub(crate) async fn canonicalize(self) -> Result<DeploymentCanonical, anyhow::Error> {
+    pub(crate) async fn canonicalize(self) -> Result<DeploymentResolved, anyhow::Error> {
         let provider = DiskProvider {
             deployment_dir: self.deployment_dir.clone(),
         };
@@ -141,7 +140,7 @@ impl DeploymentTomlValidated {
     pub(crate) async fn canonicalize_with_provider(
         self,
         provider: &dyn FileProvider,
-    ) -> Result<DeploymentCanonical, anyhow::Error> {
+    ) -> Result<DeploymentResolved, anyhow::Error> {
         resolve_local_refs_to_canonical(self, provider).await
     }
 }
@@ -881,7 +880,7 @@ impl HasOptionalNameAndFfqn for ActivityStubExtInlineConfigToml {
 
 /// Location of a JavaScript source file.
 /// Supports local file paths and OCI registry references (`oci://...`).
-/// On-disk format only; replaced by [`ScriptLocationCanonical`] before transmission and hash computation.
+/// On-disk format only; replaced by [`ScriptLocationResolved`] before transmission and hash computation.
 #[derive(Debug, Clone, Hash, JsonSchema, SerializeDisplay, DeserializeFromStr)]
 #[schemars(with = "String")]
 pub(crate) enum JsLocationToml {
@@ -1079,7 +1078,7 @@ pub(crate) enum ActivityStubConfigVerified {
     Inline(ActivityStubExtInlineConfigVerified),
 }
 
-pub(crate) trait ActivityStubComponentConfigCanonicalExt {
+pub(crate) trait ActivityStubComponentConfigResolvedExt {
     async fn fetch_and_verify(
         self,
         wasm_cache_dir: Arc<Path>,
@@ -1087,7 +1086,7 @@ pub(crate) trait ActivityStubComponentConfigCanonicalExt {
     ) -> Result<ActivityStubConfigVerified, anyhow::Error>;
 }
 
-impl ActivityStubComponentConfigCanonicalExt for ActivityStubComponentConfigCanonical {
+impl ActivityStubComponentConfigResolvedExt for ActivityStubComponentConfigResolved {
     #[instrument(skip_all, fields(component_name = self.name_str(), component_id))]
     async fn fetch_and_verify(
         self,
@@ -1193,7 +1192,7 @@ pub(crate) enum ActivityExternalConfigVerified {
     Inline(ActivityStubExtInlineConfigVerified),
 }
 
-pub(crate) trait ActivityExternalComponentConfigCanonicalExt {
+pub(crate) trait ActivityExternalComponentConfigResolvedExt {
     async fn fetch_and_verify(
         self,
         wasm_cache_dir: Arc<Path>,
@@ -1201,7 +1200,7 @@ pub(crate) trait ActivityExternalComponentConfigCanonicalExt {
     ) -> Result<ActivityExternalConfigVerified, anyhow::Error>;
 }
 
-impl ActivityExternalComponentConfigCanonicalExt for ActivityExternalComponentConfigCanonical {
+impl ActivityExternalComponentConfigResolvedExt for ActivityExternalComponentConfigResolved {
     #[instrument(skip_all, fields(component_name = self.name_str(), component_id))]
     async fn fetch_and_verify(
         self,
@@ -1527,7 +1526,7 @@ pub(crate) struct ResolvedExecProgram {
     pub(crate) source_bytes: Vec<u8>,
 }
 
-pub(crate) trait ActivityExecComponentConfigCanonicalExt {
+pub(crate) trait ActivityExecComponentConfigResolvedExt {
     async fn resolve(
         &self,
         wasm_cache_dir: &std::path::Path,
@@ -1540,14 +1539,14 @@ pub(crate) trait ActivityExecComponentConfigCanonicalExt {
     ) -> Result<ActivityExecConfigVerified, anyhow::Error>;
 }
 
-impl ActivityExecComponentConfigCanonicalExt for ActivityExecComponentConfigCanonical {
+impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResolved {
     /// Resolve the canonical program to a form the worker can execute.
     async fn resolve(
         &self,
         wasm_cache_dir: &std::path::Path,
     ) -> anyhow::Result<ResolvedExecProgram> {
         match &self.location {
-            ScriptLocationCanonical::Content { content, .. } => {
+            ScriptLocationResolved::Content { content, .. } => {
                 if let Some(expected) = self.content_digest.as_ref() {
                     let hash: [u8; 32] = Sha256::digest(content.as_bytes()).into();
                     let actual = ContentDigest(Digest(hash));
@@ -1562,7 +1561,7 @@ impl ActivityExecComponentConfigCanonicalExt for ActivityExecComponentConfigCano
                 })
             }
             // Legacy/internal canonical form; new deployment TOML cannot author absolute paths.
-            ScriptLocationCanonical::ExternalPath { path } => {
+            ScriptLocationResolved::ExternalPath { path } => {
                 let full_path = PathBuf::from(path);
                 let content = tokio::fs::read_to_string(&full_path)
                     .await
@@ -1580,7 +1579,7 @@ impl ActivityExecComponentConfigCanonicalExt for ActivityExecComponentConfigCano
                     source_bytes: content.into_bytes(),
                 })
             }
-            ScriptLocationCanonical::Oci { image } => {
+            ScriptLocationResolved::Oci { image } => {
                 let oci_ref = oci_client::Reference::from_str(image)
                     .map_err(|e| anyhow!("invalid OCI reference `{image}`: {e}"))?;
                 let exec_cache_dir = wasm_cache_dir.join("exec");
@@ -1873,7 +1872,7 @@ impl BlockingStrategyConfigTomlExt for BlockingStrategyConfigToml {
 #[serde(deny_unknown_fields)]
 pub(crate) struct ComponentBacktraceConfig {
     /// Maps a frame-symbol key to a backtrace source file path. On-disk format only;
-    /// resolved to `ComponentBacktraceConfigCanonical` before transmission and hash
+    /// resolved to `ComponentBacktraceConfigResolved` before transmission and hash
     /// computation. A relative path is deployment-dir-relative (a leading
     /// `${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.
     #[serde(rename = "sources")]
@@ -1918,7 +1917,7 @@ pub(crate) struct JsContent {
     pub(crate) file_name: String,
 }
 
-pub(crate) trait JsLocationCanonicalExt {
+pub(crate) trait JsLocationResolvedExt {
     async fn get_content(
         &self,
         wasm_cache_dir: &Path,
@@ -1926,7 +1925,7 @@ pub(crate) trait JsLocationCanonicalExt {
     ) -> anyhow::Result<JsContent>;
 }
 
-impl JsLocationCanonicalExt for ScriptLocationCanonical {
+impl JsLocationResolvedExt for ScriptLocationResolved {
     /// Return the JS source content and file name.
     /// For `Content`, returns them directly (validating digest if provided).
     /// For legacy/internal `ExternalPath`, reads the file at runtime (validating digest if provided).
@@ -1937,7 +1936,7 @@ impl JsLocationCanonicalExt for ScriptLocationCanonical {
         expected_digest: Option<&ContentDigest>,
     ) -> anyhow::Result<JsContent> {
         match self {
-            ScriptLocationCanonical::Content { content, file_name } => {
+            ScriptLocationResolved::Content { content, file_name } => {
                 if let Some(expected) = expected_digest {
                     let hash: [u8; 32] = Sha256::digest(content.as_bytes()).into();
                     let actual = ContentDigest(Digest(hash));
@@ -1960,7 +1959,7 @@ impl JsLocationCanonicalExt for ScriptLocationCanonical {
                     file_name,
                 })
             }
-            ScriptLocationCanonical::ExternalPath { path } => {
+            ScriptLocationResolved::ExternalPath { path } => {
                 let full_path = PathBuf::from(path);
                 let source = tokio::fs::read_to_string(&full_path)
                     .await
@@ -1980,7 +1979,7 @@ impl JsLocationCanonicalExt for ScriptLocationCanonical {
                     .to_string();
                 Ok(JsContent { source, file_name })
             }
-            ScriptLocationCanonical::Oci { image } => {
+            ScriptLocationResolved::Oci { image } => {
                 let oci_ref = oci_client::Reference::from_str(image)
                     .map_err(|e| anyhow::anyhow!("invalid OCI reference in canonical form: {e}"))?;
                 let js_cache_dir = wasm_cache_dir.join("js");
@@ -2035,9 +2034,9 @@ impl WorkflowConfigVerified {
     }
 }
 
-// Canonical component config types live in the `deployment-config` crate.
+// Resolved component config types live in the `deployment-config` crate.
 
-pub(crate) trait ActivityJsComponentConfigCanonicalExt {
+pub(crate) trait ActivityJsComponentConfigResolvedExt {
     async fn fetch_and_verify(
         self,
         wasm_path: Arc<Path>,
@@ -2048,7 +2047,7 @@ pub(crate) trait ActivityJsComponentConfigCanonicalExt {
     ) -> Result<ActivityJsConfigVerified, anyhow::Error>;
 }
 
-impl ActivityJsComponentConfigCanonicalExt for ActivityJsComponentConfigCanonical {
+impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved {
     #[instrument(skip_all, fields(component_name = self.name.as_str()))]
     async fn fetch_and_verify(
         self,
@@ -2144,7 +2143,7 @@ impl ActivityJsComponentConfigCanonicalExt for ActivityJsComponentConfigCanonica
     }
 }
 
-pub(crate) trait WorkflowWasmComponentConfigCanonicalExt {
+pub(crate) trait WorkflowWasmComponentConfigResolvedExt {
     async fn fetch_and_verify(
         self,
         wasm_cache_dir: Arc<Path>,
@@ -2156,7 +2155,7 @@ pub(crate) trait WorkflowWasmComponentConfigCanonicalExt {
     ) -> Result<WorkflowConfigVerified, anyhow::Error>;
 }
 
-impl WorkflowWasmComponentConfigCanonicalExt for WorkflowWasmComponentConfigCanonical {
+impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResolved {
     #[instrument(skip_all, fields(component_name = self.common.name.as_str()))]
     async fn fetch_and_verify(
         self,
@@ -2225,7 +2224,7 @@ impl WorkflowWasmComponentConfigCanonicalExt for WorkflowWasmComponentConfigCano
     }
 }
 
-pub(crate) trait WorkflowJsComponentConfigCanonicalExt {
+pub(crate) trait WorkflowJsComponentConfigResolvedExt {
     async fn fetch_and_verify(
         self,
         wasm_path: Arc<Path>,
@@ -2234,7 +2233,7 @@ pub(crate) trait WorkflowJsComponentConfigCanonicalExt {
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error>;
 }
 
-impl WorkflowJsComponentConfigCanonicalExt for WorkflowJsComponentConfigCanonical {
+impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved {
     #[instrument(skip_all, fields(component_name = self.name.as_str()))]
     async fn fetch_and_verify(
         self,
@@ -2325,16 +2324,16 @@ impl WorkflowJsComponentConfigCanonicalExt for WorkflowJsComponentConfigCanonica
     }
 }
 
-/// Resolve a `DeploymentToml` to `DeploymentCanonical` by reading all local JS and backtrace
+/// Resolve a `DeploymentToml` to `DeploymentResolved` by reading all local JS and backtrace
 /// source files.
 async fn resolve_local_refs_to_canonical(
     deployment: DeploymentTomlValidated,
     provider: &dyn FileProvider,
-) -> anyhow::Result<DeploymentCanonical> {
+) -> anyhow::Result<DeploymentResolved> {
     let deployment_dir = deployment.deployment_dir.clone();
     let mut activities_js = Vec::with_capacity(deployment.activities_js.len());
     for (a, name) in deployment.activities_js {
-        activities_js.push(ActivityJsComponentConfigCanonical {
+        activities_js.push(ActivityJsComponentConfigResolved {
             location: resolve_script_toml_to_canonical(
                 a.location,
                 a.content,
@@ -2363,7 +2362,7 @@ async fn resolve_local_refs_to_canonical(
 
     let mut workflows_wasm = Vec::with_capacity(deployment.workflows_wasm.len());
     for w in deployment.workflows_wasm {
-        workflows_wasm.push(WorkflowWasmComponentConfigCanonical {
+        workflows_wasm.push(WorkflowWasmComponentConfigResolved {
             common: w.common,
             content_digest: w.content_digest,
             component_digest: w.component_digest,
@@ -2380,7 +2379,7 @@ async fn resolve_local_refs_to_canonical(
 
     let mut workflows_js = Vec::with_capacity(deployment.workflows_js.len());
     for (w, name) in deployment.workflows_js {
-        workflows_js.push(WorkflowJsComponentConfigCanonical {
+        workflows_js.push(WorkflowJsComponentConfigResolved {
             location: resolve_script_toml_to_canonical(
                 w.location,
                 w.content,
@@ -2406,7 +2405,7 @@ async fn resolve_local_refs_to_canonical(
 
     let mut webhooks_wasm = Vec::with_capacity(deployment.webhooks_wasm.len());
     for w in deployment.webhooks_wasm {
-        webhooks_wasm.push(webhook::WebhookWasmComponentConfigCanonical {
+        webhooks_wasm.push(webhook::WebhookWasmComponentConfigResolved {
             common: w.common,
             content_digest: w.content_digest,
             http_server: w.http_server,
@@ -2423,7 +2422,7 @@ async fn resolve_local_refs_to_canonical(
 
     let mut webhooks_js = Vec::with_capacity(deployment.webhooks_js.len());
     for w in deployment.webhooks_js {
-        webhooks_js.push(webhook::WebhookJsComponentConfigCanonical {
+        webhooks_js.push(webhook::WebhookJsComponentConfigResolved {
             location: resolve_script_toml_to_canonical(
                 w.location,
                 w.content,
@@ -2456,7 +2455,7 @@ async fn resolve_local_refs_to_canonical(
             a.content_digest.as_ref(),
         )
         .await?;
-        activities_exec.push(ActivityExecComponentConfigCanonical {
+        activities_exec.push(ActivityExecComponentConfigResolved {
             name,
             location,
             content_digest: a.content_digest,
@@ -2482,10 +2481,10 @@ async fn resolve_local_refs_to_canonical(
         .into_iter()
         .map(|(c, name)| match c {
             ActivityStubComponentConfigToml::File(f) => {
-                ActivityStubComponentConfigCanonical::File(f)
+                ActivityStubComponentConfigResolved::File(f)
             }
             ActivityStubComponentConfigToml::Inline(i) => {
-                ActivityStubComponentConfigCanonical::Inline(ActivityStubExtInlineConfigCanonical {
+                ActivityStubComponentConfigResolved::Inline(ActivityStubExtInlineConfigResolved {
                     name,
                     ffqn: i.ffqn,
                     params: i.params,
@@ -2499,11 +2498,11 @@ async fn resolve_local_refs_to_canonical(
         .into_iter()
         .map(|(c, name)| match c {
             ActivityExternalComponentConfigToml::File(f) => {
-                ActivityExternalComponentConfigCanonical::File(f)
+                ActivityExternalComponentConfigResolved::File(f)
             }
             ActivityExternalComponentConfigToml::Inline(i) => {
-                ActivityExternalComponentConfigCanonical::Inline(
-                    ActivityStubExtInlineConfigCanonical {
+                ActivityExternalComponentConfigResolved::Inline(
+                    ActivityStubExtInlineConfigResolved {
                         name,
                         ffqn: i.ffqn,
                         params: i.params,
@@ -2514,7 +2513,7 @@ async fn resolve_local_refs_to_canonical(
         })
         .collect();
 
-    let canonical = DeploymentCanonical {
+    let canonical = DeploymentResolved {
         activities_wasm: deployment.activities_wasm,
         activities_stub,
         activities_external,
@@ -2536,7 +2535,7 @@ async fn resolve_local_refs_to_canonical(
 /// retrieved with `deployment get`, which writes every owned source to disk at its
 /// `file_name` and refuses to clobber. Identical re-uses of a name are allowed (they dedupe
 /// to a single file). This surfaces the failure at submit time rather than on a later round-trip.
-fn validate_owned_source_file_names(canonical: &DeploymentCanonical) -> anyhow::Result<()> {
+fn validate_owned_source_file_names(canonical: &DeploymentResolved) -> anyhow::Result<()> {
     fn register<'a>(
         seen: &mut HashMap<&'a str, &'a str>,
         file_name: &'a str,
@@ -2563,7 +2562,7 @@ fn validate_owned_source_file_names(canonical: &DeploymentCanonical) -> anyhow::
         .chain(canonical.workflows_js.iter().map(|c| &c.location))
         .chain(canonical.webhooks_js.iter().map(|c| &c.location));
     for loc in script_locations {
-        if let ScriptLocationCanonical::Content { content, file_name } = loc {
+        if let ScriptLocationResolved::Content { content, file_name } = loc {
             register(&mut seen, file_name, content)?;
         }
     }
@@ -2633,11 +2632,11 @@ async fn resolve_script_toml_to_canonical(
     _deployment_dir: &Path,
     provider: &dyn FileProvider,
     content_digest: Option<&ContentDigest>,
-) -> anyhow::Result<ScriptLocationCanonical> {
+) -> anyhow::Result<ScriptLocationResolved> {
     match (location, content) {
         (None, Some(content)) => {
             verify_content_digest(content.as_bytes(), content_digest, &default_file_name)?;
-            Ok(ScriptLocationCanonical::Content {
+            Ok(ScriptLocationResolved::Content {
                 content,
                 file_name: default_file_name,
             })
@@ -2651,12 +2650,12 @@ async fn resolve_script_toml_to_canonical(
             let content = provider.read(&path, content_digest).await?;
             let content = String::from_utf8(content)
                 .with_context(|| format!("script file {path:?} is not valid UTF-8"))?;
-            Ok(ScriptLocationCanonical::Content {
+            Ok(ScriptLocationResolved::Content {
                 content,
                 file_name: path,
             })
         }
-        (Some(JsLocationToml::Oci(reference)), None) => Ok(ScriptLocationCanonical::Oci {
+        (Some(JsLocationToml::Oci(reference)), None) => Ok(ScriptLocationResolved::Oci {
             image: reference.to_string(),
         }),
         (None, None) | (Some(_), Some(_)) => {
@@ -2669,7 +2668,7 @@ async fn resolve_backtrace_to_canonical(
     backtrace: &ComponentBacktraceConfig,
     _deployment_dir: &Path,
     provider: &dyn FileProvider,
-) -> anyhow::Result<ComponentBacktraceConfigCanonical> {
+) -> anyhow::Result<ComponentBacktraceConfigResolved> {
     let mut frame_files_to_sources = HashMap::new();
     for (key, source) in &backtrace.frame_files_to_sources {
         let path = source.path();
@@ -2693,14 +2692,14 @@ async fn resolve_backtrace_to_canonical(
         match content {
             Ok(content) => {
                 frame_files_to_sources
-                    .insert(key.clone(), BacktraceSourceCanonical { content, file_name });
+                    .insert(key.clone(), BacktraceSourceResolved { content, file_name });
             }
             Err(err) => {
                 warn!("Cannot read backtrace source {file_name:?} - {err:?}");
             }
         }
     }
-    Ok(ComponentBacktraceConfigCanonical {
+    Ok(ComponentBacktraceConfigResolved {
         frame_files_to_sources,
     })
 }
@@ -2980,7 +2979,7 @@ pub(crate) mod webhook {
     use super::{
         AllowedHostToml, ComponentBacktraceConfig, ComponentCommon, ComponentCommonFetchExt,
         ComponentStdOutputToml, ComponentStdOutputTomlExt, ConfigName, JsContent,
-        JsLocationCanonicalExt, JsLocationToml, LogLevelTomlExt, resolve_allowed_hosts,
+        JsLocationResolvedExt, JsLocationToml, LogLevelTomlExt, resolve_allowed_hosts,
         resolve_env_vars_plaintext, validate_no_env_collision,
     };
     use crate::command::server::FrameFilesToSourceContent;
@@ -2992,8 +2991,8 @@ pub(crate) mod webhook {
         storage::LogLevel,
     };
     pub(crate) use deployment_config::config::webhook::{
-        WebhookJsComponentConfigCanonical, WebhookRoute, WebhookRouteDetail,
-        WebhookWasmComponentConfigCanonical, default_external_server_name,
+        WebhookJsComponentConfigResolved, WebhookRoute, WebhookRouteDetail,
+        WebhookWasmComponentConfigResolved, default_external_server_name,
     };
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
@@ -3145,7 +3144,7 @@ pub(crate) mod webhook {
         }
     }
 
-    pub(crate) trait WebhookWasmComponentConfigCanonicalExt {
+    pub(crate) trait WebhookWasmComponentConfigResolvedExt {
         async fn fetch_and_verify(
             self,
             wasm_cache_dir: Arc<Path>,
@@ -3155,7 +3154,7 @@ pub(crate) mod webhook {
         ) -> Result<(ConfigName, WebhookWasmComponentConfigVerified), anyhow::Error>;
     }
 
-    impl WebhookWasmComponentConfigCanonicalExt for WebhookWasmComponentConfigCanonical {
+    impl WebhookWasmComponentConfigResolvedExt for WebhookWasmComponentConfigResolved {
         #[instrument(skip_all, fields(component_name = self.common.name.as_str()), err)]
         async fn fetch_and_verify(
             self,
@@ -3204,7 +3203,7 @@ pub(crate) mod webhook {
         }
     }
 
-    pub(crate) trait WebhookJsComponentConfigCanonicalExt {
+    pub(crate) trait WebhookJsComponentConfigResolvedExt {
         async fn fetch_and_verify(
             self,
             wasm_path: Arc<Path>,
@@ -3213,7 +3212,7 @@ pub(crate) mod webhook {
         ) -> Result<(ConfigName, WebhookJsConfigVerified), anyhow::Error>;
     }
 
-    impl WebhookJsComponentConfigCanonicalExt for WebhookJsComponentConfigCanonical {
+    impl WebhookJsComponentConfigResolvedExt for WebhookJsComponentConfigResolved {
         #[instrument(skip_all, fields(component_name = self.name.as_str()))]
         async fn fetch_and_verify(
             self,
@@ -3846,7 +3845,7 @@ name = "my_stub"
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("stub.wasm");
             tokio::fs::write(&path, b"actual").await.unwrap();
-            let stub = ActivityStubComponentConfigCanonical::File(ActivityStubFileConfigToml {
+            let stub = ActivityStubComponentConfigResolved::File(ActivityStubFileConfigToml {
                 common: ComponentCommon {
                     name: ConfigName::new(StrVariant::from("my_stub")).unwrap(),
                     location: ComponentLocationToml::Path(path.to_string_lossy().into_owned()),
@@ -3873,10 +3872,10 @@ name = "my_stub"
 
         use super::super::*;
 
-        fn exec_config_with_secret(value: &str) -> ActivityExecComponentConfigCanonical {
-            ActivityExecComponentConfigCanonical {
+        fn exec_config_with_secret(value: &str) -> ActivityExecComponentConfigResolved {
+            ActivityExecComponentConfigResolved {
                 name: ConfigName::new(StrVariant::from("exec-test")).unwrap(),
-                location: ScriptLocationCanonical::Content {
+                location: ScriptLocationResolved::Content {
                     content: "#!/usr/bin/env bash\necho null\n".into(),
                     file_name: "exec-test".into(),
                 },
@@ -3903,10 +3902,10 @@ name = "my_stub"
         }
 
         fn exec_config_with_source(
-            location: ScriptLocationCanonical,
+            location: ScriptLocationResolved,
             content_digest: Option<ContentDigest>,
-        ) -> ActivityExecComponentConfigCanonical {
-            ActivityExecComponentConfigCanonical {
+        ) -> ActivityExecComponentConfigResolved {
+            ActivityExecComponentConfigResolved {
                 name: ConfigName::new(StrVariant::from("exec-test")).unwrap(),
                 location,
                 content_digest,
@@ -3970,14 +3969,14 @@ name = "my_stub"
         fn fetch_and_verify_activity_exec_hashes_resolved_source_not_oci_reference() {
             let source = b"#!/usr/bin/env bash\necho null\n".to_vec();
             let inline = exec_config_with_source(
-                ScriptLocationCanonical::Content {
+                ScriptLocationResolved::Content {
                     content: String::from_utf8(source.clone()).unwrap(),
                     file_name: "exec-test".into(),
                 },
                 None,
             );
             let oci = exec_config_with_source(
-                ScriptLocationCanonical::Oci {
+                ScriptLocationResolved::Oci {
                     image: "registry.example.com/ns/exec:latest".into(),
                 },
                 None,
@@ -4012,7 +4011,7 @@ name = "my_stub"
         #[tokio::test]
         async fn resolve_activity_exec_validates_inline_content_digest() {
             let config = exec_config_with_source(
-                ScriptLocationCanonical::Content {
+                ScriptLocationResolved::Content {
                     content: "#!/usr/bin/env bash\necho null\n".into(),
                     file_name: "exec-test".into(),
                 },
@@ -4064,7 +4063,7 @@ name = "my_stub"
             .unwrap();
             assert_matches::assert_matches!(
                 location,
-                ScriptLocationCanonical::Content { content, file_name }
+                ScriptLocationResolved::Content { content, file_name }
                     if content == "export const x = 1;" && file_name == "foo.js"
             );
         }
@@ -4090,7 +4089,7 @@ name = "my_stub"
             .unwrap();
             assert_matches::assert_matches!(
                 location,
-                ScriptLocationCanonical::Content { content, file_name }
+                ScriptLocationResolved::Content { content, file_name }
                     if content == "owned content" && file_name == "scripts/a.js"
             );
         }
@@ -4117,7 +4116,7 @@ name = "my_stub"
             .unwrap();
             assert_matches::assert_matches!(
                 location,
-                ScriptLocationCanonical::Content { file_name, .. } if file_name == "scripts/a.js"
+                ScriptLocationResolved::Content { file_name, .. } if file_name == "scripts/a.js"
             );
         }
 
@@ -4184,7 +4183,7 @@ name = "my_stub"
             .unwrap();
             assert_matches::assert_matches!(
                 location,
-                ScriptLocationCanonical::Oci { image }
+                ScriptLocationResolved::Oci { image }
                     if image == "docker.io/library/example:latest"
             );
         }
@@ -4256,9 +4255,9 @@ name = "my_stub"
 
         fn js_activity(
             name: &str,
-            location: ScriptLocationCanonical,
-        ) -> ActivityJsComponentConfigCanonical {
-            ActivityJsComponentConfigCanonical {
+            location: ScriptLocationResolved,
+        ) -> ActivityJsComponentConfigResolved {
+            ActivityJsComponentConfigResolved {
                 name: ConfigName::new(StrVariant::from(name.to_string())).unwrap(),
                 location,
                 content_digest: None,
@@ -4281,17 +4280,17 @@ name = "my_stub"
         fn submit_rejects_owned_file_name_collision() {
             // Two distinct owned scripts resolving to the same `file_name` must be rejected
             // at submit time, since `deployment get` could never write both to disk.
-            let mut deployment = DeploymentCanonical::default();
+            let mut deployment = DeploymentResolved::default();
             deployment.activities_js.push(js_activity(
                 "a",
-                ScriptLocationCanonical::Content {
+                ScriptLocationResolved::Content {
                     content: "export const a = 1;".to_string(),
                     file_name: "foo".to_string(),
                 },
             ));
             deployment.activities_js.push(js_activity(
                 "b",
-                ScriptLocationCanonical::Content {
+                ScriptLocationResolved::Content {
                     content: "export const b = 2;".to_string(),
                     file_name: "foo".to_string(),
                 },
@@ -4308,11 +4307,11 @@ name = "my_stub"
         #[test]
         fn submit_allows_identical_owned_content_under_same_name() {
             // Same file_name with identical content dedupes on export, so it must pass submit.
-            let mut deployment = DeploymentCanonical::default();
+            let mut deployment = DeploymentResolved::default();
             for name in ["a", "b"] {
                 deployment.activities_js.push(js_activity(
                     name,
-                    ScriptLocationCanonical::Content {
+                    ScriptLocationResolved::Content {
                         content: "export const shared = 1;".to_string(),
                         file_name: "shared.js".to_string(),
                     },

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1946,9 +1946,18 @@ impl JsLocationCanonicalExt for ScriptLocationCanonical {
                         "content digest mismatch for inline JS `{file_name}`: expected {expected}, got {actual}"
                     );
                 }
+                // Report the basename to the JS engine so stack frames (and the source
+                // lookup keyed by them) use the bare file name, matching the `ExternalPath`
+                // and `Oci` variants. The canonical `file_name` keeps its deployment-relative
+                // subpath for `deployment get` export.
+                let file_name = std::path::Path::new(file_name)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(file_name)
+                    .to_string();
                 Ok(JsContent {
                     source: content.clone(),
-                    file_name: file_name.clone(),
+                    file_name,
                 })
             }
             ScriptLocationCanonical::ExternalPath { path } => {
@@ -2636,17 +2645,16 @@ async fn resolve_script_toml_to_canonical(
         (Some(JsLocationToml::Path(path)), None) => {
             if std::path::Path::new(&path).is_absolute() {
                 bail!("absolute local paths are not allowed in deployment manifests: `{path}`")
-            } else {
-                let path = strip_deployment_dir_prefix(&path).unwrap_or(&path);
-                let path = sanitize_deployment_relative_path(path)?;
-                let content = provider.read(&path, content_digest).await?;
-                let content = String::from_utf8(content)
-                    .with_context(|| format!("script file {path:?} is not valid UTF-8"))?;
-                Ok(ScriptLocationCanonical::Content {
-                    content,
-                    file_name: path,
-                })
             }
+            let path = strip_deployment_dir_prefix(&path).unwrap_or(&path);
+            let path = sanitize_deployment_relative_path(path)?;
+            let content = provider.read(&path, content_digest).await?;
+            let content = String::from_utf8(content)
+                .with_context(|| format!("script file {path:?} is not valid UTF-8"))?;
+            Ok(ScriptLocationCanonical::Content {
+                content,
+                file_name: path,
+            })
         }
         (Some(JsLocationToml::Oci(reference)), None) => Ok(ScriptLocationCanonical::Oci {
             image: reference.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,12 @@ pub(crate) fn project_dirs() -> Option<ProjectDirs> {
     ProjectDirs::from("", "obelisk", "obelisk")
 }
 
+/// Maximum encoded gRPC message size for the deployment repository service. Submit
+/// requests inline deployment-owned file blobs and `GetFile` returns them, so the
+/// default 4 MiB tonic limit is far too small. This caps both the server's decoding
+/// and the client's encoding/decoding for that service.
+pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
+
 type ExecutionRepositoryClient = grpc_gen::execution_repository_client::ExecutionRepositoryClient<
     tonic::service::interceptor::InterceptedService<Channel, TracingInjector>,
 >;
@@ -66,7 +72,9 @@ async fn get_deployment_repository_client(
         )
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Gzip),
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
     )
 }
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1772,21 +1772,21 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
     }
 
     #[instrument(skip_all)]
-    async fn upload_file(
+    async fn gc_orphan_files(
         &self,
-        request: tonic::Request<grpc_gen::UploadFileRequest>,
-    ) -> TonicRespResult<grpc_gen::UploadFileResponse> {
-        let request = request.into_inner();
-        let deployment_id: DeploymentId = request
-            .deployment_id
-            .argument_must_exist("deployment_id")?
-            .try_into()?;
-        let digest =
-            server::upload_deployment_file(self.db_pool.clone(), deployment_id, &request.content)
-                .await
-                .map_err(|err| tonic::Status::failed_precondition(format!("{err:#}")))?;
-        Ok(tonic::Response::new(grpc_gen::UploadFileResponse {
-            digest: digest.to_string(),
+        _request: tonic::Request<grpc_gen::GcOrphanFilesRequest>,
+    ) -> TonicRespResult<grpc_gen::GcOrphanFilesResponse> {
+        let conn = self
+            .db_pool
+            .external_api_conn()
+            .await
+            .map_err(map_to_status)?;
+        let deleted_count = conn
+            .gc_orphan_files()
+            .await
+            .map_err(|err| tonic::Status::internal(format!("cannot gc orphan files: {err}")))?;
+        Ok(tonic::Response::new(grpc_gen::GcOrphanFilesResponse {
+            deleted_count,
         }))
     }
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1703,7 +1703,16 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             .map(DeploymentId::try_from)
             .transpose()?;
         let mut termination_watcher = self.termination_watcher.clone();
-        let (deployment_id, missing_digests) = Box::pin(server::submit_deployment(
+        let supplied_files = request
+            .files
+            .into_iter()
+            .map(|file| server::SuppliedFile {
+                path: file.path,
+                supplied_digest: file.digest,
+                content: file.content,
+            })
+            .collect();
+        let result = Box::pin(server::submit_deployment(
             self.server_verified.clone(),
             &request.deployment_toml,
             request.verify,
@@ -1711,15 +1720,23 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             request.description.clone(),
             requested_deployment_id,
             &self.prepared_dirs,
+            supplied_files,
             self.db_pool.clone(),
             &mut termination_watcher,
         ))
-        .await
-        .map_err(|err| tonic::Status::failed_precondition(format!("{err:#}")))?;
+        .await;
+        let deployment_id = match result {
+            Ok(deployment_id) => deployment_id,
+            Err(server::SubmitDeploymentError::Other(err)) => {
+                return Err(tonic::Status::failed_precondition(format!("{err:#}")));
+            }
+            Err(server::SubmitDeploymentError::Package(pkg)) => {
+                return Err(submit_package_status(&pkg));
+            }
+        };
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         Ok(tonic::Response::new(grpc_gen::SubmitDeploymentResponse {
             deployment_id: Some(deployment_id.into()),
-            missing_digests: missing_digests.iter().map(ToString::to_string).collect(),
         }))
     }
 
@@ -1796,6 +1813,74 @@ fn status_to_grpc(status: DeploymentStatus) -> grpc_gen::DeploymentStatus {
         DeploymentStatus::Enqueued => grpc_gen::DeploymentStatus::Enqueued,
         DeploymentStatus::Active => grpc_gen::DeploymentStatus::Active,
     }
+}
+
+fn file_issue_to_grpc(issue: server::SubmitFileIssue) -> grpc_gen::FileIssue {
+    grpc_gen::FileIssue {
+        section: issue.section,
+        component_name: issue.component_name,
+        field_path: issue.field_path,
+        path: issue.path,
+        digest: issue.digest,
+        message: issue.message,
+    }
+}
+
+/// Build a `FAILED_PRECONDITION` status carrying the prost-encoded
+/// `SubmitDeploymentErrorDetail` so non-interactive clients can map the missing
+/// files back to local blobs and retry without persisting an incomplete deployment.
+fn submit_package_status(pkg: &server::SubmitPackageError) -> tonic::Status {
+    use prost::Message as _;
+    let detail = grpc_gen::SubmitDeploymentErrorDetail {
+        missing_digest_fields: pkg
+            .missing_digest_fields
+            .iter()
+            .cloned()
+            .map(file_issue_to_grpc)
+            .collect(),
+        missing_files: pkg
+            .missing_files
+            .iter()
+            .cloned()
+            .map(file_issue_to_grpc)
+            .collect(),
+        unexpected_files: pkg
+            .unexpected_files
+            .iter()
+            .cloned()
+            .map(file_issue_to_grpc)
+            .collect(),
+        digest_mismatches: pkg
+            .digest_mismatches
+            .iter()
+            .cloned()
+            .map(|mismatch| grpc_gen::DigestMismatch {
+                file: Some(file_issue_to_grpc(mismatch.file)),
+                supplied_digest: mismatch.supplied_digest,
+                actual_digest: mismatch.actual_digest,
+            })
+            .collect(),
+        oversized_files: pkg
+            .oversized_files
+            .iter()
+            .cloned()
+            .map(file_issue_to_grpc)
+            .collect(),
+    };
+    let message = format!(
+        "deployment package is incomplete or invalid: {} missing field(s), {} missing file(s), \
+         {} unexpected file(s), {} digest mismatch(es), {} oversized file(s)",
+        detail.missing_digest_fields.len(),
+        detail.missing_files.len(),
+        detail.unexpected_files.len(),
+        detail.digest_mismatches.len(),
+        detail.oversized_files.len(),
+    );
+    tonic::Status::with_details(
+        tonic::Code::FailedPrecondition,
+        message,
+        detail.encode_to_vec().into(),
+    )
 }
 
 fn file_refs_to_grpc(

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1658,6 +1658,7 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
     ) -> TonicRespResult<grpc_gen::SwitchDeploymentResponse> {
         use grpc_gen::switch_deployment_response::Outcome;
         let request = request.into_inner();
+        let runtime_config_check = runtime_config_check_from_grpc(request.runtime_config_check());
         let deployment_id: DeploymentId = request
             .deployment_id
             .argument_must_exist("deployment_id")?
@@ -1667,7 +1668,8 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
         let outcome = Box::pin(server::switch_deployment(
             self.server_verified.clone(),
             deployment_id,
-            SwitchDeploymentAction::new(request.hot_redeploy, request.verify),
+            SwitchDeploymentAction::new(request.hot_redeploy),
+            runtime_config_check,
             &self.prepared_dirs,
             self.db_pool.clone(),
             &mut termination_watcher,
@@ -1698,6 +1700,7 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
         request: tonic::Request<grpc_gen::SubmitDeploymentRequest>,
     ) -> TonicRespResult<grpc_gen::SubmitDeploymentResponse> {
         let request = request.into_inner();
+        let runtime_config_check = runtime_config_check_from_grpc(request.runtime_config_check());
         let requested_deployment_id = request
             .deployment_id
             .map(DeploymentId::try_from)
@@ -1715,7 +1718,7 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
         let result = Box::pin(server::submit_deployment(
             self.server_verified.clone(),
             &request.deployment_toml,
-            request.verify,
+            runtime_config_check,
             request.created_by.clone(),
             request.description.clone(),
             requested_deployment_id,
@@ -1823,6 +1826,19 @@ fn file_issue_to_grpc(issue: server::SubmitFileIssue) -> grpc_gen::FileIssue {
         path: issue.path,
         digest: issue.digest,
         message: issue.message,
+    }
+}
+
+/// Map the wire `RuntimeConfigCheck` to its server-side counterpart. `UNSPECIFIED`
+/// (the proto3 default for an unset field) is treated as `STRICT`.
+fn runtime_config_check_from_grpc(
+    check: grpc_gen::RuntimeConfigCheck,
+) -> server::RuntimeConfigCheck {
+    match check {
+        grpc_gen::RuntimeConfigCheck::AllowMissing => server::RuntimeConfigCheck::AllowMissing,
+        grpc_gen::RuntimeConfigCheck::Unspecified | grpc_gen::RuntimeConfigCheck::Strict => {
+            server::RuntimeConfigCheck::Strict
+        }
     }
 }
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1757,11 +1757,14 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
         request: tonic::Request<grpc_gen::UploadFileRequest>,
     ) -> TonicRespResult<grpc_gen::UploadFileResponse> {
         let request = request.into_inner();
-        let cas = self.db_pool.cas_conn().await.map_err(map_to_status)?;
-        let digest = cas
-            .write_blob(&request.content)
-            .await
-            .map_err(|err| tonic::Status::internal(format!("cannot store file: {err}")))?;
+        let deployment_id: DeploymentId = request
+            .deployment_id
+            .argument_must_exist("deployment_id")?
+            .try_into()?;
+        let digest =
+            server::upload_deployment_file(self.db_pool.clone(), deployment_id, &request.content)
+                .await
+                .map_err(|err| tonic::Status::failed_precondition(format!("{err:#}")))?;
         Ok(tonic::Response::new(grpc_gen::UploadFileResponse {
             digest: digest.to_string(),
         }))

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -240,7 +240,10 @@ fn v1_router() -> Router<Arc<WebApiState>> {
         .route("/deployments", routing::get(list_deployments))
         .route("/deployments", routing::post(submit_deployment))
         .route("/deployments/{deployment-id}", routing::get(get_deployment))
-        .route("/files", routing::post(upload_file))
+        .route(
+            "/deployments/{deployment-id}/files",
+            routing::post(upload_file),
+        )
         .route("/files/{digest}", routing::get(get_file))
         .route(
             "/deployments/{deployment-id}/switch",
@@ -3314,17 +3317,23 @@ mod deployment {
     #[derive(Deserialize, ToSchema)]
     pub struct DeploymentSubmitPayload {
         /// Verbatim deployment manifest (`deployment.toml`). Referenced file blobs must
-        /// already be uploaded to the content-addressed store.
+        /// be uploaded separately after the server returns `missing_digests`.
         pub deployment_toml: String,
         /// Optional human-readable deployment description
         pub description: Option<String>,
-        /// Verify all environment variables before persisting
+        /// Deprecated for submit: verification happens when the deployment is activated.
         #[serde(default)]
         pub verify: bool,
         /// Optional client-supplied deployment ID for idempotent submission.
         /// If a deployment with this ID already exists and its content digest
         /// matches, the submission is a no-op; a digest mismatch is rejected.
         pub deployment_id: Option<String>,
+    }
+
+    #[derive(Debug, Serialize, ToSchema)]
+    pub struct DeploymentSubmitResponse {
+        pub deployment_id: String,
+        pub missing_digests: Vec<String>,
     }
 
     /// Submit a new deployment
@@ -3334,7 +3343,7 @@ mod deployment {
         tag = "deployments",
         request_body = DeploymentSubmitPayload,
         responses(
-            (status = 200, description = "Deployment submitted", body = String),
+            (status = 200, description = "Deployment submitted", body = DeploymentSubmitResponse),
             (status = 400, description = "Invalid config"),
             (status = 409, description = "Validation failed")
         )
@@ -3356,38 +3365,48 @@ mod deployment {
                 accept,
             })?;
         let mut termination_watcher = state.termination_watcher.clone();
-        let (deployment_id, _missing_digests) =
-            Box::pin(crate::command::server::submit_deployment(
-                state.server_verified.clone(),
-                &payload.deployment_toml,
-                payload.verify,
-                Some("web-api".to_string()),
-                payload.description,
-                requested_deployment_id,
-                &state.prepared_dirs,
-                state.db_pool.clone(),
-                &mut termination_watcher,
-            ))
-            .await
-            .map_err(|err| HttpResponse {
-                status: StatusCode::BAD_REQUEST,
-                message: format!("{err:#}"),
-                accept,
-            })?;
-        Ok(HttpResponse {
-            status: StatusCode::OK,
-            message: deployment_id.to_string(),
+        let (deployment_id, missing_digests) = Box::pin(crate::command::server::submit_deployment(
+            state.server_verified.clone(),
+            &payload.deployment_toml,
+            payload.verify,
+            Some("web-api".to_string()),
+            payload.description,
+            requested_deployment_id,
+            &state.prepared_dirs,
+            state.db_pool.clone(),
+            &mut termination_watcher,
+        ))
+        .await
+        .map_err(|err| HttpResponse {
+            status: StatusCode::BAD_REQUEST,
+            message: format!("{err:#}"),
             accept,
-        }
-        .into_response())
+        })?;
+        Ok(match accept {
+            AcceptHeader::Json => pretty_json_response(
+                StatusCode::OK,
+                &DeploymentSubmitResponse {
+                    deployment_id: deployment_id.to_string(),
+                    missing_digests: missing_digests.iter().map(ToString::to_string).collect(),
+                },
+            ),
+            AcceptHeader::Text => HttpResponse {
+                status: StatusCode::OK,
+                message: deployment_id.to_string(),
+                accept,
+            }
+            .into_response(),
+        })
     }
 
     /// Upload a deployment file blob to the content-addressed store. The request body is the
-    /// raw file content; the response is the server-computed content digest.
+    /// raw file content; the response is the server-computed content digest. The digest must be
+    /// referenced by the deployment.
     #[utoipa::path(
         post,
-        path = "/v1/files",
+        path = "/v1/deployments/{deployment_id}/files",
         tag = "deployments",
+        params(("deployment_id" = String, Path, description = "Deployment ID that references the file")),
         request_body(content = Vec<u8>, content_type = "application/octet-stream"),
         responses(
             (status = 200, description = "Stored; returns the content digest", body = String)
@@ -3397,16 +3416,18 @@ mod deployment {
     pub(crate) async fn upload_file(
         state: State<Arc<WebApiState>>,
         accept: AcceptHeader,
+        Path(deployment_id): Path<DeploymentId>,
         body: axum::body::Bytes,
     ) -> Result<Response, HttpResponse> {
-        let cas = state
-            .db_pool
-            .cas_conn()
-            .await
-            .map_err(|e| ErrorWrapper(e, accept))?;
-        let digest = cas.write_blob(&body).await.map_err(|err| HttpResponse {
-            status: StatusCode::INTERNAL_SERVER_ERROR,
-            message: format!("cannot store file: {err}"),
+        let digest = crate::command::server::upload_deployment_file(
+            state.db_pool.clone(),
+            deployment_id,
+            &body,
+        )
+        .await
+        .map_err(|err| HttpResponse {
+            status: StatusCode::BAD_REQUEST,
+            message: format!("{err:#}"),
             accept,
         })?;
         Ok(HttpResponse {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -139,6 +139,10 @@ pub(crate) struct WebApiState {
         components::ParameterTypeLite,
         functions::FunctionOutput,
         deployment::DeploymentStateSer,
+        deployment::DeploymentSubmitResponse,
+        deployment::SubmitPackageErrorBody,
+        deployment::FileIssue,
+        deployment::DigestMismatch,
         backtrace::BacktraceInfoSer,
     ))
 )]
@@ -3021,12 +3025,13 @@ mod functions {
 
 mod deployment {
     use crate::{
-        command::server::{RuntimeConfigCheck, SwitchDeploymentAction},
+        command::server::{self, RuntimeConfigCheck, SwitchDeploymentAction},
         server::web_api_server::{
             AcceptHeader, ErrorWrapper, HttpResponse, TextDefaultAcceptHeader, WebApiState,
             pretty_json_response,
         },
     };
+    use http::header;
 
     /// Map the REST `allow_missing_runtime_config` flag to the runtime config policy.
     fn runtime_config_check_from_bool(allow_missing: bool) -> RuntimeConfigCheck {
@@ -3345,7 +3350,169 @@ mod deployment {
         pub deployment_id: String,
     }
 
-    /// Submit a new deployment
+    /// A single file-set problem found while validating a submit package.
+    #[derive(Debug, Serialize, ToSchema)]
+    pub struct FileIssue {
+        pub section: String,
+        pub component_name: Option<String>,
+        pub field_path: String,
+        pub path: Option<String>,
+        pub digest: Option<String>,
+        pub message: String,
+    }
+
+    #[derive(Debug, Serialize, ToSchema)]
+    pub struct DigestMismatch {
+        pub file: FileIssue,
+        pub supplied_digest: String,
+        pub actual_digest: String,
+    }
+
+    /// Structured `409` body describing why a submit package was rejected. No
+    /// deployment is stored when this is returned. A client retries the same submit
+    /// with the `missing_files` blobs attached.
+    #[derive(Debug, Serialize, ToSchema)]
+    pub struct SubmitPackageErrorBody {
+        pub missing_digest_fields: Vec<FileIssue>,
+        pub missing_files: Vec<FileIssue>,
+        pub unexpected_files: Vec<FileIssue>,
+        pub digest_mismatches: Vec<DigestMismatch>,
+        pub oversized_files: Vec<FileIssue>,
+    }
+
+    impl From<&server::SubmitFileIssue> for FileIssue {
+        fn from(issue: &server::SubmitFileIssue) -> Self {
+            FileIssue {
+                section: issue.section.clone(),
+                component_name: issue.component_name.clone(),
+                field_path: issue.field_path.clone(),
+                path: issue.path.clone(),
+                digest: issue.digest.clone(),
+                message: issue.message.clone(),
+            }
+        }
+    }
+
+    impl From<&server::SubmitPackageError> for SubmitPackageErrorBody {
+        fn from(pkg: &server::SubmitPackageError) -> Self {
+            SubmitPackageErrorBody {
+                missing_digest_fields: pkg.missing_digest_fields.iter().map(Into::into).collect(),
+                missing_files: pkg.missing_files.iter().map(Into::into).collect(),
+                unexpected_files: pkg.unexpected_files.iter().map(Into::into).collect(),
+                digest_mismatches: pkg
+                    .digest_mismatches
+                    .iter()
+                    .map(|m| DigestMismatch {
+                        file: (&m.file).into(),
+                        supplied_digest: m.supplied_digest.clone(),
+                        actual_digest: m.actual_digest.clone(),
+                    })
+                    .collect(),
+                oversized_files: pkg.oversized_files.iter().map(Into::into).collect(),
+            }
+        }
+    }
+
+    /// Parsed inputs for a submit request, from either a JSON body or a multipart package.
+    struct SubmitInputs {
+        deployment_toml: String,
+        description: Option<String>,
+        allow_missing_runtime_config: bool,
+        deployment_id: Option<String>,
+        files: Vec<server::SuppliedFile>,
+    }
+
+    /// Parse a `multipart/form-data` submit package. Text fields `deployment_toml`,
+    /// `description`, `allow_missing_runtime_config`, and `deployment_id` carry the
+    /// manifest and options. Every other part is a deployment-owned file blob: its
+    /// `filename` is the deployment-relative path and its form-field `name` is the
+    /// claimed `sha256:...` content digest (or `file` when unknown).
+    async fn parse_multipart_submit(
+        mut multipart: axum::extract::Multipart,
+        accept: AcceptHeader,
+    ) -> Result<SubmitInputs, HttpResponse> {
+        let bad = |message: String| HttpResponse {
+            status: StatusCode::BAD_REQUEST,
+            message,
+            accept,
+        };
+        let mut deployment_toml = None;
+        let mut description = None;
+        let mut allow_missing_runtime_config = false;
+        let mut deployment_id = None;
+        let mut files = Vec::new();
+        while let Some(field) = multipart
+            .next_field()
+            .await
+            .map_err(|err| bad(format!("invalid multipart body: {err}")))?
+        {
+            let name = field.name().unwrap_or_default().to_string();
+            let file_name = field.file_name().map(str::to_string);
+            match name.as_str() {
+                "deployment_toml" => {
+                    deployment_toml =
+                        Some(field.text().await.map_err(|err| {
+                            bad(format!("invalid `deployment_toml` field: {err}"))
+                        })?);
+                }
+                "description" => {
+                    description = Some(
+                        field
+                            .text()
+                            .await
+                            .map_err(|err| bad(format!("invalid `description` field: {err}")))?,
+                    );
+                }
+                "allow_missing_runtime_config" => {
+                    let value = field.text().await.map_err(|err| {
+                        bad(format!(
+                            "invalid `allow_missing_runtime_config` field: {err}"
+                        ))
+                    })?;
+                    allow_missing_runtime_config = value.trim() == "true";
+                }
+                "deployment_id" => {
+                    deployment_id = Some(
+                        field
+                            .text()
+                            .await
+                            .map_err(|err| bad(format!("invalid `deployment_id` field: {err}")))?,
+                    );
+                }
+                // Any other part is a file blob. `name` is the claimed digest (or `file`).
+                _ => {
+                    let supplied_digest = (name != "file").then_some(name);
+                    let path = file_name.unwrap_or_default();
+                    let content = field
+                        .bytes()
+                        .await
+                        .map_err(|err| bad(format!("cannot read file blob `{path}`: {err}")))?
+                        .to_vec();
+                    files.push(server::SuppliedFile {
+                        path,
+                        supplied_digest,
+                        content,
+                    });
+                }
+            }
+        }
+        Ok(SubmitInputs {
+            deployment_toml: deployment_toml
+                .ok_or_else(|| bad("missing `deployment_toml` field".to_string()))?,
+            description,
+            allow_missing_runtime_config,
+            deployment_id,
+            files,
+        })
+    }
+
+    /// Submit a new deployment.
+    ///
+    /// Accepts either an `application/json` body (no attached file blobs; referenced
+    /// files must already exist in the CAS) or a `multipart/form-data` package whose
+    /// parts carry the manifest and the deployment-owned file blobs. On an incomplete
+    /// package the server stores nothing and returns a `409` `SubmitPackageErrorBody`
+    /// listing the missing files to attach and retry.
     #[utoipa::path(
         post,
         path = "/v1/deployments",
@@ -3354,16 +3521,50 @@ mod deployment {
         responses(
             (status = 200, description = "Deployment submitted", body = DeploymentSubmitResponse),
             (status = 400, description = "Invalid config"),
-            (status = 409, description = "Validation failed")
+            (status = 409, description = "Incomplete or invalid package", body = SubmitPackageErrorBody)
         )
     )]
     #[instrument(skip_all)]
     pub(crate) async fn submit_deployment(
         state: State<Arc<WebApiState>>,
         accept: AcceptHeader,
-        Json(payload): Json<DeploymentSubmitPayload>,
+        request: axum::extract::Request,
     ) -> Result<Response, HttpResponse> {
-        let requested_deployment_id = payload
+        use axum::extract::FromRequest as _;
+
+        let is_multipart = request
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|ct| ct.starts_with("multipart/form-data"));
+
+        let inputs = if is_multipart {
+            let multipart = axum::extract::Multipart::from_request(request, &*state)
+                .await
+                .map_err(|err| HttpResponse {
+                    status: StatusCode::BAD_REQUEST,
+                    message: format!("invalid multipart request: {err}"),
+                    accept,
+                })?;
+            parse_multipart_submit(multipart, accept).await?
+        } else {
+            let Json(payload) = Json::<DeploymentSubmitPayload>::from_request(request, &*state)
+                .await
+                .map_err(|err| HttpResponse {
+                    status: StatusCode::BAD_REQUEST,
+                    message: format!("invalid JSON body: {err}"),
+                    accept,
+                })?;
+            SubmitInputs {
+                deployment_toml: payload.deployment_toml,
+                description: payload.description,
+                allow_missing_runtime_config: payload.allow_missing_runtime_config,
+                deployment_id: payload.deployment_id,
+                files: Vec::new(),
+            }
+        };
+
+        let requested_deployment_id = inputs
             .deployment_id
             .as_deref()
             .map(str::parse::<DeploymentId>)
@@ -3374,34 +3575,42 @@ mod deployment {
                 accept,
             })?;
         let mut termination_watcher = state.termination_watcher.clone();
-        // JSON submit cannot attach blobs yet (multipart package support is a later
-        // phase); referenced files must already exist in the CAS or submit fails.
-        let deployment_id = Box::pin(crate::command::server::submit_deployment(
+        let result = Box::pin(crate::command::server::submit_deployment(
             state.server_verified.clone(),
-            &payload.deployment_toml,
-            runtime_config_check_from_bool(payload.allow_missing_runtime_config),
+            &inputs.deployment_toml,
+            runtime_config_check_from_bool(inputs.allow_missing_runtime_config),
             Some("web-api".to_string()),
-            payload.description,
+            inputs.description,
             requested_deployment_id,
             &state.prepared_dirs,
-            Vec::new(),
+            inputs.files,
             state.db_pool.clone(),
             &mut termination_watcher,
         ))
-        .await
-        .map_err(|err| {
-            let message = match err {
-                crate::command::server::SubmitDeploymentError::Other(err) => format!("{err:#}"),
-                crate::command::server::SubmitDeploymentError::Package(pkg) => {
-                    format!("{pkg:?}")
-                }
-            };
-            HttpResponse {
-                status: StatusCode::BAD_REQUEST,
-                message,
-                accept,
+        .await;
+
+        let deployment_id = match result {
+            Ok(deployment_id) => deployment_id,
+            Err(server::SubmitDeploymentError::Other(err)) => {
+                return Err(HttpResponse {
+                    status: StatusCode::BAD_REQUEST,
+                    message: format!("{err:#}"),
+                    accept,
+                });
             }
-        })?;
+            Err(server::SubmitDeploymentError::Package(pkg)) => {
+                let body = SubmitPackageErrorBody::from(&pkg);
+                return Ok(match accept {
+                    AcceptHeader::Json => pretty_json_response(StatusCode::CONFLICT, &body),
+                    AcceptHeader::Text => HttpResponse {
+                        status: StatusCode::CONFLICT,
+                        message: format!("{pkg:?}"),
+                        accept,
+                    }
+                    .into_response(),
+                });
+            }
+        };
         Ok(match accept {
             AcceptHeader::Json => pretty_json_response(
                 StatusCode::OK,
@@ -3421,6 +3630,9 @@ mod deployment {
     /// Upload a deployment file blob to the content-addressed store. The request body is the
     /// raw file content; the response is the server-computed content digest. The digest must be
     /// referenced by the deployment.
+    ///
+    /// Deprecated: attach file blobs to a `multipart/form-data` `POST /v1/deployments`
+    /// package instead. Retained as admin CAS tooling.
     #[utoipa::path(
         post,
         path = "/v1/deployments/{deployment_id}/files",

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3021,12 +3021,21 @@ mod functions {
 
 mod deployment {
     use crate::{
-        command::server::SwitchDeploymentAction,
+        command::server::{RuntimeConfigCheck, SwitchDeploymentAction},
         server::web_api_server::{
             AcceptHeader, ErrorWrapper, HttpResponse, TextDefaultAcceptHeader, WebApiState,
             pretty_json_response,
         },
     };
+
+    /// Map the REST `allow_missing_runtime_config` flag to the runtime config policy.
+    fn runtime_config_check_from_bool(allow_missing: bool) -> RuntimeConfigCheck {
+        if allow_missing {
+            RuntimeConfigCheck::AllowMissing
+        } else {
+            RuntimeConfigCheck::Strict
+        }
+    }
     use axum::{
         Json,
         extract::{Path, Query, State},
@@ -3321,9 +3330,10 @@ mod deployment {
         pub deployment_toml: String,
         /// Optional human-readable deployment description
         pub description: Option<String>,
-        /// Deprecated for submit: verification happens when the deployment is activated.
+        /// Tolerate missing environment variables / secrets while verifying the
+        /// deployment before persisting it. Defaults to strict (missing config fails).
         #[serde(default)]
-        pub verify: bool,
+        pub allow_missing_runtime_config: bool,
         /// Optional client-supplied deployment ID for idempotent submission.
         /// If a deployment with this ID already exists and its content digest
         /// matches, the submission is a no-op; a digest mismatch is rejected.
@@ -3369,7 +3379,7 @@ mod deployment {
         let deployment_id = Box::pin(crate::command::server::submit_deployment(
             state.server_verified.clone(),
             &payload.deployment_toml,
-            payload.verify,
+            runtime_config_check_from_bool(payload.allow_missing_runtime_config),
             Some("web-api".to_string()),
             payload.description,
             requested_deployment_id,
@@ -3489,9 +3499,10 @@ mod deployment {
     /// Request payload for switching deployment
     #[derive(Deserialize, ToSchema)]
     pub struct DeploymentSwitchPayload {
-        /// Verify config before switching
+        /// Tolerate missing environment variables / secrets while verifying. Rejected
+        /// for a hot redeploy, which requires all runtime config to be available.
         #[serde(default)]
-        pub verify: bool,
+        pub allow_missing_runtime_config: bool,
         /// Hot redeploy without restart
         #[serde(default)]
         pub hot_redeploy: bool,
@@ -3524,7 +3535,8 @@ mod deployment {
         let outcome = Box::pin(crate::command::server::switch_deployment(
             state.server_verified.clone(),
             deployment_id,
-            SwitchDeploymentAction::new(payload.hot_redeploy, payload.verify),
+            SwitchDeploymentAction::new(payload.hot_redeploy),
+            runtime_config_check_from_bool(payload.allow_missing_runtime_config),
             &state.prepared_dirs,
             state.db_pool.clone(),
             &mut termination_watcher,

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3333,7 +3333,6 @@ mod deployment {
     #[derive(Debug, Serialize, ToSchema)]
     pub struct DeploymentSubmitResponse {
         pub deployment_id: String,
-        pub missing_digests: Vec<String>,
     }
 
     /// Submit a new deployment
@@ -3365,7 +3364,9 @@ mod deployment {
                 accept,
             })?;
         let mut termination_watcher = state.termination_watcher.clone();
-        let (deployment_id, missing_digests) = Box::pin(crate::command::server::submit_deployment(
+        // JSON submit cannot attach blobs yet (multipart package support is a later
+        // phase); referenced files must already exist in the CAS or submit fails.
+        let deployment_id = Box::pin(crate::command::server::submit_deployment(
             state.server_verified.clone(),
             &payload.deployment_toml,
             payload.verify,
@@ -3373,21 +3374,29 @@ mod deployment {
             payload.description,
             requested_deployment_id,
             &state.prepared_dirs,
+            Vec::new(),
             state.db_pool.clone(),
             &mut termination_watcher,
         ))
         .await
-        .map_err(|err| HttpResponse {
-            status: StatusCode::BAD_REQUEST,
-            message: format!("{err:#}"),
-            accept,
+        .map_err(|err| {
+            let message = match err {
+                crate::command::server::SubmitDeploymentError::Other(err) => format!("{err:#}"),
+                crate::command::server::SubmitDeploymentError::Package(pkg) => {
+                    format!("{pkg:?}")
+                }
+            };
+            HttpResponse {
+                status: StatusCode::BAD_REQUEST,
+                message,
+                accept,
+            }
         })?;
         Ok(match accept {
             AcceptHeader::Json => pretty_json_response(
                 StatusCode::OK,
                 &DeploymentSubmitResponse {
                     deployment_id: deployment_id.to_string(),
-                    missing_digests: missing_digests.iter().map(ToString::to_string).collect(),
                 },
             ),
             AcceptHeader::Text => HttpResponse {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -5,7 +5,7 @@ use crate::{
         components::{component_wit, components_list},
         deployment::{
             get_current_deployment_id, get_deployment, get_file, list_deployments,
-            submit_deployment, switch_deployment, upload_file,
+            submit_deployment, switch_deployment,
         },
         functions::{function_wit, functions_list},
     },
@@ -112,7 +112,6 @@ pub(crate) struct WebApiState {
         deployment::get_deployment,
         deployment::submit_deployment,
         deployment::switch_deployment,
-        deployment::upload_file,
         deployment::get_file,
     ),
     components(schemas(
@@ -244,10 +243,6 @@ fn v1_router() -> Router<Arc<WebApiState>> {
         .route("/deployments", routing::get(list_deployments))
         .route("/deployments", routing::post(submit_deployment))
         .route("/deployments/{deployment-id}", routing::get(get_deployment))
-        .route(
-            "/deployments/{deployment-id}/files",
-            routing::post(upload_file),
-        )
         .route("/files/{digest}", routing::get(get_file))
         .route(
             "/deployments/{deployment-id}/switch",
@@ -3625,48 +3620,6 @@ mod deployment {
             }
             .into_response(),
         })
-    }
-
-    /// Upload a deployment file blob to the content-addressed store. The request body is the
-    /// raw file content; the response is the server-computed content digest. The digest must be
-    /// referenced by the deployment.
-    ///
-    /// Deprecated: attach file blobs to a `multipart/form-data` `POST /v1/deployments`
-    /// package instead. Retained as admin CAS tooling.
-    #[utoipa::path(
-        post,
-        path = "/v1/deployments/{deployment_id}/files",
-        tag = "deployments",
-        params(("deployment_id" = String, Path, description = "Deployment ID that references the file")),
-        request_body(content = Vec<u8>, content_type = "application/octet-stream"),
-        responses(
-            (status = 200, description = "Stored; returns the content digest", body = String)
-        )
-    )]
-    #[instrument(skip_all)]
-    pub(crate) async fn upload_file(
-        state: State<Arc<WebApiState>>,
-        accept: AcceptHeader,
-        Path(deployment_id): Path<DeploymentId>,
-        body: axum::body::Bytes,
-    ) -> Result<Response, HttpResponse> {
-        let digest = crate::command::server::upload_deployment_file(
-            state.db_pool.clone(),
-            deployment_id,
-            &body,
-        )
-        .await
-        .map_err(|err| HttpResponse {
-            status: StatusCode::BAD_REQUEST,
-            message: format!("{err:#}"),
-            accept,
-        })?;
-        Ok(HttpResponse {
-            status: StatusCode::OK,
-            message: digest.to_string(),
-            accept,
-        }
-        .into_response())
     }
 
     /// Fetch a deployment file blob by content digest.


### PR DESCRIPTION
- **refactor: defer deployment verification until activation**
- **refactor: reject absolute deployment manifest paths**
- **refactor: introduce DeploymentManifest validated stage type**
- **feat: validate deployment submit package before persisting**
- **feat: verify deployment before persisting it**
- **refactor: persist component metadata when submitting a deployment**
- **refactor: report basename to the JS engine for deployment-owned scripts**
- **feat: replace submit/switch verify flag with RuntimeConfigCheck**
- **feat: accept a multipart deployment package over REST**
- **refactor: rename Canonical config types to Resolved**
- **feat: remove UploadFile and add orphan CAS blob GC**
