### PR TITLE
feat(activity,webhook,toml)!: Require `path_prefixes` in outbound HTTP allowances

### DIFF
--- a/assets/schemas/deployment-canonical.json
+++ b/assets/schemas/deployment-canonical.json
@@ -369,6 +369,16 @@
             }
           ]
         },
+        "path_prefixes": {
+          "description": "Allowed URL path prefixes, matched literally against the request path.\n- Required. Use `path_prefixes = [\"/\"]` to allow all paths.\n- Each entry must start with `/`. `\"/foo\"` matches `/foo`, `/foobar`, and\n  `/foo/x`; `\"/foo/\"` matches only `/foo/...`. Query strings are ignored.\n- Omitting it, or `path_prefixes = []`, allows nothing (warning emitted).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "secrets": {
           "description": "Optional secrets for this host.",
           "anyOf": [

--- a/assets/schemas/oci-metadata-annotation.json
+++ b/assets/schemas/oci-metadata-annotation.json
@@ -283,6 +283,16 @@
             }
           ]
         },
+        "path_prefixes": {
+          "description": "Allowed URL path prefixes, matched literally against the request path.\n- Required. Use `path_prefixes = [\"/\"]` to allow all paths.\n- Each entry must start with `/`. `\"/foo\"` matches `/foo`, `/foobar`, and\n  `/foo/x`; `\"/foo/\"` matches only `/foo/...`. Query strings are ignored.\n- Omitting it, or `path_prefixes = []`, allows nothing (warning emitted).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "secrets": {
           "description": "Optional secrets for this host.",
           "anyOf": [

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -367,6 +367,16 @@
             }
           ]
         },
