### PR TITLE
deployment manager

### DIFF
--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1534,9 +1534,13 @@ pub trait DbExternalApi: DbConnection {
     ) -> Result<(), DbErrorWrite>;
 
     /// Mark a deployment as Enqueued (pending next server restart).
-    /// Returns `Err(DbErrorWriteNonRetriable::Conflict)` if the deployment is currently Active.
-    /// Any previously Enqueued deployment is demoted to Inactive.
-    async fn enqueue_deployment(&self, deployment_id: DeploymentId) -> Result<(), DbErrorWrite>;
+    /// Any previously Enqueued deployment is demoted to Inactive. If the target deployment is
+    /// currently Active, it remains Active and any previously Enqueued deployment is cleared.
+    /// The returned [`EnqueueOutcome`] reflects which of those happened.
+    async fn enqueue_deployment(
+        &self,
+        deployment_id: DeploymentId,
+    ) -> Result<EnqueueOutcome, DbErrorWrite>;
 
     /// Returned [`DeploymentRecord`] must contain `deployment_toml`.
     async fn get_deployment(
@@ -1630,6 +1634,16 @@ pub enum DeploymentStatus {
     /// Queued to become Active on the next server restart.
     Enqueued,
     Active,
+}
+
+/// Outcome of [`DbExternalApi::enqueue_deployment`], reflecting what the transaction did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnqueueOutcome {
+    /// The target was inactive and is now Enqueued for the next restart.
+    Enqueued,
+    /// The target was already Active; it stays Active and any previously Enqueued
+    /// deployment was cleared.
+    AlreadyActive,
 }
 
 impl DeploymentStatus {

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -15,7 +15,7 @@ use concepts::{
         DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
         DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentComponentDetail,
         DeploymentComponentRecord, DeploymentExecutionCounts, DeploymentFileRecord,
-        DeploymentRecord, DeploymentState, DeploymentStatus, ExecutionEvent,
+        DeploymentRecord, DeploymentState, DeploymentStatus, EnqueueOutcome, ExecutionEvent,
         ExecutionListPagination, ExecutionRequest, ExecutionWithState,
         ExecutionWithStateRequestsResponses, ExpiredDelay, ExpiredLock, ExpiredTimer,
         HISTORY_EVENT_TYPE_JOIN_NEXT, HistoryEvent, JoinSetRequest, JoinSetResponse,
@@ -4884,20 +4884,21 @@ impl DbExternalApi for PostgresConnection {
         Ok(())
     }
 
-    async fn enqueue_deployment(&self, deployment_id: DeploymentId) -> Result<(), DbErrorWrite> {
+    async fn enqueue_deployment(
+        &self,
+        deployment_id: DeploymentId,
+    ) -> Result<EnqueueOutcome, DbErrorWrite> {
         let mut client_guard = self.client.lock().await;
         let tx = client_guard.transaction().await?;
-        // Guard: reject if target deployment is currently active.
         let status_opt = tx
             .query_opt(
                 "SELECT status FROM t_deployment WHERE deployment_id = $1",
                 &[&deployment_id.to_string()],
             )
             .await?;
-        match status_opt.as_ref().map(|r| r.get::<_, &str>("status")) {
-            None => return Err(DbErrorWrite::NotFound),
-            Some("active") => return Err(DbErrorWriteNonRetriable::Conflict.into()),
-            _ => {}
+        let status = status_opt.as_ref().map(|r| r.get::<_, &str>("status"));
+        if status.is_none() {
+            return Err(DbErrorWrite::NotFound);
         }
         // Demote any previously enqueued deployment to inactive.
         tx.execute(
@@ -4905,6 +4906,11 @@ impl DbExternalApi for PostgresConnection {
             &[],
         )
         .await?;
+        // The target is already active: it stays active, only the pending one was cleared.
+        if status == Some("active") {
+            tx.commit().await?;
+            return Ok(EnqueueOutcome::AlreadyActive);
+        }
         // Set target deployment to enqueued.
         let rows = tx
             .execute(
@@ -4916,7 +4922,7 @@ impl DbExternalApi for PostgresConnection {
         if rows == 0 {
             return Err(DbErrorWrite::NotFound);
         }
-        Ok(())
+        Ok(EnqueueOutcome::Enqueued)
     }
 
     #[instrument(skip(self))]

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -15,7 +15,7 @@ use concepts::{
         DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
         DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentComponentDetail,
         DeploymentComponentRecord, DeploymentExecutionCounts, DeploymentFileRecord,
-        DeploymentRecord, DeploymentState, DeploymentStatus, ExecutionEvent,
+        DeploymentRecord, DeploymentState, DeploymentStatus, EnqueueOutcome, ExecutionEvent,
         ExecutionListPagination, ExecutionRequest, ExecutionWithState,
         ExecutionWithStateRequestsResponses, ExpiredDelay, ExpiredLock, ExpiredTimer,
         HISTORY_EVENT_TYPE_JOIN_NEXT, HistoryEvent, JoinSetRequest, JoinSetResponse,
@@ -3643,8 +3643,7 @@ impl SqlitePool {
     fn enqueue_deployment_tx(
         tx: &Transaction,
         deployment_id: DeploymentId,
-    ) -> Result<(), DbErrorWrite> {
-        // Guard: reject if target deployment is currently active.
+    ) -> Result<EnqueueOutcome, DbErrorWrite> {
         let status_opt: Option<String> = tx
             .query_row(
                 "SELECT status FROM t_deployment WHERE deployment_id = :deployment_id",
@@ -3653,10 +3652,9 @@ impl SqlitePool {
             )
             .optional()
             .map_err(RusqliteError::from)?;
-        match status_opt.as_deref() {
-            None => return Err(DbErrorWrite::NotFound),
-            Some("active") => return Err(DbErrorWriteNonRetriable::Conflict.into()),
-            _ => {}
+        let status = status_opt.as_deref();
+        if status.is_none() {
+            return Err(DbErrorWrite::NotFound);
         }
         // Demote any previously enqueued deployment to inactive.
         tx.execute(
@@ -3664,6 +3662,10 @@ impl SqlitePool {
             [],
         )
         .map_err(RusqliteError::from)?;
+        // The target is already active: it stays active, only the pending one was cleared.
+        if status == Some("active") {
+            return Ok(EnqueueOutcome::AlreadyActive);
+        }
         // Set target deployment to enqueued.
         let rows = tx
             .execute(
@@ -3676,7 +3678,7 @@ impl SqlitePool {
         if rows == 0 {
             return Err(DbErrorWrite::NotFound);
         }
-        Ok(())
+        Ok(EnqueueOutcome::Enqueued)
     }
 
     fn get_deployment_tx(
@@ -4832,7 +4834,10 @@ impl DbExternalApi for SqlitePool {
         .await
     }
 
-    async fn enqueue_deployment(&self, deployment_id: DeploymentId) -> Result<(), DbErrorWrite> {
+    async fn enqueue_deployment(
+        &self,
+        deployment_id: DeploymentId,
+    ) -> Result<EnqueueOutcome, DbErrorWrite> {
         self.transaction(
             move |tx| Self::enqueue_deployment_tx(tx, deployment_id),
             TxType::MultipleWrites,

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -11,7 +11,9 @@ use concepts::storage::{
     PendingStateLocked, PendingStatePaused, PendingStatePendingAt, ResponseCursor, TimeoutOutcome,
     Unlocked, Version, VersionType, WasmBacktrace,
 };
-use concepts::storage::{DbErrorWrite, DbPoolCloseable, DeploymentRecord, DeploymentStatus};
+use concepts::storage::{
+    DbErrorWrite, DbPoolCloseable, DeploymentRecord, DeploymentStatus, EnqueueOutcome,
+};
 use concepts::storage::{DbErrorWriteNonRetriable, HistoryEvent, ListExecutionsFilter};
 use concepts::storage::{HistoryEventScheduleAt, JoinSetResponseEvent, LogFilter};
 use concepts::storage::{LogCursor, LogEntry, LogInfoAppendRow};
@@ -4059,6 +4061,74 @@ async fn deployment_only_one_active_allowed(database: Database) {
     // id1 must be inactive.
     let d1 = api_conn.get_deployment(id1).await.unwrap().unwrap();
     assert_eq!(DeploymentStatus::Inactive, d1.status);
+
+    drop(api_conn);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn deployment_enqueue_active_clears_pending(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+
+    let now = sim_clock.now();
+    let active_id = concepts::prefixed_ulid::DeploymentId::generate();
+    let pending_id = concepts::prefixed_ulid::DeploymentId::generate();
+    for id in [active_id, pending_id] {
+        api_conn
+            .insert_deployment(DeploymentRecord {
+                deployment_id: id,
+                description: None,
+                digest: DeploymentRecord::compute_digest("{}"),
+                created_at: now,
+                last_active_at: None,
+                status: DeploymentStatus::Inactive,
+                deployment_toml: "{}".to_string(),
+                obelisk_version: "0.0.0-test".to_string(),
+                created_by: None,
+                files: Vec::new(),
+            })
+            .await
+            .unwrap();
+    }
+
+    api_conn.activate_deployment(active_id, now).await.unwrap();
+    assert_eq!(
+        EnqueueOutcome::Enqueued,
+        api_conn.enqueue_deployment(pending_id).await.unwrap()
+    );
+    assert_eq!(
+        pending_id,
+        api_conn
+            .get_current_deployment()
+            .await
+            .unwrap()
+            .unwrap()
+            .deployment_id
+    );
+
+    assert_eq!(
+        EnqueueOutcome::AlreadyActive,
+        api_conn.enqueue_deployment(active_id).await.unwrap()
+    );
+
+    let active = api_conn.get_deployment(active_id).await.unwrap().unwrap();
+    let pending = api_conn.get_deployment(pending_id).await.unwrap().unwrap();
+    assert_eq!(DeploymentStatus::Active, active.status);
+    assert_eq!(DeploymentStatus::Inactive, pending.status);
+    assert_eq!(
+        active_id,
+        api_conn
+            .get_current_deployment()
+            .await
+            .unwrap()
+            .unwrap()
+            .deployment_id
+    );
 
     drop(api_conn);
     db_close.close().await;

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -72,7 +72,7 @@ impl args::Deployment {
                     &mut client,
                     id,
                     runtime_config_check,
-                    false, // hot
+                    SwitchCommand::Enqueue,
                 )
                 .await
             }
@@ -97,13 +97,7 @@ impl args::Deployment {
                     deployment_id,
                 )
                 .await?;
-                switch_deployment(
-                    &mut client,
-                    id,
-                    runtime_config_check,
-                    true, // hot
-                )
-                .await
+                switch_deployment(&mut client, id, runtime_config_check, SwitchCommand::Apply).await
             }
 
             args::Deployment::List { api_url } => {
@@ -515,34 +509,41 @@ async fn switch_deployment(
     client: &mut DeploymentClient,
     id: DeploymentId,
     runtime_config_check: grpc_gen::RuntimeConfigCheck,
-    hot: bool,
+    command: SwitchCommand,
 ) -> anyhow::Result<()> {
     let resp = client
         .switch_deployment(grpc_gen::SwitchDeploymentRequest {
             deployment_id: Some(grpc_gen::DeploymentId::from(id)),
             runtime_config_check: runtime_config_check.into(),
-            hot_redeploy: hot,
+            hot_redeploy: command == SwitchCommand::Apply,
         })
         .await?
         .into_inner();
 
-    match resp.outcome() {
-        Outcome::SwitchOutcomeSwitched => {
+    match (command, resp.outcome()) {
+        (SwitchCommand::Apply, Outcome::SwitchOutcomeSwitched) => {
             println!("Applied successfully.");
         }
-        Outcome::SwitchOutcomeRestartRequired => {
-            if hot {
-                bail!(
-                    "Could not apply immediately; deployment enqueued. Restart the server to apply."
-                );
-            }
+        (SwitchCommand::Apply, Outcome::SwitchOutcomeRestartRequired) => {
+            bail!("Could not apply immediately; deployment enqueued. Restart the server to apply.");
+        }
+        (SwitchCommand::Enqueue, Outcome::SwitchOutcomeSwitched) => {
+            println!("Deployment already active; it will remain active after restart.");
+        }
+        (SwitchCommand::Enqueue, Outcome::SwitchOutcomeRestartRequired) => {
             println!("Deployment enqueued. Restart the server to apply.");
         }
-        Outcome::SwitchOutcomeUnspecified => {
+        (_, Outcome::SwitchOutcomeUnspecified) => {
             bail!("Unexpected outcome from server.");
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SwitchCommand {
+    Apply,
+    Enqueue,
 }
 
 async fn prepare_manifest_from_file_or_empty(

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -85,6 +85,7 @@ use concepts::storage::DbExternalApi;
 use concepts::storage::DbPool;
 use concepts::storage::DbPoolCloseable;
 use concepts::storage::DeploymentComponentRecord;
+use concepts::storage::EnqueueOutcome;
 use concepts::storage::LogInfoAppendRow;
 use concepts::storage::LogLevel;
 use concepts::storage::{ComponentMetadataRecord, DeploymentRecord, DeploymentStatus};
@@ -1515,7 +1516,7 @@ pub(crate) async fn run_internal(
     switch_deployment(
         deployment_switch_manager.clone(),
         active_deployment_id,
-        SwitchDeploymentAction::HotRedeploy,
+        SwitchDeploymentAction::Activate,
     )
     .instrument(info_span!("startup deployment manager no-op", %active_deployment_id))
     .await
@@ -2372,16 +2373,37 @@ impl RuntimeConfigCheck {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SwitchDeploymentAction {
-    HotRedeploy,
-    VerifyAndStore(RuntimeConfigCheck),
+    Activate,
+    Enqueue(RuntimeConfigCheck),
 }
 impl SwitchDeploymentAction {
     fn ignore_missing_env_vars(self) -> bool {
         match self {
-            SwitchDeploymentAction::VerifyAndStore(check) => check.ignore_missing_env_vars(),
-            SwitchDeploymentAction::HotRedeploy => false,
+            SwitchDeploymentAction::Enqueue(check) => check.ignore_missing_env_vars(),
+            SwitchDeploymentAction::Activate => false,
         }
     }
+}
+
+/// Enqueue `deployment_id` for the next restart, returning the DB-decided [`EnqueueOutcome`],
+/// then release the switch permit needed for serializability.
+async fn enqueue_deployment_and_release(
+    deployment_switch_manager: &DeploymentSwitchManagerHandle,
+    deployment_id: DeploymentId,
+    permit: OwnedSemaphorePermit,
+) -> Result<EnqueueOutcome, SwitchError> {
+    let db_conn = deployment_switch_manager
+        .inner
+        .db_pool
+        .external_api_conn()
+        .await
+        .map_err(|e| SwitchError::Other(e.into()))?;
+    let outcome = db_conn
+        .enqueue_deployment(deployment_id)
+        .await
+        .map_err(|e| SwitchError::Other(e.into()))?;
+    drop(permit);
+    Ok(outcome)
 }
 
 #[instrument(skip_all, fields(%deployment_id))]
@@ -2390,46 +2412,62 @@ pub(crate) async fn switch_deployment(
     deployment_id: DeploymentId,
     action: SwitchDeploymentAction,
 ) -> Result<SwitchOutcome, SwitchError> {
-    if deployment_switch_manager
+    let deployment_already_active = deployment_switch_manager
         .inner
         .deployment_ctx
         .read()
         .await
         .deployment_id
-        == deployment_id
-    {
-        info!(%deployment_id, "Deployment switch no-op: deployment already active");
-        return Ok(SwitchOutcome::Switched);
-    }
-
-    let permit = deployment_switch_manager.try_acquire_switch_permit()?;
-    let mut termination_watcher = deployment_switch_manager.inner.termination_watcher.clone();
-    let prepared = prepare_switch_deployment(
-        &deployment_switch_manager,
-        deployment_id,
-        action,
-        &mut termination_watcher,
-    )
-    .await?;
+        == deployment_id;
 
     match action {
-        SwitchDeploymentAction::VerifyAndStore(_) => {
-            let db_conn = deployment_switch_manager
-                .inner
-                .db_pool
-                .external_api_conn()
-                .await
-                .map_err(|e| SwitchError::Other(e.into()))?;
-            db_conn
-                .enqueue_deployment(deployment_id)
-                .await
-                .map_err(|e| SwitchError::Other(e.into()))?;
-            drop(permit);
-
-            info!(%deployment_id, "Deployment enqueued for next restart");
-            Ok(SwitchOutcome::RestartRequired)
+        SwitchDeploymentAction::Enqueue(_) => {
+            let permit = deployment_switch_manager.try_acquire_switch_permit()?;
+            if !deployment_already_active {
+                // Validate (compile + link) so the queued deployment is known-good against
+                // the current host before enqueuing. An already-active deployment is already
+                // running, hence known-good, so this is skipped.
+                let mut termination_watcher =
+                    deployment_switch_manager.inner.termination_watcher.clone();
+                prepare_switch_deployment(
+                    &deployment_switch_manager,
+                    deployment_id,
+                    action,
+                    &mut termination_watcher,
+                )
+                .await?;
+            }
+            // The outcome is decided inside the DB transaction, so it is authoritative even
+            // if the active deployment changed since the read above.
+            let outcome =
+                enqueue_deployment_and_release(&deployment_switch_manager, deployment_id, permit)
+                    .await?;
+            Ok(match outcome {
+                EnqueueOutcome::Enqueued => {
+                    info!(%deployment_id, "Deployment enqueued for next restart");
+                    SwitchOutcome::RestartRequired
+                }
+                EnqueueOutcome::AlreadyActive => {
+                    info!(%deployment_id, "Deployment already active; it will remain active after restart");
+                    SwitchOutcome::Switched
+                }
+            })
         }
-        SwitchDeploymentAction::HotRedeploy => {
+        SwitchDeploymentAction::Activate => {
+            if deployment_already_active {
+                info!(%deployment_id, "Deployment switch no-op: deployment already active");
+                return Ok(SwitchOutcome::Switched);
+            }
+            let permit = deployment_switch_manager.try_acquire_switch_permit()?;
+            let mut termination_watcher =
+                deployment_switch_manager.inner.termination_watcher.clone();
+            let prepared = prepare_switch_deployment(
+                &deployment_switch_manager,
+                deployment_id,
+                action,
+                &mut termination_watcher,
+            )
+            .await?;
             // Pre-critical, fallible commit work. Run the cron seeding and the durable
             // DB activation before the non-cancel-safe critical switch, so the section
             // after `exec_task_handles` is taken cannot fail and strand the context.

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -200,13 +200,13 @@ pub(crate) struct DeploymentSwitchManagerHandle {
 }
 
 struct DeploymentSwitchManager {
+    /// Independent lane for submit, so a long hot switch does not block submissions.
+    /// Holds `submit_concurrency` permits; `close()` drains all of them.
+    submit_lane: Arc<Semaphore>,
     /// Serializes hot redeploys and cold switch/enqueue: at most one in flight,
     /// surplus requests get `Busy`. Must stay at exactly 1 permit: `close()` drains this
     /// lane with a single `acquire_owned()`, which only accounts for one permit.
     switch_gate: Arc<Semaphore>,
-    /// Independent lane for submit, so a long hot switch does not block submissions.
-    /// Holds `submit_concurrency` permits; `close()` drains all of them.
-    submit_gate: Arc<Semaphore>,
     /// Permit count of `submit_gate`, retained so `close()` can drain every permit.
     submit_concurrency: u32,
     latest_prepared: Mutex<Option<PreparedDeploymentSwitch>>,
@@ -235,9 +235,8 @@ impl DeploymentSwitchManagerHandle {
     ) -> Self {
         Self {
             inner: Arc::new(DeploymentSwitchManager {
-                // Pinned at 1: `close()` drains this lane with a single `acquire_owned()`.
-                switch_gate: Arc::new(Semaphore::new(1)),
-                submit_gate: Arc::new(Semaphore::new(submit_concurrency as usize)),
+                submit_lane: Arc::new(Semaphore::new(submit_concurrency as usize)),
+                switch_gate: Arc::new(Semaphore::new(1)), // at most 1
                 submit_concurrency,
                 latest_prepared: Mutex::new(None),
                 server_verified,
@@ -252,7 +251,7 @@ impl DeploymentSwitchManagerHandle {
         }
     }
 
-    fn try_acquire_switch_gate(&self) -> Result<OwnedSemaphorePermit, SwitchError> {
+    fn try_acquire_switch_permit(&self) -> Result<OwnedSemaphorePermit, SwitchError> {
         match self.inner.switch_gate.clone().try_acquire_owned() {
             Ok(permit) => Ok(permit),
             Err(TryAcquireError::NoPermits) => Err(SwitchError::Busy),
@@ -262,8 +261,8 @@ impl DeploymentSwitchManagerHandle {
         }
     }
 
-    fn try_acquire_submit_gate(&self) -> Result<OwnedSemaphorePermit, SubmitDeploymentError> {
-        match self.inner.submit_gate.clone().try_acquire_owned() {
+    fn try_acquire_submit_permit(&self) -> Result<OwnedSemaphorePermit, SubmitDeploymentError> {
+        match self.inner.submit_lane.clone().try_acquire_owned() {
             Ok(permit) => Ok(permit),
             Err(TryAcquireError::NoPermits) => Err(SubmitDeploymentError::Busy),
             Err(TryAcquireError::Closed) => Err(SubmitDeploymentError::Other(anyhow::anyhow!(
@@ -335,12 +334,12 @@ impl DeploymentSwitchManagerHandle {
         let _switch_permit = self.inner.switch_gate.clone().acquire_owned().await;
         let _submit_permits = self
             .inner
-            .submit_gate
+            .submit_lane
             .clone()
             .acquire_many_owned(self.inner.submit_concurrency)
             .await;
         self.inner.switch_gate.close();
-        self.inner.submit_gate.close();
+        self.inner.submit_lane.close();
     }
 }
 
@@ -2170,7 +2169,7 @@ pub(crate) async fn submit_deployment(
 ) -> Result<DeploymentId, SubmitDeploymentError> {
     info!("Submitting deployment");
     let _submit_permit = if let Some(manager) = &deployment_switch_manager {
-        Some(manager.try_acquire_submit_gate()?)
+        Some(manager.try_acquire_submit_permit()?)
     } else {
         None
     };
@@ -2403,7 +2402,7 @@ pub(crate) async fn switch_deployment(
         return Ok(SwitchOutcome::Switched);
     }
 
-    let permit = deployment_switch_manager.try_acquire_switch_gate()?;
+    let permit = deployment_switch_manager.try_acquire_switch_permit()?;
     let mut termination_watcher = deployment_switch_manager.inner.termination_watcher.clone();
     let prepared = prepare_switch_deployment(
         &deployment_switch_manager,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2544,6 +2544,41 @@ async fn prepare_switch_deployment(
     })
 }
 
+/// Spawn the executor tasks for `deployment_id` and assemble its `DeploymentContext`.
+/// Shared by initial startup ([`spawn_tasks_and_threads`]) and hot redeploy
+/// ([`switch_hot_redeploy`]) so the two paths cannot drift. Webhook-registry wiring
+/// (create vs swap) and where the context is stored differ and stay at the call sites.
+fn spawn_deployment_context(
+    deployment_id: DeploymentId,
+    workers_linked: Vec<WorkerLinked>,
+    component_registry_ro: ComponentConfigRegistryRO,
+    db_pool: &Arc<dyn DbPool>,
+    cancel_registry: &CancelRegistry,
+    log_forwarder_sender: &mpsc::Sender<LogInfoAppendRow>,
+) -> DeploymentContext {
+    let mut exec_task_handles: Vec<ExecutorTaskHandle> = Vec::with_capacity(workers_linked.len());
+    let mut replay_workers = ReplayWorkerRegistry::default();
+    for pre_spawn in workers_linked {
+        let (handle, replay_entry) = pre_spawn.spawn(
+            deployment_id,
+            db_pool,
+            cancel_registry.clone(),
+            log_forwarder_sender,
+        );
+        exec_task_handles.push(handle);
+        if let Some((component_id, worker)) = replay_entry {
+            replay_workers.insert(component_id, worker);
+        }
+    }
+    DeploymentContext {
+        deployment_id,
+        component_registry_ro,
+        exec_task_handles,
+        replay_workers: Arc::new(replay_workers),
+        closed: false,
+    }
+}
+
 /// Write lock pretected switch to the new deployment
 #[instrument(skip_all, fields(%deployment_id))]
 async fn switch_hot_redeploy(
@@ -2584,29 +2619,14 @@ async fn switch_hot_redeploy(
             .map(|(http_server, (_instance, state))| (http_server.name.to_string(), state.clone())),
     );
 
-    let mut new_handles: Vec<ExecutorTaskHandle> =
-        Vec::with_capacity(server_compiled_linked.workers_linked.len());
-    let mut replay_workers = ReplayWorkerRegistry::default();
-    for pre_spawn in server_compiled_linked.workers_linked {
-        let (handle, replay_entry) = pre_spawn.spawn(
-            deployment_id,
-            &db_pool,
-            cancel_registry.clone(),
-            &log_forwarder_sender,
-        );
-        new_handles.push(handle);
-        if let Some((component_id, worker)) = replay_entry {
-            replay_workers.insert(component_id, worker);
-        }
-    }
-
-    *write_guard_ctx = DeploymentContext {
+    *write_guard_ctx = spawn_deployment_context(
         deployment_id,
-        component_registry_ro: server_compiled_linked.component_registry_ro.clone(),
-        exec_task_handles: new_handles,
-        replay_workers: Arc::new(replay_workers),
-        closed: false,
-    };
+        server_compiled_linked.workers_linked,
+        server_compiled_linked.component_registry_ro,
+        &db_pool,
+        &cancel_registry,
+        &log_forwarder_sender,
+    );
 
     info!(%deployment_id, "Switched to new deployment");
     Ok(SwitchOutcome::Switched)
@@ -2715,23 +2735,6 @@ async fn spawn_tasks_and_threads(
         (log_forwarder_sender, log_db_forarder)
     };
 
-    // Spawn executors
-    let mut exec_join_handles: Vec<ExecutorTaskHandle> =
-        Vec::with_capacity(server_compiled_linked.workers_linked.len());
-    let mut replay_workers = ReplayWorkerRegistry::default();
-    for pre_spawn in server_compiled_linked.workers_linked {
-        let (handle, replay_entry) = pre_spawn.spawn(
-            deployment_id,
-            &db_pool,
-            cancel_registry.clone(),
-            &log_forwarder_sender,
-        );
-        exec_join_handles.push(handle);
-        if let Some((component_id, worker)) = replay_entry {
-            replay_workers.insert(component_id, worker);
-        }
-    }
-
     let webhook_registry = WebhookRegistry::new(
         server_compiled_linked
             .http_servers_to_webhooks_and_state
@@ -2755,13 +2758,14 @@ async fn spawn_tasks_and_threads(
     )
     .await?;
     let deployment_ctx: DeploymentContextHandle =
-        Arc::new(tokio::sync::RwLock::new(DeploymentContext {
+        Arc::new(tokio::sync::RwLock::new(spawn_deployment_context(
             deployment_id,
-            component_registry_ro: server_compiled_linked.component_registry_ro,
-            exec_task_handles: exec_join_handles,
-            replay_workers: Arc::new(replay_workers),
-            closed: false,
-        }));
+            server_compiled_linked.workers_linked,
+            server_compiled_linked.component_registry_ro,
+            &db_pool,
+            cancel_registry,
+            &log_forwarder_sender,
+        )));
     let server_init = ServerInit {
         server_verified,
         deployment_ctx,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -310,20 +310,44 @@ impl DeploymentSwitchManagerHandle {
         let webhook_registry = self.inner.webhook_registry.clone();
         let cancel_registry = self.inner.cancel_registry.clone();
         let log_forwarder_sender = self.inner.log_forwarder_sender.clone();
-        // The critical switch is not cancel-safe, so own it in a detached task: a dropped
-        // caller only stops observing the result. The permit is held until the task
-        // finishes, which is what `close()` drains on during shutdown.
+        // Own the whole commit in a detached task: a dropped caller only stops observing the
+        // result via `rx`, it cannot abort the switch. This covers the durable pre-critical
+        // commits (cron seeds + activate) as well as the non-cancel-safe critical swap, so a
+        // cancellation can never leave the DB activated while the old workers keep running.
+        // The permit is held until the task finishes, which is what `close()` drains on.
         tokio::spawn(async move {
             let _switch_permit = switch_permit;
-            let result = switch_hot_redeploy(
-                prepared.compiled_linked,
-                prepared.deployment_id,
-                db_pool,
-                deployment_ctx,
-                webhook_registry,
-                cancel_registry,
-                log_forwarder_sender,
-            )
+            let deployment_id = prepared.deployment_id;
+            let result = async {
+                // Pre-critical, fallible commit work, before the critical swap so the section
+                // after `exec_task_handles` is taken cannot fail and strand the context.
+                // `activate_deployment` is the durable source of truth for which deployment is
+                // active, so commit it first: startup reconciles cron seeds (and workers) from
+                // the active deployment, so a crash after activate self-heals on restart, while
+                // a crash before it leaves no orphan seeds.
+                let db_conn = db_pool
+                    .external_api_conn()
+                    .await
+                    .map_err(|e| SwitchError::Other(e.into()))?;
+                db_conn
+                    .activate_deployment(deployment_id, chrono::Utc::now())
+                    .await
+                    .map_err(|e| SwitchError::Other(e.into()))?;
+                prepared
+                    .compiled_linked
+                    .create_missing_cron_seeds(&db_pool, deployment_id)
+                    .await?;
+                switch_hot_redeploy(
+                    prepared.compiled_linked,
+                    deployment_id,
+                    db_pool,
+                    deployment_ctx,
+                    webhook_registry,
+                    cancel_registry,
+                    log_forwarder_sender,
+                )
+                .await
+            }
             .await;
             let _ = tx.send(result);
         });
@@ -2471,6 +2495,8 @@ pub(crate) async fn switch_deployment(
             let switch_permit = deployment_switch_manager.try_acquire_switch_permit()?;
             let mut termination_watcher =
                 deployment_switch_manager.inner.termination_watcher.clone();
+            // Cancellable: validation only. The durable commit and critical swap are owned by
+            // the detached task spawned below, so they cannot be aborted by a dropped caller.
             let prepared = prepare_switch_deployment(
                 &deployment_switch_manager,
                 deployment_id,
@@ -2478,23 +2504,6 @@ pub(crate) async fn switch_deployment(
                 &mut termination_watcher,
             )
             .await?;
-            // Pre-critical, fallible commit work. Run the cron seeding and the durable
-            // DB activation before the non-cancel-safe critical switch, so the section
-            // after `exec_task_handles` is taken cannot fail and strand the context.
-            prepared
-                .compiled_linked
-                .create_missing_cron_seeds(&deployment_switch_manager.inner.db_pool, deployment_id)
-                .await?;
-            let db_conn = deployment_switch_manager
-                .inner
-                .db_pool
-                .external_api_conn()
-                .await
-                .map_err(|e| SwitchError::Other(e.into()))?;
-            db_conn
-                .activate_deployment(deployment_id, chrono::Utc::now())
-                .await
-                .map_err(|e| SwitchError::Other(e.into()))?;
             deployment_switch_manager
                 .spawn_critical_hot_switch(prepared, switch_permit)
                 .await

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -117,7 +117,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio::sync::TryAcquireError;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tonic::codec::CompressionEncoding;
 use tonic::service::RoutesBuilder;
@@ -183,7 +188,165 @@ pub(crate) struct DeploymentContext {
 
 pub(crate) type DeploymentContextHandle = Arc<tokio::sync::RwLock<DeploymentContext>>;
 
+struct PreparedDeploymentSwitch {
+    deployment_id: DeploymentId,
+    digest: ContentDigest,
+    compiled_linked: ServerCompiledLinked,
+}
+
+#[derive(Clone)]
+pub(crate) struct DeploymentSwitchManagerHandle {
+    inner: Arc<DeploymentSwitchManager>,
+}
+
+struct DeploymentSwitchManager {
+    /// Serializes hot redeploys and cold switch/enqueue: at most one in flight,
+    /// surplus requests get `Busy`. Must stay at exactly 1 permit: `close()` drains this
+    /// lane with a single `acquire_owned()`, which only accounts for one permit.
+    switch_gate: Arc<Semaphore>,
+    /// Independent lane for submit, so a long hot switch does not block submissions.
+    /// Holds `submit_concurrency` permits; `close()` drains all of them.
+    submit_gate: Arc<Semaphore>,
+    /// Permit count of `submit_gate`, retained so `close()` can drain every permit.
+    submit_concurrency: u32,
+    latest_prepared: Mutex<Option<PreparedDeploymentSwitch>>,
+    server_verified: ServerVerified,
+    prepared_dirs: PreparedDirs,
+    db_pool: Arc<dyn DbPool>,
+    termination_watcher: watch::Receiver<()>,
+    deployment_ctx: DeploymentContextHandle,
+    webhook_registry: Arc<WebhookRegistry>,
+    cancel_registry: CancelRegistry,
+    log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
+}
+
+impl DeploymentSwitchManagerHandle {
+    #[expect(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        server_verified: ServerVerified,
+        prepared_dirs: PreparedDirs,
+        db_pool: Arc<dyn DbPool>,
+        termination_watcher: watch::Receiver<()>,
+        deployment_ctx: DeploymentContextHandle,
+        webhook_registry: Arc<WebhookRegistry>,
+        cancel_registry: CancelRegistry,
+        log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
+        submit_concurrency: u32,
+    ) -> Self {
+        Self {
+            inner: Arc::new(DeploymentSwitchManager {
+                // Pinned at 1: `close()` drains this lane with a single `acquire_owned()`.
+                switch_gate: Arc::new(Semaphore::new(1)),
+                submit_gate: Arc::new(Semaphore::new(submit_concurrency as usize)),
+                submit_concurrency,
+                latest_prepared: Mutex::new(None),
+                server_verified,
+                prepared_dirs,
+                db_pool,
+                termination_watcher,
+                deployment_ctx,
+                webhook_registry,
+                cancel_registry,
+                log_forwarder_sender,
+            }),
+        }
+    }
+
+    fn try_acquire_switch_gate(&self) -> Result<OwnedSemaphorePermit, SwitchError> {
+        match self.inner.switch_gate.clone().try_acquire_owned() {
+            Ok(permit) => Ok(permit),
+            Err(TryAcquireError::NoPermits) => Err(SwitchError::Busy),
+            Err(TryAcquireError::Closed) => Err(SwitchError::Other(anyhow::anyhow!(
+                "server is being shut down"
+            ))),
+        }
+    }
+
+    fn try_acquire_submit_gate(&self) -> Result<OwnedSemaphorePermit, SubmitDeploymentError> {
+        match self.inner.submit_gate.clone().try_acquire_owned() {
+            Ok(permit) => Ok(permit),
+            Err(TryAcquireError::NoPermits) => Err(SubmitDeploymentError::Busy),
+            Err(TryAcquireError::Closed) => Err(SubmitDeploymentError::Other(anyhow::anyhow!(
+                "server is being shut down"
+            ))),
+        }
+    }
+
+    async fn take_latest_prepared(
+        &self,
+        deployment_id: DeploymentId,
+        digest: &ContentDigest,
+    ) -> Option<PreparedDeploymentSwitch> {
+        let mut latest = self.inner.latest_prepared.lock().await;
+        if latest.as_ref().is_some_and(|prepared| {
+            prepared.deployment_id == deployment_id && &prepared.digest == digest
+        }) {
+            latest.take()
+        } else {
+            None
+        }
+    }
+
+    async fn store_latest_prepared(&self, prepared: PreparedDeploymentSwitch) {
+        let mut latest = self.inner.latest_prepared.lock().await;
+        *latest = Some(prepared);
+    }
+
+    async fn spawn_critical_hot_switch(
+        &self,
+        prepared: PreparedDeploymentSwitch,
+        permit: OwnedSemaphorePermit,
+    ) -> Result<SwitchOutcome, SwitchError> {
+        let (tx, rx) = oneshot::channel();
+        let db_pool = self.inner.db_pool.clone();
+        let deployment_ctx = self.inner.deployment_ctx.clone();
+        let webhook_registry = self.inner.webhook_registry.clone();
+        let cancel_registry = self.inner.cancel_registry.clone();
+        let log_forwarder_sender = self.inner.log_forwarder_sender.clone();
+        // The critical switch is not cancel-safe, so own it in a detached task: a dropped
+        // caller only stops observing the result. The permit is held until the task
+        // finishes, which is what `close()` drains on during shutdown.
+        tokio::spawn(async move {
+            let _permit = permit;
+            let result = switch_hot_redeploy(
+                prepared.compiled_linked,
+                prepared.deployment_id,
+                db_pool,
+                deployment_ctx,
+                webhook_registry,
+                cancel_registry,
+                log_forwarder_sender,
+            )
+            .await;
+            let _ = tx.send(result);
+        });
+        rx.await.map_err(|_| {
+            SwitchError::Other(anyhow::anyhow!("deployment switch critical task exited"))
+        })?
+    }
+
+    pub(crate) async fn close(&self) {
+        // Drain both lanes: an in-flight operation holds its lane's permit(s) until it
+        // completes (the hot switch holds the switch permit through its critical task), so
+        // acquiring waits for completion. The switch lane has exactly one permit; the
+        // submit lane has `submit_concurrency`, so drain all of them. Then close the gates
+        // so no new work is accepted; once closed, `try_acquire_*` returns the shutdown
+        // error atomically (no separate flag).
+        let _switch_permit = self.inner.switch_gate.clone().acquire_owned().await;
+        let _submit_permits = self
+            .inner
+            .submit_gate
+            .clone()
+            .acquire_many_owned(self.inner.submit_concurrency)
+            .await;
+        self.inner.switch_gate.close();
+        self.inner.submit_gate.close();
+    }
+}
+
 const EPOCH_MILLIS: u64 = 10;
+/// Default number of concurrent deployment submits the switch manager accepts.
+const DEFAULT_SUBMIT_CONCURRENCY: u32 = 1;
 const WEBUI_LOCATION: &str = include_str!("../../assets/webui-version.txt");
 #[cfg(not(feature = "activity-js-local"))]
 pub(crate) const ACTIVITY_JS_LOCATION: &str =
@@ -1337,6 +1500,33 @@ pub(crate) async fn run_internal(
     )
     .instrument(span)
     .await?;
+    let mut server_init = server_init;
+    let deployment_switch_manager = DeploymentSwitchManagerHandle::new(
+        server_init.server_verified.clone(),
+        server_init.prepared_dirs.clone(),
+        server_init.db_pool.clone(),
+        termination_watcher.clone(),
+        server_init.deployment_ctx.clone(),
+        server_init.webhook_registry.clone(),
+        cancel_registry.clone(),
+        server_init.log_forwarder_sender.clone(),
+        DEFAULT_SUBMIT_CONCURRENCY,
+    );
+    server_init.deployment_switch_manager = Some(deployment_switch_manager.clone());
+    switch_deployment(
+        deployment_switch_manager.clone(),
+        active_deployment_id,
+        SwitchDeploymentAction::HotRedeploy,
+    )
+    .instrument(info_span!("startup deployment manager no-op", %active_deployment_id))
+    .await
+    .map_err(|err| match err {
+        SwitchError::Busy => anyhow::anyhow!("deployment switch manager busy during startup"),
+        SwitchError::NotFound => {
+            anyhow::anyhow!("active deployment {active_deployment_id} not found during startup")
+        }
+        SwitchError::Other(err) => err,
+    })?;
 
     let grpc_server = Arc::new(GrpcServer::new(
         server_init.server_verified.clone(),
@@ -1344,9 +1534,8 @@ pub(crate) async fn run_internal(
         termination_watcher.clone(),
         cancel_registry.clone(),
         prepared_dirs.clone(),
-        server_init.log_forwarder_sender.clone(),
         server_init.deployment_ctx.clone(),
-        server_init.webhook_registry.clone(),
+        deployment_switch_manager.clone(),
     ));
 
     let mut grpc = RoutesBuilder::default();
@@ -1405,9 +1594,8 @@ pub(crate) async fn run_internal(
         cancel_registry,
         termination_watcher: termination_watcher.clone(),
         subscription_interruption,
-        log_forwarder_sender: server_init.log_forwarder_sender.clone(),
         prepared_dirs: server_init.prepared_dirs.clone(),
-        webhook_registry: server_init.webhook_registry.clone(),
+        deployment_switch_manager,
     });
     let app: axum::Router<()> = app_router.fallback_service(grpc_service);
     let app_svc = app.into_make_service();
@@ -1846,6 +2034,7 @@ impl SubmitPackageError {
 /// Submit failure: either a structured file-set error (no deployment stored) or any
 /// other error (parse/idempotency/storage).
 pub(crate) enum SubmitDeploymentError {
+    Busy,
     Package(SubmitPackageError),
     Other(anyhow::Error),
 }
@@ -1977,8 +2166,14 @@ pub(crate) async fn submit_deployment(
     supplied_files: Vec<SuppliedFile>,
     db_pool: Arc<dyn DbPool>,
     termination_watcher: &mut watch::Receiver<()>,
+    deployment_switch_manager: Option<DeploymentSwitchManagerHandle>,
 ) -> Result<DeploymentId, SubmitDeploymentError> {
     info!("Submitting deployment");
+    let _submit_permit = if let Some(manager) = &deployment_switch_manager {
+        Some(manager.try_acquire_submit_gate()?)
+    } else {
+        None
+    };
     // The deployment digest is the hash of the verbatim manifest; it transitively covers
     // every referenced file because the manifest embeds each file's content digest. It is
     // used only for idempotency, not returned (the client already has the manifest).
@@ -2087,7 +2282,7 @@ pub(crate) async fn submit_deployment(
     conn.insert_deployment(DeploymentRecord {
         deployment_id,
         description,
-        digest,
+        digest: digest.clone(),
         created_at: now,
         last_active_at: None,
         status: DeploymentStatus::Inactive,
@@ -2111,6 +2306,21 @@ pub(crate) async fn submit_deployment(
     .map_err(SubmitDeploymentError::Other)?;
     upsert_backtrace_sources(conn.as_ref(), &compiled_linked).await;
 
+    // Only cache strict-verified artifacts. A hot redeploy is always strict, so an
+    // artifact compiled while tolerating missing env vars (AllowMissing) must not be
+    // reused to satisfy a later strict switch; a strict artifact satisfies any consumer.
+    if let Some(manager) = deployment_switch_manager
+        && !runtime_config_check.ignore_missing_env_vars()
+    {
+        manager
+            .store_latest_prepared(PreparedDeploymentSwitch {
+                deployment_id,
+                digest,
+                compiled_linked,
+            })
+            .await;
+    }
+
     info!(%deployment_id, "Deployment submitted");
     Ok(deployment_id)
 }
@@ -2131,6 +2341,8 @@ pub(crate) enum SwitchOutcome {
 
 /// Error returned by [`switch_deployment`].
 pub(crate) enum SwitchError {
+    /// Another deployment submit/switch operation is queued or running.
+    Busy,
     /// The requested deployment ID does not exist.
     NotFound,
     /// Any other failure (verification, compilation, DB write, etc.).
@@ -2173,21 +2385,86 @@ impl SwitchDeploymentAction {
     }
 }
 
-#[expect(clippy::too_many_arguments)]
 #[instrument(skip_all, fields(%deployment_id))]
 pub(crate) async fn switch_deployment(
-    server_verified: ServerVerified,
+    deployment_switch_manager: DeploymentSwitchManagerHandle,
     deployment_id: DeploymentId,
     action: SwitchDeploymentAction,
-    prepared_dirs: &PreparedDirs,
-    db_pool: Arc<dyn DbPool>,
-    termination_watcher: &mut watch::Receiver<()>,
-    deployment_ctx: &DeploymentContextHandle,
-    webhook_registry: &WebhookRegistry,
-    cancel_registry: CancelRegistry,
-    log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
 ) -> Result<SwitchOutcome, SwitchError> {
-    let db_conn = db_pool
+    if deployment_switch_manager
+        .inner
+        .deployment_ctx
+        .read()
+        .await
+        .deployment_id
+        == deployment_id
+    {
+        info!(%deployment_id, "Deployment switch no-op: deployment already active");
+        return Ok(SwitchOutcome::Switched);
+    }
+
+    let permit = deployment_switch_manager.try_acquire_switch_gate()?;
+    let mut termination_watcher = deployment_switch_manager.inner.termination_watcher.clone();
+    let prepared = prepare_switch_deployment(
+        &deployment_switch_manager,
+        deployment_id,
+        action,
+        &mut termination_watcher,
+    )
+    .await?;
+
+    match action {
+        SwitchDeploymentAction::VerifyAndStore(_) => {
+            let db_conn = deployment_switch_manager
+                .inner
+                .db_pool
+                .external_api_conn()
+                .await
+                .map_err(|e| SwitchError::Other(e.into()))?;
+            db_conn
+                .enqueue_deployment(deployment_id)
+                .await
+                .map_err(|e| SwitchError::Other(e.into()))?;
+            drop(permit);
+
+            info!(%deployment_id, "Deployment enqueued for next restart");
+            Ok(SwitchOutcome::RestartRequired)
+        }
+        SwitchDeploymentAction::HotRedeploy => {
+            // Pre-critical, fallible commit work. Run the cron seeding and the durable
+            // DB activation before the non-cancel-safe critical switch, so the section
+            // after `exec_task_handles` is taken cannot fail and strand the context.
+            prepared
+                .compiled_linked
+                .create_missing_cron_seeds(&deployment_switch_manager.inner.db_pool, deployment_id)
+                .await?;
+            let db_conn = deployment_switch_manager
+                .inner
+                .db_pool
+                .external_api_conn()
+                .await
+                .map_err(|e| SwitchError::Other(e.into()))?;
+            db_conn
+                .activate_deployment(deployment_id, chrono::Utc::now())
+                .await
+                .map_err(|e| SwitchError::Other(e.into()))?;
+            deployment_switch_manager
+                .spawn_critical_hot_switch(prepared, permit)
+                .await
+        }
+    }
+}
+
+#[instrument(skip_all, fields(%deployment_id))]
+async fn prepare_switch_deployment(
+    deployment_switch_manager: &DeploymentSwitchManagerHandle,
+    deployment_id: DeploymentId,
+    action: SwitchDeploymentAction,
+    termination_watcher: &mut watch::Receiver<()>,
+) -> Result<PreparedDeploymentSwitch, SwitchError> {
+    let db_conn = deployment_switch_manager
+        .inner
+        .db_pool
         .external_api_conn()
         .await
         .map_err(|e| SwitchError::Other(e.into()))?;
@@ -2197,6 +2474,14 @@ pub(crate) async fn switch_deployment(
         .await
         .map_err(|e| SwitchError::Other(e.into()))?
         .ok_or(SwitchError::NotFound)?;
+
+    if let Some(prepared) = deployment_switch_manager
+        .take_latest_prepared(deployment_id, &deployment_record.digest)
+        .await
+    {
+        debug!(%deployment_id, "Using cached prepared deployment artifact");
+        return Ok(prepared);
+    }
 
     let missing = db_conn
         .missing_digests(deployment_id)
@@ -2214,12 +2499,16 @@ pub(crate) async fn switch_deployment(
         )));
     }
 
-    let target_deployment =
-        deployment_resolved_from_manifest(&*db_pool, &deployment_record.deployment_toml)
-            .await
-            .map_err(SwitchError::Other)?;
+    let target_deployment = deployment_resolved_from_manifest(
+        &*deployment_switch_manager.inner.db_pool,
+        &deployment_record.deployment_toml,
+    )
+    .await
+    .map_err(SwitchError::Other)?;
 
-    let cas: Arc<dyn concepts::cas::Cas> = db_pool
+    let cas: Arc<dyn concepts::cas::Cas> = deployment_switch_manager
+        .inner
+        .db_pool
         .cas_conn()
         .await
         .map_err(|e| SwitchError::Other(e.into()))?
@@ -2235,63 +2524,36 @@ pub(crate) async fn switch_deployment(
         suppress_linking_errors: false,
     };
 
-    if action == SwitchDeploymentAction::HotRedeploy {
-        let server_compiled_linked = deployment_verify_config_compile_link(
-            server_verified,
-            prepared_dirs,
-            target_deployment,
-            Some(cas),
-            DeploymentId::generate(),
-            verify_params,
-            termination_watcher,
-        )
-        .await?;
-        switch_hot_redeploy(
-            server_compiled_linked,
-            db_conn.as_ref(),
-            deployment_id,
-            &db_pool,
-            deployment_ctx,
-            webhook_registry,
-            cancel_registry,
-            &log_forwarder_sender,
-        )
-        .await
-    } else {
-        // Cold switch: validation (compile + link) always runs before enqueuing, so a
-        // deployment queued for the next restart is known-good against the current host.
-        deployment_verify_config_compile_link(
-            server_verified,
-            prepared_dirs,
-            target_deployment,
-            Some(cas),
-            DeploymentId::generate(),
-            verify_params,
-            termination_watcher,
-        )
-        .await?;
-        db_conn
-            .enqueue_deployment(deployment_id)
-            .await
-            .map_err(|e| SwitchError::Other(e.into()))?;
+    // Cold switch: validation (compile + link) always runs before enqueuing, so a
+    // deployment queued for the next restart is known-good against the current host.
+    let compiled_linked = deployment_verify_config_compile_link(
+        deployment_switch_manager.inner.server_verified.clone(),
+        &deployment_switch_manager.inner.prepared_dirs,
+        target_deployment,
+        Some(cas),
+        deployment_id,
+        verify_params,
+        termination_watcher,
+    )
+    .await?;
 
-        info!(%deployment_id, "Deployment enqueued for next restart");
-        Ok(SwitchOutcome::RestartRequired)
-    }
+    Ok(PreparedDeploymentSwitch {
+        deployment_id,
+        digest: deployment_record.digest,
+        compiled_linked,
+    })
 }
 
 /// Write lock pretected switch to the new deployment
 #[instrument(skip_all, fields(%deployment_id))]
-#[expect(clippy::too_many_arguments)]
 async fn switch_hot_redeploy(
     server_compiled_linked: ServerCompiledLinked,
-    db_conn: &dyn DbExternalApi,
     deployment_id: DeploymentId,
-    db_pool: &Arc<dyn DbPool>,
-    deployment_ctx: &DeploymentContextHandle,
-    webhook_registry: &WebhookRegistry,
+    db_pool: Arc<dyn DbPool>,
+    deployment_ctx: DeploymentContextHandle,
+    webhook_registry: Arc<WebhookRegistry>,
     cancel_registry: CancelRegistry,
-    log_forwarder_sender: &mpsc::Sender<LogInfoAppendRow>,
+    log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
 ) -> Result<SwitchOutcome, SwitchError> {
     let mut write_guard_ctx = deployment_ctx.write().await;
     if write_guard_ctx.closed {
@@ -2322,19 +2584,15 @@ async fn switch_hot_redeploy(
             .map(|(http_server, (_instance, state))| (http_server.name.to_string(), state.clone())),
     );
 
-    server_compiled_linked
-        .create_missing_cron_seeds(db_pool, deployment_id)
-        .await?;
-
     let mut new_handles: Vec<ExecutorTaskHandle> =
         Vec::with_capacity(server_compiled_linked.workers_linked.len());
     let mut replay_workers = ReplayWorkerRegistry::default();
     for pre_spawn in server_compiled_linked.workers_linked {
         let (handle, replay_entry) = pre_spawn.spawn(
             deployment_id,
-            db_pool,
+            &db_pool,
             cancel_registry.clone(),
-            log_forwarder_sender,
+            &log_forwarder_sender,
         );
         new_handles.push(handle);
         if let Some((component_id, worker)) = replay_entry {
@@ -2350,12 +2608,7 @@ async fn switch_hot_redeploy(
         closed: false,
     };
 
-    db_conn
-        .activate_deployment(deployment_id, chrono::Utc::now())
-        .await
-        .map_err(|e| SwitchError::Other(e.into()))?;
-
-    info!(%deployment_id, "Switched to new  deployment");
+    info!(%deployment_id, "Switched to new deployment");
     Ok(SwitchOutcome::Switched)
 }
 
@@ -2525,6 +2778,7 @@ async fn spawn_tasks_and_threads(
         log_forwarder_sender,
         webhook_registry: Arc::new(webhook_registry),
         prepared_dirs,
+        deployment_switch_manager: None,
     };
     Ok(server_init)
 }
@@ -2543,6 +2797,7 @@ struct ServerInit {
     log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
     webhook_registry: Arc<WebhookRegistry>,
     prepared_dirs: PreparedDirs,
+    deployment_switch_manager: Option<DeploymentSwitchManagerHandle>,
 }
 impl ServerInit {
     async fn close(self) {
@@ -2562,7 +2817,12 @@ impl ServerInit {
             log_forwarder_sender,
             webhook_registry,
             prepared_dirs: _,
+            deployment_switch_manager,
         } = self;
+
+        if let Some(deployment_switch_manager) = deployment_switch_manager {
+            deployment_switch_manager.close().await;
+        }
 
         debug!("Closing executors");
         let executors = {

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -200,6 +200,13 @@ pub(crate) struct DeploymentSwitchManagerHandle {
     inner: Arc<DeploymentSwitchManager>,
 }
 
+/// Permit for the switch lane (hot redeploy / enqueue), held for its `Drop` which releases
+/// the slot. A distinct type from [`SubmitPermit`] so the two lanes cannot be mixed up.
+struct SwitchPermit(#[expect(dead_code)] OwnedSemaphorePermit);
+
+/// Permit for the submit lane, held for its `Drop` which releases a slot.
+struct SubmitPermit(#[expect(dead_code)] OwnedSemaphorePermit);
+
 struct DeploymentSwitchManager {
     /// Independent lane for submit, so a long hot switch does not block submissions.
     /// Holds `submit_concurrency` permits; `close()` drains all of them.
@@ -252,9 +259,9 @@ impl DeploymentSwitchManagerHandle {
         }
     }
 
-    fn try_acquire_switch_permit(&self) -> Result<OwnedSemaphorePermit, SwitchError> {
+    fn try_acquire_switch_permit(&self) -> Result<SwitchPermit, SwitchError> {
         match self.inner.switch_gate.clone().try_acquire_owned() {
-            Ok(permit) => Ok(permit),
+            Ok(permit) => Ok(SwitchPermit(permit)),
             Err(TryAcquireError::NoPermits) => Err(SwitchError::Busy),
             Err(TryAcquireError::Closed) => Err(SwitchError::Other(anyhow::anyhow!(
                 "server is being shut down"
@@ -262,9 +269,9 @@ impl DeploymentSwitchManagerHandle {
         }
     }
 
-    fn try_acquire_submit_permit(&self) -> Result<OwnedSemaphorePermit, SubmitDeploymentError> {
+    fn try_acquire_submit_permit(&self) -> Result<SubmitPermit, SubmitDeploymentError> {
         match self.inner.submit_lane.clone().try_acquire_owned() {
-            Ok(permit) => Ok(permit),
+            Ok(permit) => Ok(SubmitPermit(permit)),
             Err(TryAcquireError::NoPermits) => Err(SubmitDeploymentError::Busy),
             Err(TryAcquireError::Closed) => Err(SubmitDeploymentError::Other(anyhow::anyhow!(
                 "server is being shut down"
@@ -295,7 +302,7 @@ impl DeploymentSwitchManagerHandle {
     async fn spawn_critical_hot_switch(
         &self,
         prepared: PreparedDeploymentSwitch,
-        permit: OwnedSemaphorePermit,
+        switch_permit: SwitchPermit,
     ) -> Result<SwitchOutcome, SwitchError> {
         let (tx, rx) = oneshot::channel();
         let db_pool = self.inner.db_pool.clone();
@@ -307,7 +314,7 @@ impl DeploymentSwitchManagerHandle {
         // caller only stops observing the result. The permit is held until the task
         // finishes, which is what `close()` drains on during shutdown.
         tokio::spawn(async move {
-            let _permit = permit;
+            let _switch_permit = switch_permit;
             let result = switch_hot_redeploy(
                 prepared.compiled_linked,
                 prepared.deployment_id,
@@ -2390,7 +2397,7 @@ impl SwitchDeploymentAction {
 async fn enqueue_deployment_and_release(
     deployment_switch_manager: &DeploymentSwitchManagerHandle,
     deployment_id: DeploymentId,
-    permit: OwnedSemaphorePermit,
+    switch_permit: SwitchPermit,
 ) -> Result<EnqueueOutcome, SwitchError> {
     let db_conn = deployment_switch_manager
         .inner
@@ -2402,7 +2409,7 @@ async fn enqueue_deployment_and_release(
         .enqueue_deployment(deployment_id)
         .await
         .map_err(|e| SwitchError::Other(e.into()))?;
-    drop(permit);
+    drop(switch_permit);
     Ok(outcome)
 }
 
@@ -2422,7 +2429,7 @@ pub(crate) async fn switch_deployment(
 
     match action {
         SwitchDeploymentAction::Enqueue(_) => {
-            let permit = deployment_switch_manager.try_acquire_switch_permit()?;
+            let switch_permit = deployment_switch_manager.try_acquire_switch_permit()?;
             if !deployment_already_active {
                 // Validate (compile + link) so the queued deployment is known-good against
                 // the current host before enqueuing. An already-active deployment is already
@@ -2439,9 +2446,12 @@ pub(crate) async fn switch_deployment(
             }
             // The outcome is decided inside the DB transaction, so it is authoritative even
             // if the active deployment changed since the read above.
-            let outcome =
-                enqueue_deployment_and_release(&deployment_switch_manager, deployment_id, permit)
-                    .await?;
+            let outcome = enqueue_deployment_and_release(
+                &deployment_switch_manager,
+                deployment_id,
+                switch_permit,
+            )
+            .await?;
             Ok(match outcome {
                 EnqueueOutcome::Enqueued => {
                     info!(%deployment_id, "Deployment enqueued for next restart");
@@ -2458,7 +2468,7 @@ pub(crate) async fn switch_deployment(
                 info!(%deployment_id, "Deployment switch no-op: deployment already active");
                 return Ok(SwitchOutcome::Switched);
             }
-            let permit = deployment_switch_manager.try_acquire_switch_permit()?;
+            let switch_permit = deployment_switch_manager.try_acquire_switch_permit()?;
             let mut termination_watcher =
                 deployment_switch_manager.inner.termination_watcher.clone();
             let prepared = prepare_switch_deployment(
@@ -2486,7 +2496,7 @@ pub(crate) async fn switch_deployment(
                 .await
                 .map_err(|e| SwitchError::Other(e.into()))?;
             deployment_switch_manager
-                .spawn_critical_hot_switch(prepared, permit)
+                .spawn_critical_hot_switch(prepared, switch_permit)
                 .await
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "512"]
+
 mod args;
 mod command;
 mod config;

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1672,9 +1672,9 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             if check == RuntimeConfigCheck::AllowMissing {
                 return Err(tonic::Status::invalid_argument("argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_MISSING` cannot be used with `hot_redeploy = true`".to_string()));
             }
-            SwitchDeploymentAction::HotRedeploy
+            SwitchDeploymentAction::Activate
         } else {
-            SwitchDeploymentAction::VerifyAndStore(check)
+            SwitchDeploymentAction::Enqueue(check)
         };
         let outcome = server::switch_deployment(
             self.deployment_switch_manager.clone(),

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1,10 +1,10 @@
 use crate::command::server;
-use crate::command::server::DeploymentContextHandle;
 use crate::command::server::PreparedDirs;
 use crate::command::server::RuntimeConfigCheck;
 use crate::command::server::ServerVerified;
 use crate::command::server::SubmitError;
 use crate::command::server::SwitchDeploymentAction;
+use crate::command::server::{DeploymentContextHandle, DeploymentSwitchManagerHandle};
 use crate::server::deployment_summary;
 use base64::Engine as _;
 use base64::prelude::BASE64_STANDARD;
@@ -35,7 +35,6 @@ use concepts::storage::LIST_DEPLOYMENT_STATES_DEFAULT_LENGTH;
 use concepts::storage::LIST_DEPLOYMENT_STATES_DEFAULT_PAGINATION;
 use concepts::storage::LogCursor;
 use concepts::storage::LogFilter;
-use concepts::storage::LogInfoAppendRow;
 use concepts::storage::LogLevel;
 use concepts::storage::LogStreamType;
 use concepts::storage::Pagination;
@@ -80,7 +79,6 @@ use tracing::instrument;
 use val_json::wast_val_ser::deserialize_slice;
 use wasm_workers::activity::cancel_registry::CancelRegistry;
 use wasm_workers::registry::ReplayWorker;
-use wasm_workers::webhook::webhook_registry::WebhookRegistry;
 use wasm_workers::workflow::workflow_worker::{AdvanceError, ReplayAdvanceable, ReplayResponse};
 
 pub(crate) struct GrpcServer {
@@ -89,22 +87,19 @@ pub(crate) struct GrpcServer {
     termination_watcher: watch::Receiver<()>,
     cancel_registry: CancelRegistry,
     prepared_dirs: PreparedDirs,
-    log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
     deployment_ctx: DeploymentContextHandle,
-    webhook_registry: Arc<WebhookRegistry>,
+    deployment_switch_manager: DeploymentSwitchManagerHandle,
 }
 
 impl GrpcServer {
-    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         server_verified: ServerVerified,
         db_pool: Arc<dyn DbPool>,
         termination_watcher: watch::Receiver<()>,
         cancel_registry: CancelRegistry,
         prepared_dirs: PreparedDirs,
-        log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
         deployment_ctx: DeploymentContextHandle,
-        webhook_registry: Arc<WebhookRegistry>,
+        deployment_switch_manager: DeploymentSwitchManagerHandle,
     ) -> Self {
         Self {
             server_verified,
@@ -112,9 +107,8 @@ impl GrpcServer {
             termination_watcher,
             cancel_registry,
             prepared_dirs,
-            log_forwarder_sender,
             deployment_ctx,
-            webhook_registry,
+            deployment_switch_manager,
         }
     }
 }
@@ -1674,7 +1668,6 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             .argument_must_exist("deployment_id")?
             .try_into()?;
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
-        let mut termination_watcher = self.termination_watcher.clone();
         let action = if request.hot_redeploy {
             if check == RuntimeConfigCheck::AllowMissing {
                 return Err(tonic::Status::invalid_argument("argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_MISSING` cannot be used with `hot_redeploy = true`".to_string()));
@@ -1683,37 +1676,16 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
         } else {
             SwitchDeploymentAction::VerifyAndStore(check)
         };
-        let outcome = tokio::spawn({
-            let server_verified = self.server_verified.clone();
-            let db_pool = self.db_pool.clone();
-            let prepared_dirs = self.prepared_dirs.clone();
-            let deployment_ctx = self.deployment_ctx.clone();
-            let webhook_registry = self.webhook_registry.clone();
-            let cancel_registry = self.cancel_registry.clone();
-            let log_forwarder_sender = self.log_forwarder_sender.clone();
-            async move {
-                // Cancel safety
-                server::switch_deployment(
-                    server_verified,
-                    deployment_id,
-                    action,
-                    &prepared_dirs,
-                    db_pool,
-                    &mut termination_watcher,
-                    &deployment_ctx,
-                    &webhook_registry,
-                    cancel_registry,
-                    log_forwarder_sender,
-                )
-                .await
-            }
-        })
+        let outcome = server::switch_deployment(
+            self.deployment_switch_manager.clone(),
+            deployment_id,
+            action,
+        )
         .await
-        .map_err(|join_err| {
-            error!("Panic in switch_deployment: {join_err:?}");
-            tonic::Status::internal("internal error")
-        })?
         .map_err(|err| match err {
+            server::SwitchError::Busy => tonic::Status::resource_exhausted(
+                "another deployment submit or switch is already running",
+            ),
             server::SwitchError::NotFound => tonic::Status::not_found("deployment not found"),
             server::SwitchError::Other(e) => tonic::Status::failed_precondition(format!("{e:#}")),
         })?;
@@ -1760,10 +1732,16 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             supplied_files,
             self.db_pool.clone(),
             &mut termination_watcher,
+            Some(self.deployment_switch_manager.clone()),
         ))
         .await;
         let deployment_id = match result {
             Ok(deployment_id) => deployment_id,
+            Err(server::SubmitDeploymentError::Busy) => {
+                return Err(tonic::Status::resource_exhausted(
+                    "another deployment submit or switch is already running",
+                ));
+            }
             Err(server::SubmitDeploymentError::Other(err)) => {
                 return Err(tonic::Status::failed_precondition(format!("{err:#}")));
             }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3727,9 +3727,9 @@ mod deployment {
                         .to_string(),
                 ));
             }
-            SwitchDeploymentAction::HotRedeploy
+            SwitchDeploymentAction::Activate
         } else {
-            SwitchDeploymentAction::VerifyAndStore(runtime_config_check_from_bool(
+            SwitchDeploymentAction::Enqueue(runtime_config_check_from_bool(
                 payload.allow_missing_runtime_config,
             ))
         };

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -28,10 +28,9 @@ use concepts::{
     storage::{
         self, BacktraceFilter, CancelOutcome, DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout,
         DbErrorWrite, DbErrorWriteNonRetriable, DbPool, ExecutionEvent, ExecutionListPagination,
-        ExecutionRequest, ExecutionWithState, FunctionNameFilter, ListExecutionsFilter,
-        LogInfoAppendRow, Pagination, PendingState, PendingStateFinishedError,
-        PendingStateFinishedResultKind, ResponseCursor, ResponseWithCursor, TimeoutOutcome,
-        Version, VersionType,
+        ExecutionRequest, ExecutionWithState, FunctionNameFilter, ListExecutionsFilter, Pagination,
+        PendingState, PendingStateFinishedError, PendingStateFinishedResultKind, ResponseCursor,
+        ResponseWithCursor, TimeoutOutcome, Version, VersionType,
     },
     time::{ClockFn as _, Now, Sleep as _},
 };
@@ -50,7 +49,7 @@ use utoipa::{IntoParams, OpenApi, ToSchema};
 use val_json::{wast_val::WastVal, wast_val_ser::deserialize_value};
 use wasm_workers::{
     activity::cancel_registry::CancelRegistry, registry::ReplayWorker,
-    webhook::webhook_registry::WebhookRegistry, workflow::workflow_worker::AdvanceError,
+    workflow::workflow_worker::AdvanceError,
 };
 
 #[derive(Clone)]
@@ -61,9 +60,8 @@ pub(crate) struct WebApiState {
     pub(crate) cancel_registry: CancelRegistry,
     pub(crate) termination_watcher: watch::Receiver<()>,
     pub(crate) subscription_interruption: Option<Duration>,
-    pub(crate) log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
     pub(crate) prepared_dirs: PreparedDirs,
-    pub(crate) webhook_registry: Arc<WebhookRegistry>,
+    pub(crate) deployment_switch_manager: crate::command::server::DeploymentSwitchManagerHandle,
 }
 
 /// `OpenAPI` documentation for the Obelisk REST API
@@ -3055,7 +3053,7 @@ mod deployment {
     use serde::{Deserialize, Serialize};
     use std::fmt::Write as _;
     use std::sync::Arc;
-    use tracing::{error, info, instrument};
+    use tracing::{info, instrument};
     use utoipa::{IntoParams, ToSchema};
 
     #[derive(Debug, Serialize, ToSchema)]
@@ -3598,11 +3596,19 @@ mod deployment {
             inputs.files,
             state.db_pool.clone(),
             &mut termination_watcher,
+            Some(state.deployment_switch_manager.clone()),
         ))
         .await;
 
         let deployment_id = match result {
             Ok(deployment_id) => deployment_id,
+            Err(server::SubmitDeploymentError::Busy) => {
+                return Err(HttpResponse {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    message: "another deployment submit or switch is already running".to_string(),
+                    accept,
+                });
+            }
             Err(server::SubmitDeploymentError::Other(err)) => {
                 return Err(HttpResponse {
                     status: StatusCode::BAD_REQUEST,
@@ -3712,7 +3718,6 @@ mod deployment {
         accept: AcceptHeader,
         Json(payload): Json<DeploymentSwitchPayload>,
     ) -> Result<Response, HttpResponse> {
-        let mut termination_watcher = state.termination_watcher.clone();
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         let action = if payload.hot_redeploy {
             if payload.allow_missing_runtime_config {
@@ -3728,32 +3733,18 @@ mod deployment {
                 payload.allow_missing_runtime_config,
             ))
         };
-        let outcome = tokio::spawn(async move {
-            // Cancel safety
-            crate::command::server::switch_deployment(
-                state.server_verified.clone(),
-                deployment_id,
-                action,
-                &state.prepared_dirs,
-                state.db_pool.clone(),
-                &mut termination_watcher,
-                &state.deployment_ctx,
-                &state.webhook_registry,
-                state.cancel_registry.clone(),
-                state.log_forwarder_sender.clone(),
-            )
-            .await
-        })
+        let outcome = crate::command::server::switch_deployment(
+            state.deployment_switch_manager.clone(),
+            deployment_id,
+            action,
+        )
         .await
-        .map_err(|join_err| {
-            error!("Panic in switch_deployment: {join_err:?}");
-            HttpResponse {
-                status: StatusCode::SERVICE_UNAVAILABLE,
-                message: "internal error".to_string(),
-                accept,
-            }
-        })?
         .map_err(|err| match err {
+            crate::command::server::SwitchError::Busy => HttpResponse {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                message: "another deployment submit or switch is already running".to_string(),
+                accept,
+            },
             crate::command::server::SwitchError::NotFound => {
                 HttpResponse::not_found(accept, Some("deployment"))
             }


### PR DESCRIPTION
- **refactor(server): Extract `DeploymentSwitchManager`, submit lane, switch gate**
- **refactor: Extract `spawn_deployment_context`**
- **refactor: Rename `submit_gate` to `submit_lane`, `try_acquire..`**
- **feat(deployment): enqueue of the active deployment clears the pending one**
- **refactor(server): newtype switch and submit lane permits**
- **refactor(server): Move hot-redeploy durable commits to the detached task**
