### PR TITLE
refactor(wit): Bump obelisk_webhook to 5.3.0, add get-status-v2 with cancelling

### DIFF
--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-06-09@sha256:66fadb55c49ad97d4ad58cb7b66c6469d672f2e905c8e36b1c7ae1bad8cafa22
+oci://docker.io/getobelisk/webhook-js-runtime:2026-07-04@sha256:1b7f5d66b731ea2824e6ea656f6bbb98a0429c7342492dcc17c15648ba54b80b

--- a/crates/testing/component-builder/src/lib.rs
+++ b/crates/testing/component-builder/src/lib.rs
@@ -99,7 +99,17 @@ fn is_transformation_to_wasm_component_needed(target_tripple: &str) -> bool {
 /// ```
 fn get_target_dir() -> PathBuf {
     if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
-        PathBuf::from(target_dir)
+        let target_dir = PathBuf::from(target_dir);
+        if target_dir.is_relative() {
+            // Cargo resolves a relative `CARGO_TARGET_DIR` against the workspace root;
+            // do the same so the baked-in wasm paths are absolute and resolve regardless
+            // of the test's cwd.
+            let workspace_dir =
+                std::env::var("CARGO_WORKSPACE_DIR").expect("CARGO_WORKSPACE_DIR must be set");
+            Path::new(&workspace_dir).join(target_dir)
+        } else {
+            target_dir
+        }
     } else if let Ok(workspace_dir) = std::env::var("CARGO_WORKSPACE_DIR") {
         Path::new(&workspace_dir).join("target")
     } else {

--- a/crates/testing/component-builder/src/lib.rs
+++ b/crates/testing/component-builder/src/lib.rs
@@ -89,7 +89,7 @@ fn is_transformation_to_wasm_component_needed(target_tripple: &str) -> bool {
     target_tripple == WASM_CORE_MODULE
 }
 
-/// Get the path to the target directory using `CARGO_WORKSPACE_DIR` environment variable.
+/// Get the path to the target directory using `CARGO_TARGET_DIR` or `CARGO_WORKSPACE_DIR` environment variable.
 ///
 /// To set the environment variable automatically, modify `.cargo/config.toml`:
 /// ```toml
@@ -98,8 +98,9 @@ fn is_transformation_to_wasm_component_needed(target_tripple: &str) -> bool {
 /// CARGO_WORKSPACE_DIR = { value = "", relative = true }
 /// ```
 fn get_target_dir() -> PathBuf {
-    // Try to get `CARGO_WORKSPACE_DIR` from the environment
-    if let Ok(workspace_dir) = std::env::var("CARGO_WORKSPACE_DIR") {
+    if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
+        PathBuf::from(target_dir)
+    } else if let Ok(workspace_dir) = std::env::var("CARGO_WORKSPACE_DIR") {
         Path::new(&workspace_dir).join("target")
     } else {
         unreachable!("CARGO_WORKSPACE_DIR must be set")

--- a/crates/testing/test-programs/js/webhook/get_status.js
+++ b/crates/testing/test-programs/js/webhook/get_status.js
@@ -1,0 +1,5 @@
+export default function handle(request) {
+    const execId = request.headers.get("x-execution-id");
+    const status = obelisk.getStatus(execId);
+    return Response.json({ executionStatus: status });
+}

--- a/crates/utils/src/wit.rs
+++ b/crates/utils/src/wit.rs
@@ -52,11 +52,11 @@ pub const WIT_OBELISK_WORKFLOW_PACKAGE: [&str; 3] = [
 ];
 
 pub const WIT_OBELISK_WEBHOOK_PACKAGE: [&str; 3] = [
-    "obelisk_webhook@5.2.0",
-    "obelisk_webhook@5.2.0.wit",
+    "obelisk_webhook@5.3.0",
+    "obelisk_webhook@5.3.0.wit",
     include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
-        "/wit/obelisk_webhook@5.2.0/obelisk_webhook@5.2.0.wit"
+        "/wit/obelisk_webhook@5.3.0/obelisk_webhook@5.3.0.wit"
     )),
 ];
 

--- a/crates/wasm-workers/src/registry.rs
+++ b/crates/wasm-workers/src/registry.rs
@@ -273,7 +273,8 @@ impl ComponentConfigRegistry {
                     "wasi" => true,
                     "obelisk" => matches!(
                         import.ffqn.ifc_fqn.pkg_fqn_name().to_string().as_str(),
-                        "obelisk:webhook@5.2.0"
+                        "obelisk:webhook@5.3.0"
+                            | "obelisk:webhook@5.2.0"
                             | "obelisk:webhook@5.1.0"
                             | "obelisk:webhook@5.0.0"
                             | "obelisk:log@1.0.0"

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -73,7 +73,7 @@ pub(crate) mod types {
                     import obelisk:types/execution@4.2.0;
                     import obelisk:types/backtrace@4.2.0;
                     import obelisk:types/join-set@4.2.0;
-                    import obelisk:webhook/webhook-support@5.2.0;
+                    import obelisk:webhook/webhook-support@5.3.0;
                 }",
         world: "any:any/bindings",
         imports: {
@@ -129,6 +129,35 @@ pub(crate) mod types {
 }
 
 // Conversions from webhook types to internal types
+
+/// Convert a `PendingAt` scheduled time to the WIT `datetime`.
+fn datetime_from_scheduled_at(
+    scheduled_at: &chrono::DateTime<chrono::Utc>,
+) -> types::obelisk::types::time::Datetime {
+    types::obelisk::types::time::Datetime {
+        seconds: u64::try_from(scheduled_at.timestamp())
+            .expect("pending at before unix epoch is unsupported"),
+        nanoseconds: scheduled_at.timestamp_subsec_nanos(),
+    }
+}
+
+/// Map a finished execution's `result_kind` to the WIT `execution-status-finished`
+/// (shared by `get-status` and `get-status-v2`).
+fn finished_status_to_wit(
+    result_kind: &PendingStateFinishedResultKind,
+) -> types::obelisk::webhook::webhook_support::ExecutionStatusFinished {
+    use types::obelisk::webhook::webhook_support::ExecutionStatusFinished;
+    match result_kind {
+        PendingStateFinishedResultKind::Ok => ExecutionStatusFinished::Ok,
+        PendingStateFinishedResultKind::Err(PendingStateFinishedError::Error) => {
+            ExecutionStatusFinished::Err
+        }
+        PendingStateFinishedResultKind::Err(PendingStateFinishedError::ExecutionFailure(_)) => {
+            ExecutionStatusFinished::ExecutionFailure
+        }
+    }
+}
+
 /// Convert `SupportedFunctionReturnValue` to the JSON result format expected by webhook-support.
 /// Returns Ok(Some(json)) for successful result with value,
 /// Ok(None) for successful result with no value,
@@ -1053,57 +1082,22 @@ impl WebhookSupportHost for WebhookEndpointCtx {
         }
     }
 
+    /// Deprecated, use `get_status_v2`. Reports a `cancelling` execution as the
+    /// underlying state it is suspended from, since `execution-status` has no
+    /// `cancelling` case.
     async fn get_status(
         &mut self,
         execution_id: types::obelisk::webhook::webhook_support::ExecutionId,
         _backtrace: Option<types::obelisk::types::backtrace::WasmBacktrace>,
     ) -> Result<types::obelisk::webhook::webhook_support::ExecutionStatus, GetStatusErrorTrappable>
     {
-        use types::obelisk::webhook::webhook_support::{
-            ExecutionStatus, ExecutionStatusFinished, GetStatusError,
-        };
+        use types::obelisk::webhook::webhook_support::ExecutionStatus;
 
-        // Parse the execution ID
-        let execution_id = match concepts::ExecutionId::from_str(&execution_id.id) {
-            Ok(id) => id,
-            Err(err) => {
-                let msg = format!("get-status: cannot parse execution ID: {err}");
-                self.error(msg.clone()).await;
-                return Err(GetStatusError::ExecutionIdParsingError(msg).into());
-            }
-        };
-
-        // Get execution status from database
-        let db_connection = match self.db_pool.connection().await {
-            Ok(conn) => conn,
-            Err(err) => {
-                return Err(
-                    wasmtime::Error::msg(format!("database connection error: {err:?}")).into(),
-                );
-            }
-        };
-
-        let execution_with_state = match db_connection.get_pending_state(&execution_id).await {
-            Ok(state) => state,
-            Err(DbErrorRead::NotFound) => {
-                return Err(GetStatusError::NotFound.into());
-            }
-            Err(err) => {
-                return Err(wasmtime::Error::msg(format!("database read error: {err:?}")).into());
-            }
-        };
-
-        // Convert PendingState to ExecutionStatus.
-        // The webhook host API has no dedicated `cancelling` status yet, so a
-        // cancelling execution reports the underlying state it is suspended from.
-        let status = match execution_with_state.pending_state {
+        let pending_state = self.get_status_pending_state(&execution_id).await?;
+        let status = match pending_state {
             PendingState::PendingAt(state)
             | PendingState::Cancelling(PendingStateSuspended::PendingAt(state)) => {
-                ExecutionStatus::PendingAt(types::obelisk::types::time::Datetime {
-                    seconds: u64::try_from(state.scheduled_at.timestamp())
-                        .expect("pending at before unix epoch is unsupported"),
-                    nanoseconds: state.scheduled_at.timestamp_subsec_nanos(),
-                })
+                ExecutionStatus::PendingAt(datetime_from_scheduled_at(&state.scheduled_at))
             }
             PendingState::Locked(_) => ExecutionStatus::Locked,
             PendingState::BlockedByJoinSet(_)
@@ -1112,16 +1106,32 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             }
             PendingState::Paused(_) => ExecutionStatus::Paused,
             PendingState::Finished(finished) => {
-                let finished_status = match finished.result_kind {
-                    PendingStateFinishedResultKind::Ok => ExecutionStatusFinished::Ok,
-                    PendingStateFinishedResultKind::Err(PendingStateFinishedError::Error) => {
-                        ExecutionStatusFinished::Err
-                    }
-                    PendingStateFinishedResultKind::Err(
-                        PendingStateFinishedError::ExecutionFailure(_),
-                    ) => ExecutionStatusFinished::ExecutionFailure,
-                };
-                ExecutionStatus::Finished(finished_status)
+                ExecutionStatus::Finished(finished_status_to_wit(&finished.result_kind))
+            }
+        };
+
+        Ok(status)
+    }
+
+    async fn get_status_v2(
+        &mut self,
+        execution_id: types::obelisk::webhook::webhook_support::ExecutionId,
+        _backtrace: Option<types::obelisk::types::backtrace::WasmBacktrace>,
+    ) -> Result<types::obelisk::webhook::webhook_support::ExecutionStatusV2, GetStatusErrorTrappable>
+    {
+        use types::obelisk::webhook::webhook_support::ExecutionStatusV2;
+
+        let pending_state = self.get_status_pending_state(&execution_id).await?;
+        let status = match pending_state {
+            PendingState::PendingAt(state) => {
+                ExecutionStatusV2::PendingAt(datetime_from_scheduled_at(&state.scheduled_at))
+            }
+            PendingState::Locked(_) => ExecutionStatusV2::Locked,
+            PendingState::BlockedByJoinSet(_) => ExecutionStatusV2::BlockedByJoinSet,
+            PendingState::Cancelling(_) => ExecutionStatusV2::Cancelling,
+            PendingState::Paused(_) => ExecutionStatusV2::Paused,
+            PendingState::Finished(finished) => {
+                ExecutionStatusV2::Finished(finished_status_to_wit(&finished.result_kind))
             }
         };
 
@@ -1263,6 +1273,37 @@ impl wasmtime::component::HasData for WebhookEndpointCtx {
 }
 
 impl WebhookEndpointCtx {
+    /// Parse the execution ID and read its current `PendingState`, shared by
+    /// `get_status` and `get_status_v2`.
+    async fn get_status_pending_state(
+        &mut self,
+        execution_id: &types::obelisk::webhook::webhook_support::ExecutionId,
+    ) -> Result<PendingState, GetStatusErrorTrappable> {
+        use types::obelisk::webhook::webhook_support::GetStatusError;
+
+        let execution_id = match concepts::ExecutionId::from_str(&execution_id.id) {
+            Ok(id) => id,
+            Err(err) => {
+                let msg = format!("get-status: cannot parse execution ID: {err}");
+                self.error(msg.clone()).await;
+                return Err(GetStatusError::ExecutionIdParsingError(msg).into());
+            }
+        };
+        let db_connection = match self.db_pool.connection().await {
+            Ok(conn) => conn,
+            Err(err) => {
+                return Err(
+                    wasmtime::Error::msg(format!("database connection error: {err:?}")).into(),
+                );
+            }
+        };
+        match db_connection.get_pending_state(&execution_id).await {
+            Ok(state) => Ok(state.pending_state),
+            Err(DbErrorRead::NotFound) => Err(GetStatusError::NotFound.into()),
+            Err(err) => Err(wasmtime::Error::msg(format!("database read error: {err:?}")).into()),
+        }
+    }
+
     // Create new execution if this is the first call of the request/response cycle
     async fn get_version_or_create(&mut self) -> Result<Version, DbErrorWrite> {
         if let Some(found) = &self.version {

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -66,7 +66,7 @@
 //! ## Check Execution Status
 //! ```js
 //! const status = obelisk.getStatus(execId);
-//! // status = "pending" | "locked" | "blockedByJoinSet" | "finished"
+//! // status = "pendingAt" | "locked" | "paused" | "blockedByJoinSet" | "cancelling" | "finished"
 //! // If finished: status.finishedStatus = "ok" | "err" | "executionFailure"
 //! ```
 //!
@@ -105,7 +105,7 @@ use crate::generated::obelisk::types::backtrace::{FrameInfo, FrameSymbol, WasmBa
 use crate::generated::obelisk::types::execution::{ExecutionId, Function, SubmitConfig};
 use crate::generated::obelisk::types::time::{Datetime, Duration, ScheduleAt};
 use crate::generated::obelisk::webhook::webhook_support::{
-    self, ExecutionStatus, ExecutionStatusFinished,
+    self, ExecutionStatusFinished, ExecutionStatusV2,
 };
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::crypto::setup_crypto;
@@ -577,11 +577,11 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         let exec_id = ExecutionId { id: exec_id_str };
 
         let backtrace = capture_backtrace(ctx);
-        match webhook_support::get_status(&exec_id, Some(&backtrace)) {
+        match webhook_support::get_status_v2(&exec_id, Some(&backtrace)) {
             Ok(status) => {
                 let result_obj = new_object(ctx);
                 match status {
-                    ExecutionStatus::PendingAt(dt) => {
+                    ExecutionStatusV2::PendingAt(dt) => {
                         result_obj.set(
                             js_string!("status"),
                             js_string!("pendingAt"),
@@ -598,13 +598,13 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                         )?;
                         result_obj.set(js_string!("pendingAt"), dt_obj, false, ctx)?;
                     }
-                    ExecutionStatus::Locked => {
+                    ExecutionStatusV2::Locked => {
                         result_obj.set(js_string!("status"), js_string!("locked"), false, ctx)?;
                     }
-                    ExecutionStatus::Paused => {
+                    ExecutionStatusV2::Paused => {
                         result_obj.set(js_string!("status"), js_string!("paused"), false, ctx)?;
                     }
-                    ExecutionStatus::BlockedByJoinSet => {
+                    ExecutionStatusV2::BlockedByJoinSet => {
                         result_obj.set(
                             js_string!("status"),
                             js_string!("blockedByJoinSet"),
@@ -612,7 +612,15 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                             ctx,
                         )?;
                     }
-                    ExecutionStatus::Finished(finished) => {
+                    ExecutionStatusV2::Cancelling => {
+                        result_obj.set(
+                            js_string!("status"),
+                            js_string!("cancelling"),
+                            false,
+                            ctx,
+                        )?;
+                    }
+                    ExecutionStatusV2::Finished(finished) => {
                         result_obj.set(js_string!("status"), js_string!("finished"), false, ctx)?;
                         let finished_status = match finished {
                             ExecutionStatusFinished::Ok => "ok",

--- a/crates/webhook-js-runtime/wit/world.wit
+++ b/crates/webhook-js-runtime/wit/world.wit
@@ -1,6 +1,6 @@
 package any:any;
 
 world any {
-    import obelisk:webhook/webhook-support@5.2.0;
+    import obelisk:webhook/webhook-support@5.3.0;
     import obelisk:log/log@1.0.0;
 }

--- a/scripts/push-activity-js-runtime.sh
+++ b/scripts/push-activity-js-runtime.sh
@@ -16,14 +16,14 @@ OUTPUT_FILE="${2:-assets/activity-js-runtime-version.txt}"
 cargo check --package activity-js-runtime-builder # triggers build.rs of activity-js-runtime-builder
 
 if [ "$TAG" != "dry-run" ]; then
-    TMP_TOML=$(mktemp -t workflow-deployment-XXXXXX.toml)
+    TMP_TOML="activity-deployment-for-push.toml"
     trap "rm -f $TMP_TOML" EXIT
     cat > "$TMP_TOML" <<EOF
 [[activity_wasm]]
-name = "pushed"
-location = "$(pwd)/target/release_wasm_runtime/wasm32-wasip2/release_wasm_runtime/activity_js_runtime.wasm"
+name = "target_component"
+location = "target/release_wasm_runtime/wasm32-wasip2/release_wasm_runtime/activity_js_runtime.wasm"
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \
-        pushed "oci://docker.io/getobelisk/activity-js-runtime:$TAG")
+        target_component "oci://docker.io/getobelisk/activity-js-runtime:$TAG")
     echo -n $OUTPUT > $OUTPUT_FILE
 fi

--- a/scripts/push-webhook-js-runtime.sh
+++ b/scripts/push-webhook-js-runtime.sh
@@ -16,15 +16,15 @@ OUTPUT_FILE="${2:-assets/webhook-js-runtime-version.txt}"
 cargo check --package webhook-js-runtime-builder # triggers build.rs of webhook-js-runtime-builder
 
 if [ "$TAG" != "dry-run" ]; then
-    TMP_TOML=$(mktemp -t webhook-deployment-XXXXXX.toml)
+    TMP_TOML="webhook-deployment-for-push.toml"
     trap "rm -f $TMP_TOML" EXIT
     cat > "$TMP_TOML" <<EOF
 [[webhook_endpoint_wasm]]
-name = "pushed"
-location = "$(pwd)/target/wasm-cache/webhook_js_runtime.wasm"
+name = "target_component"
+location = "target/wasm-cache/webhook_js_runtime.wasm"
 routes = [""]
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \
-        pushed "oci://docker.io/getobelisk/webhook-js-runtime:$TAG")
+        target_component "oci://docker.io/getobelisk/webhook-js-runtime:$TAG")
     echo -n $OUTPUT > $OUTPUT_FILE
 fi

--- a/scripts/push-workflow-js-runtime.sh
+++ b/scripts/push-workflow-js-runtime.sh
@@ -16,14 +16,14 @@ OUTPUT_FILE="${2:-assets/workflow-js-runtime-version.txt}"
 cargo check --package workflow-js-runtime-builder # triggers build.rs of workflow-js-runtime-builder
 
 if [ "$TAG" != "dry-run" ]; then
-    TMP_TOML=$(mktemp -t workflow-deployment-XXXXXX.toml)
+    TMP_TOML="workflow-deployment-for-push.toml"
     trap "rm -f $TMP_TOML" EXIT
     cat > "$TMP_TOML" <<EOF
 [[workflow_wasm]]
-name = "pushed"
-location = "$(pwd)/target/wasm-cache/workflow_js_runtime_component.wasm"
+name = "target_component"
+location = "target/wasm-cache/workflow_js_runtime_component.wasm"
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \
-        pushed "oci://docker.io/getobelisk/workflow-js-runtime:$TAG")
+        target_component "oci://docker.io/getobelisk/workflow-js-runtime:$TAG")
     echo -n $OUTPUT > $OUTPUT_FILE
 fi

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -581,6 +581,11 @@ location = "{ws}/crates/testing/test-programs/js/webhook/generate_execution_id.j
 routes = [{{ methods = ["GET"], route = "/generate-execution-id" }}]
 
 [[webhook_endpoint_js]]
+name = "test_get_status_webhook"
+location = "{ws}/crates/testing/test-programs/js/webhook/get_status.js"
+routes = [{{ methods = ["GET"], route = "/get-status" }}]
+
+[[webhook_endpoint_js]]
 name = "test_import_call_activity_webhook"
 location = "{ws}/crates/testing/test-programs/js/webhook/import_call_activity.js"
 routes = [{{ methods = ["GET"], route = "/import-call-activity" }}]
@@ -3459,6 +3464,121 @@ async fn webhook_js_hello() {
     );
     let body = resp.text().await.unwrap();
     assert_eq!(body, "Hello from JS webhook!");
+    server.shutdown().await;
+}
+
+/// A JS webhook's `getStatus` reports the first-class `cancelling` state
+/// (via `get-status-v2`).
+///
+/// The seed needs an *uncancellable* child, not just one execution: the running
+/// server's cancellation driver finishes any `cancelling` execution once all its
+/// join-set members have responded, so a lone one would be `Finished(Cancelled)`
+/// before the webhook reads it. An uncancellable child that never responds is an
+/// await barrier the driver can't clear, holding the parent in `cancelling`.
+#[tokio::test]
+async fn webhook_js_get_status_cancelling() {
+    use concepts::prefixed_ulid::DEPLOYMENT_ID_DUMMY;
+    use concepts::storage::{
+        AppendRequest, CreateRequest, ExecutionRequest, HistoryEvent, JoinSetRequest,
+    };
+    use concepts::{
+        ComponentId, ExecutionId, ExecutionMetadata, JoinSetId, JoinSetKind, Params, StrVariant,
+    };
+
+    // Uncancellable child (no `-cancellable` suffix) → permanent await barrier.
+    const PARENT_FFQN: FunctionFqn =
+        FunctionFqn::new_static("testing:cancel/ifc", "parent-cancellable");
+    const CHILD_FFQN: FunctionFqn = FunctionFqn::new_static("testing:cancel/ifc", "child");
+
+    let server = TestServer::start(test_addr!(86)).await;
+
+    // Seed a cancelling parent with an unfinished uncancellable child directly in
+    // the server's sqlite DB.
+    let parent_id = {
+        let pool = SqlitePool::new(&server.sqlite_file, SqliteConfig::default())
+            .await
+            .unwrap();
+        let conn = pool.connection().await.unwrap();
+        let now = chrono::Utc::now();
+        let create = |execution_id: ExecutionId, ffqn: FunctionFqn| CreateRequest {
+            created_at: now,
+            execution_id,
+            ffqn,
+            params: Params::empty(),
+            parent: None,
+            scheduled_at: now,
+            component_id: ComponentId::dummy_workflow(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            metadata: ExecutionMetadata::empty(),
+            scheduled_by: None,
+            paused: false,
+        };
+
+        let parent_id = ExecutionId::generate();
+        let version = conn
+            .create(create(parent_id.clone(), PARENT_FFQN))
+            .await
+            .unwrap();
+        let join_set_id = JoinSetId::new(JoinSetKind::OneOff, StrVariant::empty()).unwrap();
+        let version = conn
+            .append(
+                parent_id.clone(),
+                version,
+                AppendRequest {
+                    created_at: now,
+                    event: ExecutionRequest::HistoryEvent {
+                        event: HistoryEvent::JoinSetCreate {
+                            join_set_id: join_set_id.clone(),
+                        },
+                    },
+                },
+            )
+            .await
+            .unwrap();
+        let child_id = parent_id.next_level(&join_set_id);
+        conn.append(
+            parent_id.clone(),
+            version,
+            AppendRequest {
+                created_at: now,
+                event: ExecutionRequest::HistoryEvent {
+                    event: HistoryEvent::JoinSetRequest {
+                        join_set_id,
+                        request: JoinSetRequest::ChildExecutionRequest {
+                            child_execution_id: child_id.clone(),
+                            target_ffqn: CHILD_FFQN,
+                            params: Params::empty(),
+                            result: Ok(()),
+                        },
+                    },
+                },
+            },
+        )
+        .await
+        .unwrap();
+        conn.create(create(ExecutionId::Derived(child_id), CHILD_FFQN))
+            .await
+            .unwrap();
+        conn.request_cancellation_with_retries(&parent_id, now)
+            .await
+            .unwrap();
+        pool.close().await;
+        parent_id
+    };
+
+    let resp = server
+        .client
+        .get(format!("{}/get-status", server.webhook_base_url))
+        .header("x-execution-id", parent_id.to_string())
+        .send()
+        .await
+        .expect("webhook request failed");
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["executionStatus"]["status"],
+        serde_json::json!("cancelling")
+    );
     server.shutdown().await;
 }
 

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1513,7 +1513,9 @@ impl TestServer {
     /// cancelled the cancellation driver can never advance it to `Finished` — it stays
     /// `Cancelling` for the rest of the test. Cancelling a trivial workflow instead
     /// races the driver, which finishes an empty-join-set cancellation on its next tick.
-    async fn seed_cancellable_parent_blocked_on_uncancellable_child(&self) -> concepts::ExecutionId {
+    async fn seed_cancellable_parent_blocked_on_uncancellable_child(
+        &self,
+    ) -> concepts::ExecutionId {
         use concepts::prefixed_ulid::DEPLOYMENT_ID_DUMMY;
         use concepts::storage::{
             AppendRequest, CreateRequest, ExecutionRequest, HistoryEvent, JoinSetRequest,

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1505,6 +1505,95 @@ impl TestServer {
         summary.expect("summary must be present")
     }
 
+    /// Seed a cancellable parent workflow blocked on a join set holding an unfinished
+    /// **uncancellable** child, directly in the server's sqlite DB, and return the
+    /// parent id.
+    ///
+    /// The uncancellable child is a permanent await barrier, so once the parent is
+    /// cancelled the cancellation driver can never advance it to `Finished` — it stays
+    /// `Cancelling` for the rest of the test. Cancelling a trivial workflow instead
+    /// races the driver, which finishes an empty-join-set cancellation on its next tick.
+    async fn seed_cancellable_parent_blocked_on_uncancellable_child(&self) -> concepts::ExecutionId {
+        use concepts::prefixed_ulid::DEPLOYMENT_ID_DUMMY;
+        use concepts::storage::{
+            AppendRequest, CreateRequest, ExecutionRequest, HistoryEvent, JoinSetRequest,
+        };
+        use concepts::{
+            ComponentId, ExecutionId, ExecutionMetadata, JoinSetId, JoinSetKind, Params, StrVariant,
+        };
+
+        const PARENT_FFQN: FunctionFqn =
+            FunctionFqn::new_static("testing:cancel/ifc", "parent-cancellable");
+        const CHILD_FFQN: FunctionFqn = FunctionFqn::new_static("testing:cancel/ifc", "child");
+
+        let pool = SqlitePool::new(&self.sqlite_file, SqliteConfig::default())
+            .await
+            .unwrap();
+        let conn = pool.connection().await.unwrap();
+        let now = chrono::Utc::now();
+        let create = |execution_id: ExecutionId, ffqn: FunctionFqn| CreateRequest {
+            created_at: now,
+            execution_id,
+            ffqn,
+            params: Params::empty(),
+            parent: None,
+            scheduled_at: now,
+            component_id: ComponentId::dummy_workflow(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            metadata: ExecutionMetadata::empty(),
+            scheduled_by: None,
+            paused: false,
+        };
+
+        let parent_id = ExecutionId::generate();
+        let version = conn
+            .create(create(parent_id.clone(), PARENT_FFQN))
+            .await
+            .unwrap();
+        let join_set_id = JoinSetId::new(JoinSetKind::OneOff, StrVariant::empty()).unwrap();
+        let version = conn
+            .append(
+                parent_id.clone(),
+                version,
+                AppendRequest {
+                    created_at: now,
+                    event: ExecutionRequest::HistoryEvent {
+                        event: HistoryEvent::JoinSetCreate {
+                            join_set_id: join_set_id.clone(),
+                        },
+                    },
+                },
+            )
+            .await
+            .unwrap();
+        let child_id = parent_id.next_level(&join_set_id);
+        conn.append(
+            parent_id.clone(),
+            version,
+            AppendRequest {
+                created_at: now,
+                event: ExecutionRequest::HistoryEvent {
+                    event: HistoryEvent::JoinSetRequest {
+                        join_set_id,
+                        request: JoinSetRequest::ChildExecutionRequest {
+                            child_execution_id: child_id.clone(),
+                            target_ffqn: CHILD_FFQN,
+                            params: Params::empty(),
+                            result: Ok(()),
+                        },
+                    },
+                },
+            },
+        )
+        .await
+        .unwrap();
+        conn.create(create(ExecutionId::Derived(child_id), CHILD_FFQN))
+            .await
+            .unwrap();
+        pool.close().await;
+        parent_id
+    }
+
     async fn step_execution_until_finished_grpc(
         &self,
         ffqn: &str,
@@ -2608,14 +2697,10 @@ async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
         Some(grpc::grpc_gen::execution_status::Status::Finished(_))
     ));
 
-    let cancellable_workflow_id = server.generate_execution_id().await;
-    server
-        .submit_paused_grpc(
-            &cancellable_workflow_id,
-            "testing:integration/workflow-add.add-workflow-cancellable",
-            vec![json!(10), json!(20)],
-        )
-        .await;
+    let cancellable_workflow_id = server
+        .seed_cancellable_parent_blocked_on_uncancellable_child()
+        .await
+        .to_string();
     let resp = grpc_client
         .cancel_execution(CancelExecutionRequest {
             execution_id: Some(GrpcExecutionId {
@@ -2706,14 +2791,10 @@ async fn cancel_execution_webapi_routes_activities_and_cancellable_workflows() {
         Some(grpc::grpc_gen::execution_status::Status::Finished(_))
     ));
 
-    let cancellable_workflow_id = server.generate_execution_id().await;
-    server
-        .submit_paused_webapi(
-            &cancellable_workflow_id,
-            "testing:integration/workflow-add.add-workflow-cancellable",
-            vec![json!(10), json!(20)],
-        )
-        .await;
+    let cancellable_workflow_id = server
+        .seed_cancellable_parent_blocked_on_uncancellable_child()
+        .await
+        .to_string();
     let resp = server
         .client
         .put(format!(

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -209,6 +209,13 @@ expression: components
   {
     "component_id": {
       "component_type": "webhook_endpoint",
+      "name": "test_get_status_webhook",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "webhook_endpoint",
       "name": "test_headers_webhook",
       "component_digest": "sha256:<REDACTED>"
     }

--- a/wit/obelisk_webhook@5.3.0/obelisk_webhook@5.3.0.wit
+++ b/wit/obelisk_webhook@5.3.0/obelisk_webhook@5.3.0.wit
@@ -1,4 +1,4 @@
-package obelisk:webhook@5.2.0;
+package obelisk:webhook@5.3.0;
 
 @since(version = 5.0.0)
 interface webhook-support {
@@ -36,6 +36,9 @@ interface webhook-support {
     }
 
     /// The status of an execution.
+    ///
+    /// Superseded by `execution-status-v2`, which additionally reports the
+    /// `cancelling` state. Kept unchanged for backwards compatibility.
     @since(version = 5.0.0)
     variant execution-status {
         /// Execution is scheduled to run at a specific time.
@@ -46,6 +49,24 @@ interface webhook-support {
         paused,
         /// Execution is waiting for child executions to complete (workflows only).
         blocked-by-join-set,
+        /// Execution has finished.
+        finished(execution-status-finished),
+    }
+
+    /// The status of an execution, including cancellation.
+    @since(version = 5.3.0)
+    variant execution-status-v2 {
+        /// Execution is scheduled to run at a specific time.
+        pending-at(datetime),
+        /// Execution is currently being processed.
+        locked,
+        /// Execution is currently paused.
+        paused,
+        /// Execution is waiting for child executions to complete (workflows only).
+        blocked-by-join-set,
+        /// Cancellation has been requested; the execution is being torn down
+        /// (cancellable workflows only).
+        cancelling,
         /// Execution has finished.
         finished(execution-status-finished),
     }
@@ -91,9 +112,17 @@ interface webhook-support {
     @since(version = 5.0.0)
     schedule-json: func(execution-id: execution-id, schedule-at: schedule-at, function: function, params: string, config: option<submit-config>, backtrace: option<wasm-backtrace>) -> result<_, schedule-json-error>;
 
-    /// Get the current status of an execution.
+    /// Use `get-status-v2`, which additionally reports the `cancelling` state.
+    // TODO: Remove this deprecated function (and `execution-status`) on the next
+    // major version bump of this package.
     @since(version = 5.0.0)
+    @deprecated(version = 5.3.0)
     get-status: func(execution-id: execution-id, backtrace: option<wasm-backtrace>) -> result<execution-status, get-status-error>;
+
+    /// Get the current status of an execution.
+    /// Additionally reports the `cancelling` state for cancellable workflows.
+    @since(version = 5.3.0)
+    get-status-v2: func(execution-id: execution-id, backtrace: option<wasm-backtrace>) -> result<execution-status-v2, get-status-error>;
 
     /// Get the result of an execution, blocking until it finishes.
     /// Returns Ok(Some(json)) for successful result with value,

--- a/wit/obelisk_webhook@latest
+++ b/wit/obelisk_webhook@latest
@@ -1,1 +1,1 @@
-obelisk_webhook@5.2.0/
+obelisk_webhook@5.3.0/


### PR DESCRIPTION
- **refactor(wit): Bump obelisk_webhook to 5.3.0, add get-status-v2 with cancelling**
- **test(webhook): Integration test for JS getStatus reporting cancelling**
- **build: Fix `push-*-runime.sh` scripts with relative paths**
- **chore: Push webhook JS runtime**
- **build: Respect `CARGO_TARGET_DIR` in `component-builder`**
