### PR TITLE
Fix executor close detection in WASM,JS activities

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,6 @@
 
 ## Activities
 * External activity executor gRPC API
-* Lock extension - define max duration, but lock is extended periodically every `lock_duration`, makes for a heartbeat.
 
 ## Security
 * Dynamic secrets loaded from Vault, missing dynamic secrets should be a warning

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -321,10 +321,10 @@ mod bench {
         });
 
         tokio.block_on(async move {
-            workflow_exec_task.close().await;
+            workflow_exec_task.close_outer_task().await;
         });
         tokio.block_on(async move {
-            activity_exec_task.close().await;
+            activity_exec_task.close_outer_task().await;
         });
 
         tokio.block_on(async move { db_close.close().await });

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -211,19 +211,21 @@ impl ExecTask {
         clock_fn: Box<dyn ClockFn>,
         db_pool: Arc<dyn DbPool>,
         ffqns: Arc<[FunctionFqn]>,
-    ) -> Self {
+    ) -> (Self, tokio::sync::watch::Sender<bool>) {
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
         let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
-        std::mem::forget(close_tx); // FIXME: leak
-        ExecTask {
-            worker,
-            locking_strategy_holder: config.locking_strategy.holder(ffqns),
-            config,
-            clock_fn,
-            db_pool,
-            worker_count_tx,
-            executor_close_watcher,
-        }
+        (
+            ExecTask {
+                worker,
+                locking_strategy_holder: config.locking_strategy.holder(ffqns),
+                config,
+                clock_fn,
+                db_pool,
+                worker_count_tx,
+                executor_close_watcher,
+            },
+            close_tx,
+        )
     }
 
     #[cfg(feature = "test")]
@@ -232,20 +234,22 @@ impl ExecTask {
         config: ExecConfig,
         clock_fn: Box<dyn ClockFn>,
         db_pool: Arc<dyn DbPool>,
-    ) -> Self {
+    ) -> (Self, tokio::sync::watch::Sender<bool>) {
         let ffqns = extract_exported_ffqns_noext(worker.as_ref());
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
         let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
-        std::mem::forget(close_tx); // FIXME: leak
-        Self {
-            worker,
-            locking_strategy_holder: config.locking_strategy.holder(ffqns),
-            config,
-            clock_fn,
-            db_pool,
-            worker_count_tx,
-            executor_close_watcher,
-        }
+        (
+            Self {
+                worker,
+                locking_strategy_holder: config.locking_strategy.holder(ffqns),
+                config,
+                clock_fn,
+                db_pool,
+                worker_count_tx,
+                executor_close_watcher,
+            },
+            close_tx,
+        )
     }
 
     #[cfg(feature = "test")]
