### PR TITLE
latest pr

### DIFF
--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -35,6 +35,8 @@ jobs:
             report: junit-default.xml
             features: ""
           - name: test-js-local.sh
+            report: junit-js-local.xml
+            features: "-F activity-js-local,workflow-js-local,webhook-js-local"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -35,8 +35,6 @@ jobs:
             report: junit-default.xml
             features: ""
           - name: test-js-local.sh
-            report: junit-js-local.xml
-            features: "-F activity-js-local,workflow-js-local,webhook-js-local"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/release-2-cargo-publish.yml
+++ b/.github/workflows/release-2-cargo-publish.yml
@@ -87,7 +87,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
         run: |
-          nix develop --command cargo publish --workspace --locked ${{ inputs.extra-args }}
+          nix develop .#publish --command cargo publish --workspace --locked ${{ inputs.extra-args }}
 
   call_child:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.3](https://github.com/obeli-sk/obelisk/compare/v0.39.2...v0.39.3)
+
+Re-release because `cargo publish` failed on an internal error.
+
 ## [0.39.2](https://github.com/obeli-sk/obelisk/compare/v0.39.1...v0.39.2)
 
 Re-release because `cargo publish` failed on an internal error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.1](https://github.com/obeli-sk/obelisk/compare/v0.39.0...v0.39.1)
+
+Re-release because `cargo publish` failed on an interal error.
+
 ## [0.39.0](https://github.com/obeli-sk/obelisk/compare/v0.38.3...v0.39.0)
 
 This release makes deployments more self-contained and easier to inspect. Obelisk now stores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,42 +6,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0](https://github.com/obeli-sk/obelisk/compare/v0.38.3...v0.39.0)
+
+This release makes deployments more self-contained and easier to inspect. Obelisk now stores
+deployment TOML and deployment-owned source files, can reconstruct deployments back to disk, verifies
+deployment packages earlier, and exposes more deployment metadata through the CLI, gRPC, and web API.
+It also includes important database fixes for response ordering and missed notifications.
+
 ### Added
 
-- *(cli)* `deployment get <ID> [--output DIR] [--force]` retrieves a stored deployment to disk as a re-submittable
-`deployment.toml` plus its source files. Owned scripts and backtrace sources are recreated (subfolders mirrored,
-relative to the deployment directory); WASM bytes are referenced but not recreated.
-- *(deployment)* Verify a user-supplied `content_digest` at submit time, in addition to runtime.
-- *(deployment)* Reject at submit time deployments where two distinct deployment-owned sources
- (inline/owned scripts or backtrace sources) resolve to the same `file_name`, since `deployment get`
- could not recreate both on disk.
- - *(cli)* `deployment active` prints the ID of the currently active deployment.
-- *(deployment)* `activity_exec` components gained `params_via_stdin` (default `false`). When enabled,
-  parameters are passed to the program via the stdin JSON `params` array instead of argv, allowing
-  payloads larger than the `execve` argument-size limit.
+- *(cli)* `deployment get <ID> [--output DIR] [--force]` retrieves a stored deployment as a
+  re-submittable `deployment.toml` plus deployment-owned source files - ([c9b4ecd](https://github.com/obeli-sk/obelisk/commit/c9b4ecd716f4914fa9d4acbd67fb5a50d0f38e19))
+- *(cli)* `deployment show <ID>` can show reconstructed deployment TOML or a specific stored source
+  file; pass `--json` to render the stored TOML manifest as JSON - ([d4294b0](https://github.com/obeli-sk/obelisk/commit/d4294b0d47e8e77851811c666158c08f4efb4b87))
+- *(cli)* `deployment active` prints the active deployment ID - ([dd2279b](https://github.com/obeli-sk/obelisk/commit/dd2279b030b0da24d8f810c60d33829f5db7f6fe))
+- *(deployment)* REST accepts multipart deployment packages and verifies deployment packages before
+  persisting them - ([4fdb2fc](https://github.com/obeli-sk/obelisk/commit/4fdb2fc64233b08f5f877e07115081c405882710)), ([8378c30](https://github.com/obeli-sk/obelisk/commit/8378c3075ae01940462c55153457ea11c84f59a6)), ([f5f088b](https://github.com/obeli-sk/obelisk/commit/f5f088b634fae3dc2b7aa57156d6bff3a4284f58))
+- *(deployment)* Deployment records now include optional descriptions, deployment digests, WASM
+  content digests, and backtrace source digests - ([886f298](https://github.com/obeli-sk/obelisk/commit/886f298a0d2df43e8473f8f188002e3e4a667b0c)), ([4baf221](https://github.com/obeli-sk/obelisk/commit/4baf2218ab80141d003058cefdb5fa95b97ce871)), ([988f61e](https://github.com/obeli-sk/obelisk/commit/988f61e9c1d80f30cea79ae7462514add6374aa1)), ([f7a5a2e](https://github.com/obeli-sk/obelisk/commit/f7a5a2e51a4dcade3887113829485c9c43f1eb7a))
+- *(grpc,webapi)* Deployment and execution list APIs expose component summaries and support broader
+  filtering - ([5a29d42](https://github.com/obeli-sk/obelisk/commit/5a29d42a36aa4b6ffafd9aee4858a9b9e1672cc6)), ([f39f595](https://github.com/obeli-sk/obelisk/commit/f39f595ecd36b2247e708deee175db80027f672e))
+- *(toml)* `activity_exec.params_via_stdin` passes activity parameters through stdin, avoiding
+  `execve` argument-size limits - ([e4f52f8](https://github.com/obeli-sk/obelisk/commit/e4f52f8bbf25fc77276daae7fa6c6bb571329f44))
+
+### Fixed
+
+- *(pg)* Avoid nondeterministic response replay caused by out-of-order response IDs and missed
+  watermark refetches - ([75e09b1](https://github.com/obeli-sk/obelisk/commit/75e09b199d37faec6841e68870499700ae0c50cc)), ([4d59e0f](https://github.com/obeli-sk/obelisk/commit/4d59e0f880074202d084f957d11250dd5ab8826a))
+- *(sqlite)* Avoid needless waits for unlock on unordered response notifications - ([7d61726](https://github.com/obeli-sk/obelisk/commit/7d61726ecca28c315fa8a1e67eff50d6ee54e743))
+- *(toml)* Disallow configuration that lets the Web UI hijack the server listener - ([e700e3d](https://github.com/obeli-sk/obelisk/commit/e700e3d7dd64401eb24fc2c4e99cef35fe8ec51d))
+- *(webapi)* Paginate logs by index and serialize log cursors as opaque strings - ([1a6e0c1](https://github.com/obeli-sk/obelisk/commit/1a6e0c13d2751d872b0385261389fdc67f7f9d43))
+- *(webhook)* Persist the execution ID on the first app log - ([c56caf8](https://github.com/obeli-sk/obelisk/commit/c56caf83661c950ddb09f99746f60b1d3cdd07be))
 
 ### Changed
 
-- *(deployment)* [**breaking**] **`activity_exec` secrets stdin format changed.** Secrets are now nested under a
-  `secrets` key (`{"secrets":{"KEY":"value",...}}`) instead of being the top-level object, so they can
-  coexist with the new `params` key. Scripts that parsed `.KEY` from stdin must now read `.secrets.KEY`.
-
-- *(cli)* `deployment show <ID>` now prints the reconstructed `deployment.toml` (with local file
-  references, the same TOML `deployment get` writes) instead of the raw canonical config. Pass a
-  FILE argument to print a single deployment-owned source file as `deployment get` would serialize
-  it, or `--json` to print the raw canonical config as before.
-
-- *(deployment)* The `${DEPLOYMENT_DIR}/` path prefix is now implicit: a bare relative path in a
-  deployment.toml (component `location`, `backtrace.sources`) is already resolved relative to the
-  directory containing the file. The explicit `${DEPLOYMENT_DIR}/` prefix is still accepted for
-  backwards compatibility but is no longer needed and has been removed from the bundled
-  example/testing configs.
-- *(deployment)* [**breaking**] Deployment-local paths are now required for JS/exec sources and
-  backtrace source files. Relative paths are resolved from the directory containing `deployment.toml`
-  and must stay inside that directory; absolute local paths and `..` escapes are rejected. JS/exec
-  sources referenced by relative path are read and stored with the deployment, so `deployment get`
-  can recreate them later. Existing deployments that used absolute JS/exec source paths, or older
-  stored deployment records using the previous source-file format, must be re-submitted.
+- *(deployment)* `deployment.toml` is now the stored source of truth, and deployment-owned files are
+  stored in a content-addressed store - ([0b76c74](https://github.com/obeli-sk/obelisk/commit/0b76c748b71b23f777e48fa8104b83a00bc7e8dd)), ([91e8125](https://github.com/obeli-sk/obelisk/commit/91e81253be12605e401d963b434d2c9549071ba7))
+- *(deployment)* The `${DEPLOYMENT_DIR}/` prefix is now implicit for deployment-local paths. The
+  prefix is still accepted for compatibility, but bare relative paths are resolved from the
+  `deployment.toml` directory - ([208779a](https://github.com/obeli-sk/obelisk/commit/208779aa4304a7496dd87a84b97ea0971ab8808b))
+- *(deployment)* [**breaking**] JS and exec source files and backtrace source files must now be
+  deployment-local. Absolute local paths and `..` escapes are rejected, and referenced source files
+  are stored with the deployment - ([d187edd](https://github.com/obeli-sk/obelisk/commit/d187eddb41f164c15d3960eda39b72169cf9d912)), ([c1dd1a5](https://github.com/obeli-sk/obelisk/commit/c1dd1a51c9b6d1ca49333b70d2a69ae3c43e164e)), ([386bcb4](https://github.com/obeli-sk/obelisk/commit/386bcb47c9c6ff2ed256253793763f428c54ec51))
+- *(deployment)* [**breaking**] `activity_exec` secrets passed over stdin are now nested under
+  `"secrets"` instead of being the top-level JSON object - ([3874aba](https://github.com/obeli-sk/obelisk/commit/3874aba4596bce800358132bf7921d6b470fbbd9))
+- *(grpc)* [**breaking**] Deployment execution summaries are now optional in gRPC responses - ([746c211](https://github.com/obeli-sk/obelisk/commit/746c2114ac30a61e8a04aabc84a49f5e4ebf6cff))
+- *(webapi)* [**breaking**] The top-level error variant serializes as `err` again, and structural
+  endpoints now default to JSON output - ([b315a3a](https://github.com/obeli-sk/obelisk/commit/b315a3a373b65b9991e7502c3492ff5dfb3bc424)), ([02625d6](https://github.com/obeli-sk/obelisk/commit/02625d6ed7cf38372fa6a0e34bff2e3bd9855622))
+- *(api,cli)* Deployment submission can provide an optional deployment ID for idempotency, and
+  deployment list calls can skip execution counts - ([2c9b894](https://github.com/obeli-sk/obelisk/commit/2c9b894e9877ea3b3b078f353a5042ff07040a5f)), ([607fc42](https://github.com/obeli-sk/obelisk/commit/607fc42767f63208ee40ff22ebcaaad98af07729))
+- *(js)* JavaScript runtime errors are more consistent, and mixed imports are verified during
+  linking - ([34eca8b](https://github.com/obeli-sk/obelisk/commit/34eca8b5aa6f127e7450f89e25c7435287cfad78)), ([c08b817](https://github.com/obeli-sk/obelisk/commit/c08b817f3318870a3222e494f76360a43a6c4e13))
 
 ## [0.38.3](https://github.com/obeli-sk/obelisk/compare/v0.38.2...v0.38.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.2](https://github.com/obeli-sk/obelisk/compare/v0.39.1...v0.39.2)
+
+Re-release because `cargo publish` failed on an internal error.
+
 ## [0.39.1](https://github.com/obeli-sk/obelisk/compare/v0.39.0...v0.39.1)
 
 Re-release because `cargo publish` failed on an interal error.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -350,7 +350,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-deployment-config"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "arbitrary",
  "const_format",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "chrono",
  "http",
@@ -3288,7 +3288,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3418,7 +3418,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "quote",
  "syn",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5206,14 +5206,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5223,14 +5223,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5241,14 +5241,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5257,14 +5257,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5274,14 +5274,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5291,14 +5291,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5307,14 +5307,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5323,14 +5323,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5339,14 +5339,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5355,14 +5355,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5372,14 +5372,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5389,14 +5389,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5405,14 +5405,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5421,14 +5421,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6913,7 +6913,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7421,7 +7421,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -350,7 +350,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-deployment-config"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "arbitrary",
  "const_format",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "chrono",
  "http",
@@ -3288,7 +3288,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3418,7 +3418,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "activity-js-runtime-builder",
  "anyhow",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5192,7 +5192,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "quote",
  "syn",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5209,14 +5209,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5226,14 +5226,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5244,14 +5244,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5260,14 +5260,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5277,14 +5277,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5294,14 +5294,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5310,14 +5310,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5326,14 +5326,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5342,14 +5342,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5358,14 +5358,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5375,14 +5375,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5392,14 +5392,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5408,14 +5408,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5424,14 +5424,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7410,7 +7410,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7424,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.38.3"
+version = "0.39.0"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,6 +3420,7 @@ dependencies = [
 name = "obelisk"
 version = "0.39.3"
 dependencies = [
+ "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3498,8 +3499,10 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
+ "webhook-js-runtime-builder",
  "wit-component 0.251.0",
  "wit-parser 0.251.0",
+ "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -350,7 +350,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-deployment-config"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "arbitrary",
  "const_format",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "chrono",
  "http",
@@ -3288,7 +3288,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3418,7 +3418,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "quote",
  "syn",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5206,14 +5206,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5223,14 +5223,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5241,14 +5241,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5257,14 +5257,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5274,14 +5274,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5291,14 +5291,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5307,14 +5307,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5323,14 +5323,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5339,14 +5339,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5355,14 +5355,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5372,14 +5372,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5389,14 +5389,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5405,14 +5405,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5421,14 +5421,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6913,7 +6913,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7421,7 +7421,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.39.2"
+version = "0.39.3"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,7 +3420,6 @@ dependencies = [
 name = "obelisk"
 version = "0.39.0"
 dependencies = [
- "activity-js-runtime-builder",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3499,10 +3498,8 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "wasmtime",
- "webhook-js-runtime-builder",
  "wit-component 0.251.0",
  "wit-parser 0.251.0",
- "workflow-js-runtime-builder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "activity-js-runtime"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "activity-js-runtime-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -350,7 +350,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "assert_matches",
  "codspeed-divan-compat",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "boa-common"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "futures-concurrency",
  "futures-lite 2.6.1",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-db-tests"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-concepts"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-common"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "chrono",
  "hashbrown 0.16.1",
@@ -3149,7 +3149,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-postgres"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-db-sqlite"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-deployment-config"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "arbitrary",
  "const_format",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-executor"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-grpc"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "chrono",
  "http",
@@ -3288,7 +3288,7 @@ checksum = "2ece24ad8393257ced609693a3acc6f68d1b09da2a99b0ace33592031d7fc05c"
 
 [[package]]
 name = "obeli-sk-utils"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-val-json"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "obeli-sk-wasm-workers"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "activity-js-runtime-builder",
  "arbitrary",
@@ -3418,7 +3418,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "obelisk-component-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "cargo_metadata",
  "indexmap 2.14.0",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "test-db-macro"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "quote",
  "syn",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5206,14 +5206,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-activity-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-webhook"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5223,14 +5223,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-webhook-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5241,14 +5241,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-fibo-workflow-outer"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5257,14 +5257,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-fibo-workflow-outer-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-activity"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5274,14 +5274,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-activity-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-webhook"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5291,14 +5291,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-webhook-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-http-get-workflow"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5307,14 +5307,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-http-get-workflow-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-activity"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5323,14 +5323,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-activity-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-serde-workflow"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5339,14 +5339,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-serde-workflow-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-activity"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5355,14 +5355,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-activity-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-webhook"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5372,14 +5372,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-webhook-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-sleep-workflow"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5389,14 +5389,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-sleep-workflow-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-activity"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5405,14 +5405,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-activity-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-programs-stub-workflow"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "wit-bindgen",
@@ -5421,14 +5421,14 @@ dependencies = [
 
 [[package]]
 name = "test-programs-stub-workflow-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
 
 [[package]]
 name = "test-utils"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -6913,7 +6913,7 @@ dependencies = [
 
 [[package]]
 name = "webhook-js-runtime-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "boa-common",
@@ -7421,7 +7421,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-js-runtime-builder"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "obelisk-component-builder",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.38.3"
+version = "0.39.0"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -203,14 +203,14 @@ rust-version = "1.96.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.38.3" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.38.3" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.38.3" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.38.3" }
-deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.38.3" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.0" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.0" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.0" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.0" }
+deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.0" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.38.3" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.38.3" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.0" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.0" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -228,9 +228,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.38.3" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.38.3" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.38.3" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.0" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.0" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.0" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.39.2"
+version = "0.39.3"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -200,14 +200,14 @@ rust-version = "1.96.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.2" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.2" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.2" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.2" }
-deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.2" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.3" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.3" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.3" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.3" }
+deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.3" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.2" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.2" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.3" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.3" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -225,9 +225,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.2" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.2" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.2" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.3" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.3" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.3" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
+activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -124,9 +127,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = []
-"webhook-js-local" = []
-"workflow-js-local" = []
+"activity-js-local" = ["dep:activity-js-runtime-builder"]
+"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
+"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
 default = ["otlp"]
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ utils.workspace = true
 val-json.workspace = true
 wasm-workers.workspace = true
 
-activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
-webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
-workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -127,9 +124,9 @@ otlp = [
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
 ]
-"activity-js-local" = ["dep:activity-js-runtime-builder"]
-"webhook-js-local" = ["dep:webhook-js-runtime-builder"]
-"workflow-js-local" = ["dep:workflow-js-runtime-builder"]
+"activity-js-local" = []
+"webhook-js-local" = []
+"workflow-js-local" = []
 default = ["otlp"]
 
 [lints]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.39.0"
+version = "0.39.1"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -200,14 +200,14 @@ rust-version = "1.96.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.0" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.0" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.0" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.0" }
-deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.0" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.1" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.1" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.1" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.1" }
+deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.1" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.0" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.0" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.1" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.1" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -225,9 +225,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.0" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.0" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.0" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.1" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.1" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.1" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.39.1"
+version = "0.39.2"
 description = "Deterministic workflow engine"
 license = "AGPL-3.0-only"
 repository = "https://github.com/obeli-sk/obelisk"
@@ -200,14 +200,14 @@ rust-version = "1.96.0"
 activity-js-runtime-builder = { path = "crates/activity-js-runtime/builder" }
 boa-common = { path = "crates/boa-common" }
 webhook-js-runtime-builder = { path = "crates/webhook-js-runtime/builder" }
-concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.1" }
-db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.1" }
-db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.1" }
-db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.1" }
-deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.1" }
+concepts = { package = "obeli-sk-concepts", path = "crates/concepts", version = "0.39.2" }
+db-common = { package = "obeli-sk-db-common", path = "crates/db-common", version = "0.39.2" }
+db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", version = "0.39.2" }
+db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.39.2" }
+deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.39.2" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
-executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.1" }
-grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.1" }
+executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.39.2" }
+grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.39.2" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [
     "genrs",
 ] }
@@ -225,9 +225,9 @@ test-programs-sleep-workflow-builder = { path = "crates/testing/test-programs/sl
 test-programs-stub-activity-builder = { path = "crates/testing/test-programs/stub/activity/builder" }
 test-programs-stub-workflow-builder = { path = "crates/testing/test-programs/stub/workflow/builder" }
 test-utils = { path = "crates/testing/test-utils" }
-utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.1" }
-val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.1" }
-wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.1" }
+utils = { package = "obeli-sk-utils", path = "crates/utils", version = "0.39.2" }
+val-json = { package = "obeli-sk-val-json", path = "crates/val-json", version = "0.39.2" }
+wasm-workers = { package = "obeli-sk-wasm-workers", path = "crates/wasm-workers", version = "0.39.2" }
 workflow-js-runtime-builder = { path = "crates/workflow-js-runtime/builder" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,21 +3,15 @@
 # Upcoming goals
 
 ## Activities
-* External activity executor gRPC API, streaming connection ends on hot redeploy
+* External activity executor gRPC API
 * Lock extension - define max duration, but lock is extended periodically every `lock_duration`, makes for a heartbeat.
 
 ## Security
 * Dynamic secrets loaded from Vault, missing dynamic secrets should be a warning
-* Secure API endpoint: JS webhook "around" function defined in server.toml
+* Secure API endpoints, webhooks: JS or WASM function defined in server.toml
 
 ## Workflows
-workflow.legacy - not part of fn registry, can execute old execs without upgrades
-
-## Extend /execution/list
-ExecutionsListParams needs to be able to search by pending status (finished, !finished),
-also fetch only pending in the future / range, also in webUI. WebUI should show pending at relative to now.
-
-Add finished column to execution/list, allow sorting by created, first scheduled, finished
+Ability to drive old workflows to completion when auto upgrade fails.
 
 ## feat: Retention
 Perform a cascading delete of top-level executions that finished more than a certain number of days ago.

--- a/flake.nix
+++ b/flake.nix
@@ -197,6 +197,22 @@
                 cargo-zigbuild
             ];
           };
+          # Used only by release-2-cargo-publish to get a cargo with the
+          # workspace-publish fix (rust-lang/cargo#17071), which is missing
+          # from the 1.96.0 stable toolchain pinned in rust-toolchain.toml.
+          # TODO: remove this devshell once rust-toolchain.toml is on >= 1.98
+          # (the first stable with the fix) and revert release-2 to the
+          # default `nix develop`.
+          devShells.publish = pkgs.mkShell {
+            nativeBuildInputs = with pkgs;
+              [
+                (rust-bin.beta.latest.default.override {
+                  targets = [ "wasm32-unknown-unknown" "wasm32-wasip2" ];
+                })
+                pkg-config
+                protobuf
+              ];
+          };
           packages = rec {
             obeliskLibcNixDev = makeObelisk "dev" null ./rust-toolchain.toml;
             obeliskLibcNix = makeObelisk "release" null ./rust-toolchain.toml;

--- a/scripts/strip-js-local-deps.sh
+++ b/scripts/strip-js-local-deps.sh
@@ -17,4 +17,4 @@ sed -i 's/"workflow-js-local" = \["dep:workflow-js-runtime-builder"\]/"workflow-
 # Remove the js-local test matrix entry from the CI workflow
 sed -i '/junit-js-local.xml/,+1d' .github/workflows/check-test.yml
 
-cargo check
+cargo metadata

--- a/scripts/strip-js-local-deps.sh
+++ b/scripts/strip-js-local-deps.sh
@@ -14,7 +14,7 @@ sed -i 's/"activity-js-local" = \["dep:activity-js-runtime-builder"\]/"activity-
 sed -i 's/"webhook-js-local" = \["dep:webhook-js-runtime-builder"\]/"webhook-js-local" = []/' Cargo.toml
 sed -i 's/"workflow-js-local" = \["dep:workflow-js-runtime-builder"\]/"workflow-js-local" = []/' Cargo.toml
 
-# Remove the js-local test matrix entry from the CI workflow
-sed -i '/junit-js-local.xml/,+1d' .github/workflows/check-test.yml
+# Remove the js-local test matrix entry from check-test.yml
+sed -i '/- name: test-js-local.sh/,+2d' .github/workflows/check-test.yml
 
 cargo metadata


### PR DESCRIPTION
- **build: Prepare release 0.39.0**
- **build: Speed up lock file regen in `strip-js-local-deps.sh`**
- **chore: Strip local features before release**
- **doc: Update the roadmap**
- **chore: Prepare release 0.39.1**
- **ci: use beta cargo for release-2 workspace publish**
- **chore: Prepare release 0.39.2**
- **chore: Prepare release 0.39.3**
- **Revert "chore: Strip local features before release"**
- **build: Fix `strip-js-local-deps.sh`**
