### PR TITLE
fix: emit synthesized component WIT with world in root:component package

### DIFF
--- a/crates/utils/src/wit.rs
+++ b/crates/utils/src/wit.rs
@@ -902,7 +902,7 @@ pub(crate) fn build_primary_resolve(
         resolve.interfaces.get_mut(ifc_id).unwrap().types = types;
     }
 
-    if let Some(world_name) = world_name {
+    let main_pkg_id = if let Some(world_name) = world_name {
         let world_exports: IndexMap<WorldKey, WorldItem> = resolve.packages[pkg_id]
             .interfaces
             .values()
@@ -917,12 +917,28 @@ pub(crate) fn build_primary_resolve(
                 )
             })
             .collect();
+        // Put the synthesized world in a dedicated `root:component` package to avoid
+        // a package-level dependency cycle.
+        let root_pkg = wit_parser::Package {
+            name: PackageName {
+                namespace: "root".to_string(),
+                name: "component".to_string(),
+                version: None,
+            },
+            docs: wit_parser::Docs::default(),
+            interfaces: IndexMap::default(),
+            worlds: IndexMap::default(),
+        };
+        let root_pkg_id = resolve.packages.alloc(root_pkg);
+        resolve
+            .package_names
+            .insert(resolve.packages[root_pkg_id].name.clone(), root_pkg_id);
         let world = World {
             name: world_name.to_string(),
             docs: wit_parser::Docs::default(),
             imports: IndexMap::default(),
             exports: world_exports,
-            package: Some(pkg_id),
+            package: Some(root_pkg_id),
             span: Span::default(),
             includes: vec![],
             stability: Stability::Unknown,
@@ -930,13 +946,16 @@ pub(crate) fn build_primary_resolve(
         let world_id = resolve.worlds.alloc(world);
         resolve
             .packages
-            .get_mut(pkg_id)
+            .get_mut(root_pkg_id)
             .unwrap()
             .worlds
             .insert(world_name.to_string(), world_id);
-    }
+        root_pkg_id
+    } else {
+        pkg_id
+    };
 
-    Ok((resolve, pkg_id))
+    Ok((resolve, main_pkg_id))
 }
 
 // TODO: Make the wit_component's OutputToString configurable for number of spaces

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -4807,6 +4807,15 @@ mod tests {
         let config = compile_activity_inline(component_id, &ffqn, &params, &ret_type)
             .expect("compile must succeed");
 
+        // The synthesized WIT must re-parse: the world lives in a dedicated `root:component`
+        // package so the extension packages do not form a package dependency cycle.
+        let group =
+            wit_parser::UnresolvedPackageGroup::parse(std::path::PathBuf::new(), &config.wit)
+                .expect("synthesized WIT must parse");
+        wit_parser::Resolve::new()
+            .push_group(group)
+            .expect("synthesized WIT must not contain a package dependency cycle");
+
         // The rebuilt WIT includes extension packages absent from the raw synthesized string.
         insta::assert_snapshot!(config.wit);
     }

--- a/src/command/snapshots/obelisk__command__server__tests__wit_includes_obelisk_extension_packages.snap
+++ b/src/command/snapshots/obelisk__command__server__tests__wit_includes_obelisk_extension_packages.snap
@@ -2,17 +2,20 @@
 source: src/command/server.rs
 expression: config.wit
 ---
-package ns:pkg;
-
-interface ifc {
-    my-fn: func(id: u64) -> result<string, string>;
-}
+package root:component;
 
 world stub-activity {
-    export ifc;
+    export ns:pkg/ifc;
     export ns:pkg-obelisk-ext/ifc;
     export ns:pkg-obelisk-stub/ifc;
 }
+package ns:pkg {
+    interface ifc {
+        my-fn: func(id: u64) -> result<string, string>;
+    }
+}
+
+
 package obelisk:types@4.2.0 {
     @since(version = 3.0.0)
     interface time {


### PR DESCRIPTION
Synthetic components built from a function signature (exec activities, JS
activities/workflows, inline stub activities) placed the generated world in
the user's package. Because that world exports the generated
-obelisk-ext/-schedule/-stub interfaces while those packages import the
user's package, the result was a package dependency cycle that wit-parser
rejects on re-parse ("package depends on itself"), leaving consumers unable
to render the WIT. Emit the world in a dedicated root:component package
(mirroring wasm-tools' decode of a real component) so the package graph
stays a DAG. Verified by re-parsing the synthesized WIT in the test.