@@ -1077,7 +1081,7 @@ mod tests {
     ) -> Vec<ExecutionId> {
         trace!("Ticking with {worker:?}");
         let ffqns = super::extract_exported_ffqns_noext(worker.as_ref());
-        let executor = ExecTask::new_test(config, worker, clock_fn, db_pool, ffqns);
+        let (executor, _close_tx) = ExecTask::new_test(config, worker, clock_fn, db_pool, ffqns);
         executor
             .tick_test_await(executed_at, RunId::generate())
             .await
@@ -1845,7 +1849,7 @@ mod tests {
             .unwrap();
 
         let ffqns = super::extract_exported_ffqns_noext(worker.as_ref());
-        let executor = ExecTask::new_test(
+        let (executor, _close_tx) = ExecTask::new_test(
             exec_config.clone(),
             worker,
             sim_clock.clone_box(),

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -213,6 +213,8 @@ impl ExecTask {
         ffqns: Arc<[FunctionFqn]>,
     ) -> Self {
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
+        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        std::mem::forget(close_tx); // FIXME: leak
         ExecTask {
             worker,
             locking_strategy_holder: config.locking_strategy.holder(ffqns),
@@ -220,7 +222,7 @@ impl ExecTask {
             clock_fn,
             db_pool,
             worker_count_tx,
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            executor_close_watcher,
         }
     }
 
@@ -233,6 +235,8 @@ impl ExecTask {
     ) -> Self {
         let ffqns = extract_exported_ffqns_noext(worker.as_ref());
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
+        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        std::mem::forget(close_tx); // FIXME: leak
         Self {
             worker,
             locking_strategy_holder: config.locking_strategy.holder(ffqns),
@@ -240,7 +244,7 @@ impl ExecTask {
             clock_fn,
             db_pool,
             worker_count_tx,
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            executor_close_watcher,
         }
     }
 

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -27,7 +27,7 @@ use std::{
     },
     time::Duration,
 };
-use tokio::task::{AbortHandle, JoinHandle};
+use tokio::task::JoinHandle;
 use tracing::{Instrument, Level, Span, debug, error, info, info_span, instrument, trace, warn};
 
 #[derive(Debug, Clone)]
@@ -80,41 +80,57 @@ pub enum WorkerType {
 
 #[derive(derive_more::Debug)]
 pub struct ExecutorTaskHandle {
+    // Signals close() -> event loop to shut down
     #[debug(skip)]
     is_closing: Arc<AtomicBool>,
     #[debug(skip)]
-    abort_handle: AbortHandle,
+    join_handle: JoinHandle<()>,
     component_id: ComponentId,
     executor_id: ExecutorId,
     deployment_id: DeploymentId,
+    // Signals close() -> workers to shut down
+    executor_closing_signal_sender: tokio::sync::watch::Sender<bool>,
+    /// Tracks the number of worker tasks currently in-flight.
+    worker_count_rx: tokio::sync::watch::Receiver<usize>,
+}
+
+pub struct WorkerTasksHandle {
+    component_id: ComponentId,
+    executor_id: ExecutorId,
+    deployment_id: DeploymentId,
+    // Signals close() -> workers to shut down
     executor_closing_signal_sender: tokio::sync::watch::Sender<bool>,
     /// Tracks the number of worker tasks currently in-flight.
     worker_count_rx: tokio::sync::watch::Receiver<usize>,
 }
 
 impl ExecutorTaskHandle {
+    /// Shut down the executor task, return worker tasks handle untouched.
     #[instrument(name = "executor.close", skip_all, fields(executor_id = %self.executor_id, component_id = %self.component_id,
         deployment_id = %self.deployment_id))]
-    pub async fn close(&self) {
-        trace!("Gracefully closing");
+    pub async fn close_outer_task(mut self) -> WorkerTasksHandle {
+        debug!("Gracefully closing executor task");
         self.is_closing.store(true, Ordering::Relaxed);
-        while !self.abort_handle.is_finished() {
-            tokio::time::sleep(Duration::from_millis(1)).await;
-        }
-        trace!("Signaling workflow tasks to unlock");
-        let _ = self.executor_closing_signal_sender.send(true);
-        let mut worker_count_rx = self.worker_count_rx.clone();
+
         loop {
             tokio::select! {
                 () = tokio::time::sleep(Duration::from_secs(5)) => {
-                    info!("Waiting for {} workers to shut down", *self.worker_count_rx.borrow());
+                    info!("Waiting for executor to shut down");
                 }
-                _ = worker_count_rx.wait_for(|&count| count == 0) => {
+                _ = &mut self.join_handle => {
                     break;
                 }
             }
         }
-        debug!("Gracefully closed");
+        let worker_tasks = *self.worker_count_rx.borrow();
+        debug!("Gracefully closed executor task, {worker_tasks} workers are in progress");
+        WorkerTasksHandle {
+            component_id: self.component_id,
+            executor_id: self.executor_id,
+            deployment_id: self.deployment_id,
+            executor_closing_signal_sender: self.executor_closing_signal_sender,
+            worker_count_rx: self.worker_count_rx,
+        }
     }
 
     #[must_use]
@@ -123,14 +139,25 @@ impl ExecutorTaskHandle {
     }
 }
 
-impl Drop for ExecutorTaskHandle {
-    #[instrument(level = Level::DEBUG, name = "executor.drop", skip_all, fields(executor_id = %self.executor_id, component_id = %self.component_id))]
-    fn drop(&mut self) {
-        if self.abort_handle.is_finished() {
-            return;
+impl WorkerTasksHandle {
+    /// Signal to worker tasks, then wait for all tasks to finish.
+    #[instrument(name = "WorkerTasksHandle.close", skip_all, fields(executor_id = %self.executor_id, component_id = %self.component_id,
+        deployment_id = %self.deployment_id))]
+    pub async fn close(self) {
+        debug!("Signaling worker tasks to unlock");
+        let _ = self.executor_closing_signal_sender.send(true);
+        let mut worker_count_rx = self.worker_count_rx.clone();
+        loop {
+            tokio::select! {
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    info!("Waiting for {} workers to shut down", *self.worker_count_rx.borrow());
+                }
+                _ = worker_count_rx.wait_for(|&count| count == 0) => {
+                    break;
+                }
+            }
         }
-        warn!("Aborting the executor task");
-        self.abort_handle.abort();
+        debug!("All worker tasks are finished");
     }
 }
 
@@ -255,7 +282,7 @@ impl ExecTask {
         let (worker_count_tx, worker_count_rx) = tokio::sync::watch::channel(0);
         let (executor_closing_signal_sender, executor_close_watcher) =
             tokio::sync::watch::channel(false);
-        let abort_handle = tokio::spawn(async move {
+        let join_handle = tokio::spawn(async move {
             debug!(executor_id = %config.executor_id, component_id = %config.component_id, "Spawned executor");
             let lock_strategy_holder = config.locking_strategy.holder(ffqns);
             let task = ExecTask {
@@ -272,7 +299,14 @@ impl ExecTask {
                 let res = task.db_pool.db_exec_conn().await;
                 let res = log_err_if_new(res, &mut old_err);
                 if let Ok(db_exec) = res {
-                    let _ = task.tick(db_exec.as_ref(), clock_fn.now(), RunId::generate(), deployment_id).await;
+                    let _ = task
+                        .tick(
+                            db_exec.as_ref(),
+                            clock_fn.now(),
+                            RunId::generate(),
+                            deployment_id,
+                        )
+                        .await;
                     let timeout_fut = {
                         let sleep = sleep.clone();
                         Box::pin(async move { sleep.sleep(task.config.tick_sleep).await })
@@ -308,15 +342,14 @@ impl ExecTask {
                                 .await;
                         }
                     }
-                } else  {
+                } else {
                     sleep.sleep(task.config.tick_sleep).await;
                 }
             }
-        })
-        .abort_handle();
+        });
         ExecutorTaskHandle {
             is_closing,
-            abort_handle,
+            join_handle,
             component_id,
             executor_id,
             deployment_id,

--- a/crates/wasm-workers/src/activity/activity_ctx.rs
+++ b/crates/wasm-workers/src/activity/activity_ctx.rs
@@ -19,7 +19,6 @@ pub struct ActivityCtx {
     http_ctx: WasiHttpCtx,
     component_logger: ComponentLogger,
     pub(crate) http_hooks: HttpHooks,
-    pub(crate) executor_close_watcher: tokio::sync::watch::Receiver<bool>,
 }
 
 impl wasmtime::component::HasData for ActivityCtx {
@@ -109,7 +108,6 @@ pub(crate) fn store(
             config_section_hint: config.config_section_hint,
         },
         component_logger,
-        executor_close_watcher: ctx.executor_close_watcher,
     };
     Store::new(engine, ctx)
 }

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -359,7 +359,7 @@ impl Worker for ActivityExecWorker {
         // Register cancellation token.
         let cancel_token = self
             .cancel_registry
-            .obtain_cancellation_token(ctx.execution_id.clone());
+            .obtain_interrupt_token(ctx.execution_id.clone());
 
         // Skip stdout collection when return_type is `result` (unit ok and err variants).
         let max_stdout_bytes = if self.user_return_type.type_wrapper_tl.is_result_of_units() {

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -443,7 +443,10 @@ mod tests {
             .await
     }
 
-    fn make_worker_context(ffqn: FunctionFqn, params: &[String]) -> WorkerContext {
+    fn make_worker_context(
+        ffqn: FunctionFqn,
+        params: &[String],
+    ) -> (WorkerContext, tokio::sync::watch::Sender<bool>) {
         // The user function signature is: func(params: list<string>) -> result<string, string>
         // So we wrap the params in a list
         let params_json: Vec<serde_json::Value> = vec![json!(params)];
@@ -454,8 +457,7 @@ mod tests {
         )
         .unwrap();
         let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
-        std::mem::forget(close_tx); // FIXME: leak
-        WorkerContext {
+        let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: ExecutionMetadata::empty(),
             component_digest: component_id.component_digest.clone(),
@@ -476,13 +478,14 @@ mod tests {
                 retry_config: ComponentRetryConfig::ZERO,
             },
             executor_close_watcher,
-        }
+        };
+        (ctx, close_tx)
     }
 
     fn make_worker_context_custom(
         ffqn: FunctionFqn,
         params_json: Vec<serde_json::Value>,
-    ) -> WorkerContext {
+    ) -> (WorkerContext, tokio::sync::watch::Sender<bool>) {
         let component_id = concepts::ComponentId::new(
             ComponentType::Activity,
             StrVariant::Static("test_js"),
@@ -490,8 +493,7 @@ mod tests {
         )
         .unwrap();
         let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
-        std::mem::forget(close_tx); // FIXME: leak
-        WorkerContext {
+        let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: ExecutionMetadata::empty(),
             component_digest: component_id.component_digest.clone(),
@@ -512,7 +514,8 @@ mod tests {
                 retry_config: ComponentRetryConfig::ZERO,
             },
             executor_close_watcher,
-        }
+        };
+        (ctx, close_tx)
     }
 
     fn extract_string(val: &WastVal) -> String {
@@ -533,7 +536,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -553,7 +556,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -573,7 +576,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -595,7 +598,8 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &["World".to_string(), "Hello".to_string()]);
+        let (ctx, _close_tx) =
+            make_worker_context(ffqn, &["World".to_string(), "Hello".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -615,7 +619,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -636,7 +640,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -661,7 +665,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &["test".to_string()]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &["test".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -681,7 +685,7 @@ mod tests {
         ";
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &["test".to_string()]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &["test".to_string()]);
 
         // The JS object is JSON-serialized successfully, but fails to deserialize as result<string, string>
         // because the JSON object `{"name":"test","count":42}` is not a string.
@@ -713,7 +717,7 @@ mod tests {
         ";
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let err = worker.run(ctx).await.unwrap_err();
         assert_matches!(
@@ -743,7 +747,7 @@ mod tests {
             }
         ";
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
         let err = worker.run(ctx).await.unwrap_err();
         assert_matches!(
             err,
@@ -767,7 +771,7 @@ mod tests {
         ";
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let err = worker.run(ctx).await.unwrap_err();
         assert_matches!(
@@ -821,7 +825,7 @@ mod tests {
 
         let allowed = format!("http://127.0.0.1:{}", server.address().port());
         let worker = new_js_activity_worker_with_http(&js_source, ffqn.clone(), &allowed).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -864,7 +868,7 @@ mod tests {
 
         let allowed = format!("http://127.0.0.1:{}", server.address().port());
         let worker = new_js_activity_worker_with_http(&js_source, ffqn.clone(), &allowed).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -901,7 +905,7 @@ mod tests {
 
         let allowed = format!("http://127.0.0.1:{}", server.address().port());
         let worker = new_js_activity_worker_with_http(&js_source, ffqn.clone(), &allowed).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -922,7 +926,7 @@ mod tests {
             }
         "#;
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -943,7 +947,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &["hello".to_string()]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &["hello".to_string()]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -981,7 +985,7 @@ mod tests {
 
         let worker =
             new_js_activity_worker_custom_params(js_source, ffqn.clone(), user_params).await;
-        let ctx = make_worker_context_custom(ffqn, vec![json!("World"), json!(3)]);
+        let (ctx, _close_tx) = make_worker_context_custom(ffqn, vec![json!("World"), json!(3)]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1004,7 +1008,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker_custom_params(js_source, ffqn.clone(), vec![]).await;
-        let ctx = make_worker_context_custom(ffqn, vec![]);
+        let (ctx, _close_tx) = make_worker_context_custom(ffqn, vec![]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1042,7 +1046,7 @@ mod tests {
 
         let worker =
             new_js_activity_worker_custom_params(js_source, ffqn.clone(), user_params).await;
-        let ctx = make_worker_context_custom(
+        let (ctx, _close_tx) = make_worker_context_custom(
             ffqn,
             vec![json!(["apple", "banana", "cherry"]), json!(true)],
         );
@@ -1069,7 +1073,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let start = std::time::Instant::now();
         let result = worker.run(ctx).await.expect("worker should succeed");
@@ -1114,7 +1118,7 @@ mod tests {
         "#;
 
         let worker = new_js_activity_worker(js_source, ffqn.clone()).await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let start = std::time::Instant::now();
         let result = worker.run(ctx).await.expect("worker should succeed");
@@ -1166,7 +1170,7 @@ mod tests {
             .with_logs(logs_storage_config)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
 
@@ -1288,7 +1292,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1319,7 +1323,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1357,7 +1361,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1395,7 +1399,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1434,7 +1438,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1468,7 +1472,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let worker_ok = worker.run(ctx).await.unwrap();
         assert_matches!(
@@ -1503,7 +1507,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
@@ -1539,7 +1543,7 @@ mod tests {
             .with_return_type(return_type)
             .build()
             .await;
-        let ctx = make_worker_context(ffqn, &[]);
+        let (ctx, _close_tx) = make_worker_context(ffqn, &[]);
 
         let result = worker.run(ctx).await.expect("worker should succeed");
         let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -453,6 +453,8 @@ mod tests {
             COMPONENT_DIGEST_DUMMY,
         )
         .unwrap();
+        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        std::mem::forget(close_tx); // FIXME: leak
         WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: ExecutionMetadata::empty(),
@@ -473,7 +475,7 @@ mod tests {
                 lock_expires_at: chrono::Utc::now() + chrono::Duration::seconds(60),
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            executor_close_watcher,
         }
     }
 
@@ -487,6 +489,8 @@ mod tests {
             COMPONENT_DIGEST_DUMMY,
         )
         .unwrap();
+        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        std::mem::forget(close_tx); // FIXME: leak
         WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: ExecutionMetadata::empty(),
@@ -507,7 +511,7 @@ mod tests {
                 lock_expires_at: chrono::Utc::now() + chrono::Duration::seconds(60),
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            executor_close_watcher,
         }
     }
 

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -565,6 +565,8 @@ pub(crate) mod tests {
         wast_val::{WastVal, WastValWithType},
     };
 
+    pub(crate) type ExecTaskAndClose = (ExecTask, tokio::sync::watch::Sender<bool>);
+
     pub const SLEEP_LOOP_ACTIVITY_FFQN: FunctionFqn = FunctionFqn::new_static_tuple(
         test_programs_sleep_activity_builder::exports::testing::sleep::sleep::SLEEP_LOOP,
     ); // sleep-loop: func(millis: u64, iterations: u32);
@@ -656,7 +658,7 @@ pub(crate) mod tests {
         sleep: impl Sleep + 'static,
         retry_config: ComponentRetryConfig,
         locking_strategy: LockingStrategy,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         new_activity_with_config(
             db_pool,
             wasm_path,
@@ -677,7 +679,7 @@ pub(crate) mod tests {
         config_fn: impl FnOnce(ComponentId) -> ActivityConfig,
         retry_config: ComponentRetryConfig,
         locking_strategy: LockingStrategy,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         let engine = Engines::get_activity_engine_test(EngineConfig::on_demand_testing()).unwrap();
         let (worker, component_id) = new_activity_worker_with_config(
             wasm_path,
@@ -706,7 +708,7 @@ pub(crate) mod tests {
         clock_fn: Box<dyn ClockFn>,
         sleep: impl Sleep + 'static,
         locking_strategy: LockingStrategy,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         new_activity(
             db_pool,
             test_programs_fibo_activity_builder::TEST_PROGRAMS_FIBO_ACTIVITY,
@@ -772,7 +774,7 @@ pub(crate) mod tests {
             locking_strategy,
         };
         let ffqns = Arc::from([ffqn.clone()]);
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             exec_config,
             worker,
             sim_clock.clone_box(),
@@ -956,7 +958,7 @@ pub(crate) mod tests {
         let sim_clock = SimClock::default();
         let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
         let db_connection = db_pool.connection().await.unwrap();
-        let exec = new_activity_fibo(
+        let (exec, _close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,
@@ -1138,7 +1140,7 @@ pub(crate) mod tests {
             locking_strategy,
         };
         let ffqns = Arc::from([SLEEP_LOOP_ACTIVITY_FFQN]);
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             exec_config,
             worker,
             sim_clock.clone_box(),
@@ -1366,7 +1368,7 @@ pub(crate) mod tests {
             locking_strategy,
         };
         let ffqns = Arc::from([HTTP_GET_SUCCESSFUL_ACTIVITY]);
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             exec_config,
             worker,
             sim_clock.clone_box(),
@@ -1498,7 +1500,7 @@ pub(crate) mod tests {
             locking_strategy,
         };
         let ffqns = Arc::from([HTTP_GET_SUCCESSFUL_ACTIVITY]);
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             exec_config,
             worker,
             sim_clock.clone_box(),
@@ -1655,7 +1657,7 @@ pub(crate) mod tests {
             locking_strategy: LockingStrategy::ByComponentDigest,
         };
         let ffqns = Arc::from([HTTP_GET_SUCCESSFUL_ACTIVITY]);
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             exec_config,
             worker,
             sim_clock.clone_box(),
@@ -1792,7 +1794,7 @@ pub(crate) mod tests {
         let secret_get_ffqn: FunctionFqn =
             FunctionFqn::new_static("testing:http/http-get", "secret-get");
         let ffqns = Arc::from([secret_get_ffqn.clone()]);
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             exec_config,
             worker,
             sim_clock.clone_box(),
@@ -1878,7 +1880,7 @@ pub(crate) mod tests {
         let sim_clock = SimClock::default();
         let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
         let db_connection = db_pool.connection().await.unwrap();
-        let exec = new_activity_with_config(
+        let (exec, _close_tx) = new_activity_with_config(
             db_pool.clone(),
             test_programs_serde_activity_builder::TEST_PROGRAMS_SERDE_ACTIVITY,
             sim_clock.clone_box(),
@@ -1952,7 +1954,7 @@ pub(crate) mod tests {
         let sim_clock = SimClock::default();
         let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
         let db_connection = db_pool.connection().await.unwrap();
-        let exec = new_activity_with_config(
+        let (exec, _close_tx) = new_activity_with_config(
             db_pool.clone(),
             test_programs_serde_activity_builder::TEST_PROGRAMS_SERDE_ACTIVITY,
             sim_clock.clone_box(),
@@ -2032,7 +2034,7 @@ pub(crate) mod tests {
             max_retries: Some(1),
             retry_exp_backoff: Duration::from_millis(10),
         };
-        let exec = new_activity_with_config(
+        let (exec, _close_tx) = new_activity_with_config(
             db_pool.clone(),
             test_programs_serde_activity_builder::TEST_PROGRAMS_SERDE_ACTIVITY,
             sim_clock.clone_box(),

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -22,9 +22,9 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, info, trace};
 use utils::wasm_tools::ExIm;
+use wasmtime::Store;
 use wasmtime::component::{ComponentExportIndex, InstancePre, Type};
 use wasmtime::{Engine, component::Val};
-use wasmtime::{Store, UpdateDeadline};
 
 #[derive(Clone, Debug)]
 pub struct ActivityConfig {
@@ -179,10 +179,6 @@ impl Worker for ActivityWorker {
     async fn run(&self, ctx: WorkerContext) -> WorkerResult {
         trace!("Context: {ctx:?}");
         assert!(ctx.event_history.is_empty());
-        let cancelation_token = self
-            .cancel_registry
-            .obtain_cancellation_token(ctx.execution_id.clone());
-
         let started_at = self.clock_fn.now();
         ctx.worker_span.record(
             "execution_deadline",
@@ -193,6 +189,11 @@ impl Worker for ActivityWorker {
         let params = ctx.params.clone();
         let version = ctx.version.clone();
         let worker_span = ctx.worker_span.clone();
+
+        let interrupt_token = self
+            .cancel_registry
+            .obtain_interrupt_token(ctx.execution_id.clone());
+        let mut executor_close_watcher = ctx.executor_close_watcher.clone();
 
         let (mut store, deadline_duration) = match self.create_store(ctx, started_at) {
             Ok(store) => store,
@@ -250,12 +251,17 @@ impl Worker for ActivityWorker {
                     version,
                 });
             }
-            _signal = cancelation_token => {
+            _ = interrupt_token => {
                 // Either paused or cancelled by CancelRegistry, or timed out by `expired_timers_watcher`
                 // and Sender removed from CancelRegistry using its watcher.
                 // TODO: Add http traces
                 debug!("Activity run interrupted, DB must have been updated");
                 return WorkerResult::Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher);
+            }
+            _ = executor_close_watcher.changed() => {
+                debug!("Executor is closing");
+                // Executor will append the Unlocked event.
+                return WorkerResult::Err(WorkerError::ExecutorClosing(version.clone()))
             }
         }
     }
@@ -303,19 +309,8 @@ impl ActivityWorker {
                 .expect("engine must have `consume_fuel` enabled");
         }
 
-        // Configure epoch callback before running the initialization to avoid interruption
-        store.epoch_deadline_callback(|store_ctx| {
-            let executor_closing = *store_ctx.data().executor_close_watcher.borrow();
-            if executor_closing {
-                info!("Executor closing");
-                Ok(UpdateDeadline::Interrupt) // Interpreted as executor closing in `process_res`
-            } else {
-                Ok(UpdateDeadline::YieldCustom(
-                    1,
-                    Box::pin(tokio::task::yield_now()),
-                ))
-            }
-        });
+        // Configure epoch callback to yield to tokio periodically.
+        store.epoch_deadline_async_yield_and_update(1);
 
         let deadline_delta = lock_expires_at - started_at;
         let Ok(deadline_duration) = deadline_delta.to_std() else {
@@ -465,8 +460,6 @@ impl ActivityWorker {
                             version: version.clone(),
                             http_client_traces,
                         }
-                    } else if *trap == wasmtime::Trap::Interrupt {
-                        WorkerError::ExecutorClosing(version.clone())
                     } else {
                         WorkerError::ActivityTrap {
                             reason: trap.to_string(),

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -1044,6 +1044,8 @@ pub(crate) mod tests {
             .map(|_| {
                 let fibo_worker = fibo_worker.clone();
                 let execution_id = ExecutionId::generate();
+                let (executor_close_tx, executor_close_watcher) =
+                    tokio::sync::watch::channel(false);
                 let ctx = WorkerContext {
                     execution_id: execution_id.clone(),
                     metadata: concepts::ExecutionMetadata::empty(),
@@ -1064,9 +1066,13 @@ pub(crate) mod tests {
                         lock_expires_at: Now.now() + lock_expiry,
                         retry_config: ComponentRetryConfig::ZERO,
                     },
-                    executor_close_watcher: tokio::sync::watch::channel(false).1,
+                    executor_close_watcher,
                 };
-                tokio::spawn(async move { fibo_worker.run(ctx).await })
+                tokio::spawn(async move {
+                    let res = fibo_worker.run(ctx).await;
+                    drop(executor_close_tx);
+                    res
+                })
             })
             .collect::<Vec<_>>();
         let mut limit_reached = 0;
@@ -1213,6 +1219,7 @@ pub(crate) mod tests {
 
         let executed_at = sim_clock.now();
         let version = Version::new(10);
+        let (_executor_close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: concepts::ExecutionMetadata::empty(),
@@ -1237,7 +1244,7 @@ pub(crate) mod tests {
                 lock_expires_at: executed_at + TIMEOUT,
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            executor_close_watcher,
         };
         let WorkerResult::Err(err) = worker.run(ctx).await else {
             panic!()
@@ -1270,6 +1277,7 @@ pub(crate) mod tests {
         let execution_deadline = sim_clock.now();
         sim_clock.move_time_forward(Duration::from_millis(100));
         let version = Version::new(10);
+        let (_executor_close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: concepts::ExecutionMetadata::empty(),
@@ -1294,7 +1302,7 @@ pub(crate) mod tests {
                 lock_expires_at: execution_deadline,
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            executor_close_watcher,
         };
         let WorkerResult::Err(err) = worker.run(ctx).await else {
             panic!()

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -20,7 +20,11 @@ pub const CANCEL_RETRIES: u8 = 5;
 /// which writes the new state to db (no matter whether registered or not)
 /// and triggers the cancellation token.
 pub struct CancelRegistry {
-    tokens: Arc<Mutex<hashbrown::HashMap<ExecutionId, oneshot::Sender<()>>>>,
+    tokens: Arc<Mutex<hashbrown::HashMap<ExecutionId, ActivityInfo>>>,
+}
+
+struct ActivityInfo {
+    interrupt_sender: oneshot::Sender<()>,
 }
 
 impl Default for CancelRegistry {
@@ -82,36 +86,34 @@ impl CancelRegistry {
         }
         if !finished.is_empty() {
             let mut guard = self.tokens.lock().unwrap();
+            // Cleanup old entries.
             for execution_id in finished {
-                if let Some(sender) = guard.remove(&execution_id) {
-                    let _ = sender.send(());
+                if let Some(info) = guard.remove(&execution_id) {
+                    let _ = info.interrupt_sender.send(());
                 }
             }
         }
     }
 
-    pub(crate) fn obtain_cancellation_token(
+    pub(crate) fn obtain_interrupt_token(
         &self,
         execution_id: ExecutionId,
     ) -> oneshot::Receiver<()> {
-        // Cleanup old entries.
         let mut guard = self.tokens.lock().unwrap();
-        guard.retain(|_key, sender| !sender.is_closed());
-
-        let (sender, receiver) = oneshot::channel();
-        guard.insert(execution_id, sender);
+        let (interrupt_sender, receiver) = oneshot::channel();
+        guard.insert(execution_id, ActivityInfo { interrupt_sender });
         receiver
     }
 
     /// Best-effort local interrupt for an activity currently running in this process.
     /// Unlike `cancel_activity`, this does not write terminal cancellation state to the DB.
     pub fn interrupt_running_activity(&self, execution_id: &ExecutionId) {
-        let sender = {
+        let info = {
             let mut guard = self.tokens.lock().unwrap();
             guard.remove(execution_id)
         };
-        if let Some(sender) = sender {
-            let _ = sender.send(());
+        if let Some(info) = info {
+            let _ = info.interrupt_sender.send(());
         }
     }
 

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -2121,7 +2121,11 @@ pub(crate) mod tests {
             db_pool: Arc<dyn DbPool>,
             server_addr: SocketAddr,
             activity_exec: ExecTask,
+            #[expect(dead_code)]
+            activity_close_tx: tokio::sync::watch::Sender<bool>,
             workflow_exec: ExecTask,
+            #[expect(dead_code)]
+            workflow_close_tx: tokio::sync::watch::Sender<bool>,
             sim_clock: SimClock,
             db_close: DbPoolCloseableWrapper,
             #[expect(dead_code)]
@@ -2138,7 +2142,7 @@ pub(crate) mod tests {
                 let addr = SocketAddr::from(([127, 0, 0, 1], 0));
                 let sim_clock = SimClock::default();
                 let (guard, db_pool, db_close) = db.set_up().await;
-                let activity_exec = new_activity_fibo(
+                let (activity_exec, activity_close_tx) = new_activity_fibo(
                     db_pool.clone(),
                     sim_clock.clone_box(),
                     TokioSleep,
@@ -2161,7 +2165,7 @@ pub(crate) mod tests {
                 let cancel_registry = CancelRegistry::new();
                 let engine =
                     Engines::get_webhook_engine(EngineConfig::on_demand_testing()).unwrap();
-                let workflow_exec = new_workflow_fibo(
+                let (workflow_exec, workflow_close_tx) = new_workflow_fibo(
                     db_pool.clone(),
                     sim_clock.clone_box(),
                     JoinNextBlockingStrategy::Interrupt,
@@ -2234,7 +2238,9 @@ pub(crate) mod tests {
                     db_pool,
                     server_addr,
                     activity_exec,
+                    activity_close_tx,
                     workflow_exec,
+                    workflow_close_tx,
                     sim_clock,
                     db_close,
                     server_termination_sender,
@@ -2417,13 +2423,14 @@ pub(crate) mod tests {
                 .await;
 
             // Set up fibo workflow/activity workers (needed for schedule call)
-            let activity_exec = crate::activity::activity_worker::tests::new_activity_fibo(
-                db_pool.clone(),
-                sim_clock.clone_box(),
-                TokioSleep,
-                locking_strategy,
-            )
-            .await;
+            let (activity_exec, _activity_close_tx) =
+                crate::activity::activity_worker::tests::new_activity_fibo(
+                    db_pool.clone(),
+                    sim_clock.clone_box(),
+                    TokioSleep,
+                    locking_strategy,
+                )
+                .await;
 
             let (workflow_runnable, workflow_component_id) =
                 compile_workflow(test_programs_fibo_workflow_builder::TEST_PROGRAMS_FIBO_WORKFLOW)
@@ -2600,13 +2607,14 @@ pub(crate) mod tests {
                 .await;
 
             // Set up activity/workflow workers
-            let activity_exec = crate::activity::activity_worker::tests::new_activity_fibo(
-                db_pool.clone(),
-                sim_clock.clone_box(),
-                TokioSleep,
-                LockingStrategy::ByComponentDigest,
-            )
-            .await;
+            let (activity_exec, _activity_close_tx) =
+                crate::activity::activity_worker::tests::new_activity_fibo(
+                    db_pool.clone(),
+                    sim_clock.clone_box(),
+                    TokioSleep,
+                    LockingStrategy::ByComponentDigest,
+                )
+                .await;
 
             let (workflow_runnable, workflow_component_id) =
                 compile_workflow(test_programs_fibo_workflow_builder::TEST_PROGRAMS_FIBO_WORKFLOW)
@@ -3238,6 +3246,8 @@ pub(crate) mod tests {
             server_set: tokio::task::JoinSet<Result<(), WebhookServerError>>,
             server_addr: SocketAddr,
             activity_exec: executor::executor::ExecTask,
+            #[expect(dead_code)]
+            activity_close_tx: tokio::sync::watch::Sender<bool>,
             sim_clock: SimClock,
             db_pool: Arc<dyn concepts::storage::DbPool>,
             #[expect(dead_code)]
@@ -3257,7 +3267,7 @@ pub(crate) mod tests {
                 let (_guard, db_pool, db_close) = db_tests::Database::Sqlite.set_up().await;
 
                 // Set up fibo activity worker
-                let activity_exec = new_activity_fibo(
+                let (activity_exec, activity_close_tx) = new_activity_fibo(
                     db_pool.clone(),
                     sim_clock.clone_box(),
                     TokioSleep,
@@ -3348,6 +3358,7 @@ pub(crate) mod tests {
                     server_set,
                     server_addr,
                     activity_exec,
+                    activity_close_tx,
                     sim_clock,
                     db_pool,
                     db_close,

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -52,7 +52,7 @@ use val_json::wast_val::WastVal;
 use wasmtime::component::ResourceTable;
 use wasmtime::component::types::ComponentFunc;
 use wasmtime::component::{Linker, Val};
-use wasmtime::{Engine, Store, UpdateDeadline};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p2::bindings::ProxyPre;
@@ -1705,8 +1705,8 @@ impl WebhookEndpointCtx {
                 .expect("engine must have `consume_fuel` enabled");
         }
 
-        // Configure epoch callback before running the initialization to avoid interruption
-        store.epoch_deadline_callback(|_store_ctx| Ok(UpdateDeadline::Yield(1)));
+        // Yield to tokio periodically
+        store.epoch_deadline_async_yield_and_update(1);
         store
     }
 

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -430,6 +430,7 @@ impl EventHistory {
             let key = join_next_variant.as_key();
 
             // Subscribe to the next response.
+            // Break on `executor_close_watcher` or when timeout is reached.
             while let Some(timeout_fut) =
                 self.deadline_tracker.track(self.subscription_interruption)
             {

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -3778,7 +3778,7 @@ pub(crate) mod tests {
         let created_at = sim_clock.now();
         let db_connection = db_pool.connection_test().await.unwrap();
         let fn_registry = steps_to_registry(&steps);
-        let workflow_exec = {
+        let (workflow_exec, _close_tx) = {
             let worker = Arc::new(WorkflowWorkerMock::new(
                 FFQN_MOCK,
                 fn_registry.clone(),

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -628,6 +628,8 @@ mod tests {
     use val_json::wast_val::WastVal;
     use wasmtime::Engine;
 
+    type ExecTaskAndClose = (ExecTask, tokio::sync::watch::Sender<bool>);
+
     const FIBO_10_OUTPUT: u64 = 55;
 
     fn drain_forwarded_log_messages(
@@ -1121,7 +1123,7 @@ mod tests {
         worker: WorkflowJsWorker,
         clock_fn: Box<dyn ClockFn>,
         db_pool: Arc<dyn DbPool>,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         new_js_workflow_exec_task_with_locking_strategy(
             worker,
             clock_fn,
@@ -1135,7 +1137,7 @@ mod tests {
         clock_fn: Box<dyn ClockFn>,
         db_pool: Arc<dyn DbPool>,
         locking_strategy: LockingStrategy,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
             worker,
             clock_fn,
@@ -1151,7 +1153,7 @@ mod tests {
         db_pool: Arc<dyn DbPool>,
         locking_strategy: LockingStrategy,
         executor_id: ExecutorId,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         let exec_config = ExecConfig {
             batch_size: 1,
             lock_expiry: Duration::from_secs(3),
@@ -1364,7 +1366,7 @@ mod tests {
             workflow_engine.clone(),
         );
 
-        let workflow_exec =
+        let (workflow_exec, _workflow_close_tx) =
             new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
 
         let execution_id = ExecutionId::generate();
@@ -1413,7 +1415,7 @@ mod tests {
 
         if activity_should_win {
             info!("Step 2: Run activity to complete the fibo(10) child execution");
-            let activity_exec = new_activity_fibo(
+            let (activity_exec, _activity_close_tx) = new_activity_fibo(
                 db_pool.clone(),
                 sim_clock.clone_box(),
                 TokioSleep,
@@ -1585,6 +1587,8 @@ mod tests {
     /// Helper for running JS workflow tests with reduced boilerplate.
     struct JsWorkflowTestHarness {
         workflow_exec: ExecTask,
+        #[expect(dead_code)]
+        workflow_close_tx: tokio::sync::watch::Sender<bool>,
         execution_id: ExecutionId,
         db_connection: Box<dyn DbConnectionTest>,
         sim_clock: SimClock,
@@ -1643,7 +1647,7 @@ mod tests {
                 workflow_engine,
             );
 
-            let workflow_exec =
+            let (workflow_exec, workflow_close_tx) =
                 new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
 
             let execution_id = ExecutionId::generate();
@@ -1670,6 +1674,7 @@ mod tests {
 
             Self {
                 workflow_exec,
+                workflow_close_tx,
                 execution_id,
                 db_connection,
                 sim_clock,
@@ -2342,27 +2347,30 @@ mod tests {
             second_upgrade_component_id.component_digest
         );
 
-        let original_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
-            original_worker,
-            sim_clock.clone_box(),
-            db_pool.clone(),
-            LockingStrategy::Auto,
-            ExecutorId::from_parts(0, 9004),
-        );
-        let first_upgrade_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
-            first_upgrade_worker,
-            sim_clock.clone_box(),
-            db_pool.clone(),
-            LockingStrategy::Auto,
-            ExecutorId::from_parts(0, 9005),
-        );
-        let second_upgrade_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
-            second_upgrade_worker,
-            sim_clock.clone_box(),
-            db_pool.clone(),
-            LockingStrategy::Auto,
-            ExecutorId::from_parts(0, 9006),
-        );
+        let (original_exec, _original_close_tx) =
+            new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+                original_worker,
+                sim_clock.clone_box(),
+                db_pool.clone(),
+                LockingStrategy::Auto,
+                ExecutorId::from_parts(0, 9004),
+            );
+        let (first_upgrade_exec, _first_upgrade_close_tx) =
+            new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+                first_upgrade_worker,
+                sim_clock.clone_box(),
+                db_pool.clone(),
+                LockingStrategy::Auto,
+                ExecutorId::from_parts(0, 9005),
+            );
+        let (second_upgrade_exec, _second_upgrade_close_tx) =
+            new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+                second_upgrade_worker,
+                sim_clock.clone_box(),
+                db_pool.clone(),
+                LockingStrategy::Auto,
+                ExecutorId::from_parts(0, 9006),
+            );
 
         let execution_id = ExecutionId::from_parts(0, 9004);
         let created_at = sim_clock.now();
@@ -2607,20 +2615,22 @@ mod tests {
             upgrade_component_id.component_digest
         );
 
-        let original_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
-            original_worker,
-            sim_clock.clone_box(),
-            db_pool.clone(),
-            LockingStrategy::Auto,
-            ExecutorId::from_parts(0, 9009),
-        );
-        let upgrade_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
-            upgrade_worker,
-            sim_clock.clone_box(),
-            db_pool.clone(),
-            LockingStrategy::Auto,
-            ExecutorId::from_parts(0, 9010),
-        );
+        let (original_exec, _original_close_tx) =
+            new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+                original_worker,
+                sim_clock.clone_box(),
+                db_pool.clone(),
+                LockingStrategy::Auto,
+                ExecutorId::from_parts(0, 9009),
+            );
+        let (upgrade_exec, _upgrade_close_tx) =
+            new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+                upgrade_worker,
+                sim_clock.clone_box(),
+                db_pool.clone(),
+                LockingStrategy::Auto,
+                ExecutorId::from_parts(0, 9010),
+            );
 
         let execution_id = ExecutionId::from_parts(0, 9010);
         let created_at = sim_clock.now();
@@ -2751,13 +2761,14 @@ mod tests {
             upgrade_component_id.component_digest
         );
 
-        let upgrade_exec = new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
-            upgrade_worker,
-            sim_clock.clone_box(),
-            db_pool.clone(),
-            LockingStrategy::Auto,
-            ExecutorId::from_parts(0, 9011),
-        );
+        let (upgrade_exec, _upgrade_close_tx) =
+            new_js_workflow_exec_task_with_locking_strategy_and_executor_id(
+                upgrade_worker,
+                sim_clock.clone_box(),
+                db_pool.clone(),
+                LockingStrategy::Auto,
+                ExecutorId::from_parts(0, 9011),
+            );
 
         let execution_id = ExecutionId::from_parts(0, 9011);
         let created_at = sim_clock.now();
@@ -2886,7 +2897,7 @@ mod tests {
             workflow_engine.clone(),
         );
 
-        let workflow_exec =
+        let (workflow_exec, _workflow_close_tx) =
             new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
 
         let execution_id = ExecutionId::generate();
@@ -3046,7 +3057,7 @@ mod tests {
             workflow_engine.clone(),
         );
 
-        let workflow_exec =
+        let (workflow_exec, _workflow_close_tx) =
             new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
 
         let execution_id = ExecutionId::from_parts(0, 0);
@@ -3570,7 +3581,7 @@ mod tests {
                 }
                 ReplayResponse::Blocked => match harness.idle_action {
                     Some(WorkflowJsAdvanceIdleAction::TickFiboActivity) => {
-                        let activity_exec = new_activity_fibo(
+                        let (activity_exec, _activity_close_tx) = new_activity_fibo(
                             harness.db_pool.clone(),
                             harness.sim_clock.clone_box(),
                             TokioSleep,

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1630,6 +1630,8 @@ pub(crate) mod tests {
         matchers::{method, path},
     };
 
+    type ExecTaskAndClose = (ExecTask, tokio::sync::watch::Sender<bool>);
+
     pub const FIBOA_WORKFLOW_FFQN: FunctionFqn = FunctionFqn::new_static_tuple(
         test_programs_fibo_workflow_builder::exports::testing::fibo_workflow::workflow::FIBOA,
     ); // fiboa: func(n: u8, iterations: u32) -> u64;
@@ -1782,7 +1784,7 @@ pub(crate) mod tests {
         fn_registry: &Arc<dyn FunctionRegistry>,
         cancel_registry: CancelRegistry,
         locking_strategy: LockingStrategy,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         let worker = compile_workflow_worker(
             wasm_path,
             db_pool.clone(),
@@ -1814,7 +1816,7 @@ pub(crate) mod tests {
         fn_registry: &Arc<dyn FunctionRegistry>,
         cancel_registry: CancelRegistry,
         locking_strategy: LockingStrategy,
-    ) -> ExecTask {
+    ) -> ExecTaskAndClose {
         new_workflow_exec_task(
             db_pool,
             test_programs_fibo_workflow_builder::TEST_PROGRAMS_FIBO_WORKFLOW,
@@ -1860,7 +1862,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             join_next_blocking_strategy,
@@ -1925,7 +1927,7 @@ pub(crate) mod tests {
 
         info!("Execution should call the activity and finish");
 
-        let activity_exec = new_activity_fibo(
+        let (activity_exec, _activity_close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,
@@ -1989,7 +1991,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             join_next_blocking_strategy,
@@ -2053,7 +2055,7 @@ pub(crate) mod tests {
 
         info!("Running activity to complete the child execution");
 
-        let activity_exec = new_activity_fibo(
+        let (activity_exec, _activity_close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,
@@ -2105,7 +2107,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
@@ -2173,7 +2175,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
@@ -2239,7 +2241,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
@@ -2283,7 +2285,7 @@ pub(crate) mod tests {
         // We need to run the activity executor to cancel/complete the activity.
 
         info!("Running activity executor to process the child activity");
-        let activity_exec = new_activity_fibo(
+        let (activity_exec, _activity_close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,
@@ -2327,7 +2329,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
@@ -2381,7 +2383,7 @@ pub(crate) mod tests {
         .unwrap();
 
         info!("Running activity that returns error (n > 40)");
-        let activity_exec = new_activity_fibo(
+        let (activity_exec, _activity_close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,
@@ -2425,7 +2427,7 @@ pub(crate) mod tests {
                 .await,
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
@@ -2590,7 +2592,7 @@ pub(crate) mod tests {
         let execution_id = ExecutionId::generate();
         let db_connection = db_pool.connection().await.unwrap();
         let sim_clock = SimClock::epoch();
-        let sleep_exec = {
+        let (sleep_exec, _sleep_close_tx) = {
             let fn_registry = TestingFnRegistry::new_from_components(vec![
                 compile_activity(
                     test_programs_sleep_activity_builder::TEST_PROGRAMS_SLEEP_ACTIVITY,
@@ -2723,7 +2725,7 @@ pub(crate) mod tests {
         let db_connection = db_pool.connection().await.unwrap();
 
         let executor_id = ExecutorId::generate();
-        let sleep_exec = {
+        let (sleep_exec, _sleep_close_tx) = {
             let cancel_registry = CancelRegistry::new();
             let worker = compile_workflow_worker(
                 test_programs_sleep_workflow_builder::TEST_PROGRAMS_SLEEP_WORKFLOW,
@@ -2887,7 +2889,7 @@ pub(crate) mod tests {
             compile_workflow(test_programs_serde_workflow_builder::TEST_PROGRAMS_SERDE_WORKFLOW)
                 .await,
         ]);
-        let activity_exec = new_activity(
+        let (activity_exec, _activity_close_tx) = new_activity(
             db_pool.clone(),
             test_programs_serde_activity_builder::TEST_PROGRAMS_SERDE_ACTIVITY,
             sim_clock.clone_box(),
@@ -2897,7 +2899,7 @@ pub(crate) mod tests {
         )
         .await;
 
-        let workflow_exec = new_workflow_exec_task(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_exec_task(
             db_pool.clone(),
             test_programs_serde_workflow_builder::TEST_PROGRAMS_SERDE_WORKFLOW,
             sim_clock.clone_box(),
@@ -2993,7 +2995,7 @@ pub(crate) mod tests {
             )
             .await,
         ]);
-        let activity_exec = new_activity_with_config(
+        let (activity_exec, _activity_close_tx) = new_activity_with_config(
             db_pool.clone(),
             test_programs_http_get_activity_builder::TEST_PROGRAMS_HTTP_GET_ACTIVITY,
             sim_clock.clone_box(),
@@ -3004,7 +3006,7 @@ pub(crate) mod tests {
         )
         .await;
 
-        let workflow_exec = new_workflow_exec_task(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_exec_task(
             db_pool.clone(),
             test_programs_http_get_workflow_builder::TEST_PROGRAMS_HTTP_GET_WORKFLOW,
             sim_clock.clone_box(),
@@ -3097,7 +3099,7 @@ pub(crate) mod tests {
             .await,
         ]);
 
-        let activity_exec = new_activity_with_config(
+        let (activity_exec, _activity_close_tx) = new_activity_with_config(
             db_pool.clone(),
             test_programs_http_get_activity_builder::TEST_PROGRAMS_HTTP_GET_ACTIVITY,
             sim_clock.clone_box(),
@@ -3107,7 +3109,7 @@ pub(crate) mod tests {
             LockingStrategy::ByComponentDigest,
         )
         .await;
-        let workflow_exec = new_workflow_exec_task(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_exec_task(
             db_pool.clone(),
             test_programs_http_get_workflow_builder::TEST_PROGRAMS_HTTP_GET_WORKFLOW,
             sim_clock.clone_box(),
@@ -3236,7 +3238,7 @@ pub(crate) mod tests {
             })
             .await
             .unwrap();
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             ExecConfig {
                 batch_size: 1,
                 lock_expiry: Duration::from_secs(1),
@@ -3321,7 +3323,7 @@ pub(crate) mod tests {
             )
             .await,
         ]);
-        let activity_exec = new_activity(
+        let (activity_exec, _activity_close_tx) = new_activity(
             db_pool.clone(),
             test_programs_http_get_activity_builder::TEST_PROGRAMS_HTTP_GET_ACTIVITY,
             sim_clock.clone_box(),
@@ -3331,7 +3333,7 @@ pub(crate) mod tests {
         )
         .await;
 
-        let workflow_exec = new_workflow_exec_task(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_exec_task(
             db_pool.clone(),
             test_programs_http_get_workflow_builder::TEST_PROGRAMS_HTTP_GET_WORKFLOW,
             sim_clock.clone_box(),
@@ -3451,7 +3453,7 @@ pub(crate) mod tests {
             .unwrap();
         let executor_id = ExecutorId::generate();
 
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             ExecConfig {
                 batch_size: 1,
                 lock_expiry: Duration::from_secs(1),
@@ -3666,7 +3668,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             ExecConfig {
                 batch_size: 1,
                 lock_expiry: Duration::from_secs(1),
@@ -3961,7 +3963,7 @@ pub(crate) mod tests {
                 .await
                 .unwrap();
 
-            let direct_exec_task = ExecTask::new_test(
+            let (direct_exec_task, _direct_close_tx) = ExecTask::new_test(
                 ExecConfig {
                     batch_size: 1,
                     lock_expiry: Duration::from_secs(1),
@@ -4124,7 +4126,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let exec_task = ExecTask::new_test(
+        let (exec_task, _close_tx) = ExecTask::new_test(
             ExecConfig {
                 batch_size: 1,
                 lock_expiry: Duration::from_secs(1),
@@ -4290,7 +4292,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let exec_workflow = ExecTask::new_test(
+        let (exec_workflow, _workflow_close_tx) = ExecTask::new_test(
             ExecConfig {
                 batch_size: 1,
                 lock_expiry: Duration::from_secs(1),
@@ -4346,7 +4348,7 @@ pub(crate) mod tests {
                 activity_component_id_first.component_digest,
                 activity_component_id.component_digest
             );
-            let exec_activity = ExecTask::new_all_ffqns_test(
+            let (exec_activity, _activity_close_tx) = ExecTask::new_all_ffqns_test(
                 activity_worker,
                 ExecConfig {
                     batch_size: 1,
@@ -4491,7 +4493,7 @@ pub(crate) mod tests {
             (workflow_runnable.clone(), workflow_component_id),
         ]);
         let cancel_registry = CancelRegistry::new();
-        let workflow_exec = new_workflow_fibo(
+        let (workflow_exec, _workflow_close_tx) = new_workflow_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
@@ -4567,7 +4569,7 @@ pub(crate) mod tests {
         }
         assert_matches!(next_events.last().unwrap(), HistoryEvent::JoinNext { .. });
 
-        let activity_exec = new_activity_fibo(
+        let (activity_exec, _activity_close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,
@@ -5057,7 +5059,7 @@ pub(crate) mod tests {
             min_level: concepts::storage::LogLevel::Debug,
             log_sender: log_sender.clone(),
         });
-        let activity_exec = new_activity_fibo(
+        let (activity_exec, _activity_close_tx) = new_activity_fibo(
             db_pool.clone(),
             sim_clock.clone_box(),
             TokioSleep,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -94,6 +94,7 @@ use directories::BaseDirs;
 use directories::ProjectDirs;
 use executor::AbortOnDropHandle;
 use executor::executor::ExecutorTaskHandle;
+use executor::executor::WorkerTasksHandle;
 use executor::executor::{ExecConfig, ExecTask};
 use executor::expired_timers_watcher;
 use executor::expired_timers_watcher::TimersWatcherConfig;
@@ -2306,13 +2307,14 @@ async fn switch_hot_redeploy(
     debug!("Closing old executors");
     let old = std::mem::take(&mut write_guard_ctx.exec_task_handles);
     let worker_tasks_handles =
-        futures_util::future::join_all(old.into_iter().map(|exec| exec.close_outer_task())).await;
+        futures_util::future::join_all(old.into_iter().map(ExecutorTaskHandle::close_outer_task))
+            .await;
 
     debug!("Waiting for workers");
     futures_util::future::join_all(
         worker_tasks_handles
             .into_iter()
-            .map(|handle| handle.close()),
+            .map(WorkerTasksHandle::close),
     )
     .await;
 
@@ -2574,14 +2576,16 @@ impl ServerInit {
             std::mem::take(&mut deployment_lock.exec_task_handles)
         };
         let worker_tasks_handles = futures_util::future::join_all(
-            executors.into_iter().map(|exec| exec.close_outer_task()),
+            executors
+                .into_iter()
+                .map(ExecutorTaskHandle::close_outer_task),
         )
         .await;
         debug!("Waiting for workers");
         futures_util::future::join_all(
             worker_tasks_handles
                 .into_iter()
-                .map(|handle| handle.close()),
+                .map(WorkerTasksHandle::close),
         )
         .await;
         // Explicit drop to avoid the pattern match footgun.

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2163,15 +2163,6 @@ pub(crate) enum SwitchDeploymentAction {
     HotRedeploy,
     VerifyAndStore,
 }
-impl SwitchDeploymentAction {
-    pub(crate) fn new(hot_redeploy: bool) -> SwitchDeploymentAction {
-        if hot_redeploy {
-            SwitchDeploymentAction::HotRedeploy
-        } else {
-            SwitchDeploymentAction::VerifyAndStore
-        }
-    }
-}
 
 #[expect(clippy::too_many_arguments)]
 #[instrument(skip_all, fields(%deployment_id))]
@@ -2311,14 +2302,21 @@ async fn switch_hot_redeploy(
             "server is being shut down"
         )));
     }
+
     debug!("Closing old executors");
     let old = std::mem::take(&mut write_guard_ctx.exec_task_handles);
+    let worker_tasks_handles =
+        futures_util::future::join_all(old.into_iter().map(|exec| exec.close_outer_task())).await;
+
+    debug!("Waiting for workers");
     futures_util::future::join_all(
-        old.iter()
-            .map(executor::executor::ExecutorTaskHandle::close),
+        worker_tasks_handles
+            .into_iter()
+            .map(|handle| handle.close()),
     )
     .await;
 
+    debug!("Swapping webhook registry");
     webhook_registry.swap(
         server_compiled_linked
             .http_servers_to_webhooks_and_state
@@ -2575,7 +2573,17 @@ impl ServerInit {
             deployment_lock.closed = true;
             std::mem::take(&mut deployment_lock.exec_task_handles)
         };
-        futures_util::future::join_all(executors.iter().map(ExecutorTaskHandle::close)).await;
+        let worker_tasks_handles = futures_util::future::join_all(
+            executors.into_iter().map(|exec| exec.close_outer_task()),
+        )
+        .await;
+        debug!("Waiting for workers");
+        futures_util::future::join_all(
+            worker_tasks_handles
+                .into_iter()
+                .map(|handle| handle.close()),
+        )
+        .await;
         // Explicit drop to avoid the pattern match footgun.
         // Close everything that is a dependency of executors or workers.
         drop(db_pool);
@@ -2587,6 +2595,7 @@ impl ServerInit {
         drop(webhook_registry);
         drop(log_forwarder_sender);
         drop(log_db_forarder); // Some activity messages might not be stored.
+        debug!("Closing db");
         db_close.await;
     }
 }

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1674,20 +1674,42 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             .try_into()?;
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         let mut termination_watcher = self.termination_watcher.clone();
-        let outcome = Box::pin(server::switch_deployment(
-            self.server_verified.clone(),
-            deployment_id,
-            SwitchDeploymentAction::new(request.hot_redeploy),
-            runtime_config_check,
-            &self.prepared_dirs,
-            self.db_pool.clone(),
-            &mut termination_watcher,
-            &self.deployment_ctx,
-            &self.webhook_registry,
-            self.cancel_registry.clone(),
-            self.log_forwarder_sender.clone(),
-        ))
+        let action = if request.hot_redeploy {
+            SwitchDeploymentAction::HotRedeploy
+        } else {
+            SwitchDeploymentAction::VerifyAndStore
+        };
+        let outcome = tokio::spawn({
+            let server_verified = self.server_verified.clone();
+            let db_pool = self.db_pool.clone();
+            let prepared_dirs = self.prepared_dirs.clone();
+            let deployment_ctx = self.deployment_ctx.clone();
+            let webhook_registry = self.webhook_registry.clone();
+            let cancel_registry = self.cancel_registry.clone();
+            let log_forwarder_sender = self.log_forwarder_sender.clone();
+            async move {
+                // Cancel safety
+                server::switch_deployment(
+                    server_verified,
+                    deployment_id,
+                    action,
+                    runtime_config_check,
+                    &prepared_dirs,
+                    db_pool,
+                    &mut termination_watcher,
+                    &deployment_ctx,
+                    &webhook_registry,
+                    cancel_registry,
+                    log_forwarder_sender,
+                )
+                .await
+            }
+        })
         .await
+        .map_err(|join_err| {
+            error!("Panic in switch_deployment: {join_err:?}");
+            tonic::Status::internal("internal error")
+        })?
         .map_err(|err| match err {
             server::SwitchError::NotFound => tonic::Status::not_found("deployment not found"),
             server::SwitchError::Other(e) => tonic::Status::failed_precondition(format!("{e:#}")),

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3055,7 +3055,7 @@ mod deployment {
     use serde::{Deserialize, Serialize};
     use std::fmt::Write as _;
     use std::sync::Arc;
-    use tracing::{info, instrument};
+    use tracing::{error, info, instrument};
     use utoipa::{IntoParams, ToSchema};
 
     #[derive(Debug, Serialize, ToSchema)]
@@ -3714,20 +3714,37 @@ mod deployment {
     ) -> Result<Response, HttpResponse> {
         let mut termination_watcher = state.termination_watcher.clone();
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
-        let outcome = Box::pin(crate::command::server::switch_deployment(
-            state.server_verified.clone(),
-            deployment_id,
-            SwitchDeploymentAction::new(payload.hot_redeploy),
-            runtime_config_check_from_bool(payload.allow_missing_runtime_config),
-            &state.prepared_dirs,
-            state.db_pool.clone(),
-            &mut termination_watcher,
-            &state.deployment_ctx,
-            &state.webhook_registry,
-            state.cancel_registry.clone(),
-            state.log_forwarder_sender.clone(),
-        ))
+        let action = if payload.hot_redeploy {
+            SwitchDeploymentAction::HotRedeploy
+        } else {
+            SwitchDeploymentAction::VerifyAndStore
+        };
+        let outcome = tokio::spawn(async move {
+            // Cancel safety
+            crate::command::server::switch_deployment(
+                state.server_verified.clone(),
+                deployment_id,
+                action,
+                runtime_config_check_from_bool(payload.allow_missing_runtime_config),
+                &state.prepared_dirs,
+                state.db_pool.clone(),
+                &mut termination_watcher,
+                &state.deployment_ctx,
+                &state.webhook_registry,
+                state.cancel_registry.clone(),
+                state.log_forwarder_sender.clone(),
+            )
+            .await
+        })
         .await
+        .map_err(|join_err| {
+            error!("Panic in switch_deployment: {join_err:?}");
+            HttpResponse {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                message: "internal error".to_string(),
+                accept,
+            }
+        })?
         .map_err(|err| match err {
             crate::command::server::SwitchError::NotFound => {
                 HttpResponse::not_found(accept, Some("deployment"))


### PR DESCRIPTION
- **doc: Remove long running activity extension from the roadmap**
- **fix(activity-wasm): Move executor shutdown signal to the main `select!`**
- **fix(api): Make `switch_deployment` cancel safe**
- **refactor(webhook): Simplify epoch handling**
- **doc: Update comment for `deadline_tracker.track`**
- **test: Fix tests failing on closed `executor_close_watcher` by leaking the `tx`**
- **test: Do not leak `executor_close_tx`**
