### PR TITLE
Clean up cancel registry and others

### DIFF
--- a/assets/schemas/db.json
+++ b/assets/schemas/db.json
@@ -402,7 +402,7 @@
       "type": "object",
       "properties": {
         "backoff_expires_at": {
-          "description": "Instant used when releasing a currently locked execution back to\n[`PendingState::PendingAt`]. This field keeps the released JSON and gRPC name.",
+          "description": "Instant used when releasing a currently locked execution back to [`PendingState::PendingAt`].",
           "type": "string",
           "format": "date-time"
         },

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -439,11 +439,11 @@ pub enum ComponentUpgradeReason {
     Clone, Debug, PartialEq, Eq, derive_more::Display, Serialize, Deserialize, schemars::JsonSchema,
 )]
 #[cfg_attr(any(test, feature = "test"), derive(arbitrary::Arbitrary))]
-#[display("{reason}, pending at {backoff_expires_at}")]
+#[display("{reason}, pending at {unlocked_at}")]
 pub struct Unlocked {
-    /// Instant used when releasing a currently locked execution back to
-    /// [`PendingState::PendingAt`]. This field keeps the released JSON and gRPC name.
-    pub backoff_expires_at: DateTime<Utc>,
+    /// Instant used when releasing a currently locked execution back to [`PendingState::PendingAt`].
+    #[serde(rename = "backoff_expires_at")] // backcompat
+    pub unlocked_at: DateTime<Utc>,
     #[cfg_attr(any(test, feature = "test"), arbitrary(value = StrVariant::Static("reason")))]
     pub reason: StrVariant,
 }

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2280,7 +2280,7 @@ async fn append(
                         tx,
                         execution_id,
                         combined_state.execution_with_state.component_digest,
-                        unlocked.backoff_expires_at,
+                        unlocked.unlocked_at,
                         &appending_version,
                     )
                     .await?;