+        "path_prefixes": {
+          "description": "Allowed URL path prefixes, matched literally against the request path.\n- Required. Use `path_prefixes = [\"/\"]` to allow all paths.\n- Each entry must start with `/`. `\"/foo\"` matches `/foo`, `/foobar`, and\n  `/foo/x`; `\"/foo/\"` matches only `/foo/...`. Query strings are ignored.\n- Omitting it, or `path_prefixes = []`, allows nothing (warning emitted).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "secrets": {
           "description": "Optional secrets for this host.",
           "anyOf": [

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -296,6 +296,12 @@ pub struct AllowedHostToml {
     /// - `methods = ["GET", "POST"]` to allow specific methods.
     /// - `methods = []` to allow nothing (warning emitted).
     pub methods: Option<MethodsInput>,
+    /// Allowed URL path prefixes, matched literally against the request path.
+    /// - Required. Use `path_prefixes = ["/"]` to allow all paths.
+    /// - Each entry must start with `/`. `"/foo"` matches `/foo`, `/foobar`, and
+    ///   `/foo/x`; `"/foo/"` matches only `/foo/...`. Query strings are ignored.
+    /// - Omitting it, or `path_prefixes = []`, allows nothing (warning emitted).
+    pub path_prefixes: Option<Vec<String>>,
     /// Optional secrets for this host.
     #[serde(default)]
     pub secrets: Option<AllowedHostSecretsToml>,

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -354,9 +354,8 @@ mod tests {
         }
 
         fn with_allowed_host(mut self, host: &str) -> Self {
-            use crate::http_request_policy::{AllowedHostConfig, HostPattern, MethodsPattern};
-            let pattern =
-                HostPattern::parse_with_methods(host, MethodsPattern::AllMethods).unwrap();
+            use crate::http_request_policy::{AllowedHostConfig, HostPattern};
+            let pattern = HostPattern::parse_with_all_methods_and_paths(host).unwrap();
             self.allowed_hosts.push(AllowedHostConfig {
                 pattern,
                 secret_env_mappings: Vec::new(),

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -539,7 +539,7 @@ pub(crate) mod tests {
     use crate::engines::PoolingOptions;
     use crate::engines::{EngineConfig, Engines};
     use crate::http_hooks::ConfigSectionHint;
-    use crate::http_request_policy::{AllowedHostConfig, HostPattern, MethodsPattern};
+    use crate::http_request_policy::{AllowedHostConfig, HostPattern};
     use assert_matches::assert_matches;
     use concepts::prefixed_ulid::{DEPLOYMENT_ID_DUMMY, RunId};
     use concepts::storage::Locked;
@@ -610,8 +610,7 @@ pub(crate) mod tests {
 
             fuel: None,
             allowed_hosts: Arc::from(vec![AllowedHostConfig {
-                pattern: HostPattern::parse_with_methods(allowed_host, MethodsPattern::AllMethods)
-                    .unwrap(),
+                pattern: HostPattern::parse_with_all_methods_and_paths(allowed_host).unwrap(),
                 secret_env_mappings: Vec::new(),
                 replace_in: hashbrown::HashSet::new(),
             }]),
@@ -1722,7 +1721,7 @@ pub(crate) mod tests {
         #[values(LockingStrategy::ByFfqns, LockingStrategy::ByComponentDigest)]
         locking_strategy: LockingStrategy,
     ) {
-        use crate::http_request_policy::{AllowedHostConfig, MethodsPattern, ReplacementLocation};
+        use crate::http_request_policy::{AllowedHostConfig, ReplacementLocation};
         use hashbrown::HashSet;
         use secrecy::SecretString;
         use wiremock::{
@@ -1739,8 +1738,7 @@ pub(crate) mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let server_address = listener.local_addr().unwrap();
         let allowed_host = format!("http://127.0.0.1:{port}", port = server_address.port());
-        let host_pattern =
-            HostPattern::parse_with_methods(&allowed_host, MethodsPattern::AllMethods).unwrap();
+        let host_pattern = HostPattern::parse_with_all_methods_and_paths(&allowed_host).unwrap();
 
         // Create worker with secret configuration
         let (worker, component_id) = new_activity_worker_with_config(

--- a/crates/wasm-workers/src/http_hooks.rs
+++ b/crates/wasm-workers/src/http_hooks.rs
@@ -58,6 +58,7 @@ fn generate_toml_snippet(
         scheme,
         host,
         port,
+        path,
     } = err
     {
         let pattern = format_host_pattern(scheme, host, *port);
@@ -66,7 +67,8 @@ fn generate_toml_snippet(
              To allow this request, add the following to your configuration:\n\n\
              [[{section}.allowed_host]]\n\
              pattern = \"{pattern}\"\n\
-             methods = [\"{method}\"]",
+             methods = [\"{method}\"]\n\
+             path_prefixes = [\"{path}\"]",
             section = config_section_hint,
             method = method.as_str()
         ))

--- a/crates/wasm-workers/src/http_request_policy.rs
+++ b/crates/wasm-workers/src/http_request_policy.rs
@@ -79,6 +79,9 @@ pub struct HostPattern {
     pub port: PortPattern,
     /// Allowed HTTP methods.
     pub methods: MethodsPattern,
+    /// Allowed URL path prefixes. A request is allowed if its path starts with
+    /// any of these prefixes. Empty list matches no URL.
+    pub path_prefixes: Vec<String>,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -87,11 +90,15 @@ pub enum HostPatternError {
     Wildcard { host: String },
     #[error("host pattern must not contain a path: `{input}`")]
     ContainsPath { input: String },
+    #[error("path prefix must start with `/`: `{prefix}`")]
+    PathPrefix { prefix: String },
 }
 
 impl HostPattern {
-    /// Parse a host specification string into a `HostPattern`.
-    /// Rules:
+    /// Parse a host specification string into a `HostPattern` with the given
+    /// allowed `methods` and `path_prefixes`.
+    ///
+    /// Host rules:
     /// - No scheme → HTTPS assumed
     /// - `*://` prefix → matches both http and https
     /// - No port → default for scheme (443 for HTTPS, 80 for HTTP)
@@ -102,18 +109,35 @@ impl HostPattern {
     /// - `*://*` matches any scheme, any host, default ports only (80 for http, 443 for https)
     /// - `*://*:*` matches any scheme, any host, any port
     ///
+    /// Each path prefix must start with `/`; matching is a literal string prefix
+    /// (`"/foo"` matches `/foobar` and `/foo/x`, `"/foo/"` only matches `/foo/...`).
+    ///
     /// # Errors
-    /// Returns an error if the wildcard is in the middle of the host.
-    pub fn parse_with_methods(
+    /// Returns an error if the host wildcard is misplaced, the host contains a
+    /// path, or a path prefix does not start with `/`.
+    pub fn parse_with(
         input: &str,
         methods: MethodsPattern,
+        path_prefixes: Vec<String>,
     ) -> Result<Self, HostPatternError> {
-        let mut host_pattern = Self::parse(input)?;
-        host_pattern.methods = methods;
-        Ok(host_pattern)
+        if let Some(prefix) = path_prefixes.iter().find(|p| !p.starts_with('/')) {
+            return Err(HostPatternError::PathPrefix {
+                prefix: prefix.clone(),
+            });
+        }
+
+        let (scheme, host_pattern, port) = Self::parse(input)?;
+
+        Ok(HostPattern {
+            scheme,
+            host_pattern,
+            port,
+            methods,
+            path_prefixes,
+        })
     }
 
-    fn parse(input: &str) -> Result<Self, HostPatternError> {
+    fn parse(input: &str) -> Result<(SchemePattern, String, PortPattern), HostPatternError> {
         // Check for `*://` prefix (any scheme)
         let (scheme, rest) = if let Some(rest) = input.strip_prefix("*://") {
             (SchemePattern::Any, rest)
@@ -156,13 +180,15 @@ impl HostPattern {
         if host.contains('*') && !host.starts_with('*') && !host.ends_with('*') {
             return Err(HostPatternError::Wildcard { host });
         }
+        Ok((scheme, host, port))
+    }
 
-        Ok(HostPattern {
-            scheme,
-            host_pattern: host,
-            port,
-            methods: MethodsPattern::AllMethods,
-        })
+    /// Check if a request path is allowed by this pattern's path prefixes.
+    #[must_use]
+    fn path_matches(&self, path: &str) -> bool {
+        self.path_prefixes
+            .iter()
+            .any(|prefix| path.starts_with(prefix.as_str()))
     }
 
     /// Check if a (scheme, host, port, method) tuple matches this pattern.
@@ -231,6 +257,11 @@ impl fmt::Display for HostPattern {
                 write!(f, " [{}]", method_strs.join(", "))?;
             }
         }
+
+        // Write path prefixes (omit the default "all paths")
+        if self.path_prefixes != ["/"] {
+            write!(f, " path_prefixes=[{}]", self.path_prefixes.join(", "))?;
+        }
         Ok(())
     }
 }
@@ -272,25 +303,27 @@ pub fn is_text_content_type(content_type: &str) -> bool {
         || ct.starts_with("application/x-www-form-urlencoded")
 }
 
-/// Extract (scheme, host, port) from a URI.
-fn extract_request_target(uri: &hyper::Uri) -> Option<(String, String, u16)> {
+/// Extract (scheme, host, port, path) from a URI.
+fn extract_request_target(uri: &hyper::Uri) -> Option<(String, String, u16, String)> {
     let scheme = uri.scheme_str().unwrap_or("https").to_string();
     let host = uri.host()?.to_string();
     let default_port = if scheme == "https" { 443 } else { 80 };
     let port = uri.port_u16().unwrap_or(default_port);
-    Some((scheme, host, port))
+    let path = uri.path().to_string();
+    Some((scheme, host, port, path))
 }
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum PolicyError {
     #[error("outgoing HTTP request has no host in URI: {0}")]
     RequestHasNoHost(Uri),
-    #[error("outgoing HTTP {method} request to {scheme}://{host}:{port} denied")]
+    #[error("outgoing HTTP {method} request to {scheme}://{host}:{port}{path} denied")]
     RequestDenied {
         method: Method,
         scheme: String,
         host: String,
         port: u16,
+        path: String,
     },
 }
 impl From<PolicyError> for ErrorCode {
@@ -306,16 +339,18 @@ impl HttpRequestPolicy {
         &self,
         request: &mut hyper::Request<wasmtime_wasi_http::p2::body::HyperOutgoingBody>,
     ) -> Result<(), PolicyError> {
-        let Some((scheme, host, port)) = extract_request_target(request.uri()) else {
+        let Some((scheme, host, port, path)) = extract_request_target(request.uri()) else {
             return Err(PolicyError::RequestHasNoHost(request.uri().clone()));
         };
         let method = request.method().clone();
 
-        // 1. Find matching host entries (check host + method)
+        // 1. Find matching host entries (check host + method + path)
         let matching: Vec<&AllowedHostPolicy> = self
             .hosts
             .iter()
-            .filter(|h| h.pattern.matches(&scheme, &host, port, &method))
+            .filter(|h| {
+                h.pattern.matches(&scheme, &host, port, &method) && h.pattern.path_matches(&path)
+            })
             .collect();
         if matching.is_empty() {
             return Err(PolicyError::RequestDenied {
@@ -323,6 +358,7 @@ impl HttpRequestPolicy {
                 scheme,
                 host,
                 port,
+                path,
             });
         }
 
@@ -387,12 +423,14 @@ impl HttpRequestPolicy {
 
     /// Get body secrets applicable for the request's target host and method.
     fn body_secrets_for(&self, uri: &hyper::Uri, method: &Method) -> Vec<&PlaceholderSecret> {
-        let Some((scheme, host, port)) = extract_request_target(uri) else {
+        let Some((scheme, host, port, path)) = extract_request_target(uri) else {
             return Vec::new();
         };
         self.hosts
             .iter()
-            .filter(|h| h.pattern.matches(&scheme, &host, port, method))
+            .filter(|h| {
+                h.pattern.matches(&scheme, &host, port, method) && h.pattern.path_matches(&path)
+            })
             .flat_map(|h| h.secrets.iter())
             .filter(|s| s.replace_in.contains(&ReplacementLocation::Body))
             .collect()
@@ -485,88 +523,118 @@ pub struct AllowedHostConfig {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parse_host_pattern_bare_hostname() {
-        let p = HostPattern::parse("api.openai.com").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Https);
-        assert_eq!(p.host_pattern, "api.openai.com");
-        assert_eq!(p.port, PortPattern::Default);
-        assert!(p.matches("https", "api.openai.com", 443, &Method::GET));
-        assert!(!p.matches("http", "api.openai.com", 80, &Method::GET));
+    impl HostPattern {
+        pub(crate) fn parse_with_methods_and_all_paths(
+            input: &str,
+            methods: MethodsPattern,
+        ) -> Result<Self, HostPatternError> {
+            Self::parse_with(input, methods, vec!["/".to_string()])
+        }
+
+        pub(crate) fn parse_with_all_methods_and_paths(
+            input: &str,
+        ) -> Result<Self, HostPatternError> {
+            Self::parse_with(input, MethodsPattern::AllMethods, vec!["/".to_string()])
+        }
     }
 
     #[test]
-    fn parse_host_pattern_with_scheme_and_port() {
-        let p = HostPattern::parse("http://localhost:8080").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Http);
-        assert_eq!(p.host_pattern, "localhost");
-        assert_eq!(p.port, PortPattern::Specific(8080));
-        assert!(p.matches("http", "localhost", 8080, &Method::GET));
-        assert!(!p.matches("https", "localhost", 8080, &Method::GET));
+    fn parse_fields() {
+        // (input, scheme, host_pattern, port)
+        let cases = [
+            (
+                "api.openai.com",
+                SchemePattern::Https,
+                "api.openai.com",
+                PortPattern::Default,
+            ),
+            (
+                "http://localhost:8080",
+                SchemePattern::Http,
+                "localhost",
+                PortPattern::Specific(8080),
+            ),
+            (
+                "http://example.com",
+                SchemePattern::Http,
+                "example.com",
+                PortPattern::Default,
+            ),
+            (
+                "internal.corp.com:8443",
+                SchemePattern::Https,
+                "internal.corp.com",
+                PortPattern::Specific(8443),
+            ),
+            ("*://*", SchemePattern::Any, "*", PortPattern::Default),
+            ("*://*:*", SchemePattern::Any, "*", PortPattern::Any),
+            (
+                "http://localhost:*",
+                SchemePattern::Http,
+                "localhost",
+                PortPattern::Any,
+            ),
+            (
+                "http://192.*:*",
+                SchemePattern::Http,
+                "192.*",
+                PortPattern::Any,
+            ),
+        ];
+        for (input, scheme, host, port) in cases {
+            let p = HostPattern::parse_with_all_methods_and_paths(input).unwrap();
+            assert_eq!(p.scheme, scheme, "{input}");
+            assert_eq!(p.host_pattern, host, "{input}");
+            assert_eq!(p.port, port, "{input}");
+        }
     }
 
     #[test]
-    fn parse_host_pattern_http_default_port() {
-        let p = HostPattern::parse("http://example.com").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Http);
-        assert_eq!(p.host_pattern, "example.com");
-        assert_eq!(p.port, PortPattern::Default);
-        assert!(p.matches("http", "example.com", 80, &Method::GET));
-        assert!(!p.matches("http", "example.com", 8080, &Method::GET));
+    fn matches_scheme_host_port() {
+        // (pattern, scheme, host, port, expected)
+        let cases = [
+            ("api.openai.com", "https", "api.openai.com", 443, true), // bare = https only
+            ("api.openai.com", "http", "api.openai.com", 80, false),
+            ("http://localhost:8080", "http", "localhost", 8080, true),
+            ("http://localhost:8080", "https", "localhost", 8080, false),
+            ("http://example.com", "http", "example.com", 80, true),
+            ("http://example.com", "http", "example.com", 8080, false), // default port only
+            ("*.example.com", "https", "api.example.com", 443, true),
+            ("*.example.com", "https", "foo.bar.example.com", 443, true),
+            ("*.example.com", "https", "example.com", 443, false), // no bare apex
+            ("192.168.1.*", "https", "192.168.1.100", 443, true),
+            ("192.168.1.*", "https", "192.168.2.100", 443, false),
+            ("*", "https", "anything.com", 443, true), // all https, default port
+            ("*", "http", "anything.com", 80, false),
+            ("http://*", "http", "anything.com", 80, true),
+            ("http://*", "https", "anything.com", 443, false),
+            ("*://*", "http", "foo.com", 80, true), // any scheme, default ports only
+            ("*://*", "https", "foo.com", 443, true),
+            ("*://*", "http", "foo.com", 8080, false),
+            ("*://*", "https", "foo.com", 8443, false),
+            ("*://*:*", "http", "foo.com", 8080, true), // any scheme, any port
+            ("*://*:*", "https", "foo.com", 8443, true),
+            ("http://localhost:*", "http", "localhost", 3000, true), // http only, any port
+            ("http://localhost:*", "https", "localhost", 443, false),
+            ("http://localhost:*", "http", "other.com", 80, false),
+            ("http://192.*:*", "http", "192.0.0.1", 3000, true), // wildcard host + any port
+            ("http://192.*:*", "http", "10.0.0.1", 80, false),
+            ("http://192.*:*", "https", "192.168.1.1", 443, false),
+        ];
+        for (pattern, scheme, host, port, expected) in cases {
+            let p = HostPattern::parse_with_all_methods_and_paths(pattern).unwrap();
+            assert_eq!(
+                p.matches(scheme, host, port, &Method::GET),
+                expected,
+                "pattern={pattern} req={scheme}://{host}:{port}"
+            );
+        }
     }
 
     #[test]
-    fn parse_host_pattern_wildcard_prefix() {
-        let p = HostPattern::parse("*.example.com").unwrap();
-        assert!(p.matches("https", "api.example.com", 443, &Method::GET));
-        assert!(p.matches("https", "foo.bar.example.com", 443, &Method::POST));
-        assert!(!p.matches("https", "example.com", 443, &Method::GET));
-    }
-
-    #[test]
-    fn parse_host_pattern_wildcard_suffix() {
-        let p = HostPattern::parse("192.168.1.*").unwrap();
-        assert!(p.matches("https", "192.168.1.100", 443, &Method::GET));
-        assert!(!p.matches("https", "192.168.2.100", 443, &Method::GET));
-    }
-
-    #[test]
-    fn parse_host_pattern_wildcard_all_https() {
-        let p = HostPattern::parse("*").unwrap();
-        assert!(p.matches("https", "anything.com", 443, &Method::GET));
-        assert!(!p.matches("http", "anything.com", 80, &Method::GET));
-    }
-
-    #[test]
-    fn parse_host_pattern_wildcard_http() {
-        let p = HostPattern::parse("http://*").unwrap();
-        assert!(!p.matches("https", "anything.com", 443, &Method::GET));
-        assert!(p.matches("http", "anything.com", 80, &Method::GET));
-    }
-
-    #[test]
-    fn parse_host_pattern_wildcard_middle_rejected() {
-        assert!(HostPattern::parse("foo.*.com").is_err());
-    }
-
-    #[test]
-    fn parse_host_pattern_trailing_slash_rejected() {
-        assert!(HostPattern::parse("http://localhost:8080/").is_err());
-        assert!(HostPattern::parse("https://api.example.com/v1").is_err());
-        assert!(HostPattern::parse("example.com/path").is_err());
-    }
-
-    #[test]
-    fn parse_host_pattern_https_non_default_port() {
-        let p = HostPattern::parse("internal.corp.com:8443").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Https);
-        assert_eq!(p.host_pattern, "internal.corp.com");
-        assert_eq!(p.port, PortPattern::Specific(8443));
-    }
-
-    #[test]
-    fn host_pattern_method_restriction() {
-        let p = HostPattern::parse_with_methods(
+    fn method_restriction() {
+        // Specific subset: only listed methods match.
+        let p = HostPattern::parse_with_methods_and_all_paths(
             "api.example.com",
             MethodsPattern::Specific(vec![Method::GET, Method::HEAD]),
         )
@@ -574,147 +642,131 @@ mod tests {
         assert!(p.matches("https", "api.example.com", 443, &Method::GET));
         assert!(p.matches("https", "api.example.com", 443, &Method::HEAD));
         assert!(!p.matches("https", "api.example.com", 443, &Method::POST));
-        assert!(!p.matches("https", "api.example.com", 443, &Method::DELETE));
-    }
 
-    #[test]
-    fn host_pattern_all_methods_allows_all() {
-        let p = HostPattern::parse("api.example.com").unwrap();
+        // All methods match.
+        let p = HostPattern::parse_with_all_methods_and_paths("api.example.com").unwrap();
         assert_eq!(p.methods, MethodsPattern::AllMethods);
-        assert!(p.matches("https", "api.example.com", 443, &Method::GET));
-        assert!(p.matches("https", "api.example.com", 443, &Method::POST));
         assert!(p.matches("https", "api.example.com", 443, &Method::DELETE));
-        assert!(p.matches("https", "api.example.com", 443, &Method::PUT));
-    }
 
-    #[test]
-    fn host_pattern_empty_methods_matches_nothing() {
-        let p =
-            HostPattern::parse_with_methods("api.example.com", MethodsPattern::Specific(vec![]))
-                .unwrap();
+        // Empty list matches nothing.
+        let p = HostPattern::parse_with_methods_and_all_paths(
+            "api.example.com",
+            MethodsPattern::Specific(vec![]),
+        )
+        .unwrap();
         assert!(!p.matches("https", "api.example.com", 443, &Method::GET));
-        assert!(!p.matches("https", "api.example.com", 443, &Method::POST));
-        assert!(!p.matches("https", "api.example.com", 443, &Method::DELETE));
     }
 
     #[test]
-    fn display_host_pattern_with_methods() {
-        let p = HostPattern::parse_with_methods(
+    fn parse_rejects_invalid() {
+        // Host wildcard in the middle, or a path embedded in the host pattern.
+        for input in [
+            "foo.*.com",
+            "http://localhost:8080/",
+            "https://api.example.com/v1",
+            "example.com/path",
+        ] {
+            assert!(
+                HostPattern::parse_with_all_methods_and_paths(input).is_err(),
+                "{input}"
+            );
+        }
+        // Path prefix must start with `/`.
+        let err = HostPattern::parse_with(
+            "api.example.com",
+            MethodsPattern::AllMethods,
+            vec!["foo".to_string()],
+        )
+        .unwrap_err();
+        assert!(matches!(err, HostPatternError::PathPrefix { .. }));
+    }
+
+    #[test]
+    fn path_matches() {
+        // Default is "all paths".
+        let p = HostPattern::parse_with_all_methods_and_paths("api.example.com").unwrap();
+        assert_eq!(p.path_prefixes, vec!["/".to_string()]);
+
+        // (prefixes, path, expected) - matching is a literal string prefix.
+        let cases: [(&[&str], &str, bool); 13] = [
+            (&["/"], "/", true),
+            (&["/"], "/v1/chat", true),
+            (&["/foo"], "/foo", true),
+            (&["/foo"], "/foobar", true), // not segment-aware
+            (&["/foo"], "/foo/bar", true),
+            (&["/foo"], "/bar", false),
+            (&["/foo"], "/", false),
+            (&["/foo/"], "/foo/bar", true),
+            (&["/foo/"], "/foo", false), // bare prefix not covered by "/foo/"
+            (&["/foo/"], "/foobar", false),
+            (&["/v1/", "/health"], "/v1/chat", true),
+            (&["/v1/", "/health"], "/healthz", true),
+            (&["/v1/", "/health"], "/v2/chat", false),
+        ];
+        for (prefixes, path, expected) in cases {
+            let p = HostPattern::parse_with(
+                "api.example.com",
+                MethodsPattern::AllMethods,
+                prefixes.iter().map(|s| (*s).to_string()).collect(),
+            )
+            .unwrap();
+            assert_eq!(
+                p.path_matches(path),
+                expected,
+                "prefixes={prefixes:?} path={path}"
+            );
+        }
+    }
+
+    #[test]
+    fn display_host_pattern() {
+        // Scheme/host/port rendering (all methods + default paths are omitted).
+        let host_cases = [
+            ("api.openai.com", "https://api.openai.com"),
+            ("http://localhost:8080", "http://localhost:8080"),
+            ("internal.corp.com:8443", "https://internal.corp.com:8443"),
+            ("*://*", "*://*"),
+            ("*://*:*", "*://*:*"),
+            ("http://localhost:*", "http://localhost:*"),
+        ];
+        for (input, expected) in host_cases {
+            let p = HostPattern::parse_with_all_methods_and_paths(input).unwrap();
+            assert_eq!(p.to_string(), expected, "{input}");
+        }
+
+        // Methods and non-default path prefixes are appended.
+        let p = HostPattern::parse_with_methods_and_all_paths(
             "api.example.com",
             MethodsPattern::Specific(vec![Method::GET, Method::POST]),
         )
         .unwrap();
         assert_eq!(p.to_string(), "https://api.example.com [GET, POST]");
-    }
 
-    #[test]
-    fn parse_host_pattern_any_scheme_default_ports() {
-        // `*://*` matches any scheme, any host, default ports only
-        let p = HostPattern::parse("*://*").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Any);
-        assert_eq!(p.host_pattern, "*");
-        assert_eq!(p.port, PortPattern::Default);
-
-        // Should match http on port 80
-        assert!(p.matches("http", "foo.com", 80, &Method::GET));
-        // Should match https on port 443
-        assert!(p.matches("https", "foo.com", 443, &Method::GET));
-        // Should NOT match http on non-default port
-        assert!(!p.matches("http", "foo.com", 8080, &Method::GET));
-        // Should NOT match https on non-default port
-        assert!(!p.matches("https", "foo.com", 8443, &Method::GET));
-    }
-
-    #[test]
-    fn parse_host_pattern_any_scheme_any_port() {
-        // `*://*:*` matches any scheme, any host, any port
-        let p = HostPattern::parse("*://*:*").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Any);
-        assert_eq!(p.host_pattern, "*");
-        assert_eq!(p.port, PortPattern::Any);
-
-        // Should match everything
-        assert!(p.matches("http", "foo.com", 80, &Method::GET));
-        assert!(p.matches("https", "foo.com", 443, &Method::GET));
-        assert!(p.matches("http", "foo.com", 8080, &Method::GET));
-        assert!(p.matches("https", "foo.com", 8443, &Method::GET));
-        assert!(p.matches("http", "localhost", 3000, &Method::POST));
-    }
-
-    #[test]
-    fn parse_host_pattern_any_port_specific_scheme() {
-        // `http://localhost:*` matches http, localhost, any port
-        let p = HostPattern::parse("http://localhost:*").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Http);
-        assert_eq!(p.host_pattern, "localhost");
-        assert_eq!(p.port, PortPattern::Any);
-
-        assert!(p.matches("http", "localhost", 80, &Method::GET));
-        assert!(p.matches("http", "localhost", 8080, &Method::GET));
-        assert!(p.matches("http", "localhost", 3000, &Method::GET));
-        assert!(!p.matches("https", "localhost", 443, &Method::GET));
-        assert!(!p.matches("http", "other.com", 80, &Method::GET));
-    }
-
-    #[test]
-    fn parse_host_pattern_wildcard_host_any_port() {
-        // `http://192.*:*` matches http, any host starting with 192., any port
-        let p = HostPattern::parse("http://192.*:*").unwrap();
-        assert_eq!(p.scheme, SchemePattern::Http);
-        assert_eq!(p.host_pattern, "192.*");
-        assert_eq!(p.port, PortPattern::Any);
-
-        assert!(p.matches("http", "192.168.1.1", 80, &Method::GET));
-        assert!(p.matches("http", "192.168.1.1", 8080, &Method::GET));
-        assert!(p.matches("http", "192.0.0.1", 3000, &Method::POST));
-        assert!(!p.matches("https", "192.168.1.1", 443, &Method::GET));
-        assert!(!p.matches("http", "10.0.0.1", 80, &Method::GET));
-    }
-
-    #[test]
-    fn display_host_pattern_any_scheme() {
-        let p = HostPattern::parse("*://*").unwrap();
-        assert_eq!(p.to_string(), "*://*");
-
-        let p = HostPattern::parse("*://*:*").unwrap();
-        assert_eq!(p.to_string(), "*://*:*");
-
-        let p = HostPattern::parse("http://localhost:*").unwrap();
-        assert_eq!(p.to_string(), "http://localhost:*");
-    }
-
-    #[test]
-    fn display_host_pattern_empty_methods() {
-        let p =
-            HostPattern::parse_with_methods("api.example.com", MethodsPattern::Specific(vec![]))
-                .unwrap();
+        let p = HostPattern::parse_with_methods_and_all_paths(
+            "api.example.com",
+            MethodsPattern::Specific(vec![]),
+        )
+        .unwrap();
         assert_eq!(p.to_string(), "https://api.example.com [NONE]");
+
+        let p = HostPattern::parse_with(
+            "api.example.com",
+            MethodsPattern::AllMethods,
+            vec!["/v1/".to_string(), "/health".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            p.to_string(),
+            "https://api.example.com path_prefixes=[/v1/, /health]"
+        );
     }
 
     #[test]
-    fn generate_placeholder_format() {
+    fn generate_placeholder_format_and_uniqueness() {
         let p = generate_placeholder();
         assert!(p.starts_with("OBELISK_SECRET_"));
         assert_eq!(p.len(), 15 + 64); // prefix + 64 hex chars
-    }
-
-    #[test]
-    fn generate_placeholder_unique() {
-        let p1 = generate_placeholder();
-        let p2 = generate_placeholder();
-        assert_ne!(p1, p2);
-    }
-
-    #[test]
-    fn display_host_pattern() {
-        let p = HostPattern::parse("api.openai.com").unwrap();
-        assert_eq!(p.to_string(), "https://api.openai.com");
-
-        let p = HostPattern::parse("http://localhost:8080").unwrap();
-        assert_eq!(p.to_string(), "http://localhost:8080");
-
-        let p = HostPattern::parse("internal.corp.com:8443").unwrap();
-        assert_eq!(p.to_string(), "https://internal.corp.com:8443");
+        assert_ne!(p, generate_placeholder());
     }
 
     #[test]

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -2081,7 +2081,7 @@ pub(crate) mod tests {
         use crate::activity::cancel_registry::CancelRegistry;
         use crate::engines::{EngineConfig, Engines};
         use crate::http_hooks::ConfigSectionHint;
-        use crate::http_request_policy::{AllowedHostConfig, HostPattern, MethodsPattern};
+        use crate::http_request_policy::{AllowedHostConfig, HostPattern};
         use crate::std_output_stream::StdOutputConfig;
         use crate::testing_fn_registry::TestingFnRegistry;
         use crate::webhook::webhook_trigger::{
@@ -2471,9 +2471,8 @@ pub(crate) mod tests {
                         subscription_interruption: None,
                         logs_store_min_level: None,
                         allowed_hosts: Arc::from(vec![AllowedHostConfig {
-                            pattern: HostPattern::parse_with_methods(
+                            pattern: HostPattern::parse_with_all_methods_and_paths(
                                 &mock_allowed_host,
-                                MethodsPattern::AllMethods,
                             )
                             .unwrap(),
                             secret_env_mappings: Vec::new(),
@@ -2888,9 +2887,8 @@ pub(crate) mod tests {
             SocketAddr,
             WatchGuard,
         ) {
-            use crate::http_request_policy::{AllowedHostConfig, HostPattern, MethodsPattern};
-            let host_pattern =
-                HostPattern::parse_with_methods(allowed_host, MethodsPattern::AllMethods).unwrap();
+            use crate::http_request_policy::{AllowedHostConfig, HostPattern};
+            let host_pattern = HostPattern::parse_with_all_methods_and_paths(allowed_host).unwrap();
             let sim_clock = SimClock::default();
             let (_guard, db_pool, _db_close) = db_tests::Database::Sqlite.set_up().await;
             let fn_registry = TestingFnRegistry::new_from_components(vec![]);

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -55,11 +55,19 @@
 ## - `methods = []` allows nothing (config warning)
 ## - Omitting `methods` entirely allows nothing (config warning)
 ##
+## Path restrictions (matched literally against the request URL path, query ignored):
+## - `path_prefixes = ["/"]` allows all paths
+## - `path_prefixes = ["/v1", "/health"]` restricts to those prefixes
+##   ("/foo" matches /foo, /foobar and /foo/x; "/foo/" matches only /foo/...)
+## - `path_prefixes = []` allows nothing (config warning)
+## - Omitting `path_prefixes` entirely allows nothing (config warning)
+##
 ## Multiple entries can match the same request; they form a union (secrets are merged).
 ## The `pattern` field supports `${VAR}` and `${VAR:-default}` env var interpolation.
 # [[activity_wasm.allowed_host]]
 # pattern = "api.github.com"
 # methods = "*"
+# path_prefixes = ["/"]
 ## Optional secrets: injected via placeholder replacement in outgoing HTTP requests.
 ## WASM receives an opaque placeholder instead of the real value.
 ## The runtime replaces placeholders with real values only for requests to this host.
@@ -111,6 +119,7 @@
 # [[activity_js.allowed_host]]
 # pattern = "api.example.com"
 # methods = ["GET", "POST"]
+# path_prefixes = ["/"]
 # [activity_js.allowed_host.secrets]
 # env_vars = ["API_KEY"]
 # replace_in = ["headers"]
@@ -321,6 +330,7 @@
 # [[webhook_endpoint_wasm.allowed_host]]
 # pattern = "api.example.com"
 # methods = ["GET", "POST"]
+# path_prefixes = ["/"]
 # [webhook_endpoint_wasm.allowed_host.secrets]
 # env_vars = ["API_KEY"]
 # replace_in = ["headers"]
@@ -355,6 +365,7 @@
 # [[webhook_endpoint_js.allowed_host]]
 # pattern = "api.example.com"
 # methods = ["GET", "POST"]
+# path_prefixes = ["/"]
 # [webhook_endpoint_js.allowed_host.secrets]
 # env_vars = ["API_KEY"]
 # replace_in = ["headers"]

--- a/obelisk-testing-js-local.toml
+++ b/obelisk-testing-js-local.toml
@@ -50,6 +50,7 @@ max_retries = 0
 [[activity_js.allowed_host]]
 pattern = "http://localhost:5005"
 methods = ["GET"]
+path_prefixes = ["/"]
 
 [[workflow_js]]
 location = "crates/testing/test-programs/js/workflow/fetch_components.js"
@@ -130,6 +131,7 @@ routes = [{ methods = ["GET"], route = "/fetch" }]
 [[webhook_endpoint_js.allowed_host]]
 pattern = "http://localhost:5005"
 methods = ["GET"]
+path_prefixes = ["/"]
 
 [[webhook_endpoint_js]]
 name = "webhook_js_call_activity"

--- a/obelisk-testing-wasm-local.toml
+++ b/obelisk-testing-wasm-local.toml
@@ -29,10 +29,12 @@ exec.lock_expiry.seconds = 5
 [[activity_wasm.allowed_host]]
 pattern = "*" # only https allowed
 methods = "*"
+path_prefixes = ["/"]
 
 [[activity_wasm.allowed_host]]
 pattern = "httpbin.org"
 methods = "*"
+path_prefixes = ["/"]
 secrets = {env_vars = [{key = "API_KEY", value = "foo"}], replace_in = ["headers", "params", "body"] }
 
 [[workflow_wasm]]

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -807,6 +807,7 @@ mod tests {
                     "GET".to_string(),
                     "POST".to_string(),
                 ])),
+                path_prefixes: Some(vec!["/v1".to_string()]),
                 secrets: Some(AllowedHostSecretsToml {
                     env_vars: vec![EnvVarConfig::Key("API_KEY".to_string())],
                     replace_in: vec![ReplaceIn::Headers],

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -220,6 +220,7 @@ return_type = "result<string, string>"
 [[activity_js.allowed_host]]
 pattern = "http://{ip}:{API_PORT}"
 methods = ["GET"]
+path_prefixes = ["/"]
 
 [[activity_js]]
 name = "test_read_env_activity"
@@ -540,6 +541,7 @@ routes = [{{ methods = ["GET"], route = "/fetch-allowed" }}]
 [[webhook_endpoint_js.allowed_host]]
 pattern = "http://{ip}:{API_PORT}"
 methods = ["GET"]
+path_prefixes = ["/"]
 
 [[webhook_endpoint_js]]
 name = "test_fetch_denied_webhook"

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2854,6 +2854,7 @@ impl DeploymentVerified {
                     allowed_hosts: vec![AllowedHostToml {
                         pattern: target_url,
                         methods: Some(MethodsInput::Star(MethodsInputStar::default())),
+                        path_prefixes: Some(vec!["/".to_string()]),
                         secrets: None,
                     }],
                 });

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -3371,7 +3371,27 @@ fn resolve_allowed_hosts(
                     )));
                 }
             };
-            let pattern = match HostPattern::parse_with_methods(&pattern_str, methods) {
+            // Resolve path prefixes (deny-by-default, like methods):
+            // omitted or `[]` => deny & skip; `"/"` => allow all paths.
+            let path_prefixes = match entry.path_prefixes {
+                None => {
+                    warn!(
+                        "allowed_host `{}` has no `path_prefixes` field - no requests will be allowed; \
+                         use `path_prefixes = [\"/\"]` to allow all paths",
+                        entry.pattern
+                    );
+                    return None;
+                }
+                Some(list) if list.is_empty() => {
+                    warn!(
+                        "allowed_host `{}` has empty `path_prefixes = []` - no requests will be allowed",
+                        entry.pattern
+                    );
+                    return None;
+                }
+                Some(list) => list,
+            };
+            let pattern = match HostPattern::parse_with(&pattern_str, methods, path_prefixes) {
                 Ok(p) => p,
                 Err(e) => return Some(Err(e.into())),
             };


### PR DESCRIPTION
Path restrictions (matched literally against the request URL path, query ignored):
- `path_prefixes = ["/"]` allows all paths
- `path_prefixes = ["/v1", "/health"]` restricts to those prefixes
  ("/foo" matches /foo, /foobar and /foo/x; "/foo/" matches only /foo/...)
- `path_prefixes = []` allows nothing (config warning)
- Omitting `path_prefixes` entirely allows nothing (config warning)