@@ -5070,7 +5070,7 @@ impl DbExternalApi for PostgresConnection {
                 AppendRequest {
                     created_at: paused_at,
                     event: ExecutionRequest::Unlocked(Unlocked {
-                        backoff_expires_at: paused_at,
+                        unlocked_at: paused_at,
                         reason: "paused".into(),
                     }),
                 },

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2194,7 +2194,7 @@ impl SqlitePool {
                                 execution_id,
                                 &appending_version,
                                 PendingAfterEventUpdate {
-                                    scheduled_at: unlocked.backoff_expires_at,
+                                    scheduled_at: unlocked.unlocked_at,
                                     intermittent_failure: false,
                                     component_input_digest: combined_state
                                         .execution_with_state
@@ -3799,7 +3799,7 @@ impl SqlitePool {
                 AppendRequest {
                     created_at: paused_at,
                     event: ExecutionRequest::Unlocked(Unlocked {
-                        backoff_expires_at: paused_at, // does not matter, about to append `Paused` in same tx.
+                        unlocked_at: paused_at, // does not matter, about to append `Paused` in same tx.
                         reason: "paused".into(),
                     }),
                 },

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -712,7 +712,7 @@ impl ExecTask {
                 let (primary_event, child_finished, version) = match err {
                     WorkerError::ExecutorClosing(version) => {
                         let primary_event = ExecutionRequest::Unlocked(Unlocked {
-                            backoff_expires_at: result_obtained_at,
+                            unlocked_at: result_obtained_at,
                             reason: "executor closing".into(),
                         });
                         (primary_event, None, version)
@@ -825,7 +825,7 @@ impl ExecTask {
                         );
                         (
                             ExecutionRequest::Unlocked(Unlocked {
-                                backoff_expires_at: expires_at,
+                                unlocked_at: expires_at,
                                 reason: StrVariant::from(reason),
                             }),
                             None,

--- a/crates/executor/src/expired_timers_watcher.rs
+++ b/crates/executor/src/expired_timers_watcher.rs
@@ -110,7 +110,7 @@ pub(crate) async fn tick(
                         primary_event: AppendRequest {
                             created_at: executed_at,
                             event: ExecutionRequest::Unlocked(Unlocked {
-                                backoff_expires_at: executed_at,
+                                unlocked_at: executed_at,
                                 reason: "made progress".into(),
                             }),
                         },

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -964,7 +964,7 @@ pub fn from_execution_event_to_grpc(event: ExecutionEvent) -> grpc_gen::Executio
                 grpc_gen::execution_event::Unlocked {
                     reason: unlocked.reason.to_string(),
                     backoff_expires_at: Some(prost_wkt_types::Timestamp::from(
-                        unlocked.backoff_expires_at,
+                        unlocked.unlocked_at,
                     )),
                 },
             ),
@@ -1128,7 +1128,7 @@ impl TryFrom<grpc_gen::ExecutionEvent> for ExecutionEvent {
             }),
             grpc_gen::execution_event::Event::Unlocked(unlocked) => {
                 ExecutionRequest::Unlocked(Unlocked {
-                    backoff_expires_at: unlocked
+                    unlocked_at: unlocked
                         .backoff_expires_at
                         .argument_must_exist("backoff_expires_at")?
                         .into(),

--- a/crates/testing/db-tests/tests/diff-tests.rs
+++ b/crates/testing/db-tests/tests/diff-tests.rs
@@ -180,7 +180,7 @@ fn normalize_timestamps(
             locked.lock_expires_at = arbitrary_valid_datetime(unstructured)?;
         }
         ExecutionRequest::Unlocked(unlocked) => {
-            unlocked.backoff_expires_at = arbitrary_valid_datetime(unstructured)?;
+            unlocked.unlocked_at = arbitrary_valid_datetime(unstructured)?;
         }
         ExecutionRequest::TemporarilyFailed {
             backoff_expires_at,

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -346,13 +346,13 @@ async fn locking_in_unlock_backoff_should_not_be_possible(
 
     // The Executor / Worker responds with a Unlock
     let backoff = Duration::from_millis(500);
-    let backoff_expires_at = sim_clock.now() + backoff;
+    let unlocked_at = sim_clock.now() + backoff;
     let _version = {
         let created_at = sim_clock.now();
         info!(now = %created_at, "unlock");
         let req = AppendRequest {
             event: ExecutionRequest::Unlocked(Unlocked {
-                backoff_expires_at,
+                unlocked_at,
                 reason: StrVariant::Static("reason"),
             }),
             created_at,
@@ -389,7 +389,7 @@ async fn locking_in_unlock_backoff_should_not_be_possible(
         assert!(locked_executions.is_empty());
     }
 
-    sim_clock.move_time_to(backoff_expires_at);
+    sim_clock.move_time_to(unlocked_at);
     {
         let created_at = sim_clock.now();
         info!(now = %created_at, "Locking exactly at `backoff_expires_at` should succeed");
@@ -1839,7 +1839,7 @@ async fn cannot_append_unlocked_to_blocked_execution(database: Database) {
             AppendRequest {
                 created_at: sim_clock.now(),
                 event: ExecutionRequest::Unlocked(Unlocked {
-                    backoff_expires_at: sim_clock.now(),
+                    unlocked_at: sim_clock.now(),
                     reason: "should fail".into(),
                 }),
             },
@@ -1901,7 +1901,7 @@ async fn cannot_append_unlocked_to_paused_execution(database: Database) {
             AppendRequest {
                 created_at: sim_clock.now(),
                 event: ExecutionRequest::Unlocked(Unlocked {
-                    backoff_expires_at: sim_clock.now(),
+                    unlocked_at: sim_clock.now(),
                     reason: "should fail".into(),
                 }),
             },
@@ -2396,8 +2396,8 @@ async fn pause_and_unpause_locked_execution_should_return_to_pending_at(
     assert_eq!(Some(found_locked_by.clone()), paused_pending_at.1);
     let reason = assert_matches!(
         &log.events[2].event,
-        ExecutionRequest::Unlocked(Unlocked { backoff_expires_at, reason }) => {
-            assert_eq!(&paused_at, backoff_expires_at);
+        ExecutionRequest::Unlocked(Unlocked { unlocked_at, reason }) => {
+            assert_eq!(&paused_at, unlocked_at);
             reason
         }
     );
@@ -2623,7 +2623,7 @@ async fn pause_then_join_next_then_unpause_should_restore_blocked_by_join_set(da
             AppendRequest {
                 created_at,
                 event: ExecutionRequest::Unlocked(Unlocked {
-                    backoff_expires_at: created_at,
+                    unlocked_at: created_at,
                     reason: "paused".into(),
                 }),
             },

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -359,7 +359,7 @@ impl Worker for ActivityExecWorker {
         // Register cancellation token.
         let cancel_token = self
             .cancel_registry
-            .obtain_interrupt_token(ctx.execution_id.clone());
+            .activity_obtain_interrupt_token(ctx.execution_id.clone());
 
         // Skip stdout collection when return_type is `result` (unit ok and err variants).
         let max_stdout_bytes = if self.user_return_type.type_wrapper_tl.is_result_of_units() {

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -192,7 +192,7 @@ impl Worker for ActivityWorker {
 
         let interrupt_token = self
             .cancel_registry
-            .obtain_interrupt_token(ctx.execution_id.clone());
+            .activity_obtain_interrupt_token(ctx.execution_id.clone());
         let mut executor_close_watcher = ctx.executor_close_watcher.clone();
 
         let (mut store, deadline_duration) = match self.create_store(ctx, started_at) {

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -310,7 +310,15 @@ impl ActivityWorker {
         }
 
         // Configure epoch callback to yield to tokio periodically.
-        store.epoch_deadline_async_yield_and_update(1);
+        // Unlike `epoch_deadline_async_yield_and_update` (which yields via wasmtime's
+        // runtime-agnostic yield), `tokio::task::yield_now()` cooperates with tokio's
+        // task budget so the fiber yields fairly to other tokio tasks on the worker.
+        store.epoch_deadline_callback(|_store_ctx| {
+            Ok(wasmtime::UpdateDeadline::YieldCustom(
+                1,
+                Box::pin(tokio::task::yield_now()),
+            ))
+        });
 
         let deadline_delta = lock_expires_at - started_at;
         let Ok(deadline_duration) = deadline_delta.to_std() else {

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -61,7 +61,7 @@ impl CancelRegistry {
         guard.retain(|_exe, info| !info.interrupt_sender.is_closed());
     }
 
-    pub(crate) fn obtain_interrupt_token(
+    pub(crate) fn activity_obtain_interrupt_token(
         &self,
         execution_id: ExecutionId,
     ) -> oneshot::Receiver<()> {
@@ -73,6 +73,7 @@ impl CancelRegistry {
 
     /// Best-effort local interrupt for an activity currently running in this process.
     /// Unlike `cancel_activity`, this does not write terminal cancellation state to the DB.
+    /// Noop if the execution is not an activity tracked by this registry.
     pub fn interrupt_running_activity(&self, execution_id: &ExecutionId) {
         let info = {
             let mut guard = self.tokens.lock().unwrap();

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use concepts::{
     prefixed_ulid::ExecutionId,
-    storage::{CancelOutcome, DbConnection, DbErrorGeneric, DbErrorWrite, DbPool},
+    storage::{CancelOutcome, DbConnection, DbErrorWrite},
 };
 use executor::AbortOnDropHandle;
 use std::{
@@ -9,16 +9,14 @@ use std::{
     time::Duration,
 };
 use tokio::sync::oneshot;
-use tracing::{Instrument, debug, info, info_span, warn};
-
-pub const CANCEL_RETRIES: u8 = 5;
+use tracing::{Instrument, debug, info, info_span};
 
 #[derive(Clone)]
 /// All currently running activities in this process.
-/// Activity worker tasks register themselves and listen on cancellation token.
-/// RPCs and workflow worker can trigger `cancel_activity`
+/// Activity worker tasks register themselves and listen on interruption token.
+/// Cancel RPCs and workflow workers call `cancel_activity`
 /// which writes the new state to db (no matter whether registered or not)
-/// and triggers the cancellation token.
+/// and triggers the interruption token.
 pub struct CancelRegistry {
     tokens: Arc<Mutex<hashbrown::HashMap<ExecutionId, ActivityInfo>>>,
 }
@@ -41,27 +39,14 @@ impl CancelRegistry {
         }
     }
 
-    pub fn spawn_cancel_watcher(
-        &self,
-        db_pool: Arc<dyn DbPool>,
-        sleep_duration: Duration,
-    ) -> AbortOnDropHandle {
+    pub fn spawn_cancel_watcher(&self, sleep_duration: Duration) -> AbortOnDropHandle {
         let clone = self.clone();
         AbortOnDropHandle::new(
             tokio::spawn({
                 async move {
                     debug!("Spawned the cancel watcher");
-                    let mut old_err = None;
                     loop {
-                        let res = db_pool.connection().await;
-                        let res = match res {
-                            Ok(conn) => {
-                                clone.tick(conn.as_ref()).await;
-                                Ok(())
-                            }
-                            Err(err) => Err(err),
-                        };
-                        log_err_if_new(res, &mut old_err);
+                        clone.tick();
                         tokio::time::sleep(sleep_duration).await;
                     }
                 }
@@ -71,28 +56,9 @@ impl CancelRegistry {
         )
     }
 
-    async fn tick(&self, db_connection: &dyn DbConnection) {
-        let execution_ids: Vec<_> = {
-            let guard = self.tokens.lock().unwrap();
-            guard.keys().cloned().collect()
-        };
-        let mut finished = Vec::new();
-        for execution_id in execution_ids {
-            if let Ok(execution_with_state) = db_connection.get_pending_state(&execution_id).await
-                && execution_with_state.pending_state.is_finished()
-            {
-                finished.push(execution_id);
-            }
-        }
-        if !finished.is_empty() {
-            let mut guard = self.tokens.lock().unwrap();
-            // Cleanup old entries.
-            for execution_id in finished {
-                if let Some(info) = guard.remove(&execution_id) {
-                    let _ = info.interrupt_sender.send(());
-                }
-            }
-        }
+    fn tick(&self) {
+        let mut guard = self.tokens.lock().unwrap();
+        guard.retain(|_exe, info| !info.interrupt_sender.is_closed());
     }
 
     pub(crate) fn obtain_interrupt_token(
@@ -133,18 +99,5 @@ impl CancelRegistry {
             self.interrupt_running_activity(execution_id);
         }
         Ok(outcome)
-    }
-}
-
-fn log_err_if_new(res: Result<(), DbErrorGeneric>, old_err: &mut Option<DbErrorGeneric>) {
-    match (res, &old_err) {
-        (Ok(()), _) => {
-            *old_err = None;
-        }
-        (Err(err), Some(old)) if err == *old => {}
-        (Err(err), _) => {
-            warn!("Tick failed: {err:?}");
-            *old_err = Some(err);
-        }
     }
 }

--- a/crates/wasm-workers/src/cron/cron_worker.rs
+++ b/crates/wasm-workers/src/cron/cron_worker.rs
@@ -140,7 +140,7 @@ impl Worker for CronWorker {
                 AppendRequest {
                     created_at: now,
                     event: ExecutionRequest::Unlocked(Unlocked {
-                        backoff_expires_at: next_fire,
+                        unlocked_at: next_fire,
                         reason: "cron".into(),
                     }),
                 }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -1705,8 +1705,16 @@ impl WebhookEndpointCtx {
                 .expect("engine must have `consume_fuel` enabled");
         }
 
-        // Yield to tokio periodically
-        store.epoch_deadline_async_yield_and_update(1);
+        // Yield to tokio periodically. `tokio::task::yield_now()` cooperates with
+        // tokio's task budget (unlike `epoch_deadline_async_yield_and_update`, which
+        // yields via wasmtime's runtime-agnostic yield), so the fiber yields fairly
+        // to other tokio tasks on the worker.
+        store.epoch_deadline_callback(|_store_ctx| {
+            Ok(wasmtime::UpdateDeadline::YieldCustom(
+                1,
+                Box::pin(tokio::task::yield_now()),
+            ))
+        });
         store
     }
 

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -398,7 +398,7 @@ fn normalize_execution_request_for_matching(req: ExecutionRequest) -> ExecutionR
             ExecutionRequest::Locked(locked)
         }
         ExecutionRequest::Unlocked(mut unlocked) => {
-            unlocked.backoff_expires_at = DateTime::UNIX_EPOCH;
+            unlocked.unlocked_at = DateTime::UNIX_EPOCH;
             ExecutionRequest::Unlocked(unlocked)
         }
         ExecutionRequest::ComponentUpgradeFinished {

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -660,6 +660,10 @@ impl WorkflowWorker {
         store.epoch_deadline_callback(|store_ctx| {
             let ctx = store_ctx.data();
             match ctx.check_epoch_callback() {
+                // `UpdateDeadline::Yield` performs wasmtime's runtime-agnostic yield
+                // (wake self, return `Pending` once), which does not cooperate with
+                // tokio's cooperative task budget. `tokio::task::yield_now()` does, so
+                // the fiber yields fairly to other tokio tasks on the same worker.
                 Ok(()) => Ok(wasmtime::UpdateDeadline::YieldCustom(
                     1,
                     Box::pin(tokio::task::yield_now()),

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1334,7 +1334,7 @@ impl WorkflowWorker {
                         AppendRequest {
                             created_at,
                             event: ExecutionRequest::Unlocked(Unlocked {
-                                backoff_expires_at: created_at,
+                                unlocked_at: created_at,
                                 reason: "auto-upgrade failed".into(),
                             }),
                         },
@@ -1368,7 +1368,7 @@ impl WorkflowWorker {
                         AppendRequest {
                             created_at,
                             event: ExecutionRequest::Unlocked(Unlocked {
-                                backoff_expires_at: created_at,
+                                unlocked_at: created_at,
                                 reason: "auto-upgrade failed".into(),
                             }),
                         },
@@ -1428,7 +1428,7 @@ impl WorkflowWorker {
                         AppendRequest {
                             created_at,
                             event: ExecutionRequest::Unlocked(Unlocked {
-                                backoff_expires_at: created_at,
+                                unlocked_at: created_at,
                                 reason: "auto-upgrade succeeded".into(),
                             }),
                         },

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2142,9 +2142,8 @@ env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
         })
         .await
         .expect_err("hot redeploy must reject allow-missing-runtime-config");
-    assert!(
-        status.message().contains("allow-missing-runtime-config"),
-        "error must explain the rejection, got: {}",
+    assert_eq!(
+        "argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_MISSING` cannot be used with `hot_redeploy = true`",
         status.message()
     );
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2449,8 +2449,7 @@ async fn spawn_tasks_and_threads(
         None
     };
 
-    let cancel_watcher =
-        cancel_registry.spawn_cancel_watcher(db_pool.clone(), cancel_watcher.tick_sleep.into());
+    let cancel_watcher = cancel_registry.spawn_cancel_watcher(cancel_watcher.tick_sleep.into());
 
     server_compiled_linked
         .create_missing_cron_seeds(&db_pool, deployment_id)

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -6,6 +6,7 @@ use crate::config::config_holder::PathPrefixes;
 use crate::config::config_holder::load_deployment_canonical;
 use crate::config::content_digest_to_wasm_file;
 use crate::config::env_var::EnvVarConfig;
+use crate::config::file_provider::CasFileProvider;
 use crate::config::toml::ActivityExecComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityExecConfigVerified;
 use crate::config::toml::ActivityExternalComponentConfigResolved;
@@ -827,7 +828,7 @@ async fn get_deployment_canonical_from_db(
         .as_ref()
         .map(|(pool, _)| pool.clone())
         .expect("db pool was set above");
-    let deployment = canonical_from_manifest(pool.as_ref(), &record.deployment_toml)
+    let deployment = deployment_resolved_from_manifest(pool.as_ref(), &record.deployment_toml)
         .await
         .with_context(|| {
             format!(
@@ -906,48 +907,50 @@ impl crate::config::file_provider::FileProvider for RecordingCasProvider {
     }
 }
 
-/// Canonicalize a stored verbatim manifest by reading its referenced blobs from the CAS,
+/// Resolve a stored verbatim TOML manifest by reading its referenced blobs from the CAS,
 /// returning the canonical form and the `(path, digest)` of every file it referenced.
 ///
 /// `${...}` env vars and secrets resolve here, in the server's environment.
-async fn canonical_and_files_from_manifest(
+async fn deployment_resolved_and_files_from_manifest(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_toml: &str,
 ) -> anyhow::Result<(
     DeploymentResolved,
     Vec<concepts::storage::DeploymentFileRecord>,
 )> {
-    let cas: std::sync::Arc<dyn concepts::cas::Cas> = db_pool
+    let cas: Arc<dyn concepts::cas::Cas> = db_pool
         .cas_conn()
         .await
         .context("cannot get CAS connection for deployment canonicalization")?
         .into();
     let provider = RecordingCasProvider {
-        inner: crate::config::file_provider::CasFileProvider { cas },
+        inner: CasFileProvider { cas },
         seen: std::sync::Mutex::new(Vec::new()),
     };
-    let canonical = crate::config::manifest::manifest_to_canonical(
+    let resolved = crate::config::manifest::manifest_to_resolved(
         deployment_toml,
         &cas_deployment_dir(),
         &provider,
     )
     .await
-    .context("cannot canonicalize deployment manifest from the content-addressed store")?;
+    .context("cannot resolve deployment manifest from the content-addressed store")?;
     let files = provider
         .seen
         .into_inner()
         .expect("RecordingCasProvider mutex poisoned");
-    Ok((canonical, files))
+    Ok((resolved, files))
 }
 
-/// Canonicalize a stored verbatim manifest by reading its referenced blobs from the CAS.
-async fn canonical_from_manifest(
+/// Resolve a stored verbatim manifest by reading its referenced blobs from the CAS.
+async fn deployment_resolved_from_manifest(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_toml: &str,
 ) -> anyhow::Result<DeploymentResolved> {
-    Ok(canonical_and_files_from_manifest(db_pool, deployment_toml)
-        .await?
-        .0)
+    Ok(
+        deployment_resolved_and_files_from_manifest(db_pool, deployment_toml)
+            .await?
+            .0,
+    )
 }
 
 /// A [`DeploymentResolved`] whose every WASM component location is a concrete, runnable
@@ -1251,7 +1254,8 @@ pub(crate) async fn run_internal(
                     .await
                     .context("cannot activate enqueued deployment")?;
             }
-            let canonical = canonical_from_manifest(&*db_pool, &record.deployment_toml).await?;
+            let canonical =
+                deployment_resolved_from_manifest(&*db_pool, &record.deployment_toml).await?;
             span.record(
                 "deployment_id",
                 tracing::field::display(&record.deployment_id),
@@ -2050,7 +2054,7 @@ pub(crate) async fn submit_deployment(
     // parse JS, validate WIT/WASM, and compile + link every component. Activation no
     // longer performs first-time package validation. Blobs already written to the CAS
     // when verification fails are acceptable GC input; no deployment row is inserted.
-    let canonical = canonical_from_manifest(&*db_pool, deployment_toml)
+    let deployment_resolved = deployment_resolved_from_manifest(&*db_pool, deployment_toml)
         .await
         .map_err(SubmitDeploymentError::Other)?;
     let cas_arc: Arc<dyn concepts::cas::Cas> = db_pool
@@ -2062,7 +2066,7 @@ pub(crate) async fn submit_deployment(
     let compiled_linked = deployment_verify_config_compile_link(
         server_verified,
         prepared_dirs,
-        canonical,
+        deployment_resolved,
         Some(cas_arc),
         deployment_id,
         VerifyParams {
@@ -2142,7 +2146,6 @@ impl From<anyhow::Error> for SwitchError {
 
 /// Policy for runtime configuration (environment variables and secrets) that a
 /// deployment references but that may be absent from the server's environment.
-/// Structural, file, compile, and link validation always runs regardless.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum RuntimeConfigCheck {
     /// Missing environment variables or secrets fail the operation.
@@ -2153,16 +2156,23 @@ pub(crate) enum RuntimeConfigCheck {
 }
 
 impl RuntimeConfigCheck {
-    /// Whether verification should tolerate missing env vars / secrets.
-    pub(crate) fn ignore_missing_env_vars(self) -> bool {
-        matches!(self, RuntimeConfigCheck::AllowMissing)
+    fn ignore_missing_env_vars(self) -> bool {
+        self == RuntimeConfigCheck::AllowMissing
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SwitchDeploymentAction {
     HotRedeploy,
-    VerifyAndStore,
+    VerifyAndStore(RuntimeConfigCheck),
+}
+impl SwitchDeploymentAction {
+    fn ignore_missing_env_vars(self) -> bool {
+        match self {
+            SwitchDeploymentAction::VerifyAndStore(check) => check.ignore_missing_env_vars(),
+            SwitchDeploymentAction::HotRedeploy => false,
+        }
+    }
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -2171,7 +2181,6 @@ pub(crate) async fn switch_deployment(
     server_verified: ServerVerified,
     deployment_id: DeploymentId,
     action: SwitchDeploymentAction,
-    runtime_config_check: RuntimeConfigCheck,
     prepared_dirs: &PreparedDirs,
     db_pool: Arc<dyn DbPool>,
     termination_watcher: &mut watch::Receiver<()>,
@@ -2180,18 +2189,6 @@ pub(crate) async fn switch_deployment(
     cancel_registry: CancelRegistry,
     log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
 ) -> Result<SwitchOutcome, SwitchError> {
-    // A hot redeploy makes the deployment immediately live, so its runtime config must be
-    // fully available; tolerating missing env vars / secrets here would yield broken
-    // running components.
-    if action == SwitchDeploymentAction::HotRedeploy
-        && runtime_config_check == RuntimeConfigCheck::AllowMissing
-    {
-        return Err(SwitchError::Other(anyhow::anyhow!(
-            "a hot redeploy requires all runtime configuration to be available; \
-             `allow-missing-runtime-config` is not permitted"
-        )));
-    }
-
     let db_conn = db_pool
         .external_api_conn()
         .await
@@ -2219,9 +2216,10 @@ pub(crate) async fn switch_deployment(
         )));
     }
 
-    let target_deployment = canonical_from_manifest(&*db_pool, &deployment_record.deployment_toml)
-        .await
-        .map_err(SwitchError::Other)?;
+    let target_deployment =
+        deployment_resolved_from_manifest(&*db_pool, &deployment_record.deployment_toml)
+            .await
+            .map_err(SwitchError::Other)?;
 
     let cas: Arc<dyn concepts::cas::Cas> = db_pool
         .cas_conn()
@@ -2234,7 +2232,7 @@ pub(crate) async fn switch_deployment(
             clean_cache: false,
             clean_codegen_cache: false,
         },
-        ignore_missing_env_vars: runtime_config_check.ignore_missing_env_vars(),
+        ignore_missing_env_vars: action.ignore_missing_env_vars(),
         suppress_type_checking_errors: false,
         suppress_linking_errors: false,
     };

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -7,6 +7,8 @@ use crate::config::config_holder::load_deployment_canonical;
 use crate::config::content_digest_to_wasm_file;
 use crate::config::env_var::EnvVarConfig;
 use crate::config::file_provider::CasFileProvider;
+use crate::config::manifest::DeploymentManifest;
+use crate::config::manifest::DeploymentManifestFile;
 use crate::config::toml::ActivityExecComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityExecConfigVerified;
 use crate::config::toml::ActivityExternalComponentConfigResolved;
@@ -847,7 +849,7 @@ async fn get_deployment_canonical_from_db(
 pub(crate) struct LocalDeployment {
     deployment_toml: String,
     canonical: DeploymentResolved,
-    files: Vec<crate::config::manifest::DeploymentManifestFile>,
+    files: Vec<DeploymentManifestFile>,
 }
 
 impl LocalDeployment {
@@ -1080,7 +1082,7 @@ async fn insert_and_activate_deployment(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_id: DeploymentId,
     deployment_toml: String,
-    files: Vec<crate::config::manifest::DeploymentManifestFile>,
+    files: Vec<DeploymentManifestFile>,
     description: Option<String>,
 ) -> anyhow::Result<()> {
     use chrono::Utc;
@@ -1887,8 +1889,8 @@ fn validate_submit_package(
     supplied: Vec<SuppliedFile>,
     cas_present: &hashbrown::HashSet<ContentDigest>,
     max_bytes: usize,
-) -> Result<Vec<crate::config::manifest::DeploymentManifestFile>, SubmitPackageError> {
-    use crate::config::manifest::DeploymentManifestFile;
+) -> Result<Vec<DeploymentManifestFile>, SubmitPackageError> {
+    use DeploymentManifestFile;
 
     let mut err = SubmitPackageError::default();
     // `expected` is already deduplicated by digest in `DeploymentManifest`.
@@ -2007,11 +2009,8 @@ pub(crate) async fn submit_deployment(
         )));
     }
 
-    let manifest = crate::config::manifest::DeploymentManifest::try_from_toml(
-        deployment_toml,
-        &cas_deployment_dir(),
-    )
-    .context("cannot read deployment file references from manifest")?;
+    let manifest = DeploymentManifest::try_from_toml(deployment_toml, &cas_deployment_dir())
+        .context("cannot read deployment file references from manifest")?;
 
     // A referenced digest already in the CAS need not be attached to the request.
     let cas = db_pool.cas_conn().await.map_err(anyhow::Error::from)?;

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2154,7 +2154,6 @@ pub(crate) enum RuntimeConfigCheck {
     /// Missing environment variables or secrets are tolerated.
     AllowMissing,
 }
-
 impl RuntimeConfigCheck {
     fn ignore_missing_env_vars(self) -> bool {
         self == RuntimeConfigCheck::AllowMissing
@@ -3224,7 +3223,7 @@ async fn compile_and_link(
     });
     let parent_span = Span::current();
 
-    // TODO: other components are not compiled in parallel.
+    // JS runtimes are compiled in parallel, then all other WASM components.
     let activity_js_runnable = if let Some(first_activity_js) = activities_js.first() {
         let engine = engines.activity_engine.clone();
         let build_semaphore = build_semaphore.clone();
@@ -3239,15 +3238,11 @@ async fn compile_and_link(
                 RunnableComponent::new(&wasm_path, &engine, component_type)
                     .context("cannot compile activity-js-runtime")
             })
-        })
-        .await
-        .context("panic while compiling activity-js-runtime")?;
+        });
         Some(runnable)
     } else {
         None
-    }
-    .transpose()?;
-
+    };
     let workflow_js_runnable = if let Some(first_workflow_js) = workflows_js.first() {
         let engine = engines.workflow_engine.clone();
         let build_semaphore = build_semaphore.clone();
@@ -3261,15 +3256,11 @@ async fn compile_and_link(
                 RunnableComponent::new(&wasm_path, &engine, ComponentType::Workflow)
                     .context("cannot compile workflow-js-runtime")
             })
-        })
-        .await
-        .context("panic while compiling workflow-js-runtime")?;
+        });
         Some(runnable)
     } else {
         None
-    }
-    .transpose()?;
-
+    };
     let webhook_js_runnable = if let Some((_, first_webhook_js)) = webhooks_js_by_names.first() {
         let engine = engines.webhook_engine.clone();
         let build_semaphore = build_semaphore.clone();
@@ -3283,14 +3274,24 @@ async fn compile_and_link(
                 RunnableComponent::new(&wasm_path, &engine, ComponentType::WebhookEndpoint)
                     .context("cannot compile webhook-js-runtime")
             })
-        })
-        .await
-        .context("panic while compiling webhook-js-runtime")?;
+        });
         Some(runnable)
     } else {
         None
-    }
-    .transpose()?;
+    };
+
+    let activity_js_runnable = match activity_js_runnable {
+        Some(wasm) => Some(wasm.await??),
+        None => None,
+    };
+    let workflow_js_runnable = match workflow_js_runnable {
+        Some(wasm) => Some(wasm.await??),
+        None => None,
+    };
+    let webhook_js_runnable = match webhook_js_runnable {
+        Some(wasm) => Some(wasm.await??),
+        None => None,
+    };
 
     let pre_spawns: Vec<tokio::task::JoinHandle<Result<CompiledComponent, anyhow::Error>>> = activities_wasm
         .into_iter()

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -38,11 +38,11 @@ impl PreparedDeploymentManifest {
     }
 }
 
-/// Parse a verbatim manifest and canonicalize it using the supplied file provider.
+/// Parse a verbatim manifest and resolve it using the supplied file provider.
 ///
 /// `deployment_dir` remains explicit until later slices move all `${DEPLOYMENT_DIR}` and
 /// WASM path resolution to the runtime environment.
-pub(crate) async fn manifest_to_canonical(
+pub(crate) async fn manifest_to_resolved(
     deployment_toml: &str,
     deployment_dir: &Path,
     provider: &dyn FileProvider,
@@ -597,7 +597,7 @@ pub(crate) async fn manifest_file_to_canonical(
     let provider = DiskProvider {
         deployment_dir: deployment_dir.clone(),
     };
-    manifest_to_canonical(&deployment_toml, &deployment_dir, &provider).await
+    manifest_to_resolved(&deployment_toml, &deployment_dir, &provider).await
 }
 
 #[cfg(test)]
@@ -859,7 +859,7 @@ ffqn = "ns:pkg/ifc.fn"
             deployment_dir: dir.path().to_path_buf(),
         };
 
-        let canonical = manifest_to_canonical(manifest, dir.path(), &provider)
+        let canonical = manifest_to_resolved(manifest, dir.path(), &provider)
             .await
             .unwrap();
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1,6 +1,7 @@
 use crate::command::server;
 use crate::command::server::DeploymentContextHandle;
 use crate::command::server::PreparedDirs;
+use crate::command::server::RuntimeConfigCheck;
 use crate::command::server::ServerVerified;
 use crate::command::server::SubmitError;
 use crate::command::server::SwitchDeploymentAction;
@@ -1667,7 +1668,7 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
     ) -> TonicRespResult<grpc_gen::SwitchDeploymentResponse> {
         use grpc_gen::switch_deployment_response::Outcome;
         let request = request.into_inner();
-        let runtime_config_check = runtime_config_check_from_grpc(request.runtime_config_check());
+        let check = runtime_config_check_from_grpc(request.runtime_config_check());
         let deployment_id: DeploymentId = request
             .deployment_id
             .argument_must_exist("deployment_id")?
@@ -1675,9 +1676,12 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         let mut termination_watcher = self.termination_watcher.clone();
         let action = if request.hot_redeploy {
+            if check == RuntimeConfigCheck::AllowMissing {
+                return Err(tonic::Status::invalid_argument("argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_MISSING` cannot be used with `hot_redeploy = true`".to_string()));
+            }
             SwitchDeploymentAction::HotRedeploy
         } else {
-            SwitchDeploymentAction::VerifyAndStore
+            SwitchDeploymentAction::VerifyAndStore(check)
         };
         let outcome = tokio::spawn({
             let server_verified = self.server_verified.clone();
@@ -1693,7 +1697,6 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
                     server_verified,
                     deployment_id,
                     action,
-                    runtime_config_check,
                     &prepared_dirs,
                     db_pool,
                     &mut termination_watcher,

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3715,9 +3715,18 @@ mod deployment {
         let mut termination_watcher = state.termination_watcher.clone();
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         let action = if payload.hot_redeploy {
+            if payload.allow_missing_runtime_config {
+                return Err(HttpResponse::bad_request(
+                    accept,
+                    "`allow_missing_runtime_config = true` not allowed with `hot_redeploy = true`"
+                        .to_string(),
+                ));
+            }
             SwitchDeploymentAction::HotRedeploy
         } else {
-            SwitchDeploymentAction::VerifyAndStore
+            SwitchDeploymentAction::VerifyAndStore(runtime_config_check_from_bool(
+                payload.allow_missing_runtime_config,
+            ))
         };
         let outcome = tokio::spawn(async move {
             // Cancel safety
@@ -3725,7 +3734,6 @@ mod deployment {
                 state.server_verified.clone(),
                 deployment_id,
                 action,
-                runtime_config_check_from_bool(payload.allow_missing_runtime_config),
                 &state.prepared_dirs,
                 state.db_pool.clone(),
                 &mut termination_watcher,


### PR DESCRIPTION
- **refactor: Move `RuntimeConfigCheck` into `SwitchDeploymentAction::VerifyAndStore`**
- **refactor: Make JS runtimes compile in parallel**
- **style: Organize imports in `server.rs`**
- **refactor: Clean old execs from `cancel_registry` solely based on channel state**
- **refactor: Prepend `activity_` to `obtain_interrupt_token`**
- **refactor: Rename `Unlocked::backoff_expires_at` to `unlocked_at`**
- **refactor: Explicitly call `yield_now()` in epoch callbacks**
