### PR TITLE
cancellable activity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,6 +3483,7 @@ dependencies = [
  "sha2 0.10.9",
  "strum 0.28.0",
  "tempfile",
+ "test-programs-fibo-workflow-outer-builder",
  "test-utils",
  "thiserror 2.0.18",
  "tikv-jemallocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,6 +3368,7 @@ dependencies = [
  "indexmap 2.14.0",
  "insta",
  "itertools",
+ "libc",
  "obeli-db-tests",
  "obeli-sk-boa-engine",
  "obeli-sk-concepts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ concepts = { workspace = true, features = ["test"] }
 db-postgres = { workspace = true, features = ["test"] }
 db-sqlite = { workspace = true, features = ["test"] }
 wasm-workers = { workspace = true, features = ["test"] }
+test-programs-fibo-workflow-outer-builder.workspace = true
 
 hmac.workspace = true
 insta.workspace = true
@@ -219,6 +220,7 @@ test-db-macro = { path = "crates/testing/db-macro" }
 test-programs-fibo-activity-builder = { path = "crates/testing/test-programs/fibo/activity/builder" }
 test-programs-fibo-webhook-builder = { path = "crates/testing/test-programs/fibo/webhook/builder" }
 test-programs-fibo-workflow-builder = { path = "crates/testing/test-programs/fibo/workflow/builder" }
+test-programs-fibo-workflow-outer-builder = { path = "crates/testing/test-programs/fibo/workflow-outer/builder" }
 test-programs-http-get-activity-builder = { path = "crates/testing/test-programs/http/activity/builder" }
 test-programs-http-get-webhook-builder = { path = "crates/testing/test-programs/http/webhook/builder" }
 test-programs-http-get-workflow-builder = { path = "crates/testing/test-programs/http/workflow/builder" }

--- a/assets/schemas/db.json
+++ b/assets/schemas/db.json
@@ -308,7 +308,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Requests cancellation of a cancellable workflow. Sets `lifecycle` to\n`cancelling` without changing the underlying state; the cancellation driver\nthen closes the subtree and appends `Finished(Cancelled)`.\n\nState transition semantics (mirrors [`ExecutionRequest::Paused`]):\n- [`PendingState::PendingAt`] / [`PendingState::BlockedByJoinSet`] set\n  `lifecycle = cancelling`, underlying state unchanged.\n- [`PendingState::Locked`] and [`PendingState::Paused`] are rejected on the\n  raw append path; they must first be released (`Unlocked` / `Unpaused`) by\n  `cancel_workflow` so `cancelling` never coexists with a lock or pause.\n- [`PendingState::Finished`] is rejected (already terminal).",
+          "description": "Requests cancellation. Sets `lifecycle` to `cancelling` without changing\nthe underlying state; the cancellation driver or activity owner then\nappends `Finished(Cancelled)`.\n\nState transition semantics (mirrors [`ExecutionRequest::Paused`]):\n- Every non-terminal state sets `lifecycle = cancelling`, underlying state\n  unchanged. A paused execution is never running; a locked activity keeps\n  its lock until teardown or lease expiry; a locked workflow's run is\n  fenced by this event's version bump.\n- [`PendingState::Finished`] is rejected (already terminal).",
           "type": "string",
           "const": "cancellation_requested"
         }
@@ -1628,7 +1628,7 @@
           ]
         },
         {
-          "description": "Underlying runnable state (`PendingAt` or `BlockedByJoinSet`) of a paused or\ncancelling execution.\n\nSuspending a locked execution must first append `Unlocked`, so `Locked` is\nnever wrapped here.",
+          "description": "Started by appending [`ExecutionRequest::Paused`] and\nended with [`ExecutionRequest::Unpaused`] or [`ExecutionRequest::CancellationRequested`].\n\nActivity must not be in-flight, cancelling or finished when pausing.\nWorkflow must not be cancelling or finished.\nPausing a locked workflow must first append `Unlocked`.\nThe previous pending state is stored for workflow unpause.",
           "type": "object",
           "properties": {
             "status": {
@@ -1665,7 +1665,7 @@
           ]
         },
         {
-          "description": "Underlying runnable state (`PendingAt` or `BlockedByJoinSet`) of a paused or\ncancelling execution.\n\nSuspending a locked execution must first append `Unlocked`, so `Locked` is\nnever wrapped here.",
+          "description": "Started by appending [`ExecutionRequest::CancellationRequested`] and\nended with [`ExecutionRequest::Finished`].",
           "type": "object",
           "properties": {
             "status": {
@@ -1674,6 +1674,17 @@
             }
           },
           "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "Locked": {
+                  "$ref": "#/$defs/PendingStateLocked"
+                }
+              },
+              "required": [
+                "Locked"
+              ]
+            },
             {
               "type": "object",
               "properties": {

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -2647,9 +2647,10 @@ pub enum PendingStatePaused {
 
 /// Underlying state of a cancelling execution.
 ///
-/// Cancelling keeps any lock: a running activity holds it until the owner confirms
-/// teardown or the lease expires, a running workflow is fenced by the cancellation's
-/// version bump.
+/// Tracked for the cancellation driver: an activity whose worker fails to confirm
+/// teardown is pronounced finished once the `Locked` lease expires. The other
+/// variants are a frozen snapshot from when cancellation was requested (incoming
+/// responses do not unblock a cancelling execution), kept for observability.
 #[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub enum PendingStateCancelling {
     #[display("Locked({_0})")]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -2521,11 +2521,20 @@ pub enum PendingState {
     #[display("BlockedByJoinSet({_0})")]
     BlockedByJoinSet(PendingStateBlockedByJoinSet),
 
+    /// Started by appending [`ExecutionRequest::Paused`] and
+    /// ended with [`ExecutionRequest::Unpaused`] or [`ExecutionRequest::CancellationRequested`].
+    ///
+    /// Activity must not be in-flight, cancelling or finished when pausing.
+    /// Workflow must not be cancelling or finished.
+    /// Pausing a locked workflow must first append `Unlocked`.
+    /// The previous pending state is stored for workflow unpause.
     #[display("Paused({_0})")]
-    Paused(PendingStateSuspended),
+    Paused(PendingStatePaused),
 
+    /// Started by appending [`ExecutionRequest::CancellationRequested`] and
+    /// ended with [`ExecutionRequest::Finished`].
     #[display("Cancelling({_0})")]
-    Cancelling(PendingStateSuspended),
+    Cancelling(PendingStateCancelling),
 
     #[display("Finished: {_0}")]
     Finished(PendingStateFinished),
@@ -2566,29 +2575,35 @@ impl From<PendingState> for PendingStateMerged {
                 lifecycle: Lifecycle::Active,
             },
 
-            PendingState::Paused(inner) => Self::from_suspended(inner, Lifecycle::Paused),
+            PendingState::Paused(inner) => match inner {
+                PendingStatePaused::PendingAt(s) => PendingStateMerged::PendingAt {
+                    state: s,
+                    lifecycle: Lifecycle::Paused,
+                },
+                PendingStatePaused::BlockedByJoinSet(s) => PendingStateMerged::BlockedByJoinSet {
+                    state: s,
+                    lifecycle: Lifecycle::Paused,
+                },
+            },
 
-            PendingState::Cancelling(inner) => Self::from_suspended(inner, Lifecycle::Cancelling),
+            PendingState::Cancelling(inner) => match inner {
+                PendingStateCancelling::Locked(s) => PendingStateMerged::Locked {
+                    state: s,
+                    lifecycle: Lifecycle::Cancelling,
+                },
+                PendingStateCancelling::PendingAt(s) => PendingStateMerged::PendingAt {
+                    state: s,
+                    lifecycle: Lifecycle::Cancelling,
+                },
+                PendingStateCancelling::BlockedByJoinSet(s) => {
+                    PendingStateMerged::BlockedByJoinSet {
+                        state: s,
+                        lifecycle: Lifecycle::Cancelling,
+                    }
+                }
+            },
 
             PendingState::Finished(s) => PendingStateMerged::Finished(s),
-        }
-    }
-}
-impl PendingStateMerged {
-    fn from_suspended(inner: PendingStateSuspended, lifecycle: Lifecycle) -> Self {
-        match inner {
-            PendingStateSuspended::Locked(s) => PendingStateMerged::Locked {
-                state: s,
-                lifecycle,
-            },
-            PendingStateSuspended::PendingAt(s) => PendingStateMerged::PendingAt {
-                state: s,
-                lifecycle,
-            },
-            PendingStateSuspended::BlockedByJoinSet(s) => PendingStateMerged::BlockedByJoinSet {
-                state: s,
-                lifecycle,
-            },
         }
     }
 }
@@ -2618,13 +2633,25 @@ pub struct PendingStateBlockedByJoinSet {
     pub closing: bool,
 }
 
-/// Underlying runnable state of a paused or cancelling execution.
+/// State of execution before it was paused.
 ///
-/// Pausing a locked execution must first append `Unlocked`. Cancelling keeps any
-/// lock: a running activity holds it until the owner confirms teardown or the lease
-/// expires, a running workflow is fenced by the cancellation's version bump.
+/// A paused activity is always `PendingAt`. Pausing a locked workflow must first
+/// append `Unlocked`, so `Locked` is never wrapped here.
 #[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
-pub enum PendingStateSuspended {
+pub enum PendingStatePaused {
+    #[display("PendingAt({_0})")]
+    PendingAt(PendingStatePendingAt),
+    #[display("BlockedByJoinSet({_0})")]
+    BlockedByJoinSet(PendingStateBlockedByJoinSet),
+}
+
+/// Underlying state of a cancelling execution.
+///
+/// Cancelling keeps any lock: a running activity holds it until the owner confirms
+/// teardown or the lease expires, a running workflow is fenced by the cancellation's
+/// version bump.
+#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+pub enum PendingStateCancelling {
     #[display("Locked({_0})")]
     Locked(PendingStateLocked),
     #[display("PendingAt({_0})")]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1272,7 +1272,10 @@ pub trait DbExecutor: Send + Sync {
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let mut retries = 5;
         loop {
-            match self.cancel_activity(execution_id, cancelled_at).await {
+            match self
+                .append_activity_cancellation_requested(execution_id, cancelled_at)
+                .await
+            {
                 Err(DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::VersionConflict {
                     ..
                 })) if retries > 0 => retries -= 1,
@@ -1317,7 +1320,7 @@ pub trait DbExecutor: Send + Sync {
         execution_id: &ExecutionId,
     ) -> Result<ExecutionEvent, DbErrorRead>;
 
-    async fn cancel_activity(
+    async fn append_activity_cancellation_requested(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -456,11 +456,10 @@ pub enum ExecutionRequest {
     /// appends `Finished(Cancelled)`.
     ///
     /// State transition semantics (mirrors [`ExecutionRequest::Paused`]):
-    /// - [`PendingState::PendingAt`] / [`PendingState::BlockedByJoinSet`] /
-    ///   [`PendingState::Paused`] set `lifecycle = cancelling`, underlying state
-    ///   unchanged (a paused execution is guaranteed not to be running).
-    /// - [`PendingState::Locked`] is accepted for activities and rejected for
-    ///   workflows; workflows must first be released by `cancel_workflow`.
+    /// - Every non-terminal state sets `lifecycle = cancelling`, underlying state
+    ///   unchanged. A paused execution is never running; a locked activity keeps
+    ///   its lock until teardown or lease expiry; a locked workflow's run is
+    ///   fenced by this event's version bump.
     /// - [`PendingState::Finished`] is rejected (already terminal).
     #[display("CancellationRequested")]
     CancellationRequested,
@@ -2621,8 +2620,9 @@ pub struct PendingStateBlockedByJoinSet {
 
 /// Underlying runnable state of a paused or cancelling execution.
 ///
-/// Pausing a locked execution must first append `Unlocked`; cancelling a running
-/// activity keeps the lock until the owner confirms teardown or the lease expires.
+/// Pausing a locked execution must first append `Unlocked`. Cancelling keeps any
+/// lock: a running activity holds it until the owner confirms teardown or the lease
+/// expires, a running workflow is fenced by the cancellation's version bump.
 #[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub enum PendingStateSuspended {
     #[display("Locked({_0})")]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -5,7 +5,6 @@ use crate::ContentDigest;
 use crate::ExecutionFailureKind;
 use crate::ExecutionId;
 use crate::ExecutionMetadata;
-use crate::FinishedExecutionFailure;
 use crate::FunctionExtension;
 use crate::FunctionFqn;
 use crate::FunctionMetadata;
@@ -32,7 +31,6 @@ use std::panic::Location;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::debug;
 use tracing::instrument;
 use tracing_error::SpanTrace;
 
@@ -453,16 +451,16 @@ pub enum ExecutionRequest {
     Paused,
     #[display("Unpaused")]
     Unpaused,
-    /// Requests cancellation of a cancellable workflow. Sets `lifecycle` to
-    /// `cancelling` without changing the underlying state; the cancellation driver
-    /// then closes the subtree and appends `Finished(Cancelled)`.
+    /// Requests cancellation. Sets `lifecycle` to `cancelling` without changing
+    /// the underlying state; the cancellation driver or activity owner then
+    /// appends `Finished(Cancelled)`.
     ///
     /// State transition semantics (mirrors [`ExecutionRequest::Paused`]):
     /// - [`PendingState::PendingAt`] / [`PendingState::BlockedByJoinSet`] set
     ///   `lifecycle = cancelling`, underlying state unchanged.
-    /// - [`PendingState::Locked`] and [`PendingState::Paused`] are rejected on the
-    ///   raw append path; they must first be released (`Unlocked` / `Unpaused`) by
-    ///   `cancel_workflow` so `cancelling` never coexists with a lock or pause.
+    /// - [`PendingState::Locked`] is accepted for activities and rejected for
+    ///   workflows; workflows must first be released by `cancel_workflow`.
+    /// - [`PendingState::Paused`] is rejected on the raw append path.
     /// - [`PendingState::Finished`] is rejected (already terminal).
     #[display("CancellationRequested")]
     CancellationRequested,
@@ -1274,11 +1272,12 @@ pub trait DbExecutor: Send + Sync {
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let mut retries = 5;
         loop {
-            let res = self.cancel_activity(execution_id, cancelled_at).await;
-            if res.is_ok() || retries == 0 {
-                return res;
+            match self.cancel_activity(execution_id, cancelled_at).await {
+                Err(DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::VersionConflict {
+                    ..
+                })) if retries > 0 => retries -= 1,
+                res => return res,
             }
-            retries -= 1;
         }
     }
 
@@ -1322,69 +1321,7 @@ pub trait DbExecutor: Send + Sync {
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
-    ) -> Result<CancelOutcome, DbErrorWrite> {
-        debug!("Determining cancellation state of {execution_id}");
-
-        let last_event = self
-            .get_last_execution_event(execution_id)
-            .await
-            .map_err(DbErrorWrite::from)?;
-        if let ExecutionRequest::Finished {
-            retval:
-                SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
-                    kind: ExecutionFailureKind::Cancelled,
-                    ..
-                }),
-            ..
-        } = last_event.event
-        {
-            return Ok(CancelOutcome::Cancelled);
-        } else if matches!(last_event.event, ExecutionRequest::Finished { .. }) {
-            debug!("Not cancelling, {execution_id} is already finished");
-            return Ok(CancelOutcome::AlreadyFinished);
-        }
-        let finished_version = last_event.version.increment();
-        let child_result =
-            SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
-                reason: None,
-                kind: ExecutionFailureKind::Cancelled,
-                detail: None,
-            });
-        let cancel_request = AppendRequest {
-            created_at: cancelled_at,
-            event: ExecutionRequest::Finished {
-                retval: child_result.clone(),
-                http_client_traces: None,
-            },
-        };
-        debug!("Cancelling activity {execution_id} at {finished_version}");
-        if let ExecutionId::Derived(execution_id) = execution_id {
-            let (parent_execution_id, join_set_id) = execution_id.split_to_parts();
-            let child_execution_id = ExecutionId::Derived(execution_id.clone());
-            self.append_batch_respond_to_parent(
-                AppendEventsToExecution {
-                    execution_id: child_execution_id,
-                    version: finished_version.clone(),
-                    batch: vec![cancel_request],
-                },
-                AppendResponseToExecution {
-                    parent_execution_id,
-                    created_at: cancelled_at,
-                    join_set_id: join_set_id.clone(),
-                    child_execution_id: execution_id.clone(),
-                    finished_version,
-                    result: child_result,
-                },
-                cancelled_at,
-            )
-            .await?;
-        } else {
-            self.append(execution_id.clone(), finished_version, cancel_request)
-                .await?;
-        }
-        debug!("Cancelled {execution_id}");
-        Ok(CancelOutcome::Cancelled)
-    }
+    ) -> Result<CancelOutcome, DbErrorWrite>;
 }
 
 pub enum AppendDelayResponseOutcome {
@@ -2638,6 +2575,10 @@ impl From<PendingState> for PendingStateMerged {
 impl PendingStateMerged {
     fn from_suspended(inner: PendingStateSuspended, lifecycle: Lifecycle) -> Self {
         match inner {
+            PendingStateSuspended::Locked(s) => PendingStateMerged::Locked {
+                state: s,
+                lifecycle,
+            },
             PendingStateSuspended::PendingAt(s) => PendingStateMerged::PendingAt {
                 state: s,
                 lifecycle,
@@ -2675,13 +2616,14 @@ pub struct PendingStateBlockedByJoinSet {
     pub closing: bool,
 }
 
-/// Underlying runnable state (`PendingAt` or `BlockedByJoinSet`) of a paused or
-/// cancelling execution.
+/// Underlying runnable state of a paused or cancelling execution.
 ///
-/// Suspending a locked execution must first append `Unlocked`, so `Locked` is
-/// never wrapped here.
+/// Pausing a locked execution must first append `Unlocked`; cancelling a running
+/// activity keeps the lock until the owner confirms teardown or the lease expires.
 #[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
 pub enum PendingStateSuspended {
+    #[display("Locked({_0})")]
+    Locked(PendingStateLocked),
     #[display("PendingAt({_0})")]
     PendingAt(PendingStatePendingAt),
     #[display("BlockedByJoinSet({_0})")]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -458,9 +458,9 @@ pub enum ExecutionRequest {
     /// State transition semantics (mirrors [`ExecutionRequest::Paused`]):
     /// - [`PendingState::PendingAt`] / [`PendingState::BlockedByJoinSet`] set
     ///   `lifecycle = cancelling`, underlying state unchanged.
-    /// - [`PendingState::Locked`] is accepted for activities and rejected for
-    ///   workflows; workflows must first be released by `cancel_workflow`.
-    /// - [`PendingState::Paused`] is rejected on the raw append path.
+    /// - [`PendingState::Locked`] and [`PendingState::Paused`] are accepted for
+    ///   activities (a paused activity is guaranteed not to be running) and rejected
+    ///   for workflows; workflows must first be released by `cancel_workflow`.
     /// - [`PendingState::Finished`] is rejected (already terminal).
     #[display("CancellationRequested")]
     CancellationRequested,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -456,11 +456,11 @@ pub enum ExecutionRequest {
     /// appends `Finished(Cancelled)`.
     ///
     /// State transition semantics (mirrors [`ExecutionRequest::Paused`]):
-    /// - [`PendingState::PendingAt`] / [`PendingState::BlockedByJoinSet`] set
-    ///   `lifecycle = cancelling`, underlying state unchanged.
-    /// - [`PendingState::Locked`] and [`PendingState::Paused`] are accepted for
-    ///   activities (a paused activity is guaranteed not to be running) and rejected
-    ///   for workflows; workflows must first be released by `cancel_workflow`.
+    /// - [`PendingState::PendingAt`] / [`PendingState::BlockedByJoinSet`] /
+    ///   [`PendingState::Paused`] set `lifecycle = cancelling`, underlying state
+    ///   unchanged (a paused execution is guaranteed not to be running).
+    /// - [`PendingState::Locked`] is accepted for activities and rejected for
+    ///   workflows; workflows must first be released by `cancel_workflow`.
     /// - [`PendingState::Finished`] is rejected (already terminal).
     #[display("CancellationRequested")]
     CancellationRequested,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1283,28 +1283,26 @@ pub trait DbExecutor: Send + Sync {
         }
     }
 
-    /// Request cancellation of an already-known-cancellable workflow, from the worker
-    /// join-set close or the cancellation driver. Unlike `cancel_workflow`, skips the
-    /// `is_cancellable` guard: the caller has already classified the target. In one
-    /// version-guarded transaction, releases any lock/pause (`Unlocked`/`Unpaused`)
-    /// then appends `CancellationRequested`; returns `AlreadyFinished`/
-    /// `AlreadyCancelling` without appending.
-    async fn request_cancellation(
+    /// Request cancellation of a cancellable workflow. In one version-guarded
+    /// transaction, appends `CancellationRequested`; rejects a non-cancellable
+    /// target and returns `AlreadyFinished`/`AlreadyCancelling` without appending.
+    /// The `Finished(Cancelled)` outcome is driven later by the cancellation driver.
+    async fn cancel_workflow(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
     ) -> Result<CancelOutcome, DbErrorWrite>;
 
-    /// Request cancellation, retrying the version-guarded transaction on the
-    /// live-worker race.
-    async fn request_cancellation_with_retries(
+    /// Request cancellation of a cancellable workflow, retrying the version-guarded
+    /// transaction on the live-worker race.
+    async fn cancel_workflow_with_retries(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let mut retries = 5;
         loop {
-            match self.request_cancellation(execution_id, cancelled_at).await {
+            match self.cancel_workflow(execution_id, cancelled_at).await {
                 Err(DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::VersionConflict {
                     ..
                 })) if retries > 0 => retries -= 1,
@@ -1609,35 +1607,6 @@ pub trait DbExternalApi: DbConnection {
         execution_id: &ExecutionId,
         unpaused_at: DateTime<Utc>,
     ) -> Result<AppendResponse, DbErrorWrite>;
-
-    /// Request cancellation of a cancellable workflow. In one transaction, releases
-    /// any lock/pause (`Unlocked`/`Unpaused`) so `cancelling` never coexists with
-    /// them, then appends `CancellationRequested`. Rejects a non-cancellable target;
-    /// returns `AlreadyFinished`/`AlreadyCancelling` without appending. The
-    /// `Finished(Cancelled)` outcome is driven later by the cancellation driver.
-    async fn cancel_workflow(
-        &self,
-        execution_id: &ExecutionId,
-        cancelled_at: DateTime<Utc>,
-    ) -> Result<CancelOutcome, DbErrorWrite>;
-
-    /// Request cancellation of a cancellable workflow, retrying the version-guarded
-    /// transaction on the live-worker race.
-    async fn cancel_workflow_with_retries(
-        &self,
-        execution_id: &ExecutionId,
-        cancelled_at: DateTime<Utc>,
-    ) -> Result<CancelOutcome, DbErrorWrite> {
-        let mut retries = 5;
-        loop {
-            match self.cancel_workflow(execution_id, cancelled_at).await {
-                Err(DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::VersionConflict {
-                    ..
-                })) if retries > 0 => retries -= 1,
-                res => return res,
-            }
-        }
-    }
 
     /// Pause a delay, preventing it from being picked up by the expired timers watcher.
     /// No-op if the delay is already paused.

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -53,12 +53,8 @@ pub struct CombinedState {
 pub enum CancelWorkflowPlan {
     AlreadyFinished,
     AlreadyCancelling,
-    /// Release the current lock/pause (`unlock`/`unpause` are mutually exclusive)
-    /// before appending `CancellationRequested`.
-    Proceed {
-        unlock: bool,
-        unpause: bool,
-    },
+    /// Release the current lock before appending `CancellationRequested`.
+    Proceed { unlock: bool },
 }
 
 impl CombinedState {
@@ -81,8 +77,9 @@ impl CombinedState {
     /// Decide how a cancellation should reach the cancelling state, without the
     /// `is_cancellable` guard. Used by the worker join-set close and the
     /// cancellation driver, which have already classified the target as cancellable.
-    /// A [`PendingState::Locked`]/[`PendingState::Paused`] execution must first be
-    /// released so `cancelling` never coexists with a lock or pause.
+    /// A [`PendingState::Locked`] workflow must first be released so `cancelling`
+    /// never coexists with a lock; paused executions are never running, so pause
+    /// needs no release.
     #[must_use]
     pub fn plan_request_cancellation(&self) -> CancelWorkflowPlan {
         match &self.execution_with_state.pending_state {
@@ -90,7 +87,6 @@ impl CombinedState {
             PendingState::Cancelling(_) => CancelWorkflowPlan::AlreadyCancelling,
             pending_state => CancelWorkflowPlan::Proceed {
                 unlock: matches!(pending_state, PendingState::Locked(_)),
-                unpause: matches!(pending_state, PendingState::Paused(_)),
             },
         }
     }

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -98,9 +98,8 @@ impl CombinedState {
         Ok(locked)
     }
 
-    /// `cancel_workflow` guard rejecting a non-cancellable target. Control-plane
-    /// entrypoint only; the worker/driver paths skip it, having already classified
-    /// the target as cancellable.
+    /// `cancel_workflow` guard rejecting a non-cancellable target. The check reads
+    /// the already-loaded ffqn, so control-plane and worker/driver paths alike run it.
     pub fn assert_cancellable_workflow_ffqn(&self) -> Result<(), DbErrorWrite> {
         if self.execution_with_state.ffqn.is_cancellable() {
             Ok(())

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -53,8 +53,7 @@ pub struct CombinedState {
 pub enum CancelWorkflowPlan {
     AlreadyFinished,
     AlreadyCancelling,
-    /// Release the current lock before appending `CancellationRequested`.
-    Proceed { unlock: bool },
+    Proceed,
 }
 
 impl CombinedState {
@@ -77,17 +76,14 @@ impl CombinedState {
     /// Decide how a cancellation should reach the cancelling state, without the
     /// `is_cancellable` guard. Used by the worker join-set close and the
     /// cancellation driver, which have already classified the target as cancellable.
-    /// A [`PendingState::Locked`] workflow must first be released so `cancelling`
-    /// never coexists with a lock; paused executions are never running, so pause
-    /// needs no release.
+    /// No state needs releasing first: paused executions are never running, and a
+    /// locked workflow's run is fenced by the version bump of `CancellationRequested`.
     #[must_use]
     pub fn plan_request_cancellation(&self) -> CancelWorkflowPlan {
         match &self.execution_with_state.pending_state {
             PendingState::Finished(_) => CancelWorkflowPlan::AlreadyFinished,
             PendingState::Cancelling(_) => CancelWorkflowPlan::AlreadyCancelling,
-            pending_state => CancelWorkflowPlan::Proceed {
-                unlock: matches!(pending_state, PendingState::Locked(_)),
-            },
+            _ => CancelWorkflowPlan::Proceed,
         }
     }
 

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -230,6 +230,42 @@ impl CombinedState {
                     lock_expires_at,
                 }),
             },
+            // Cancelling - Locked (running activity teardown pending)
+            CombinedStateDTO {
+                execution_id,
+                created_at,
+                first_scheduled_at,
+                state,
+                ffqn,
+                component_digest,
+                component_type,
+                deployment_id,
+                pending_expires_finished: lock_expires_at,
+                last_lock_version: Some(_),
+                executor_id: Some(executor_id),
+                run_id: Some(run_id),
+                join_set_id: None,
+                join_set_closing: None,
+                result_kind: None,
+                lifecycle: Lifecycle::Cancelling,
+            } if state == STATE_LOCKED => ExecutionWithState {
+                component_digest,
+                component_type,
+                deployment_id,
+                execution_id,
+                ffqn,
+                created_at,
+                first_scheduled_at,
+                pending_state: PendingState::Cancelling(PendingStateSuspended::Locked(
+                    PendingStateLocked {
+                        locked_by: LockedBy {
+                            executor_id,
+                            run_id,
+                        },
+                        lock_expires_at,
+                    },
+                )),
+            },
             CombinedStateDTO {
                 execution_id,
                 created_at,

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -6,8 +6,8 @@ use concepts::{
     component_id::ComponentDigest,
     prefixed_ulid::{DeploymentId, ExecutorId, RunId},
     storage::{
-        DbErrorGeneric, DbErrorWrite, DbErrorWriteNonRetriable, ExecutionWithState, Lifecycle,
-        LockedBy, PendingState, PendingStateBlockedByJoinSet, PendingStateFinished,
+        CancelOutcome, DbErrorGeneric, DbErrorWrite, DbErrorWriteNonRetriable, ExecutionWithState,
+        Lifecycle, LockedBy, PendingState, PendingStateBlockedByJoinSet, PendingStateFinished,
         PendingStateFinishedResultKind, PendingStateLocked, PendingStatePendingAt,
         PendingStateSuspended, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED,
         STATE_PENDING_AT, Version,
@@ -48,14 +48,6 @@ pub struct CombinedState {
     pub corresponding_version: Version,
 }
 
-/// What `cancel_workflow` should do, derived from the current [`CombinedState`].
-#[derive(Debug, Clone, Copy)]
-pub enum CancelWorkflowPlan {
-    AlreadyFinished,
-    AlreadyCancelling,
-    Proceed,
-}
-
 impl CombinedState {
     #[must_use]
     pub fn get_next_version_assert_not_finished(&self) -> Version {
@@ -73,38 +65,35 @@ impl CombinedState {
         Ok(self.corresponding_version.increment())
     }
 
-    /// Decide how a cancellation should reach the cancelling state, without the
-    /// `is_cancellable` guard. Used by the worker join-set close and the
-    /// cancellation driver, which have already classified the target as cancellable.
-    /// No state needs releasing first: paused executions are never running, and a
-    /// locked workflow's run is fenced by the version bump of `CancellationRequested`.
+    /// Outcome to return without appending `CancellationRequested`: cancellation is
+    /// already underway or the execution already finished. `None` means the append
+    /// should proceed; no state needs releasing first, since paused executions are
+    /// never running and a locked workflow's run is fenced by the version bump.
     #[must_use]
-    pub fn plan_request_cancellation(&self) -> CancelWorkflowPlan {
+    pub fn cancel_short_circuit(&self) -> Option<CancelOutcome> {
         match &self.execution_with_state.pending_state {
-            PendingState::Finished(_) => CancelWorkflowPlan::AlreadyFinished,
-            PendingState::Cancelling(_) => CancelWorkflowPlan::AlreadyCancelling,
-            _ => CancelWorkflowPlan::Proceed,
+            PendingState::Finished(_) => Some(CancelOutcome::AlreadyFinished),
+            PendingState::Cancelling(_) => Some(CancelOutcome::AlreadyCancelling),
+            _ => None,
         }
     }
 
-    /// Decide how `cancel_workflow` should reach the cancelling state, rejecting a
-    /// non-cancellable target. Control-plane entrypoint; the worker/driver paths use
-    /// [`Self::plan_request_cancellation`] instead.
-    pub fn plan_cancel_workflow(&self) -> Result<CancelWorkflowPlan, DbErrorWrite> {
-        let plan = self.plan_request_cancellation();
-        if matches!(plan, CancelWorkflowPlan::Proceed { .. })
-            && !self.execution_with_state.ffqn.is_cancellable()
-        {
-            return Err(DbErrorWrite::NonRetriable(
+    /// `cancel_workflow` guard rejecting a non-cancellable target. Control-plane
+    /// entrypoint only; the worker/driver paths skip it, having already classified
+    /// the target as cancellable.
+    pub fn assert_cancellable_workflow_ffqn(&self) -> Result<(), DbErrorWrite> {
+        if self.execution_with_state.ffqn.is_cancellable() {
+            Ok(())
+        } else {
+            Err(DbErrorWrite::NonRetriable(
                 DbErrorWriteNonRetriable::IllegalState {
                     reason: "cannot cancel, execution is not a cancellable workflow".into(),
                     context: SpanTrace::capture(),
                     source: None,
                     loc: Location::caller(),
                 },
-            ));
+            ))
         }
-        Ok(plan)
     }
 
     #[must_use]

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -78,6 +78,26 @@ impl CombinedState {
         }
     }
 
+    /// `pause_execution` guard: disallow transitioning to `Paused`
+    /// if an activity can still be in-flight.
+    pub fn reject_locked_activities(&self) -> Result<bool, DbErrorWrite> {
+        let locked = matches!(
+            self.execution_with_state.pending_state,
+            PendingState::Locked(_)
+        );
+        if locked && self.execution_with_state.component_type.is_activity() {
+            return Err(DbErrorWrite::NonRetriable(
+                DbErrorWriteNonRetriable::IllegalState {
+                    reason: "cannot pause a running activity; cancel it instead".into(),
+                    context: SpanTrace::capture(),
+                    source: None,
+                    loc: Location::caller(),
+                },
+            ));
+        }
+        Ok(locked)
+    }
+
     /// `cancel_workflow` guard rejecting a non-cancellable target. Control-plane
     /// entrypoint only; the worker/driver paths skip it, having already classified
     /// the target as cancellable.

--- a/crates/db-common/src/combined_state.rs
+++ b/crates/db-common/src/combined_state.rs
@@ -7,10 +7,10 @@ use concepts::{
     prefixed_ulid::{DeploymentId, ExecutorId, RunId},
     storage::{
         CancelOutcome, DbErrorGeneric, DbErrorWrite, DbErrorWriteNonRetriable, ExecutionWithState,
-        Lifecycle, LockedBy, PendingState, PendingStateBlockedByJoinSet, PendingStateFinished,
-        PendingStateFinishedResultKind, PendingStateLocked, PendingStatePendingAt,
-        PendingStateSuspended, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED,
-        STATE_PENDING_AT, Version,
+        Lifecycle, LockedBy, PendingState, PendingStateBlockedByJoinSet, PendingStateCancelling,
+        PendingStateFinished, PendingStateFinishedResultKind, PendingStateLocked,
+        PendingStatePaused, PendingStatePendingAt, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED,
+        STATE_LOCKED, STATE_PENDING_AT, Version,
     },
 };
 use std::panic::Location;
@@ -257,7 +257,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Cancelling(PendingStateSuspended::Locked(
+                pending_state: PendingState::Cancelling(PendingStateCancelling::Locked(
                     PendingStateLocked {
                         locked_by: LockedBy {
                             executor_id,
@@ -355,7 +355,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Paused(PendingStateSuspended::PendingAt(
+                pending_state: PendingState::Paused(PendingStatePaused::PendingAt(
                     PendingStatePendingAt {
                         scheduled_at,
                         last_lock: None,
@@ -388,7 +388,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Paused(PendingStateSuspended::PendingAt(
+                pending_state: PendingState::Paused(PendingStatePaused::PendingAt(
                     PendingStatePendingAt {
                         scheduled_at,
                         last_lock: Some(LockedBy {
@@ -424,7 +424,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Paused(PendingStateSuspended::BlockedByJoinSet(
+                pending_state: PendingState::Paused(PendingStatePaused::BlockedByJoinSet(
                     PendingStateBlockedByJoinSet {
                         join_set_id: join_set_id.clone(),
                         closing: join_set_closing,
@@ -458,7 +458,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Cancelling(PendingStateSuspended::PendingAt(
+                pending_state: PendingState::Cancelling(PendingStateCancelling::PendingAt(
                     PendingStatePendingAt {
                         scheduled_at,
                         last_lock: None,
@@ -491,7 +491,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Cancelling(PendingStateSuspended::PendingAt(
+                pending_state: PendingState::Cancelling(PendingStateCancelling::PendingAt(
                     PendingStatePendingAt {
                         scheduled_at,
                         last_lock: Some(LockedBy {
@@ -527,7 +527,7 @@ impl CombinedState {
                 ffqn,
                 created_at,
                 first_scheduled_at,
-                pending_state: PendingState::Cancelling(PendingStateSuspended::BlockedByJoinSet(
+                pending_state: PendingState::Cancelling(PendingStateCancelling::BlockedByJoinSet(
                     PendingStateBlockedByJoinSet {
                         join_set_id: join_set_id.clone(),
                         closing: join_set_closing,

--- a/crates/db-common/src/join_set_open_tracker.rs
+++ b/crates/db-common/src/join_set_open_tracker.rs
@@ -56,12 +56,12 @@ impl JoinSetMember {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct JoinSetFold {
+pub struct JoinSetOpenTracker {
     open_join_sets: IndexMap<JoinSetId, IndexMap<JoinSetResponseId, JoinSetMember>>,
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
-pub enum JoinSetFoldError {
+pub enum JoinSetOpenTrackerError {
     #[error("join set already exists: `{0}`")]
     JoinSetAlreadyExists(JoinSetId),
     #[error("join set is not open: `{0}`")]
@@ -73,14 +73,14 @@ pub enum JoinSetFoldError {
     },
 }
 
-impl JoinSetFold {
+impl JoinSetOpenTracker {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Reconstruct the open join sets from a persisted execution log, for the
-    /// cancellation driver (which cannot replay WASM). Folds the history events,
+    /// cancellation driver (which cannot replay WASM). Walks the history events,
     /// pairing each consuming `JoinNext` with the next response of its join set in
     /// cursor order. `child_component_type` classifies each child request
     /// (activity vs workflow) from the log. Members left in the result are the
@@ -89,7 +89,7 @@ impl JoinSetFold {
         history: impl IntoIterator<Item = HistoryEvent>,
         responses: impl IntoIterator<Item = (JoinSetId, JoinSetResponseId)>,
         mut child_component_type: impl FnMut(&ExecutionIdDerived) -> ComponentType,
-    ) -> Result<JoinSetFold, JoinSetFoldError> {
+    ) -> Result<JoinSetOpenTracker, JoinSetOpenTrackerError> {
         // Responses per join set in cursor order, plus how many were consumed.
         let mut per_join_set: HashMap<JoinSetId, (Vec<JoinSetResponseId>, usize)> = HashMap::new();
         for (join_set_id, response_id) in responses {
@@ -99,10 +99,12 @@ impl JoinSetFold {
                 .0
                 .push(response_id);
         }
-        let mut fold = JoinSetFold::new();
+        let mut tracker = JoinSetOpenTracker::new();
         for event in history {
             match event {
-                HistoryEvent::JoinSetCreate { join_set_id } => fold.create_join_set(join_set_id)?,
+                HistoryEvent::JoinSetCreate { join_set_id } => {
+                    tracker.create_join_set(join_set_id)?
+                }
                 HistoryEvent::JoinSetRequest {
                     join_set_id,
                     request:
@@ -114,7 +116,7 @@ impl JoinSetFold {
                         },
                 } => {
                     let component_type = child_component_type(&child_execution_id);
-                    fold.insert_child(
+                    tracker.insert_child(
                         &join_set_id,
                         child_execution_id,
                         component_type,
@@ -124,7 +126,7 @@ impl JoinSetFold {
                 HistoryEvent::JoinSetRequest {
                     join_set_id,
                     request: JoinSetRequest::DelayRequest { delay_id, .. },
-                } => fold.insert_delay(&join_set_id, delay_id)?,
+                } => tracker.insert_delay(&join_set_id, delay_id)?,
                 // A worker close appends one closing `JoinNext` per member; the first
                 // drops the whole set, the rest are no-ops.
                 HistoryEvent::JoinNext {
@@ -132,7 +134,7 @@ impl JoinSetFold {
                     closing: true,
                     ..
                 } => {
-                    let _ = fold.close_join_set(&join_set_id);
+                    let _ = tracker.close_join_set(&join_set_id);
                 }
                 HistoryEvent::JoinNext {
                     join_set_id,
@@ -146,14 +148,14 @@ impl JoinSetFold {
                     if let Some((responses, cursor)) = per_join_set.get_mut(&join_set_id)
                         && let Some(response_id) = responses.get(*cursor)
                     {
-                        fold.remove_response(&join_set_id, response_id)?;
+                        tracker.remove_response(&join_set_id, response_id)?;
                         *cursor += 1;
                     }
                 }
                 _ => {}
             }
         }
-        Ok(fold)
+        Ok(tracker)
     }
 
     #[must_use]
@@ -163,12 +165,15 @@ impl JoinSetFold {
         &self.open_join_sets
     }
 
-    pub fn create_join_set(&mut self, join_set_id: JoinSetId) -> Result<(), JoinSetFoldError> {
+    pub fn create_join_set(
+        &mut self,
+        join_set_id: JoinSetId,
+    ) -> Result<(), JoinSetOpenTrackerError> {
         let prev = self
             .open_join_sets
             .insert(join_set_id.clone(), IndexMap::new());
         if prev.is_some() {
-            Err(JoinSetFoldError::JoinSetAlreadyExists(join_set_id))
+            Err(JoinSetOpenTrackerError::JoinSetAlreadyExists(join_set_id))
         } else {
             Ok(())
         }
@@ -177,10 +182,10 @@ impl JoinSetFold {
     pub fn close_join_set(
         &mut self,
         join_set_id: &JoinSetId,
-    ) -> Result<IndexMap<JoinSetResponseId, JoinSetMember>, JoinSetFoldError> {
+    ) -> Result<IndexMap<JoinSetResponseId, JoinSetMember>, JoinSetOpenTrackerError> {
         self.open_join_sets
             .shift_remove(join_set_id)
-            .ok_or_else(|| JoinSetFoldError::JoinSetNotOpen(join_set_id.clone()))
+            .ok_or_else(|| JoinSetOpenTrackerError::JoinSetNotOpen(join_set_id.clone()))
     }
 
     pub fn insert_child(
@@ -189,7 +194,7 @@ impl JoinSetFold {
         child_execution_id: ExecutionIdDerived,
         component_type: ComponentType,
         target_ffqn: FunctionFqn,
-    ) -> Result<(), JoinSetFoldError> {
+    ) -> Result<(), JoinSetOpenTrackerError> {
         self.insert_member(
             join_set_id,
             JoinSetResponseId::ChildExecutionId(child_execution_id),
@@ -204,7 +209,7 @@ impl JoinSetFold {
         &mut self,
         join_set_id: &JoinSetId,
         delay_id: DelayId,
-    ) -> Result<(), JoinSetFoldError> {
+    ) -> Result<(), JoinSetOpenTrackerError> {
         self.insert_member(
             join_set_id,
             JoinSetResponseId::DelayId(delay_id),
@@ -216,12 +221,12 @@ impl JoinSetFold {
         &mut self,
         join_set_id: &JoinSetId,
         response_id: &JoinSetResponseId,
-    ) -> Result<JoinSetMember, JoinSetFoldError> {
+    ) -> Result<JoinSetMember, JoinSetOpenTrackerError> {
         self.open_join_sets
             .get_mut(join_set_id)
-            .ok_or_else(|| JoinSetFoldError::JoinSetNotOpen(join_set_id.clone()))?
+            .ok_or_else(|| JoinSetOpenTrackerError::JoinSetNotOpen(join_set_id.clone()))?
             .shift_remove(response_id)
-            .ok_or_else(|| JoinSetFoldError::ResponseNotPresent {
+            .ok_or_else(|| JoinSetOpenTrackerError::ResponseNotPresent {
                 join_set_id: join_set_id.clone(),
                 response_id: response_id.clone(),
             })
@@ -233,7 +238,7 @@ impl JoinSetFold {
         event: &concepts::storage::HistoryEvent,
         child_component_type: Option<ComponentType>,
         consumed_response: Option<&JoinSetResponse>,
-    ) -> Result<(), JoinSetFoldError> {
+    ) -> Result<(), JoinSetOpenTrackerError> {
         use concepts::storage::{HistoryEvent, JoinSetRequest};
         match event {
             HistoryEvent::JoinSetCreate { join_set_id } => {
@@ -292,10 +297,10 @@ impl JoinSetFold {
         join_set_id: &JoinSetId,
         response_id: JoinSetResponseId,
         member: JoinSetMember,
-    ) -> Result<(), JoinSetFoldError> {
+    ) -> Result<(), JoinSetOpenTrackerError> {
         self.open_join_sets
             .get_mut(join_set_id)
-            .ok_or_else(|| JoinSetFoldError::JoinSetNotOpen(join_set_id.clone()))?
+            .ok_or_else(|| JoinSetOpenTrackerError::JoinSetNotOpen(join_set_id.clone()))?
             .insert(response_id, member);
         Ok(())
     }
@@ -321,51 +326,54 @@ mod tests {
     }
 
     #[test]
-    fn fold_tracks_open_join_set_members() {
+    fn tracker_tracks_open_join_set_members() {
         let join_set_id = join_set_id();
         let child_id = child_id(&join_set_id, 1);
         let delay_id = delay_id(&join_set_id, 2);
         let ffqn = FunctionFqn::new_static("testing:integration/workflow-add", "add-workflow");
-        let mut fold = JoinSetFold::new();
+        let mut tracker = JoinSetOpenTracker::new();
 
-        fold.apply_history_event(
-            &HistoryEvent::JoinSetCreate {
-                join_set_id: join_set_id.clone(),
-            },
-            None,
-            None,
-        )
-        .unwrap();
-        fold.apply_history_event(
-            &HistoryEvent::JoinSetRequest {
-                join_set_id: join_set_id.clone(),
-                request: JoinSetRequest::ChildExecutionRequest {
-                    child_execution_id: child_id.clone(),
-                    target_ffqn: ffqn.clone(),
-                    params: Params::empty(),
-                    result: Ok(()),
+        tracker
+            .apply_history_event(
+                &HistoryEvent::JoinSetCreate {
+                    join_set_id: join_set_id.clone(),
                 },
-            },
-            Some(ComponentType::Workflow),
-            None,
-        )
-        .unwrap();
-        fold.apply_history_event(
-            &HistoryEvent::JoinSetRequest {
-                join_set_id: join_set_id.clone(),
-                request: JoinSetRequest::DelayRequest {
-                    delay_id: delay_id.clone(),
-                    expires_at: chrono::DateTime::UNIX_EPOCH,
-                    schedule_at: concepts::storage::HistoryEventScheduleAt::Now,
-                    paused: false,
+                None,
+                None,
+            )
+            .unwrap();
+        tracker
+            .apply_history_event(
+                &HistoryEvent::JoinSetRequest {
+                    join_set_id: join_set_id.clone(),
+                    request: JoinSetRequest::ChildExecutionRequest {
+                        child_execution_id: child_id.clone(),
+                        target_ffqn: ffqn.clone(),
+                        params: Params::empty(),
+                        result: Ok(()),
+                    },
                 },
-            },
-            None,
-            None,
-        )
-        .unwrap();
+                Some(ComponentType::Workflow),
+                None,
+            )
+            .unwrap();
+        tracker
+            .apply_history_event(
+                &HistoryEvent::JoinSetRequest {
+                    join_set_id: join_set_id.clone(),
+                    request: JoinSetRequest::DelayRequest {
+                        delay_id: delay_id.clone(),
+                        expires_at: chrono::DateTime::UNIX_EPOCH,
+                        schedule_at: concepts::storage::HistoryEventScheduleAt::Now,
+                        paused: false,
+                    },
+                },
+                None,
+                None,
+            )
+            .unwrap();
 
-        let members = fold.open_join_sets().get(&join_set_id).unwrap();
+        let members = tracker.open_join_sets().get(&join_set_id).unwrap();
         assert_eq!(members.len(), 2);
         assert_eq!(
             members.get(&JoinSetResponseId::ChildExecutionId(child_id)),
@@ -381,39 +389,47 @@ mod tests {
     }
 
     #[test]
-    fn fold_removes_consumed_response_id() {
+    fn tracker_removes_consumed_response_id() {
         let join_set_id = join_set_id();
         let child_id = child_id(&join_set_id, 3);
-        let mut fold = JoinSetFold::new();
-        fold.create_join_set(join_set_id.clone()).unwrap();
-        fold.insert_child(
-            &join_set_id,
-            child_id.clone(),
-            ComponentType::Activity,
-            FunctionFqn::new_static("testing:integration/sleep", "sleep"),
-        )
-        .unwrap();
+        let mut tracker = JoinSetOpenTracker::new();
+        tracker.create_join_set(join_set_id.clone()).unwrap();
+        tracker
+            .insert_child(
+                &join_set_id,
+                child_id.clone(),
+                ComponentType::Activity,
+                FunctionFqn::new_static("testing:integration/sleep", "sleep"),
+            )
+            .unwrap();
 
-        fold.apply_history_event(
-            &HistoryEvent::JoinNext {
-                join_set_id: join_set_id.clone(),
-                run_expires_at: chrono::DateTime::UNIX_EPOCH,
-                requested_ffqn: Some(FunctionFqn::new_static(
-                    "testing:integration/other",
-                    "other",
-                )),
-                closing: false,
-            },
-            None,
-            Some(&JoinSetResponse::ChildExecutionFinished {
-                child_execution_id: child_id.clone(),
-                finished_version: concepts::storage::Version::new(2),
-                result: concepts::SUPPORTED_RETURN_VALUE_OK_EMPTY,
-            }),
-        )
-        .unwrap();
+        tracker
+            .apply_history_event(
+                &HistoryEvent::JoinNext {
+                    join_set_id: join_set_id.clone(),
+                    run_expires_at: chrono::DateTime::UNIX_EPOCH,
+                    requested_ffqn: Some(FunctionFqn::new_static(
+                        "testing:integration/other",
+                        "other",
+                    )),
+                    closing: false,
+                },
+                None,
+                Some(&JoinSetResponse::ChildExecutionFinished {
+                    child_execution_id: child_id.clone(),
+                    finished_version: concepts::storage::Version::new(2),
+                    result: concepts::SUPPORTED_RETURN_VALUE_OK_EMPTY,
+                }),
+            )
+            .unwrap();
 
-        assert!(fold.open_join_sets().get(&join_set_id).unwrap().is_empty());
+        assert!(
+            tracker
+                .open_join_sets()
+                .get(&join_set_id)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -457,10 +473,11 @@ mod tests {
             JoinSetResponseId::ChildExecutionId(awaited),
         )];
 
-        let fold =
-            JoinSetFold::reconstruct(history, responses, |_| ComponentType::Workflow).unwrap();
+        let tracker =
+            JoinSetOpenTracker::reconstruct(history, responses, |_| ComponentType::Workflow)
+                .unwrap();
 
-        let members = fold.open_join_sets().get(&join_set_id).unwrap();
+        let members = tracker.open_join_sets().get(&join_set_id).unwrap();
         assert_eq!(
             members.len(),
             1,
@@ -472,35 +489,37 @@ mod tests {
     #[test]
     fn closing_join_next_removes_the_join_set() {
         let join_set_id = join_set_id();
-        let mut fold = JoinSetFold::new();
-        fold.create_join_set(join_set_id.clone()).unwrap();
-        fold.insert_delay(&join_set_id, delay_id(&join_set_id, 4))
+        let mut tracker = JoinSetOpenTracker::new();
+        tracker.create_join_set(join_set_id.clone()).unwrap();
+        tracker
+            .insert_delay(&join_set_id, delay_id(&join_set_id, 4))
             .unwrap();
 
-        fold.apply_history_event(
-            &HistoryEvent::JoinNext {
-                join_set_id: join_set_id.clone(),
-                run_expires_at: chrono::DateTime::UNIX_EPOCH,
-                requested_ffqn: None,
-                closing: true,
-            },
-            None,
-            None,
-        )
-        .unwrap();
+        tracker
+            .apply_history_event(
+                &HistoryEvent::JoinNext {
+                    join_set_id: join_set_id.clone(),
+                    run_expires_at: chrono::DateTime::UNIX_EPOCH,
+                    requested_ffqn: None,
+                    closing: true,
+                },
+                None,
+                None,
+            )
+            .unwrap();
 
-        assert!(!fold.open_join_sets().contains_key(&join_set_id));
+        assert!(!tracker.open_join_sets().contains_key(&join_set_id));
     }
 
-    /// Differential property test: `reconstruct` (the driver's log fold) must agree
-    /// with the worker's incremental `JoinSetFold` maintenance for every valid
+    /// Differential property test: `reconstruct` (the driver's log reconstruction) must agree
+    /// with the worker's incremental `JoinSetOpenTracker` maintenance for every valid
     /// execution log. The worker consumes each join set's responses in arrival
     /// (cursor) order — a plain `JoinNext` removes the returned response, an
     /// await-next `FunctionMismatch` removes the *arriving* id, both of which are
     /// the next unconsumed arrival — and a close drops the whole set. This test
     /// generates randomized-but-valid scripts, computes the expected open set with a
     /// worker-faithful FIFO model, and asserts `reconstruct` matches, guarding the
-    /// two folds against drift (the P8 "fiddly part": `JoinNext`<->response pairing,
+    /// two trackers against drift (the P8 "fiddly part": `JoinNext`<->response pairing,
     /// closing `JoinNext`s, per-join-set isolation).
     #[test]
     fn reconstruct_matches_worker_fifo_model() {
@@ -629,7 +648,7 @@ mod tests {
                 // Worker-faithful expected open set for this join set.
                 if will_close {
                     // Close drops the whole set (emit one closing JoinNext; the driver
-                    // fold treats the first as the drop and any extra as no-ops).
+                    // tracker treats the first as the drop and any extra as no-ops).
                     history.push(HistoryEvent::JoinNext {
                         join_set_id: js.clone(),
                         run_expires_at: chrono::DateTime::UNIX_EPOCH,
@@ -652,7 +671,7 @@ mod tests {
                 }
             }
 
-            let fold = JoinSetFold::reconstruct(history, responses, |cid| {
+            let tracker = JoinSetOpenTracker::reconstruct(history, responses, |cid| {
                 child_types
                     .get(cid)
                     .copied()
@@ -661,7 +680,7 @@ mod tests {
             .unwrap_or_else(|err| panic!("seed {seed}: reconstruct failed: {err}"));
 
             assert_eq!(
-                fold.open_join_sets(),
+                tracker.open_join_sets(),
                 &expected,
                 "seed {seed}: reconstruct diverged from the worker FIFO model"
             );

--- a/crates/db-common/src/join_set_open_tracker.rs
+++ b/crates/db-common/src/join_set_open_tracker.rs
@@ -103,7 +103,7 @@ impl JoinSetOpenTracker {
         for event in history {
             match event {
                 HistoryEvent::JoinSetCreate { join_set_id } => {
-                    tracker.create_join_set(join_set_id)?
+                    tracker.create_join_set(join_set_id)?;
                 }
                 HistoryEvent::JoinSetRequest {
                     join_set_id,

--- a/crates/db-common/src/lib.rs
+++ b/crates/db-common/src/lib.rs
@@ -6,7 +6,7 @@ mod notifiers;
 mod state_filter;
 mod subscribers;
 
-pub use combined_state::{CancelWorkflowPlan, CombinedState, CombinedStateDTO};
+pub use combined_state::{CombinedState, CombinedStateDTO};
 pub use join_set_fold::{JoinSetFold, JoinSetFoldError, JoinSetMember, JoinSetResponseId};
 pub use notifiers::{AppendNotifier, NotifierExecutionFinished, NotifierPendingAt};
 pub use state_filter::{state_filter_to_sql, state_filters_now};

--- a/crates/db-common/src/lib.rs
+++ b/crates/db-common/src/lib.rs
@@ -1,13 +1,15 @@
 //! Common types and utilities shared between database implementations.
 
 mod combined_state;
-mod join_set_fold;
+mod join_set_open_tracker;
 mod notifiers;
 mod state_filter;
 mod subscribers;
 
 pub use combined_state::{CombinedState, CombinedStateDTO};
-pub use join_set_fold::{JoinSetFold, JoinSetFoldError, JoinSetMember, JoinSetResponseId};
+pub use join_set_open_tracker::{
+    JoinSetMember, JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId,
+};
 pub use notifiers::{AppendNotifier, NotifierExecutionFinished, NotifierPendingAt};
 pub use state_filter::{state_filter_to_sql, state_filters_now};
 pub use subscribers::PendingFfqnSubscribersHolder;

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1310,7 +1310,7 @@ async fn get_combined_state(
     CombinedState::new(dto, corresponding_version).map_err(DbErrorRead::from)
 }
 
-/// Shared body of `cancel_workflow` / `request_cancellation`: release any lock/pause
+/// Shared body of `cancel_workflow` / `request_cancellation`: release any lock
 /// then append `CancellationRequested`, and commit.
 async fn apply_cancellation_plan(
     tx: deadpool_postgres::Transaction<'_>,
@@ -1319,10 +1319,10 @@ async fn apply_cancellation_plan(
     combined_state: &CombinedState,
     plan: CancelWorkflowPlan,
 ) -> Result<CancelOutcome, DbErrorWrite> {
-    let (unlock, unpause) = match plan {
+    let unlock = match plan {
         CancelWorkflowPlan::AlreadyFinished => return Ok(CancelOutcome::AlreadyFinished),
         CancelWorkflowPlan::AlreadyCancelling => return Ok(CancelOutcome::AlreadyCancelling),
-        CancelWorkflowPlan::Proceed { unlock, unpause } => (unlock, unpause),
+        CancelWorkflowPlan::Proceed { unlock } => unlock,
     };
     let mut version = combined_state.get_next_version_assert_not_finished();
     if unlock {
@@ -1335,17 +1335,6 @@ async fn apply_cancellation_plan(
                     unlocked_at: cancelled_at, // does not matter, about to append `CancellationRequested` in same tx.
                     reason: "cancelling".into(),
                 }),
-            },
-            version,
-        )
-        .await?;
-    } else if unpause {
-        (version, _) = append(
-            &tx,
-            execution_id,
-            AppendRequest {
-                created_at: cancelled_at,
-                event: ExecutionRequest::Unpaused,
             },
             version,
         )
@@ -2624,18 +2613,16 @@ async fn append(
                 PendingState::Finished { .. } => {
                     unreachable!("handled above");
                 }
-                // Paused activities are guaranteed not to be running.
-                PendingState::Locked(..) | PendingState::Paused(..)
+                PendingState::Locked(..)
                     if combined_state
                         .execution_with_state
                         .component_type
                         .is_activity() => {}
-                // Locked and paused workflows must first be released
-                // (`Unlocked` / `Unpaused`) by `cancel_workflow`.
-                PendingState::Locked(..) | PendingState::Paused(..) => {
+                // Locked workflows must first be released (`Unlocked`) by `cancel_workflow`.
+                PendingState::Locked(..) => {
                     return Err(DbErrorWriteNonRetriable::IllegalState {
                         reason:
-                            "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow"
+                            "cannot append CancellationRequested event on a locked workflow; use cancel_workflow"
                                 .into(),
                         context: SpanTrace::capture(),
                         source: None,
@@ -2652,7 +2639,10 @@ async fn append(
                     }
                     .into());
                 }
-                PendingState::PendingAt(..) | PendingState::BlockedByJoinSet(..) => {}
+                // Paused executions are guaranteed not to be running.
+                PendingState::PendingAt(..)
+                | PendingState::BlockedByJoinSet(..)
+                | PendingState::Paused(..) => {}
             }
             let next_version =
                 update_state_cancelling(tx, execution_id, &appending_version).await?;

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1365,7 +1365,7 @@ async fn apply_cancellation_plan(
     Ok(CancelOutcome::Cancelled)
 }
 
-async fn apply_activity_cancellation(
+async fn append_activity_cancellation_requested_tx(
     tx: deadpool_postgres::Transaction<'_>,
     execution_id: &ExecutionId,
     cancelled_at: DateTime<Utc>,
@@ -4072,7 +4072,7 @@ impl DbExecutor for PostgresConnection {
     }
 
     #[instrument(skip(self))]
-    async fn cancel_activity(
+    async fn append_activity_cancellation_requested(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
@@ -4081,7 +4081,8 @@ impl DbExecutor for PostgresConnection {
         let tx = client_guard.transaction().await?;
 
         let combined_state = get_combined_state(&tx, execution_id).await?;
-        apply_activity_cancellation(tx, execution_id, cancelled_at, &combined_state).await
+        append_activity_cancellation_requested_tx(tx, execution_id, cancelled_at, &combined_state)
+            .await
     }
 
     #[instrument(skip(self))]

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -31,8 +31,8 @@ use concepts::{
     },
 };
 use db_common::{
-    AppendNotifier, CombinedState, CombinedStateDTO, NotifierExecutionFinished,
-    NotifierPendingAt, PendingFfqnSubscribersHolder, state_filter_to_sql, state_filters_now,
+    AppendNotifier, CombinedState, CombinedStateDTO, NotifierExecutionFinished, NotifierPendingAt,
+    PendingFfqnSubscribersHolder, state_filter_to_sql, state_filters_now,
 };
 use deadpool_postgres::{Client, ManagerConfig, Pool, RecyclingMethod};
 use hashbrown::HashMap;
@@ -5282,49 +5282,23 @@ impl DbExternalApi for PostgresConnection {
         let tx = client_guard.transaction().await?;
 
         let combined_state = get_combined_state(&tx, execution_id).await?;
-        let appending_version = combined_state.get_next_version_fail_if_finished()?;
+        let mut appending_version = combined_state.get_next_version_fail_if_finished()?;
         debug!("Pausing with {appending_version}");
-        // A running (Locked) activity cannot be paused: pausing would unlock without confirming
-        // the in-flight WASM/exec invocation has stopped, so `Paused` would not mean quiescent and
-        // an unpause could start a second run in parallel. Cancel it instead. Workflows and
-        // not-yet-running activities remain pausable.
-        if matches!(
-            combined_state.execution_with_state.pending_state,
-            PendingState::Locked(_)
-        ) && combined_state
-            .execution_with_state
-            .component_type
-            .is_activity()
-        {
-            return Err(DbErrorWriteNonRetriable::IllegalState {
-                reason: "cannot pause a running activity; cancel it instead".into(),
-                context: SpanTrace::capture(),
-                source: None,
-                loc: Location::caller(),
-            }
-            .into());
-        }
-        let next_version = if matches!(
-            combined_state.execution_with_state.pending_state,
-            PendingState::Locked(_)
-        ) {
-            let (next_version, _notifier) = append(
+        if combined_state.reject_locked_activities()? {
+            (appending_version, _) = append(
                 &tx,
                 execution_id,
                 AppendRequest {
                     created_at: paused_at,
                     event: ExecutionRequest::Unlocked(Unlocked {
-                        unlocked_at: paused_at,
+                        unlocked_at: paused_at, // does not matter, about to append `Paused` in same tx.
                         reason: "paused".into(),
                     }),
                 },
                 appending_version,
             )
             .await?;
-            next_version
-        } else {
-            appending_version
-        };
+        }
         let (next_version, _notifier) = append(
             &tx,
             execution_id,
@@ -5332,7 +5306,7 @@ impl DbExternalApi for PostgresConnection {
                 created_at: paused_at,
                 event: ExecutionRequest::Paused,
             },
-            next_version,
+            appending_version,
         )
         .await?;
         tx.commit().await?;

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -31,7 +31,7 @@ use concepts::{
     },
 };
 use db_common::{
-    AppendNotifier, CancelWorkflowPlan, CombinedState, CombinedStateDTO, NotifierExecutionFinished,
+    AppendNotifier, CombinedState, CombinedStateDTO, NotifierExecutionFinished,
     NotifierPendingAt, PendingFfqnSubscribersHolder, state_filter_to_sql, state_filters_now,
 };
 use deadpool_postgres::{Client, ManagerConfig, Pool, RecyclingMethod};
@@ -1310,20 +1310,13 @@ async fn get_combined_state(
     CombinedState::new(dto, corresponding_version).map_err(DbErrorRead::from)
 }
 
-/// Shared body of `cancel_workflow` / `request_cancellation`: append
-/// `CancellationRequested` and commit.
-async fn apply_cancellation_plan(
+/// Appends `CancellationRequested` and commits.
+async fn append_cancellation_requested(
     tx: deadpool_postgres::Transaction<'_>,
     execution_id: &ExecutionId,
     cancelled_at: DateTime<Utc>,
     combined_state: &CombinedState,
-    plan: CancelWorkflowPlan,
 ) -> Result<CancelOutcome, DbErrorWrite> {
-    match plan {
-        CancelWorkflowPlan::AlreadyFinished => return Ok(CancelOutcome::AlreadyFinished),
-        CancelWorkflowPlan::AlreadyCancelling => return Ok(CancelOutcome::AlreadyCancelling),
-        CancelWorkflowPlan::Proceed => {}
-    }
     append(
         &tx,
         execution_id,
@@ -1358,18 +1351,7 @@ async fn append_activity_cancellation_requested_tx(
         PendingState::Cancelling(_) => return Ok(CancelOutcome::Cancelled),
         _ => {}
     }
-    append(
-        &tx,
-        execution_id,
-        AppendRequest {
-            created_at: cancelled_at,
-            event: ExecutionRequest::CancellationRequested,
-        },
-        combined_state.get_next_version_assert_not_finished(),
-    )
-    .await?;
-    tx.commit().await?;
-    Ok(CancelOutcome::Cancelled)
+    append_cancellation_requested(tx, execution_id, cancelled_at, combined_state).await
 }
 
 async fn list_executions(
@@ -4056,8 +4038,10 @@ impl DbExecutor for PostgresConnection {
         let tx = client_guard.transaction().await?;
 
         let combined_state = get_combined_state(&tx, execution_id).await?;
-        let plan = combined_state.plan_request_cancellation();
-        apply_cancellation_plan(tx, execution_id, cancelled_at, &combined_state, plan).await
+        if let Some(outcome) = combined_state.cancel_short_circuit() {
+            return Ok(outcome);
+        }
+        append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state).await
     }
 }
 #[async_trait]
@@ -5392,8 +5376,11 @@ impl DbExternalApi for PostgresConnection {
         let tx = client_guard.transaction().await?;
 
         let combined_state = get_combined_state(&tx, execution_id).await?;
-        let plan = combined_state.plan_cancel_workflow()?;
-        apply_cancellation_plan(tx, execution_id, cancelled_at, &combined_state, plan).await
+        if let Some(outcome) = combined_state.cancel_short_circuit() {
+            return Ok(outcome);
+        }
+        combined_state.assert_cancellable_workflow_ffqn()?;
+        append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state).await
     }
 
     #[instrument(skip(self))]

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -76,6 +76,12 @@ mod embedded {
 
 const JOIN_SET_RESPONSE_LOCK_NAMESPACE: i32 = 0x4f42_4c52; // "OBLR"
 
+#[derive(Debug, Clone, Copy)]
+enum CancellationFfqnCheck {
+    Required,
+    Skipped,
+}
+
 #[derive(Debug, Clone)]
 pub struct PostgresConfig {
     pub host: String,
@@ -1316,7 +1322,11 @@ async fn append_cancellation_requested(
     execution_id: &ExecutionId,
     cancelled_at: DateTime<Utc>,
     combined_state: &CombinedState,
+    ffqn_check: CancellationFfqnCheck,
 ) -> Result<CancelOutcome, DbErrorWrite> {
+    if matches!(ffqn_check, CancellationFfqnCheck::Required) {
+        combined_state.assert_cancellable_workflow_ffqn()?;
+    }
     append(
         &tx,
         execution_id,
@@ -1329,6 +1339,25 @@ async fn append_cancellation_requested(
     .await?;
     tx.commit().await?;
     Ok(CancelOutcome::Cancelled)
+}
+
+async fn cancel_workflow_tx(
+    tx: deadpool_postgres::Transaction<'_>,
+    execution_id: &ExecutionId,
+    cancelled_at: DateTime<Utc>,
+) -> Result<CancelOutcome, DbErrorWrite> {
+    let combined_state = get_combined_state(&tx, execution_id).await?;
+    if let Some(outcome) = combined_state.cancel_short_circuit() {
+        return Ok(outcome);
+    }
+    append_cancellation_requested(
+        tx,
+        execution_id,
+        cancelled_at,
+        &combined_state,
+        CancellationFfqnCheck::Required,
+    )
+    .await
 }
 
 async fn append_activity_cancellation_requested_tx(
@@ -1351,7 +1380,14 @@ async fn append_activity_cancellation_requested_tx(
         PendingState::Cancelling(_) => return Ok(CancelOutcome::Cancelled),
         _ => {}
     }
-    append_cancellation_requested(tx, execution_id, cancelled_at, combined_state).await
+    append_cancellation_requested(
+        tx,
+        execution_id,
+        cancelled_at,
+        combined_state,
+        CancellationFfqnCheck::Skipped,
+    )
+    .await
 }
 
 async fn list_executions(
@@ -4031,7 +4067,7 @@ impl DbExecutor for PostgresConnection {
     }
 
     #[instrument(skip(self))]
-    async fn request_cancellation(
+    async fn cancel_workflow(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
@@ -4039,11 +4075,7 @@ impl DbExecutor for PostgresConnection {
         let mut client_guard = self.client.lock().await;
         let tx = client_guard.transaction().await?;
 
-        let combined_state = get_combined_state(&tx, execution_id).await?;
-        if let Some(outcome) = combined_state.cancel_short_circuit() {
-            return Ok(outcome);
-        }
-        append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state).await
+        cancel_workflow_tx(tx, execution_id, cancelled_at).await
     }
 }
 #[async_trait]
@@ -5340,23 +5372,6 @@ impl DbExternalApi for PostgresConnection {
 
         tx.commit().await?;
         Ok(next_version)
-    }
-
-    #[instrument(skip(self))]
-    async fn cancel_workflow(
-        &self,
-        execution_id: &ExecutionId,
-        cancelled_at: DateTime<Utc>,
-    ) -> Result<CancelOutcome, DbErrorWrite> {
-        let mut client_guard = self.client.lock().await;
-        let tx = client_guard.transaction().await?;
-
-        let combined_state = get_combined_state(&tx, execution_id).await?;
-        if let Some(outcome) = combined_state.cancel_short_circuit() {
-            return Ok(outcome);
-        }
-        combined_state.assert_cancellable_workflow_ffqn()?;
-        append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state).await
     }
 
     #[instrument(skip(self))]

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2,8 +2,8 @@ use crate::postgres_dao::ddl::ADMIN_DB_NAME;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::{
-    ComponentId, ComponentRetryConfig, ComponentType, ContentDigest, ExecutionId, FunctionFqn,
-    JoinSetId, StrVariant, SupportedFunctionReturnValue,
+    ComponentId, ComponentRetryConfig, ComponentType, ContentDigest, ExecutionFailureKind,
+    ExecutionId, FunctionFqn, JoinSetId, StrVariant, SupportedFunctionReturnValue,
     cas::{Cas, CasError},
     component_id::{ComponentDigest, Digest},
     prefixed_ulid::{DelayId, DeploymentId, ExecutionIdDerived, ExecutorId, RunId},
@@ -24,10 +24,10 @@ use concepts::{
         ListLogsResponse, ListResponsesResponse, LockPendingResponse, Locked, LockedBy,
         LockedExecution, LogCursor, LogEntry, LogEntryRow, LogFilter, LogInfoAppendRow, LogLevel,
         LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
-        PendingStateFinishedResultKind, PendingStateMerged, RESULT_KIND_JSON_ERROR,
-        RESULT_KIND_JSON_OK, ResponseCursor, ResponseWithCursor, STATE_BLOCKED_BY_JOIN_SET,
-        STATE_FINISHED, STATE_LOCKED, STATE_PENDING_AT, TimeoutOutcome, Unlocked, Version,
-        VersionType, WasmBacktrace,
+        PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateMerged,
+        RESULT_KIND_JSON_ERROR, RESULT_KIND_JSON_OK, ResponseCursor, ResponseWithCursor,
+        STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED, STATE_PENDING_AT, TimeoutOutcome,
+        Unlocked, Version, VersionType, WasmBacktrace,
     },
 };
 use db_common::{
@@ -1365,6 +1365,40 @@ async fn apply_cancellation_plan(
     Ok(CancelOutcome::Cancelled)
 }
 
+async fn apply_activity_cancellation(
+    tx: deadpool_postgres::Transaction<'_>,
+    execution_id: &ExecutionId,
+    cancelled_at: DateTime<Utc>,
+    combined_state: &CombinedState,
+) -> Result<CancelOutcome, DbErrorWrite> {
+    match &combined_state.execution_with_state.pending_state {
+        PendingState::Finished(finished) => {
+            if finished.result_kind
+                == PendingStateFinishedResultKind::Err(PendingStateFinishedError::ExecutionFailure(
+                    ExecutionFailureKind::Cancelled,
+                ))
+            {
+                return Ok(CancelOutcome::Cancelled);
+            }
+            return Ok(CancelOutcome::AlreadyFinished);
+        }
+        PendingState::Cancelling(_) => return Ok(CancelOutcome::Cancelled),
+        _ => {}
+    }
+    append(
+        &tx,
+        execution_id,
+        AppendRequest {
+            created_at: cancelled_at,
+            event: ExecutionRequest::CancellationRequested,
+        },
+        combined_state.get_next_version_assert_not_finished(),
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(CancelOutcome::Cancelled)
+}
+
 async fn list_executions(
     read_tx: &Transaction<'_>,
     filter: ListExecutionsFilter,
@@ -2590,12 +2624,17 @@ async fn append(
                 PendingState::Finished { .. } => {
                     unreachable!("handled above");
                 }
-                // Locked and Paused must first be released (`Unlocked` / `Unpaused`)
-                // by `cancel_workflow` so `cancelling` never coexists with a lock or pause.
+                PendingState::Locked(..)
+                    if combined_state
+                        .execution_with_state
+                        .component_type
+                        .is_activity() => {}
+                // Locked workflows and paused executions must first be released
+                // (`Unlocked` / `Unpaused`) by their dedicated cancellation path.
                 PendingState::Locked(..) | PendingState::Paused(..) => {
                     return Err(DbErrorWriteNonRetriable::IllegalState {
                         reason:
-                            "cannot append CancellationRequested event unless execution is pending or blocked; use cancel_workflow"
+                            "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows"
                                 .into(),
                         context: SpanTrace::capture(),
                         source: None,
@@ -4030,6 +4069,19 @@ impl DbExecutor for PostgresConnection {
 
         tx.commit().await?;
         Ok(event)
+    }
+
+    #[instrument(skip(self))]
+    async fn cancel_activity(
+        &self,
+        execution_id: &ExecutionId,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<CancelOutcome, DbErrorWrite> {
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+
+        let combined_state = get_combined_state(&tx, execution_id).await?;
+        apply_activity_cancellation(tx, execution_id, cancelled_at, &combined_state).await
     }
 
     #[instrument(skip(self))]

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2624,17 +2624,18 @@ async fn append(
                 PendingState::Finished { .. } => {
                     unreachable!("handled above");
                 }
-                PendingState::Locked(..)
+                // Paused activities are guaranteed not to be running.
+                PendingState::Locked(..) | PendingState::Paused(..)
                     if combined_state
                         .execution_with_state
                         .component_type
                         .is_activity() => {}
-                // Locked workflows and paused executions must first be released
-                // (`Unlocked` / `Unpaused`) by their dedicated cancellation path.
+                // Locked and paused workflows must first be released
+                // (`Unlocked` / `Unpaused`) by `cancel_workflow`.
                 PendingState::Locked(..) | PendingState::Paused(..) => {
                     return Err(DbErrorWriteNonRetriable::IllegalState {
                         reason:
-                            "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows"
+                            "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow"
                                 .into(),
                         context: SpanTrace::capture(),
                         source: None,

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2794,6 +2794,8 @@ async fn append_response(
     let combined_state = get_combined_state(tx, execution_id).await?;
     debug!("previous_pending_state: {combined_state:?}");
 
+    // A cancelling execution is finished by the cancellation driver; it is never
+    // picked up by executors again, so do not unblock or notify it.
     let mut notifier = if let PendingStateMerged::BlockedByJoinSet {
         state:
             PendingStateBlockedByJoinSet {
@@ -2801,7 +2803,7 @@ async fn append_response(
                 lock_expires_at, // Set to a future time if the worker is keeping the execution warm waiting for the result.
                 closing: _,
             },
-        lifecycle: _,
+        lifecycle: Lifecycle::Active | Lifecycle::Paused,
     } =
         PendingStateMerged::from(combined_state.execution_with_state.pending_state)
         && *join_set_id == found_join_set_id

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1310,8 +1310,8 @@ async fn get_combined_state(
     CombinedState::new(dto, corresponding_version).map_err(DbErrorRead::from)
 }
 
-/// Shared body of `cancel_workflow` / `request_cancellation`: release any lock
-/// then append `CancellationRequested`, and commit.
+/// Shared body of `cancel_workflow` / `request_cancellation`: append
+/// `CancellationRequested` and commit.
 async fn apply_cancellation_plan(
     tx: deadpool_postgres::Transaction<'_>,
     execution_id: &ExecutionId,
@@ -1319,26 +1319,10 @@ async fn apply_cancellation_plan(
     combined_state: &CombinedState,
     plan: CancelWorkflowPlan,
 ) -> Result<CancelOutcome, DbErrorWrite> {
-    let unlock = match plan {
+    match plan {
         CancelWorkflowPlan::AlreadyFinished => return Ok(CancelOutcome::AlreadyFinished),
         CancelWorkflowPlan::AlreadyCancelling => return Ok(CancelOutcome::AlreadyCancelling),
-        CancelWorkflowPlan::Proceed { unlock } => unlock,
-    };
-    let mut version = combined_state.get_next_version_assert_not_finished();
-    if unlock {
-        (version, _) = append(
-            &tx,
-            execution_id,
-            AppendRequest {
-                created_at: cancelled_at,
-                event: ExecutionRequest::Unlocked(Unlocked {
-                    unlocked_at: cancelled_at, // does not matter, about to append `CancellationRequested` in same tx.
-                    reason: "cancelling".into(),
-                }),
-            },
-            version,
-        )
-        .await?;
+        CancelWorkflowPlan::Proceed => {}
     }
     append(
         &tx,
@@ -1347,7 +1331,7 @@ async fn apply_cancellation_plan(
             created_at: cancelled_at,
             event: ExecutionRequest::CancellationRequested,
         },
-        version,
+        combined_state.get_next_version_assert_not_finished(),
     )
     .await?;
     tx.commit().await?;
@@ -2613,23 +2597,6 @@ async fn append(
                 PendingState::Finished { .. } => {
                     unreachable!("handled above");
                 }
-                PendingState::Locked(..)
-                    if combined_state
-                        .execution_with_state
-                        .component_type
-                        .is_activity() => {}
-                // Locked workflows must first be released (`Unlocked`) by `cancel_workflow`.
-                PendingState::Locked(..) => {
-                    return Err(DbErrorWriteNonRetriable::IllegalState {
-                        reason:
-                            "cannot append CancellationRequested event on a locked workflow; use cancel_workflow"
-                                .into(),
-                        context: SpanTrace::capture(),
-                        source: None,
-                        loc: Location::caller(),
-                    }
-                    .into());
-                }
                 PendingState::Cancelling(..) => {
                     return Err(DbErrorWriteNonRetriable::IllegalState {
                         reason: "cannot append CancellationRequested event, execution is already cancelling".into(),
@@ -2639,10 +2606,13 @@ async fn append(
                     }
                     .into());
                 }
-                // Paused executions are guaranteed not to be running.
+                // Paused executions are never running; a locked activity keeps its lock
+                // until teardown or lease expiry; a locked workflow's run is fenced by
+                // this event's version bump.
                 PendingState::PendingAt(..)
                 | PendingState::BlockedByJoinSet(..)
-                | PendingState::Paused(..) => {}
+                | PendingState::Paused(..)
+                | PendingState::Locked(..) => {}
             }
             let next_version =
                 update_state_cancelling(tx, execution_id, &appending_version).await?;

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2542,6 +2542,8 @@ impl SqlitePool {
         // if the execution is going to be unblocked by this response...
         let combined_state = Self::get_combined_state(tx, execution_id)?;
         debug!("previous_pending_state: {combined_state:?}");
+        // A cancelling execution is finished by the cancellation driver; it is never
+        // picked up by executors again, so do not unblock or notify it.
         let mut notifier = if let PendingStateMerged::BlockedByJoinSet {
             state:
                 PendingStateBlockedByJoinSet {
@@ -2549,7 +2551,7 @@ impl SqlitePool {
                     lock_expires_at, // Set to a future time if the worker is keeping the execution warm waiting for the result.
                     closing: _,
                 },
-            lifecycle: _,
+            lifecycle: Lifecycle::Active | Lifecycle::Paused,
         } =
             PendingStateMerged::from(combined_state.execution_with_state.pending_state)
             && *join_set_id == found_join_set_id

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2352,17 +2352,18 @@ impl SqlitePool {
                     PendingState::Finished { .. } => {
                         unreachable!("handled above");
                     }
-                    PendingState::Locked(..)
+                    // Paused activities are guaranteed not to be running.
+                    PendingState::Locked(..) | PendingState::Paused(..)
                         if combined_state
                             .execution_with_state
                             .component_type
                             .is_activity() => {}
-                    // Locked workflows and paused executions must first be released
-                    // (`Unlocked` / `Unpaused`) by their dedicated cancellation path.
+                    // Locked and paused workflows must first be released
+                    // (`Unlocked` / `Unpaused`) by `cancel_workflow`.
                     PendingState::Locked(..) | PendingState::Paused(..) => {
                         return Err(DbErrorWriteNonRetriable::IllegalState {
                             reason:
-                                "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows"
+                                "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow"
                                     .into(),
                             context: SpanTrace::capture(),
                             source: None,

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -32,8 +32,8 @@ use concepts::{
 };
 use conversions::{JsonWrapper, consistency_db_err, consistency_rusqlite, from_generic_error};
 use db_common::{
-    AppendNotifier, CancelWorkflowPlan, CombinedState, CombinedStateDTO, NotifierExecutionFinished,
-    NotifierPendingAt, PendingFfqnSubscribersHolder, state_filter_to_sql, state_filters_now,
+    AppendNotifier, CombinedState, CombinedStateDTO, NotifierExecutionFinished, NotifierPendingAt,
+    PendingFfqnSubscribersHolder, state_filter_to_sql, state_filters_now,
 };
 use hashbrown::HashMap;
 use rusqlite::{
@@ -4004,8 +4004,11 @@ impl SqlitePool {
         cancelled_at: DateTime<Utc>,
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let combined_state = Self::get_combined_state(tx, execution_id)?;
-        let plan = combined_state.plan_cancel_workflow()?;
-        Self::apply_cancellation_plan(tx, execution_id, cancelled_at, &combined_state, plan)
+        if let Some(outcome) = combined_state.cancel_short_circuit() {
+            return Ok(outcome);
+        }
+        combined_state.assert_cancellable_workflow_ffqn()?;
+        Self::append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state)
     }
 
     fn request_cancellation(
@@ -4014,22 +4017,18 @@ impl SqlitePool {
         cancelled_at: DateTime<Utc>,
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let combined_state = Self::get_combined_state(tx, execution_id)?;
-        let plan = combined_state.plan_request_cancellation();
-        Self::apply_cancellation_plan(tx, execution_id, cancelled_at, &combined_state, plan)
+        if let Some(outcome) = combined_state.cancel_short_circuit() {
+            return Ok(outcome);
+        }
+        Self::append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state)
     }
 
-    fn apply_cancellation_plan(
+    fn append_cancellation_requested(
         tx: &Transaction,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
         combined_state: &CombinedState,
-        plan: CancelWorkflowPlan,
     ) -> Result<CancelOutcome, DbErrorWrite> {
-        match plan {
-            CancelWorkflowPlan::AlreadyFinished => return Ok(CancelOutcome::AlreadyFinished),
-            CancelWorkflowPlan::AlreadyCancelling => return Ok(CancelOutcome::AlreadyCancelling),
-            CancelWorkflowPlan::Proceed => {}
-        }
         Self::append(
             tx,
             execution_id,
@@ -4064,16 +4063,7 @@ impl SqlitePool {
             PendingState::Cancelling(_) => return Ok(CancelOutcome::Cancelled),
             _ => {}
         }
-        Self::append(
-            tx,
-            execution_id,
-            AppendRequest {
-                created_at: cancelled_at,
-                event: ExecutionRequest::CancellationRequested,
-            },
-            combined_state.get_next_version_assert_not_finished(),
-        )?;
-        Ok(CancelOutcome::Cancelled)
+        Self::append_cancellation_requested(tx, execution_id, cancelled_at, combined_state)
     }
 }
 

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -4079,7 +4079,7 @@ impl SqlitePool {
         Ok(CancelOutcome::Cancelled)
     }
 
-    fn apply_activity_cancellation(
+    fn append_activity_cancellation_requested_tx(
         tx: &Transaction,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
@@ -4592,7 +4592,7 @@ impl DbExecutor for SqlitePool {
     }
 
     #[instrument(skip(self))]
-    async fn cancel_activity(
+    async fn append_activity_cancellation_requested(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
@@ -4601,7 +4601,7 @@ impl DbExecutor for SqlitePool {
         self.transaction(
             move |tx| {
                 let combined_state = Self::get_combined_state(tx, &execution_id)?;
-                SqlitePool::apply_activity_cancellation(
+                SqlitePool::append_activity_cancellation_requested_tx(
                     tx,
                     &execution_id,
                     cancelled_at,
@@ -4609,7 +4609,7 @@ impl DbExecutor for SqlitePool {
                 )
             },
             TxType::MultipleWrites,
-            "cancel_activity",
+            "append_activity_cancellation_requested",
         )
         .await
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2,8 +2,8 @@ use crate::{histograms::Histograms, sqlite_dao::conversions::to_generic_error};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::{
-    ComponentId, ComponentRetryConfig, ComponentType, ContentDigest, ExecutionId, FunctionFqn,
-    JoinSetId, StrVariant, SupportedFunctionReturnValue,
+    ComponentId, ComponentRetryConfig, ComponentType, ContentDigest, ExecutionFailureKind,
+    ExecutionId, FunctionFqn, JoinSetId, StrVariant, SupportedFunctionReturnValue,
     cas::{Cas, CasError},
     component_id::{ComponentDigest, Digest},
     prefixed_ulid::{DelayId, DeploymentId, ExecutionIdDerived, ExecutorId, RunId},
@@ -24,10 +24,10 @@ use concepts::{
         ListLogsResponse, ListResponsesResponse, LockPendingResponse, Locked, LockedBy,
         LockedExecution, LogCursor, LogEntry, LogEntryRow, LogFilter, LogInfoAppendRow, LogLevel,
         LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
-        PendingStateFinishedResultKind, PendingStateMerged, RESULT_KIND_JSON_ERROR,
-        RESULT_KIND_JSON_OK, ResponseCursor, ResponseWithCursor, STATE_BLOCKED_BY_JOIN_SET,
-        STATE_FINISHED, STATE_LOCKED, STATE_PENDING_AT, TimeoutOutcome, Unlocked, Version,
-        VersionType,
+        PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateMerged,
+        RESULT_KIND_JSON_ERROR, RESULT_KIND_JSON_OK, ResponseCursor, ResponseWithCursor,
+        STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED, STATE_PENDING_AT, TimeoutOutcome,
+        Unlocked, Version, VersionType,
     },
 };
 use conversions::{JsonWrapper, consistency_db_err, consistency_rusqlite, from_generic_error};
@@ -2352,12 +2352,17 @@ impl SqlitePool {
                     PendingState::Finished { .. } => {
                         unreachable!("handled above");
                     }
-                    // Locked and Paused must first be released (`Unlocked` / `Unpaused`)
-                    // by `cancel_workflow` so `cancelling` never coexists with a lock or pause.
+                    PendingState::Locked(..)
+                        if combined_state
+                            .execution_with_state
+                            .component_type
+                            .is_activity() => {}
+                    // Locked workflows and paused executions must first be released
+                    // (`Unlocked` / `Unpaused`) by their dedicated cancellation path.
                     PendingState::Locked(..) | PendingState::Paused(..) => {
                         return Err(DbErrorWriteNonRetriable::IllegalState {
                             reason:
-                                "cannot append CancellationRequested event unless execution is pending or blocked; use cancel_workflow"
+                                "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows"
                                     .into(),
                             context: SpanTrace::capture(),
                             source: None,
@@ -4073,6 +4078,40 @@ impl SqlitePool {
         )?;
         Ok(CancelOutcome::Cancelled)
     }
+
+    fn apply_activity_cancellation(
+        tx: &Transaction,
+        execution_id: &ExecutionId,
+        cancelled_at: DateTime<Utc>,
+        combined_state: &CombinedState,
+    ) -> Result<CancelOutcome, DbErrorWrite> {
+        match &combined_state.execution_with_state.pending_state {
+            PendingState::Finished(finished) => {
+                if finished.result_kind
+                    == PendingStateFinishedResultKind::Err(
+                        PendingStateFinishedError::ExecutionFailure(
+                            ExecutionFailureKind::Cancelled,
+                        ),
+                    )
+                {
+                    return Ok(CancelOutcome::Cancelled);
+                }
+                return Ok(CancelOutcome::AlreadyFinished);
+            }
+            PendingState::Cancelling(_) => return Ok(CancelOutcome::Cancelled),
+            _ => {}
+        }
+        Self::append(
+            tx,
+            execution_id,
+            AppendRequest {
+                created_at: cancelled_at,
+                event: ExecutionRequest::CancellationRequested,
+            },
+            combined_state.get_next_version_assert_not_finished(),
+        )?;
+        Ok(CancelOutcome::Cancelled)
+    }
 }
 
 #[async_trait]
@@ -4548,6 +4587,29 @@ impl DbExecutor for SqlitePool {
             move |tx| Self::get_last_execution_event(tx, &execution_id),
             TxType::Other, // read only
             "get_last_execution_event",
+        )
+        .await
+    }
+
+    #[instrument(skip(self))]
+    async fn cancel_activity(
+        &self,
+        execution_id: &ExecutionId,
+        cancelled_at: DateTime<Utc>,
+    ) -> Result<CancelOutcome, DbErrorWrite> {
+        let execution_id = execution_id.clone();
+        self.transaction(
+            move |tx| {
+                let combined_state = Self::get_combined_state(tx, &execution_id)?;
+                SqlitePool::apply_activity_cancellation(
+                    tx,
+                    &execution_id,
+                    cancelled_at,
+                    &combined_state,
+                )
+            },
+            TxType::MultipleWrites,
+            "cancel_activity",
         )
         .await
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -3924,33 +3924,10 @@ impl SqlitePool {
         paused_at: DateTime<Utc>,
     ) -> Result<Version, DbErrorWrite> {
         let combined_state = Self::get_combined_state(tx, execution_id)?;
-        let appending_version = combined_state.get_next_version_fail_if_finished()?;
+        let mut appending_version = combined_state.get_next_version_fail_if_finished()?;
         debug!("Pausing with {appending_version}");
-        // A running (Locked) activity cannot be paused: pausing would unlock without confirming
-        // the in-flight WASM/exec invocation has stopped, so `Paused` would not mean quiescent and
-        // an unpause could start a second run in parallel. Cancel it instead. Workflows and
-        // not-yet-running activities remain pausable.
-        if matches!(
-            combined_state.execution_with_state.pending_state,
-            PendingState::Locked(_)
-        ) && combined_state
-            .execution_with_state
-            .component_type
-            .is_activity()
-        {
-            return Err(DbErrorWriteNonRetriable::IllegalState {
-                reason: "cannot pause a running activity; cancel it instead".into(),
-                context: SpanTrace::capture(),
-                source: None,
-                loc: Location::caller(),
-            }
-            .into());
-        }
-        let next_version = if matches!(
-            combined_state.execution_with_state.pending_state,
-            PendingState::Locked(_)
-        ) {
-            let (next_version, _notifier) = Self::append(
+        if combined_state.reject_locked_activities()? {
+            (appending_version, _) = Self::append(
                 tx,
                 execution_id,
                 AppendRequest {
@@ -3962,10 +3939,7 @@ impl SqlitePool {
                 },
                 appending_version,
             )?;
-            next_version
-        } else {
-            appending_version
-        };
+        }
         let (next_version, _notifier) = Self::append(
             tx,
             execution_id,
@@ -3973,7 +3947,7 @@ impl SqlitePool {
                 created_at: paused_at,
                 event: ExecutionRequest::Paused,
             },
-            next_version,
+            appending_version,
         )?;
         Ok(next_version)
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -282,6 +282,12 @@ enum TxType {
     Other,          // Read only or a single write LTX. Continue the PhyTx if LTX returns error.
 }
 
+#[derive(Debug, Clone, Copy)]
+enum CancellationFfqnCheck {
+    Required,
+    Skipped,
+}
+
 #[derive(Clone)]
 struct CommitError(RusqliteError);
 
@@ -3983,20 +3989,13 @@ impl SqlitePool {
         if let Some(outcome) = combined_state.cancel_short_circuit() {
             return Ok(outcome);
         }
-        combined_state.assert_cancellable_workflow_ffqn()?;
-        Self::append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state)
-    }
-
-    fn request_cancellation(
-        tx: &Transaction,
-        execution_id: &ExecutionId,
-        cancelled_at: DateTime<Utc>,
-    ) -> Result<CancelOutcome, DbErrorWrite> {
-        let combined_state = Self::get_combined_state(tx, execution_id)?;
-        if let Some(outcome) = combined_state.cancel_short_circuit() {
-            return Ok(outcome);
-        }
-        Self::append_cancellation_requested(tx, execution_id, cancelled_at, &combined_state)
+        Self::append_cancellation_requested(
+            tx,
+            execution_id,
+            cancelled_at,
+            &combined_state,
+            CancellationFfqnCheck::Required,
+        )
     }
 
     fn append_cancellation_requested(
@@ -4004,7 +4003,11 @@ impl SqlitePool {
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
         combined_state: &CombinedState,
+        ffqn_check: CancellationFfqnCheck,
     ) -> Result<CancelOutcome, DbErrorWrite> {
+        if matches!(ffqn_check, CancellationFfqnCheck::Required) {
+            combined_state.assert_cancellable_workflow_ffqn()?;
+        }
         Self::append(
             tx,
             execution_id,
@@ -4039,7 +4042,13 @@ impl SqlitePool {
             PendingState::Cancelling(_) => return Ok(CancelOutcome::Cancelled),
             _ => {}
         }
-        Self::append_cancellation_requested(tx, execution_id, cancelled_at, combined_state)
+        Self::append_cancellation_requested(
+            tx,
+            execution_id,
+            cancelled_at,
+            combined_state,
+            CancellationFfqnCheck::Skipped,
+        )
     }
 }
 
@@ -4544,16 +4553,16 @@ impl DbExecutor for SqlitePool {
     }
 
     #[instrument(skip(self))]
-    async fn request_cancellation(
+    async fn cancel_workflow(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let execution_id = execution_id.clone();
         self.transaction(
-            move |tx| SqlitePool::request_cancellation(tx, &execution_id, cancelled_at),
+            move |tx| SqlitePool::cancel_workflow(tx, &execution_id, cancelled_at),
             TxType::MultipleWrites,
-            "request_cancellation",
+            "cancel_workflow",
         )
         .await
     }
@@ -5146,21 +5155,6 @@ impl DbExternalApi for SqlitePool {
             move |tx| SqlitePool::unpause_execution(tx, &execution_id, unpaused_at),
             TxType::MultipleWrites,
             "unpause_execution",
-        )
-        .await
-    }
-
-    #[instrument(skip(self))]
-    async fn cancel_workflow(
-        &self,
-        execution_id: &ExecutionId,
-        cancelled_at: DateTime<Utc>,
-    ) -> Result<CancelOutcome, DbErrorWrite> {
-        let execution_id = execution_id.clone();
-        self.transaction(
-            move |tx| SqlitePool::cancel_workflow(tx, &execution_id, cancelled_at),
-            TxType::MultipleWrites,
-            "cancel_workflow",
         )
         .await
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2352,23 +2352,6 @@ impl SqlitePool {
                     PendingState::Finished { .. } => {
                         unreachable!("handled above");
                     }
-                    PendingState::Locked(..)
-                        if combined_state
-                            .execution_with_state
-                            .component_type
-                            .is_activity() => {}
-                    // Locked workflows must first be released (`Unlocked`) by `cancel_workflow`.
-                    PendingState::Locked(..) => {
-                        return Err(DbErrorWriteNonRetriable::IllegalState {
-                            reason:
-                                "cannot append CancellationRequested event on a locked workflow; use cancel_workflow"
-                                    .into(),
-                            context: SpanTrace::capture(),
-                            source: None,
-                            loc: Location::caller(),
-                        }
-                        .into());
-                    }
                     PendingState::Cancelling(..) => {
                         return Err(DbErrorWriteNonRetriable::IllegalState {
                             reason: "cannot append CancellationRequested event, execution is already cancelling".into(),
@@ -2378,10 +2361,13 @@ impl SqlitePool {
                         }
                         .into());
                     }
-                    // Paused executions are guaranteed not to be running.
+                    // Paused executions are never running; a locked activity keeps its lock
+                    // until teardown or lease expiry; a locked workflow's run is fenced by
+                    // this event's version bump.
                     PendingState::PendingAt(..)
                     | PendingState::BlockedByJoinSet(..)
-                    | PendingState::Paused(..) => {}
+                    | PendingState::Paused(..)
+                    | PendingState::Locked(..) => {}
                 }
                 let next_version =
                     Self::update_state_cancelling(tx, execution_id, &appending_version)?;
@@ -4039,25 +4025,10 @@ impl SqlitePool {
         combined_state: &CombinedState,
         plan: CancelWorkflowPlan,
     ) -> Result<CancelOutcome, DbErrorWrite> {
-        let unlock = match plan {
+        match plan {
             CancelWorkflowPlan::AlreadyFinished => return Ok(CancelOutcome::AlreadyFinished),
             CancelWorkflowPlan::AlreadyCancelling => return Ok(CancelOutcome::AlreadyCancelling),
-            CancelWorkflowPlan::Proceed { unlock } => unlock,
-        };
-        let mut version = combined_state.get_next_version_assert_not_finished();
-        if unlock {
-            (version, _) = Self::append(
-                tx,
-                execution_id,
-                AppendRequest {
-                    created_at: cancelled_at,
-                    event: ExecutionRequest::Unlocked(Unlocked {
-                        unlocked_at: cancelled_at, // does not matter, about to append `CancellationRequested` in same tx.
-                        reason: "cancelling".into(),
-                    }),
-                },
-                version,
-            )?;
+            CancelWorkflowPlan::Proceed => {}
         }
         Self::append(
             tx,
@@ -4066,7 +4037,7 @@ impl SqlitePool {
                 created_at: cancelled_at,
                 event: ExecutionRequest::CancellationRequested,
             },
-            version,
+            combined_state.get_next_version_assert_not_finished(),
         )?;
         Ok(CancelOutcome::Cancelled)
     }

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2352,18 +2352,16 @@ impl SqlitePool {
                     PendingState::Finished { .. } => {
                         unreachable!("handled above");
                     }
-                    // Paused activities are guaranteed not to be running.
-                    PendingState::Locked(..) | PendingState::Paused(..)
+                    PendingState::Locked(..)
                         if combined_state
                             .execution_with_state
                             .component_type
                             .is_activity() => {}
-                    // Locked and paused workflows must first be released
-                    // (`Unlocked` / `Unpaused`) by `cancel_workflow`.
-                    PendingState::Locked(..) | PendingState::Paused(..) => {
+                    // Locked workflows must first be released (`Unlocked`) by `cancel_workflow`.
+                    PendingState::Locked(..) => {
                         return Err(DbErrorWriteNonRetriable::IllegalState {
                             reason:
-                                "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow"
+                                "cannot append CancellationRequested event on a locked workflow; use cancel_workflow"
                                     .into(),
                             context: SpanTrace::capture(),
                             source: None,
@@ -2380,7 +2378,10 @@ impl SqlitePool {
                         }
                         .into());
                     }
-                    PendingState::PendingAt(..) | PendingState::BlockedByJoinSet(..) => {}
+                    // Paused executions are guaranteed not to be running.
+                    PendingState::PendingAt(..)
+                    | PendingState::BlockedByJoinSet(..)
+                    | PendingState::Paused(..) => {}
                 }
                 let next_version =
                     Self::update_state_cancelling(tx, execution_id, &appending_version)?;
@@ -4038,10 +4039,10 @@ impl SqlitePool {
         combined_state: &CombinedState,
         plan: CancelWorkflowPlan,
     ) -> Result<CancelOutcome, DbErrorWrite> {
-        let (unlock, unpause) = match plan {
+        let unlock = match plan {
             CancelWorkflowPlan::AlreadyFinished => return Ok(CancelOutcome::AlreadyFinished),
             CancelWorkflowPlan::AlreadyCancelling => return Ok(CancelOutcome::AlreadyCancelling),
-            CancelWorkflowPlan::Proceed { unlock, unpause } => (unlock, unpause),
+            CancelWorkflowPlan::Proceed { unlock } => unlock,
         };
         let mut version = combined_state.get_next_version_assert_not_finished();
         if unlock {
@@ -4054,16 +4055,6 @@ impl SqlitePool {
                         unlocked_at: cancelled_at, // does not matter, about to append `CancellationRequested` in same tx.
                         reason: "cancelling".into(),
                     }),
-                },
-                version,
-            )?;
-        } else if unpause {
-            (version, _) = Self::append(
-                tx,
-                execution_id,
-                AppendRequest {
-                    created_at: cancelled_at,
-                    event: ExecutionRequest::Unpaused,
                 },
                 version,
             )?;

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -5,9 +5,9 @@ use assert_matches::assert_matches;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, RunId};
 use concepts::storage::{
-    AppendEventsToExecution, AppendRequest, AppendResponseToExecution, DbErrorGeneric,
-    DbErrorWrite, DbErrorWriteNonRetriable, DbExecutor, DbPool, ExecutionLog, LockedExecution,
-    Unlocked,
+    AppendEventsToExecution, AppendRequest, AppendResponseToExecution, DbConnection,
+    DbErrorGeneric, DbErrorWrite, DbErrorWriteNonRetriable, DbExecutor, DbPool, ExecutionLog,
+    LockedExecution, Unlocked,
 };
 use concepts::time::{ClockFn, Sleep};
 use concepts::{
@@ -610,6 +610,25 @@ impl ExecTask {
         let worker_result = worker.run(ctx).await;
         debug!("Worker::run finished {worker_result:?}");
         let result_obtained_at = clock_fn.now();
+        if component_type == ComponentType::Activity
+            && matches!(
+                &worker_result,
+                WorkerResult::Err(WorkerError::FatalError(FatalError::Cancelled, _))
+            )
+        {
+            let db_conn = db_pool.connection().await?;
+            if let Some(append) = Self::cancelled_activity_to_append(
+                db_conn.as_ref(),
+                execution_id,
+                result_obtained_at,
+            )
+            .await?
+            {
+                trace!("Appending activity cancellation {append:?}");
+                append.append(db_conn.as_ref()).await?;
+            }
+            return Ok(());
+        }
         match Self::worker_result_to_execution_event(
             component_type,
             execution_id,
@@ -626,6 +645,53 @@ impl ExecTask {
             }
             None => Ok(()),
         }
+    }
+
+    async fn cancelled_activity_to_append(
+        db_conn: &dyn DbConnection,
+        execution_id: ExecutionId,
+        result_obtained_at: DateTime<Utc>,
+    ) -> Result<Option<Append>, DbErrorWrite> {
+        let log = db_conn
+            .get(&execution_id)
+            .await
+            .map_err(DbErrorWrite::from)?;
+        if log.is_finished() {
+            return Ok(None);
+        }
+        if !log.pending_state.is_cancelling() {
+            warn!(
+                %execution_id,
+                "Activity reported cancellation after teardown, but storage is not cancelling"
+            );
+            return Ok(None);
+        }
+        let result = SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
+            reason: None,
+            kind: ExecutionFailureKind::Cancelled,
+            detail: None,
+        });
+        let child_finished =
+            log.parent().map(
+                |(parent_execution_id, parent_join_set)| ChildFinishedResponse {
+                    parent_execution_id,
+                    parent_join_set,
+                    result: result.clone(),
+                },
+            );
+        Ok(Some(Append {
+            created_at: result_obtained_at,
+            primary_event: AppendRequest {
+                created_at: result_obtained_at,
+                event: ExecutionRequest::Finished {
+                    retval: result,
+                    http_client_traces: None,
+                },
+            },
+            execution_id,
+            version: log.next_version,
+            child_finished,
+        }))
     }
 
     /// Map the `WorkerError` to an optional append event
@@ -834,7 +900,7 @@ impl ExecTask {
                     }
                     WorkerError::FatalError(FatalError::Cancelled, _version) => {
                         unreachable!(
-                            "activity workers must return DbUpdatedByWorkerOrWatcher, cancellation append happens in CancelRegistry::cancel_activity"
+                            "activity Cancelled is handled before this match; workflows are cancelled via the driver and never return FatalError::Cancelled"
                         )
                     }
                     WorkerError::FatalError(fatal_error, version) => {

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -282,10 +282,10 @@ impl<T> TonicServerResultExt<T> for Result<T, DbErrorGeneric> {
 pub fn db_error_write_to_status(db_err: &DbErrorWrite) -> tonic::Status {
     match db_err {
         DbErrorWrite::NotFound => tonic::Status::not_found("entity not found"),
-        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::ValidationFailed(reason)
-| DbErrorWriteNonRetriable::IllegalState { reason, .. }) => {
-            tonic::Status::invalid_argument(reason.to_string())
-        }
+        DbErrorWrite::NonRetriable(
+            DbErrorWriteNonRetriable::ValidationFailed(reason)
+            | DbErrorWriteNonRetriable::IllegalState { reason, .. },
+        ) => tonic::Status::invalid_argument(reason.to_string()),
         _ => {
             warn!("Got db error {db_err:?}");
             tonic::Status::internal("database error".to_string())

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -10,9 +10,9 @@ use concepts::{
         AppendEventsToExecution, AppendRequest, AppendResponseToExecution, BacktraceInfo,
         CancelOutcome, CapturedDbWrite, ChildExecutionRequestError, ComponentUpgradeOutcome,
         ComponentUpgradeReason, CreateRequest, DbErrorGeneric, DbErrorRead, DbErrorWrite,
-        ExecutionEvent, ExecutionListPagination, ExecutionRequest, ExecutionWithState,
-        HistoryEvent, HistoryEventScheduleAt, JoinSetRequest, Locked, LockedBy, LogEntry,
-        LogEntryRow, LogLevel, LogStreamType, Pagination, PendingState,
+        DbErrorWriteNonRetriable, ExecutionEvent, ExecutionListPagination, ExecutionRequest,
+        ExecutionWithState, HistoryEvent, HistoryEventScheduleAt, JoinSetRequest, Locked, LockedBy,
+        LogEntry, LogEntryRow, LogLevel, LogStreamType, Pagination, PendingState,
         PendingStateBlockedByJoinSet, PendingStateFinished, PendingStateFinishedError,
         PendingStateFinishedResultKind, PendingStateLocked, PendingStatePendingAt, PersistKind,
         ScheduleRequestError, StubError, Unlocked, Version, VersionParseError,
@@ -280,11 +280,18 @@ impl<T> TonicServerResultExt<T> for Result<T, DbErrorGeneric> {
 }
 
 pub fn db_error_write_to_status(db_err: &DbErrorWrite) -> tonic::Status {
-    if matches!(*db_err, DbErrorWrite::NotFound) {
-        tonic::Status::not_found("entity not found")
-    } else {
-        warn!("Got db error {db_err:?}");
-        tonic::Status::internal("database error".to_string())
+    match db_err {
+        DbErrorWrite::NotFound => tonic::Status::not_found("entity not found"),
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::ValidationFailed(reason)) => {
+            tonic::Status::invalid_argument(reason.to_string())
+        }
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => {
+            tonic::Status::invalid_argument(reason.to_string())
+        }
+        _ => {
+            warn!("Got db error {db_err:?}");
+            tonic::Status::internal("database error".to_string())
+        }
     }
 }
 

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -282,10 +282,8 @@ impl<T> TonicServerResultExt<T> for Result<T, DbErrorGeneric> {
 pub fn db_error_write_to_status(db_err: &DbErrorWrite) -> tonic::Status {
     match db_err {
         DbErrorWrite::NotFound => tonic::Status::not_found("entity not found"),
-        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::ValidationFailed(reason)) => {
-            tonic::Status::invalid_argument(reason.to_string())
-        }
-        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => {
+        DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::ValidationFailed(reason)
+| DbErrorWriteNonRetriable::IllegalState { reason, .. }) => {
             tonic::Status::invalid_argument(reason.to_string())
         }
         _ => {

--- a/crates/testing/component-builder/src/lib.rs
+++ b/crates/testing/component-builder/src/lib.rs
@@ -216,12 +216,24 @@ fn compute_inputs_hash(
 }
 
 fn cleanup_old_hashed_files(dir: &Path, name_snake_case: &str) {
+    let prefix = format!("{name_snake_case}_");
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let file_name = entry.file_name();
             let file_name = file_name.to_string_lossy();
-            if file_name.starts_with(&format!("{name_snake_case}_")) && file_name.ends_with(".wasm")
-            {
+            let Some(rest) = file_name
+                .strip_prefix(&prefix)
+                .and_then(|rest| rest.strip_suffix(".wasm"))
+            else {
+                continue;
+            };
+            // Only this component's own hashed artifacts, named `<hash>` or
+            // `component_<hash>` with a hex `<hash>`. Without the hex check a component whose
+            // name extends this prefix (e.g. `..._fibo_workflow_outer` vs `..._fibo_workflow`)
+            // would have its cached wasm deleted here, making the shared cache build-order
+            // dependent.
+            let hash = rest.strip_prefix("component_").unwrap_or(rest);
+            if !hash.is_empty() && hash.bytes().all(|b| b.is_ascii_hexdigit()) {
                 let _ = std::fs::remove_file(entry.path());
             }
         }

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -8,8 +8,9 @@ use concepts::storage::{
     ExecutionListPagination, ExecutionRequest, ExecutionStateFilter, ExpiredDelay, ExpiredLock,
     ExpiredTimer, FrameInfo, FrameSymbol, FunctionNameFilter, JoinSetRequest, JoinSetResponse,
     JoinSetResponseEventOuter, LockedBy, LockedExecution, Pagination, PendingState,
-    PendingStateBlockedByJoinSet, PendingStateLocked, PendingStatePendingAt, PendingStateCancelling, PendingStatePaused,
-    ResponseCursor, TimeoutOutcome, Unlocked, Version, VersionType, WasmBacktrace,
+    PendingStateBlockedByJoinSet, PendingStateCancelling, PendingStateLocked, PendingStatePaused,
+    PendingStatePendingAt, ResponseCursor, TimeoutOutcome, Unlocked, Version, VersionType,
+    WasmBacktrace,
 };
 use concepts::storage::{
     DbErrorWrite, DbPoolCloseable, DeploymentRecord, DeploymentStatus, EnqueueOutcome,
@@ -3133,48 +3134,6 @@ async fn cancel_workflow_second_call_is_already_cancelling(database: Database) {
     db_close.close().await;
 }
 
-/// The worker join-set close / cancellation driver path classifies the target as
-/// cancellable itself, so `request_cancellation` skips the `is_cancellable` guard
-/// that rejects `SOME_FFQN` on the `cancel_workflow` control-plane path.
-#[expand_enum_database]
-#[rstest]
-#[tokio::test]
-async fn request_cancellation_bypasses_cancellable_guard(database: Database) {
-    set_up();
-    let sim_clock = SimClock::default();
-    let (_guard, db_pool, db_close) = database.set_up().await;
-    let db_connection = db_pool.connection().await.unwrap();
-
-    let execution_id = ExecutionId::generate();
-    // SOME_FFQN has no `-cancellable` suffix; `cancel_workflow` would reject it.
-    create_at(
-        db_connection.as_ref(),
-        &sim_clock,
-        &execution_id,
-        sim_clock.now(),
-    )
-    .await;
-
-    let outcome = db_connection
-        .request_cancellation(&execution_id, sim_clock.now())
-        .await
-        .unwrap();
-    assert_eq!(CancelOutcome::Cancelled, outcome);
-
-    let log = db_connection.get(&execution_id).await.unwrap();
-    assert_matches!(
-        log.pending_state,
-        PendingState::Cancelling(PendingStateCancelling::PendingAt(_))
-    );
-    assert_matches!(
-        log.last_event().event,
-        ExecutionRequest::CancellationRequested
-    );
-
-    drop(db_connection);
-    db_close.close().await;
-}
-
 /// `get_cancelling` (the driver's pick-up query) returns only `cancelling` rows,
 /// excluding an active one.
 #[expand_enum_database]
@@ -3187,7 +3146,7 @@ async fn get_cancelling_returns_only_cancelling_rows(database: Database) {
     let db_connection = db_pool.connection().await.unwrap();
 
     let cancelling = ExecutionId::generate();
-    create_at(
+    create_cancellable_at(
         db_connection.as_ref(),
         &sim_clock,
         &cancelling,
@@ -3195,7 +3154,7 @@ async fn get_cancelling_returns_only_cancelling_rows(database: Database) {
     )
     .await;
     db_connection
-        .request_cancellation(&cancelling, sim_clock.now())
+        .cancel_workflow(&cancelling, sim_clock.now())
         .await
         .unwrap();
 

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -8,7 +8,7 @@ use concepts::storage::{
     ExecutionListPagination, ExecutionRequest, ExecutionStateFilter, ExpiredDelay, ExpiredLock,
     ExpiredTimer, FrameInfo, FrameSymbol, FunctionNameFilter, JoinSetRequest, JoinSetResponse,
     JoinSetResponseEventOuter, LockedBy, LockedExecution, Pagination, PendingState,
-    PendingStateBlockedByJoinSet, PendingStateLocked, PendingStatePendingAt, PendingStateSuspended,
+    PendingStateBlockedByJoinSet, PendingStateLocked, PendingStatePendingAt, PendingStateCancelling, PendingStatePaused,
     ResponseCursor, TimeoutOutcome, Unlocked, Version, VersionType, WasmBacktrace,
 };
 use concepts::storage::{
@@ -2392,7 +2392,7 @@ async fn pause_and_unpause_locked_workflow_should_return_to_pending_at(#[case] d
     // Verify the lock was released before the execution was paused.
     let log = db_connection.get(&execution_id).await.unwrap();
     let paused_pending_at = assert_matches!(log.pending_state,
-        PendingState::Paused(PendingStateSuspended::PendingAt(PendingStatePendingAt { scheduled_at, last_lock })) => (scheduled_at, last_lock));
+        PendingState::Paused(PendingStatePaused::PendingAt(PendingStatePendingAt { scheduled_at, last_lock })) => (scheduled_at, last_lock));
     assert_eq!(paused_at, paused_pending_at.0);
     assert_eq!(Some(found_locked_by.clone()), paused_pending_at.1);
     let reason = assert_matches!(
@@ -2600,7 +2600,7 @@ async fn cancellation_requested_from_pending_at_should_keep_underlying_state(dat
     // PendingAt.
     let scheduled = assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(PendingStatePendingAt {
+        PendingState::Cancelling(PendingStateCancelling::PendingAt(PendingStatePendingAt {
             scheduled_at,
             ..
         })) => scheduled_at
@@ -2669,7 +2669,7 @@ async fn cancellation_requested_on_locked_workflow_should_keep_underlying_state(
     let log = db_connection.get(&execution_id).await.unwrap();
     let locked = assert_matches!(
         &log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::Locked(locked)) => locked
+        PendingState::Cancelling(PendingStateCancelling::Locked(locked)) => locked
     );
     assert_eq!(lock_expires_at, locked.lock_expires_at);
 
@@ -2714,7 +2714,7 @@ async fn cancel_activity_on_locked_execution_requests_cancellation(database: Dat
     let log = db_connection.get(&execution_id).await.unwrap();
     let locked = assert_matches!(
         &log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::Locked(locked)) => locked
+        PendingState::Cancelling(PendingStateCancelling::Locked(locked)) => locked
     );
     assert_eq!(lock_expires_at, locked.lock_expires_at);
     assert_matches!(
@@ -2764,7 +2764,7 @@ async fn cancel_activity_on_paused_execution_requests_cancellation(database: Dat
     let log = db_connection.get(&execution_id).await.unwrap();
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+        PendingState::Cancelling(PendingStateCancelling::PendingAt(_))
     );
     assert_matches!(
         log.last_event().event,
@@ -2831,7 +2831,7 @@ async fn cancellation_requested_on_paused_workflow_should_keep_underlying_state(
     // Cancel supersedes pause: cancelling, not paused.
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+        PendingState::Cancelling(PendingStateCancelling::PendingAt(_))
     );
 
     drop(db_connection);
@@ -2950,7 +2950,7 @@ async fn cancel_workflow_from_pending_at(database: Database) {
     let log = db_connection.get(&execution_id).await.unwrap();
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+        PendingState::Cancelling(PendingStateCancelling::PendingAt(_))
     );
     assert_matches!(
         log.last_event().event,
@@ -3003,7 +3003,7 @@ async fn cancel_workflow_from_locked_should_keep_underlying_state(database: Data
     // The lock is kept; the running workflow is fenced by the version bump.
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::Locked(_))
+        PendingState::Cancelling(PendingStateCancelling::Locked(_))
     );
     // ..., Locked, CancellationRequested
     assert_matches!(
@@ -3051,7 +3051,7 @@ async fn cancel_workflow_from_paused_should_keep_underlying_state(database: Data
     // Cancel supersedes pause: cancelling, not paused.
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+        PendingState::Cancelling(PendingStateCancelling::PendingAt(_))
     );
     // ..., Paused, CancellationRequested (no Unpaused: paused executions are never running)
     assert_matches!(
@@ -3164,7 +3164,7 @@ async fn request_cancellation_bypasses_cancellable_guard(database: Database) {
     let log = db_connection.get(&execution_id).await.unwrap();
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+        PendingState::Cancelling(PendingStateCancelling::PendingAt(_))
     );
     assert_matches!(
         log.last_event().event,
@@ -3528,7 +3528,7 @@ async fn pause_then_join_next_then_unpause_should_restore_blocked_by_join_set(da
     let log = db_connection.get(&execution_id).await.unwrap();
     assert_matches!(
         log.pending_state,
-        PendingState::Paused(PendingStateSuspended::BlockedByJoinSet(
+        PendingState::Paused(PendingStatePaused::BlockedByJoinSet(
             PendingStateBlockedByJoinSet {
                 join_set_id: actual_join_set_id,
                 ..

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2618,20 +2618,29 @@ async fn cancellation_requested_from_pending_at_should_keep_underlying_state(dat
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn cannot_cancel_locked_execution_directly(database: Database) {
+async fn cannot_cancel_locked_workflow_directly(database: Database) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
     let db_connection = db_pool.connection().await.unwrap();
 
     let execution_id = ExecutionId::generate();
-    create_at(
-        db_connection.as_ref(),
-        &sim_clock,
-        &execution_id,
-        sim_clock.now(),
-    )
-    .await;
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: execution_id.clone(),
+            ffqn: SOME_FFQN,
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_workflow(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
     lock(
         db_connection.as_ref(),
         &execution_id,
@@ -2655,8 +2664,57 @@ async fn cannot_cancel_locked_execution_directly(database: Database) {
         .unwrap_err();
     let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
     assert_eq!(
-        "cannot append CancellationRequested event unless execution is pending or blocked; use cancel_workflow",
+        "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows",
         reason.as_ref()
+    );
+
+    drop(db_connection);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn cancel_activity_on_locked_execution_requests_cancellation(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let db_connection = db_pool.connection().await.unwrap();
+
+    let execution_id = ExecutionId::generate();
+    create_at(
+        db_connection.as_ref(),
+        &sim_clock,
+        &execution_id,
+        sim_clock.now(),
+    )
+    .await;
+    let lock_expires_at = sim_clock.now() + Duration::from_secs(30);
+    lock(
+        db_connection.as_ref(),
+        &execution_id,
+        &sim_clock,
+        ExecutorId::generate(),
+        lock_expires_at,
+        RunId::generate(),
+    )
+    .await;
+
+    let outcome = db_connection
+        .cancel_activity(&execution_id, sim_clock.now())
+        .await
+        .unwrap();
+    assert_eq!(CancelOutcome::Cancelled, outcome);
+
+    let log = db_connection.get(&execution_id).await.unwrap();
+    let locked = assert_matches!(
+        &log.pending_state,
+        PendingState::Cancelling(PendingStateSuspended::Locked(locked)) => locked
+    );
+    assert_eq!(lock_expires_at, locked.lock_expires_at);
+    assert_matches!(
+        log.last_event().event,
+        ExecutionRequest::CancellationRequested
     );
 
     drop(db_connection);
@@ -2705,7 +2763,7 @@ async fn cannot_cancel_paused_execution_directly(database: Database) {
         .unwrap_err();
     let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
     assert_eq!(
-        "cannot append CancellationRequested event unless execution is pending or blocked; use cancel_workflow",
+        "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows",
         reason.as_ref()
     );
 

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2664,7 +2664,7 @@ async fn cannot_cancel_locked_workflow_directly(database: Database) {
         .unwrap_err();
     let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
     assert_eq!(
-        "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow",
+        "cannot append CancellationRequested event on a locked workflow; use cancel_workflow",
         reason.as_ref()
     );
 
@@ -2773,7 +2773,9 @@ async fn cancel_activity_on_paused_execution_requests_cancellation(database: Dat
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn cannot_cancel_paused_workflow_directly(database: Database) {
+async fn cancellation_requested_on_paused_workflow_should_keep_underlying_state(
+    database: Database,
+) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
@@ -2808,7 +2810,7 @@ async fn cannot_cancel_paused_workflow_directly(database: Database) {
         .await
         .unwrap();
 
-    let err = db_connection
+    db_connection
         .append(
             execution_id.clone(),
             version,
@@ -2818,11 +2820,13 @@ async fn cannot_cancel_paused_workflow_directly(database: Database) {
             },
         )
         .await
-        .unwrap_err();
-    let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
-    assert_eq!(
-        "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow",
-        reason.as_ref()
+        .unwrap();
+
+    let log = db_connection.get(&execution_id).await.unwrap();
+    // Cancel supersedes pause: cancelling, not paused.
+    assert_matches!(
+        log.pending_state,
+        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
     );
 
     drop(db_connection);
@@ -3012,7 +3016,7 @@ async fn cancel_workflow_from_locked_appends_unlocked_first(database: Database) 
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn cancel_workflow_from_paused_appends_unpaused_first(database: Database) {
+async fn cancel_workflow_from_paused_should_keep_underlying_state(database: Database) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
@@ -3043,14 +3047,14 @@ async fn cancel_workflow_from_paused_appends_unpaused_first(database: Database) 
         log.pending_state,
         PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
     );
-    // ..., Unpaused, CancellationRequested
+    // ..., Paused, CancellationRequested (no Unpaused: paused executions are never running)
     assert_matches!(
         log.last_event().event,
         ExecutionRequest::CancellationRequested
     );
     assert_matches!(
         log.events[log.events.len() - 2].event,
-        ExecutionRequest::Unpaused
+        ExecutionRequest::Paused
     );
 
     drop(db_connection);

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2664,7 +2664,7 @@ async fn cannot_cancel_locked_workflow_directly(database: Database) {
         .unwrap_err();
     let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
     assert_eq!(
-        "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows",
+        "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow",
         reason.as_ref()
     );
 
@@ -2724,7 +2724,7 @@ async fn cancel_activity_on_locked_execution_requests_cancellation(database: Dat
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn cannot_cancel_paused_execution_directly(database: Database) {
+async fn cancel_activity_on_paused_execution_requests_cancellation(database: Database) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
@@ -2738,6 +2738,64 @@ async fn cannot_cancel_paused_execution_directly(database: Database) {
         sim_clock.now(),
     )
     .await;
+    db_connection
+        .append(
+            execution_id.clone(),
+            Version::new(1),
+            AppendRequest {
+                created_at: sim_clock.now(),
+                event: ExecutionRequest::Paused,
+            },
+        )
+        .await
+        .unwrap();
+
+    let outcome = db_connection
+        .append_activity_cancellation_requested(&execution_id, sim_clock.now())
+        .await
+        .unwrap();
+    assert_eq!(CancelOutcome::Cancelled, outcome);
+
+    let log = db_connection.get(&execution_id).await.unwrap();
+    assert_matches!(
+        log.pending_state,
+        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+    );
+    assert_matches!(
+        log.last_event().event,
+        ExecutionRequest::CancellationRequested
+    );
+
+    drop(db_connection);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn cannot_cancel_paused_workflow_directly(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let db_connection = db_pool.connection().await.unwrap();
+
+    let execution_id = ExecutionId::generate();
+    db_connection
+        .create(CreateRequest {
+            created_at: sim_clock.now(),
+            execution_id: execution_id.clone(),
+            ffqn: SOME_FFQN,
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: sim_clock.now(),
+            component_id: ComponentId::dummy_workflow(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        })
+        .await
+        .unwrap();
     let version = db_connection
         .append(
             execution_id.clone(),
@@ -2763,7 +2821,7 @@ async fn cannot_cancel_paused_execution_directly(database: Database) {
         .unwrap_err();
     let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
     assert_eq!(
-        "cannot append CancellationRequested event unless execution is pending, blocked, or a locked activity; use cancel_workflow for workflows",
+        "cannot append CancellationRequested event on a locked or paused workflow; use cancel_workflow",
         reason.as_ref()
     );
 

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2618,7 +2618,9 @@ async fn cancellation_requested_from_pending_at_should_keep_underlying_state(dat
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn cannot_cancel_locked_workflow_directly(database: Database) {
+async fn cancellation_requested_on_locked_workflow_should_keep_underlying_state(
+    database: Database,
+) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
@@ -2641,17 +2643,18 @@ async fn cannot_cancel_locked_workflow_directly(database: Database) {
         })
         .await
         .unwrap();
+    let lock_expires_at = sim_clock.now() + Duration::from_secs(30);
     lock(
         db_connection.as_ref(),
         &execution_id,
         &sim_clock,
         ExecutorId::generate(),
-        sim_clock.now() + Duration::from_secs(30),
+        lock_expires_at,
         RunId::generate(),
     )
     .await;
 
-    let err = db_connection
+    db_connection
         .append(
             execution_id.clone(),
             Version::new(2),
@@ -2661,12 +2664,14 @@ async fn cannot_cancel_locked_workflow_directly(database: Database) {
             },
         )
         .await
-        .unwrap_err();
-    let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
-    assert_eq!(
-        "cannot append CancellationRequested event on a locked workflow; use cancel_workflow",
-        reason.as_ref()
+        .unwrap();
+
+    let log = db_connection.get(&execution_id).await.unwrap();
+    let locked = assert_matches!(
+        &log.pending_state,
+        PendingState::Cancelling(PendingStateSuspended::Locked(locked)) => locked
     );
+    assert_eq!(lock_expires_at, locked.lock_expires_at);
 
     drop(db_connection);
     db_close.close().await;
@@ -2959,7 +2964,7 @@ async fn cancel_workflow_from_pending_at(database: Database) {
 #[expand_enum_database]
 #[rstest]
 #[tokio::test]
-async fn cancel_workflow_from_locked_appends_unlocked_first(database: Database) {
+async fn cancel_workflow_from_locked_should_keep_underlying_state(database: Database) {
     set_up();
     let sim_clock = SimClock::default();
     let (_guard, db_pool, db_close) = database.set_up().await;
@@ -2995,18 +3000,19 @@ async fn cancel_workflow_from_locked_appends_unlocked_first(database: Database) 
     assert_eq!(CancelOutcome::Cancelled, outcome);
 
     let log = db_connection.get(&execution_id).await.unwrap();
+    // The lock is kept; the running workflow is fenced by the version bump.
     assert_matches!(
         log.pending_state,
-        PendingState::Cancelling(PendingStateSuspended::PendingAt(_))
+        PendingState::Cancelling(PendingStateSuspended::Locked(_))
     );
-    // ..., Unlocked, CancellationRequested
+    // ..., Locked, CancellationRequested
     assert_matches!(
         log.last_event().event,
         ExecutionRequest::CancellationRequested
     );
     assert_matches!(
         log.events[log.events.len() - 2].event,
-        ExecutionRequest::Unlocked(Unlocked { ref reason, .. }) if reason.as_ref() == "cancelling"
+        ExecutionRequest::Locked(_)
     );
 
     drop(db_connection);

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2701,7 +2701,7 @@ async fn cancel_activity_on_locked_execution_requests_cancellation(database: Dat
     .await;
 
     let outcome = db_connection
-        .cancel_activity(&execution_id, sim_clock.now())
+        .append_activity_cancellation_requested(&execution_id, sim_clock.now())
         .await
         .unwrap();
     assert_eq!(CancelOutcome::Cancelled, outcome);

--- a/crates/wasm-workers/Cargo.toml
+++ b/crates/wasm-workers/Cargo.toml
@@ -32,6 +32,7 @@ hyper-util.workspace = true
 hyper.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
+libc.workspace = true
 rand.workspace = true
 regex.workspace = true
 route-recognizer.workspace = true

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -19,8 +19,8 @@ use executor::worker::{
 };
 use indexmap::IndexMap;
 use secrecy::{ExposeSecret, SecretString};
-use std::path::PathBuf;
 use std::sync::Arc;
+use std::{io::ErrorKind, path::PathBuf};
 use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tracing::{debug, trace, warn};
@@ -370,13 +370,23 @@ impl Worker for ActivityExecWorker {
         let result = tokio::select! {
             biased;
             _signal = cancel_token => {
-                // Fired only by `CancelRegistry::cancel_activity`, which has already written the
-                // terminal cancellation state to the DB. Pausing a running activity is rejected,
-                // so pause never interrupts here.
-                debug!("Activity run interrupted, DB must have been updated");
-                // Kill the child once the DB state has already been updated elsewhere.
-                let _ = child.kill().await;
-                return Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher);
+                // The token fires only on cancellation (CancelRegistry::cancel_activity is its
+                // sole trigger). Kill and reap the child before finalizing; the executor appends
+                // the terminal only if still `cancelling`.
+                debug!("Activity run interrupted, killing child before finalizing cancellation");
+                kill_process_group(&child);
+                match child.kill().await {
+                    Ok(()) => {
+                        return Err(WorkerError::FatalError(FatalError::Cancelled, version));
+                    }
+                    Err(err) if err.kind() == ErrorKind::InvalidInput => {
+                        return Err(WorkerError::FatalError(FatalError::Cancelled, version));
+                    }
+                    Err(err) => {
+                        warn!(%err, "Could not confirm child process termination after cancellation");
+                        return Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher);
+                    }
+                }
             }
             result = async {
                 // Read stdout/stderr concurrently, streaming to log forwarder as chunks arrive.
@@ -471,6 +481,25 @@ impl Worker for ActivityExecWorker {
             http_client_traces: None,
         }))
     }
+}
+
+fn kill_process_group(child: &tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // `process_group(0)` at spawn makes the child its own group leader, so its
+        // PGID equals its PID. A real PID always fits in `pid_t`.
+        let Ok(pgid) = libc::pid_t::try_from(pid) else {
+            return;
+        };
+        // SAFETY: `kill` has no memory-safety preconditions; a negative PGID signals
+        // the whole process group. Best effort for descendants, reaping the direct
+        // child below is the authoritative cancellation gate.
+        unsafe {
+            libc::kill(-pgid, libc::SIGKILL);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = child;
 }
 
 fn forward_output(config: &StdOutputConfigWithSender, output: &[u8], ctx: &WorkerContext) {

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -252,12 +252,12 @@ impl Worker for ActivityWorker {
                 });
             }
             _ = interrupt_token => {
-                // Fired only by `CancelRegistry::cancel_activity`, which has already written the
-                // terminal cancellation state to the DB. Pausing a running activity is rejected,
-                // so pause never interrupts here.
+                // The token fires only on cancellation (CancelRegistry::cancel_activity is its
+                // sole trigger). Return Cancelled; dropping the store here tears down the
+                // invocation, and the executor appends the terminal only if still `cancelling`.
                 // TODO: Add http traces
-                debug!("Activity run interrupted, DB must have been updated");
-                return WorkerResult::Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher);
+                debug!("Activity run interrupted, finalizing cancellation after dropping store");
+                return WorkerResult::Err(WorkerError::FatalError(FatalError::Cancelled, version));
             }
             _ = executor_close_watcher.changed() => {
                 debug!("Executor is closing");

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -71,19 +71,6 @@ impl CancelRegistry {
         receiver
     }
 
-    /// Best-effort local interrupt for an activity currently running in this process.
-    /// Unlike `cancel_activity`, this does not write cancellation intent to the DB.
-    /// Noop if the execution is not an activity tracked by this registry.
-    fn interrupt_running_activity(&self, execution_id: &ExecutionId) {
-        let info = {
-            let mut guard = self.tokens.lock().unwrap();
-            guard.remove(execution_id)
-        };
-        if let Some(info) = info {
-            let _ = info.interrupt_sender.send(());
-        }
-    }
-
     /// It is the responsibility of the caller to check that the execution belongs to an activity!
     pub async fn cancel_activity(
         &self,
@@ -97,7 +84,13 @@ impl CancelRegistry {
             .await?;
         if outcome == CancelOutcome::Cancelled {
             // Sending the signal is best effort, the activity might not be registered yet.
-            self.interrupt_running_activity(execution_id);
+            let info = {
+                let mut guard = self.tokens.lock().unwrap();
+                guard.remove(execution_id)
+            };
+            if let Some(info) = info {
+                let _ = info.interrupt_sender.send(());
+            }
         }
         Ok(outcome)
     }

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -15,7 +15,7 @@ use tracing::{Instrument, debug, info, info_span};
 /// All currently running activities in this process.
 /// Activity worker tasks register themselves and listen on interruption token.
 /// Cancel RPCs and workflow workers call `cancel_activity`
-/// which writes the new state to db (no matter whether registered or not)
+/// which writes durable cancellation intent to db (no matter whether registered or not)
 /// and triggers the interruption token.
 pub struct CancelRegistry {
     tokens: Arc<Mutex<hashbrown::HashMap<ExecutionId, ActivityInfo>>>,
@@ -72,7 +72,7 @@ impl CancelRegistry {
     }
 
     /// Best-effort local interrupt for an activity currently running in this process.
-    /// Unlike `cancel_activity`, this does not write terminal cancellation state to the DB.
+    /// Unlike `cancel_activity`, this does not write cancellation intent to the DB.
     /// Noop if the execution is not an activity tracked by this registry.
     fn interrupt_running_activity(&self, execution_id: &ExecutionId) {
         let info = {

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -5,11 +5,12 @@
 //! digest-agnostic tick-poll task advances each one out of band, purely from the
 //! persisted log (it runs no WASM, so it also works on stuck executions).
 //!
-//! Per cancelling execution, one close-step: reconstruct the open join-set members
-//! from the log, cancel leaf activities/delays and signal cancellable children, and
-//! once every member has a response append `Finished(Cancelled)` (responding to the
-//! parent). A member finishing `Cancelled` is itself a response, so an ancestor's
-//! close wakes when its cancelled child reports back — the recursion.
+//! Per cancelling workflow, one close-step: reconstruct the open child executions
+//! and delays from the log, cancel leaf activities/delays and signal cancellable
+//! children, and once every child or delay has a response append
+//! `Finished(Cancelled)` (responding to the parent). Cancelling activities are
+//! finalized here only when not locked, or after their lock lease expires; the
+//! local activity worker owns the prompt path.
 
 use crate::activity::cancel_registry::CancelRegistry;
 use chrono::{DateTime, Utc};
@@ -20,7 +21,7 @@ use concepts::{
     storage::{
         self, AppendEventsToExecution, AppendRequest, AppendResponseToExecution, DbConnection,
         DbErrorRead, DbErrorWrite, DbPool, ExecutionLog, ExecutionRequest, HistoryEvent,
-        JoinSetRequest,
+        JoinSetRequest, PendingState, PendingStateCancelling,
     },
     time::{ClockFn, Sleep},
 };
@@ -55,10 +56,10 @@ impl CancellationDriver {
             tokio::spawn(
                 async move {
                     debug!("Spawned the cancellation driver");
-                    // Members already actioned (cancelled/signalled) this process, so a
-                    // member is signalled at most once instead of every tick until it
-                    // responds. Pruned as responses land; empty on restart (re-signal is
-                    // idempotent), so no durable state is needed.
+                    // Child executions and delays already actioned (cancelled/signalled)
+                    // this process, so each is signalled at most once instead of every tick
+                    // until it responds. Pruned as responses land; empty on restart
+                    // (re-signal is idempotent), so no durable state is needed.
                     let mut handled: HashSet<JoinSetResponseId> = HashSet::new();
                     loop {
                         match db_pool.connection().await {
@@ -105,6 +106,16 @@ async fn tick(
     }
 }
 
+#[cfg(test)]
+pub(crate) async fn tick_test(
+    conn: &dyn DbConnection,
+    cancel_registry: &CancelRegistry,
+    now: DateTime<Utc>,
+) {
+    let mut handled = HashSet::new();
+    tick(conn, cancel_registry, now, 10, &mut handled).await;
+}
+
 /// Advance one cancelling execution by a single close-step.
 async fn close_step(
     conn: &dyn DbConnection,
@@ -114,8 +125,17 @@ async fn close_step(
     handled: &mut HashSet<JoinSetResponseId>,
 ) -> Result<(), CloseStepError> {
     let log = conn.get(execution_id).await?;
+    if log.component_type.is_activity() {
+        if let PendingState::Cancelling(PendingStateCancelling::Locked(locked)) = &log.pending_state
+            && locked.lock_expires_at > now
+        {
+            return Ok(());
+        }
+        finish_cancelled(conn, &log, now).await?;
+        return Ok(());
+    }
 
-    // Responses in cursor order, plus the set of members that have one.
+    // Responses in cursor order, plus the set of children/delays that have one.
     let mut responses = Vec::with_capacity(log.responses.len());
     let mut responded: HashSet<JoinSetResponseId> = HashSet::with_capacity(log.responses.len());
     for response in &log.responses {
@@ -141,14 +161,14 @@ async fn close_step(
         },
     )?;
 
-    // Cancel/signal every still-running member; the execution is ready to finish only
-    // once each member has landed a response.
+    // Cancel/signal every still-running child or delay; the execution is ready to
+    // finish only once each child/delay has landed a response.
     let mut all_responded = true;
     for members in fold.open_join_sets().values() {
         for (response_id, member) in members {
             if responded.contains(response_id) {
-                // Response landed: this member is done, drop it from the handled set to
-                // keep the set bounded to in-flight members.
+                // Response landed: this child/delay is done, drop it from the handled
+                // set to keep it bounded to in-flight children/delays.
                 handled.remove(response_id);
                 continue;
             }
@@ -192,10 +212,10 @@ async fn resolve_child_component_types(
     Ok(types)
 }
 
-/// Best-effort teardown of one running member: cancel activities/delays, signal
-/// cancellable children (recursion). An uncancellable child is merely awaited. Each
-/// member is actioned at most once (tracked in `handled`); the action is idempotent,
-/// so re-doing it after a restart (empty set) is harmless.
+/// Best-effort teardown of one running child or delay: cancel activities/delays,
+/// signal cancellable children (recursion). An uncancellable child is merely
+/// awaited. Each child/delay is actioned at most once (tracked in `handled`); the
+/// action is idempotent, so re-doing it after a restart (empty set) is harmless.
 async fn signal_member(
     conn: &dyn DbConnection,
     cancel_registry: &CancelRegistry,
@@ -292,9 +312,9 @@ async fn finish_cancelled(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use concepts::prefixed_ulid::DEPLOYMENT_ID_DUMMY;
-    use concepts::storage::{CreateRequest, DbPoolCloseable, JoinSetRequest, PendingState};
-    use concepts::{ComponentId, JoinSetId, JoinSetKind, Params, StrVariant};
+    use concepts::prefixed_ulid::{DEPLOYMENT_ID_DUMMY, ExecutorId, RunId};
+    use concepts::storage::{CreateRequest, DbPoolCloseable, JoinSetRequest, Locked, PendingState};
+    use concepts::{ComponentId, ComponentRetryConfig, JoinSetId, JoinSetKind, Params, StrVariant};
     use db_tests::{CANCELLABLE_FFQN, Database};
     use test_utils::sim_clock::SimClock;
 
@@ -412,6 +432,93 @@ mod tests {
             );
         }
         assert!(conn.get_cancelling(10).await.unwrap().is_empty());
+        drop(conn);
+        db_close.close().await;
+    }
+
+    #[tokio::test]
+    async fn driver_finalizes_locked_activity_only_after_lease_expiry() {
+        let sim_clock = SimClock::default();
+        let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
+        let conn = db_pool.connection().await.unwrap();
+        let cancel_registry = CancelRegistry::new();
+        let now = sim_clock.now();
+        let execution_id = ExecutionId::generate();
+        let component_id = ComponentId::dummy_activity();
+        let version = conn
+            .create(CreateRequest {
+                created_at: now,
+                execution_id: execution_id.clone(),
+                ffqn: CANCELLABLE_FFQN,
+                params: Params::empty(),
+                parent: None,
+                metadata: concepts::ExecutionMetadata::empty(),
+                scheduled_at: now,
+                component_id: component_id.clone(),
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+        let lock_expires_at = now + Duration::from_secs(30);
+        let version = conn
+            .append(
+                execution_id.clone(),
+                version,
+                AppendRequest {
+                    created_at: now,
+                    event: ExecutionRequest::Locked(Locked {
+                        component_id,
+                        executor_id: ExecutorId::generate(),
+                        deployment_id: DEPLOYMENT_ID_DUMMY,
+                        run_id: RunId::generate(),
+                        lock_expires_at,
+                        retry_config: ComponentRetryConfig::ZERO,
+                    }),
+                },
+            )
+            .await
+            .unwrap();
+        conn.append(
+            execution_id.clone(),
+            version,
+            AppendRequest {
+                created_at: now,
+                event: ExecutionRequest::CancellationRequested,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut handled = HashSet::new();
+        tick(conn.as_ref(), &cancel_registry, now, 10, &mut handled).await;
+        let log = conn.get(&execution_id).await.unwrap();
+        assert_matches::assert_matches!(
+            log.pending_state,
+            PendingState::Cancelling(PendingStateCancelling::Locked(_))
+        );
+
+        tick(
+            conn.as_ref(),
+            &cancel_registry,
+            lock_expires_at + Duration::from_millis(1),
+            10,
+            &mut handled,
+        )
+        .await;
+        let log = conn.get(&execution_id).await.unwrap();
+        assert_matches::assert_matches!(log.pending_state, PendingState::Finished(_));
+        assert_matches::assert_matches!(
+            log.as_finished_result(),
+            Some(SupportedFunctionReturnValue::ExecutionFailure(
+                FinishedExecutionFailure {
+                    kind: ExecutionFailureKind::Cancelled,
+                    ..
+                }
+            ))
+        );
+
         drop(conn);
         db_close.close().await;
     }

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -25,7 +25,7 @@ use concepts::{
     },
     time::{ClockFn, Sleep},
 };
-use db_common::{JoinSetFold, JoinSetFoldError, JoinSetMember, JoinSetResponseId};
+use db_common::{JoinSetFold, JoinSetFoldError, JoinSetResponseId};
 use executor::AbortOnDropHandle;
 use std::{collections::HashMap, collections::HashSet, sync::Arc, time::Duration};
 use tracing::{Instrument, debug, info_span, warn};
@@ -56,11 +56,11 @@ impl CancellationDriver {
             tokio::spawn(
                 async move {
                     debug!("Spawned the cancellation driver");
-                    // Child executions and delays already actioned (cancelled/signalled)
-                    // this process, so each is signalled at most once instead of every tick
-                    // until it responds. Pruned as responses land; empty on restart
-                    // (re-signal is idempotent), so no durable state is needed.
-                    let mut handled: HashSet<JoinSetResponseId> = HashSet::new();
+                    // Child executions and delays whose cancellation was already
+                    // requested/signalled this process. Pruned as responses land;
+                    // empty on restart (re-request is idempotent), so no durable state
+                    // is needed.
+                    let mut cancellation_requested: HashSet<JoinSetResponseId> = HashSet::new();
                     loop {
                         match db_pool.connection().await {
                             Ok(conn) => {
@@ -69,7 +69,7 @@ impl CancellationDriver {
                                     &cancel_registry,
                                     clock_fn.now(),
                                     batch_size,
-                                    &mut handled,
+                                    &mut cancellation_requested,
                                 )
                                 .await;
                             }
@@ -90,7 +90,7 @@ async fn tick(
     cancel_registry: &CancelRegistry,
     now: DateTime<Utc>,
     batch_size: u32,
-    handled: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested: &mut HashSet<JoinSetResponseId>,
 ) {
     let ids = match conn.get_cancelling(batch_size).await {
         Ok(ids) => ids,
@@ -100,7 +100,15 @@ async fn tick(
         }
     };
     for execution_id in ids {
-        if let Err(err) = close_step(conn, cancel_registry, &execution_id, now, handled).await {
+        if let Err(err) = close_step(
+            conn,
+            cancel_registry,
+            &execution_id,
+            now,
+            cancellation_requested,
+        )
+        .await
+        {
             debug!(%execution_id, "Cancellation close-step failed, retrying next tick - {err:?}");
         }
     }
@@ -112,8 +120,8 @@ pub(crate) async fn tick_test(
     cancel_registry: &CancelRegistry,
     now: DateTime<Utc>,
 ) {
-    let mut handled = HashSet::new();
-    tick(conn, cancel_registry, now, 10, &mut handled).await;
+    let mut cancellation_requested = HashSet::new();
+    tick(conn, cancel_registry, now, 10, &mut cancellation_requested).await;
 }
 
 /// Advance one cancelling execution by a single close-step.
@@ -122,13 +130,13 @@ async fn close_step(
     cancel_registry: &CancelRegistry,
     execution_id: &ExecutionId,
     now: DateTime<Utc>,
-    handled: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested: &mut HashSet<JoinSetResponseId>,
 ) -> Result<(), CloseStepError> {
     let log = conn.get(execution_id).await?;
     if log.component_type.is_activity() {
         activity_finish_if_expired(conn, &log, now).await
     } else {
-        close_workflow_step(conn, cancel_registry, &log, now, handled).await
+        close_workflow_step(conn, cancel_registry, &log, now, cancellation_requested).await
     }
 }
 
@@ -151,7 +159,7 @@ async fn close_workflow_step(
     cancel_registry: &CancelRegistry,
     log: &ExecutionLog,
     now: DateTime<Utc>,
-    handled: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested: &mut HashSet<JoinSetResponseId>,
 ) -> Result<(), CloseStepError> {
     // Responses in cursor order, plus the set of children/delays that have one.
     let mut responses = Vec::with_capacity(log.responses.len());
@@ -179,20 +187,47 @@ async fn close_workflow_step(
         },
     )?;
 
-    // Cancel/signal every still-running child or delay; the execution is ready to
-    // finish only once each child/delay has landed a response.
+    // Classify every still-running child or delay. Activities and delays are
+    // cancelled in reverse creation order below, matching normal join-set close;
+    // cancellable workflow children are signalled; uncancellable workflow children
+    // are only awaited.
     let mut all_responded = true;
+    let mut activity_and_delay_ids = Vec::new();
+    let mut cancellable_child_ids = Vec::new();
     for members in fold.open_join_sets().values() {
         for (response_id, member) in members {
             if responded.contains(response_id) {
-                // Response landed: this child/delay is done, drop it from the handled
-                // set to keep it bounded to in-flight children/delays.
-                handled.remove(response_id);
+                // Response landed: this child/delay is done, drop it from the
+                // process-local set to keep it bounded to in-flight children/delays.
+                cancellation_requested.remove(response_id);
                 continue;
             }
             all_responded = false;
-            signal_child_or_delay(conn, cancel_registry, response_id, member, now, handled).await;
+            match response_id {
+                JoinSetResponseId::DelayId(_) => activity_and_delay_ids.push(response_id.clone()),
+                JoinSetResponseId::ChildExecutionId(child_id) => {
+                    if member.is_activity() {
+                        activity_and_delay_ids.push(response_id.clone());
+                    } else if member.is_cancellable_workflow() {
+                        cancellable_child_ids.push(child_id.clone());
+                    }
+                }
+            }
         }
+    }
+
+    for response_id in activity_and_delay_ids.iter().rev() {
+        cancel_activity_or_delay(
+            conn,
+            cancel_registry,
+            response_id,
+            now,
+            cancellation_requested,
+        )
+        .await;
+    }
+    for child_id in cancellable_child_ids {
+        signal_cancellable_child_workflow(conn, &child_id, now, cancellation_requested).await;
     }
 
     if all_responded {
@@ -230,54 +265,56 @@ async fn resolve_child_component_types(
     Ok(types)
 }
 
-/// Best-effort teardown of one running child or delay: cancel activities/delays,
-/// signal cancellable children (recursion). An uncancellable child is merely
-/// awaited. Each child/delay is actioned at most once (tracked in `handled`); the
-/// action is idempotent, so re-doing it after a restart (empty set) is harmless.
-async fn signal_child_or_delay(
+/// Best-effort teardown of one running activity or delay. Each child/delay has
+/// cancellation requested at most once per process; the action is idempotent, so
+/// re-doing it after a restart (empty set) is harmless.
+async fn cancel_activity_or_delay(
     conn: &dyn DbConnection,
     cancel_registry: &CancelRegistry,
     response_id: &JoinSetResponseId,
-    member: &JoinSetMember,
     now: DateTime<Utc>,
-    handled: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested: &mut HashSet<JoinSetResponseId>,
 ) {
-    if handled.contains(response_id) {
+    if cancellation_requested.contains(response_id) {
         return;
     }
     let outcome = match response_id {
         JoinSetResponseId::DelayId(delay_id) => storage::cancel_delay(conn, delay_id.clone(), now)
             .await
             .map(|_| ())
-            .map_err(|err| format!("Ignoring failure to cancel delay {delay_id} - {err:?}")),
+            .map_err(|err| debug!("Ignoring failure to cancel delay {delay_id} - {err:?}")),
         JoinSetResponseId::ChildExecutionId(child_id) => {
             let child = ExecutionId::Derived(child_id.clone());
-            if member.is_activity() {
-                cancel_registry
-                    .cancel_activity(conn, &child, now)
-                    .await
-                    .map(|_| ())
-                    .map_err(|err| {
-                        format!("Ignoring failure to cancel activity {child_id} - {err:?}")
-                    })
-            } else if member.is_cancellable_workflow() {
-                conn.request_cancellation_with_retries(&child, now)
-                    .await
-                    .map(|_| ())
-                    .map_err(|err| {
-                        format!("Ignoring failure to signal cancellable child {child_id} - {err:?}")
-                    })
-            } else {
-                // Uncancellable child: nothing to signal, it is simply awaited.
-                Ok(())
-            }
+            cancel_registry
+                .cancel_activity(conn, &child, now)
+                .await
+                .map(|_| ())
+                .map_err(|err| debug!("Ignoring failure to cancel activity {child_id} - {err:?}"))
         }
     };
-    match outcome {
-        Ok(()) => {
-            handled.insert(response_id.clone());
+    if outcome.is_ok() {
+        cancellation_requested.insert(response_id.clone());
+    }
+}
+
+/// Signal one cancellable workflow child. It is not finished here; its own
+/// cancellation close will append the response that lets this workflow finish.
+async fn signal_cancellable_child_workflow(
+    conn: &dyn DbConnection,
+    child_id: &ExecutionIdDerived,
+    now: DateTime<Utc>,
+    cancellation_requested: &mut HashSet<JoinSetResponseId>,
+) {
+    let response_id = JoinSetResponseId::ChildExecutionId(child_id.clone());
+    if cancellation_requested.contains(&response_id) {
+        return;
+    }
+    let child = ExecutionId::Derived(child_id.clone());
+    match conn.request_cancellation_with_retries(&child, now).await {
+        Ok(_) => {
+            cancellation_requested.insert(response_id);
         }
-        Err(msg) => debug!("{msg}"),
+        Err(err) => debug!("Ignoring failure to signal cancellable child {child_id} - {err:?}"),
     }
 }
 
@@ -426,9 +463,16 @@ mod tests {
 
         // A handful of ticks drives: parent signals child, child finishes and responds,
         // parent then finishes.
-        let mut handled = HashSet::new();
+        let mut cancellation_requested = HashSet::new();
         for _ in 0..5 {
-            tick(conn.as_ref(), &cancel_registry, now, 10, &mut handled).await;
+            tick(
+                conn.as_ref(),
+                &cancel_registry,
+                now,
+                10,
+                &mut cancellation_requested,
+            )
+            .await;
         }
 
         for id in [ExecutionId::Derived(child_id), parent_id] {
@@ -509,8 +553,15 @@ mod tests {
         .await
         .unwrap();
 
-        let mut handled = HashSet::new();
-        tick(conn.as_ref(), &cancel_registry, now, 10, &mut handled).await;
+        let mut cancellation_requested = HashSet::new();
+        tick(
+            conn.as_ref(),
+            &cancel_registry,
+            now,
+            10,
+            &mut cancellation_requested,
+        )
+        .await;
         let log = conn.get(&execution_id).await.unwrap();
         assert_matches::assert_matches!(
             log.pending_state,
@@ -522,7 +573,7 @@ mod tests {
             &cancel_registry,
             lock_expires_at + Duration::from_millis(1),
             10,
-            &mut handled,
+            &mut cancellation_requested,
         )
         .await;
         let log = conn.get(&execution_id).await.unwrap();

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -126,15 +126,33 @@ async fn close_step(
 ) -> Result<(), CloseStepError> {
     let log = conn.get(execution_id).await?;
     if log.component_type.is_activity() {
-        if let PendingState::Cancelling(PendingStateCancelling::Locked(locked)) = &log.pending_state
-            && locked.lock_expires_at > now
-        {
-            return Ok(());
-        }
-        finish_cancelled(conn, &log, now).await?;
+        activity_finish_if_expired(conn, &log, now).await
+    } else {
+        close_workflow_step(conn, cancel_registry, &log, now, handled).await
+    }
+}
+
+async fn activity_finish_if_expired(
+    conn: &dyn DbConnection,
+    log: &ExecutionLog,
+    now: DateTime<Utc>,
+) -> Result<(), CloseStepError> {
+    if let PendingState::Cancelling(PendingStateCancelling::Locked(locked)) = &log.pending_state
+        && locked.lock_expires_at > now
+    {
         return Ok(());
     }
+    append_finish_cancelled(conn, log, now).await?;
+    Ok(())
+}
 
+async fn close_workflow_step(
+    conn: &dyn DbConnection,
+    cancel_registry: &CancelRegistry,
+    log: &ExecutionLog,
+    now: DateTime<Utc>,
+    handled: &mut HashSet<JoinSetResponseId>,
+) -> Result<(), CloseStepError> {
     // Responses in cursor order, plus the set of children/delays that have one.
     let mut responses = Vec::with_capacity(log.responses.len());
     let mut responded: HashSet<JoinSetResponseId> = HashSet::with_capacity(log.responses.len());
@@ -173,12 +191,12 @@ async fn close_step(
                 continue;
             }
             all_responded = false;
-            signal_member(conn, cancel_registry, response_id, member, now, handled).await;
+            signal_child_or_delay(conn, cancel_registry, response_id, member, now, handled).await;
         }
     }
 
     if all_responded {
-        finish_cancelled(conn, &log, now).await?;
+        append_finish_cancelled(conn, log, now).await?;
     }
     Ok(())
 }
@@ -216,7 +234,7 @@ async fn resolve_child_component_types(
 /// signal cancellable children (recursion). An uncancellable child is merely
 /// awaited. Each child/delay is actioned at most once (tracked in `handled`); the
 /// action is idempotent, so re-doing it after a restart (empty set) is harmless.
-async fn signal_member(
+async fn signal_child_or_delay(
     conn: &dyn DbConnection,
     cancel_registry: &CancelRegistry,
     response_id: &JoinSetResponseId,
@@ -264,7 +282,7 @@ async fn signal_member(
 }
 
 /// Append `Finished(Cancelled)`, responding to the parent if this is a child.
-async fn finish_cancelled(
+async fn append_finish_cancelled(
     conn: &dyn DbConnection,
     log: &ExecutionLog,
     now: DateTime<Utc>,

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -21,7 +21,7 @@ use concepts::{
     storage::{
         self, AppendEventsToExecution, AppendRequest, AppendResponseToExecution, DbConnection,
         DbErrorRead, DbErrorWrite, DbPool, ExecutionLog, ExecutionRequest, HistoryEvent,
-        JoinSetRequest, PendingState, PendingStateCancelling,
+        JoinSetRequest, PendingState, PendingStateCancelling, Version,
     },
     time::{ClockFn, Sleep},
 };
@@ -150,7 +150,7 @@ async fn activity_finish_if_expired(
     {
         return Ok(());
     }
-    append_finish_cancelled(conn, log, now).await?;
+    append_finish_cancelled(conn, log, Vec::new(), now).await?;
     Ok(())
 }
 
@@ -231,9 +231,37 @@ async fn close_workflow_step(
     }
 
     if all_responded {
-        append_finish_cancelled(conn, log, now).await?;
+        // Pair each response driven during cancellation with a synthetic closing
+        // `JoinNext` (one per still-open member), mirroring a worker-run close so the
+        // UI/API can zip responses to `JoinNext`s positionally. `reconstruct` already
+        // consumed responses matched by pre-existing awaits, so the members left open
+        // are exactly the unpaired ones.
+        let closing_join_nexts = build_closing_join_nexts(&fold, now);
+        append_finish_cancelled(conn, log, closing_join_nexts, now).await?;
     }
     Ok(())
+}
+
+/// One closing `JoinNext` per still-open join-set member, matching the per-member
+/// count a worker-run close appends so responses pair 1:1.
+fn build_closing_join_nexts(fold: &JoinSetFold, now: DateTime<Utc>) -> Vec<AppendRequest> {
+    let mut reqs = Vec::new();
+    for (join_set_id, members) in fold.open_join_sets() {
+        for _ in 0..members.len() {
+            reqs.push(AppendRequest {
+                created_at: now,
+                event: ExecutionRequest::HistoryEvent {
+                    event: HistoryEvent::JoinNext {
+                        join_set_id: join_set_id.clone(),
+                        run_expires_at: now,
+                        requested_ffqn: None,
+                        closing: true,
+                    },
+                },
+            });
+        }
+    }
+    reqs
 }
 
 async fn resolve_child_component_types(
@@ -318,10 +346,14 @@ async fn signal_cancellable_child_workflow(
     }
 }
 
-/// Append `Finished(Cancelled)`, responding to the parent if this is a child.
+/// Append the synthetic closing `JoinNext`s followed by `Finished(Cancelled)` in a
+/// single atomic batch, responding to the parent if this is a child. Batching keeps
+/// the terminal transition all-or-nothing: a partial write would leave the row still
+/// `Cancelling` and the next tick would append the `JoinNext`s again.
 async fn append_finish_cancelled(
     conn: &dyn DbConnection,
     log: &ExecutionLog,
+    closing_join_nexts: Vec<AppendRequest>,
     now: DateTime<Utc>,
 ) -> Result<(), DbErrorWrite> {
     let retval = SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
@@ -329,21 +361,28 @@ async fn append_finish_cancelled(
         kind: ExecutionFailureKind::Cancelled,
         detail: None,
     });
-    let finished_version = log.next_version.clone();
-    let finished_req = AppendRequest {
+    let batch_start_version = log.next_version.clone();
+    // `Finished` is appended after the closing `JoinNext`s, so the parent response
+    // points at that later version.
+    let finished_version = Version(
+        batch_start_version.0
+            + u32::try_from(closing_join_nexts.len()).expect("open member count fits in u32"),
+    );
+    let mut batch = closing_join_nexts;
+    batch.push(AppendRequest {
         created_at: now,
         event: ExecutionRequest::Finished {
             retval: retval.clone(),
             http_client_traces: None,
         },
-    };
+    });
     if let ExecutionId::Derived(derived) = &log.execution_id {
         let (parent_execution_id, join_set_id) = derived.split_to_parts();
         conn.append_batch_respond_to_parent(
             AppendEventsToExecution {
                 execution_id: log.execution_id.clone(),
-                version: finished_version.clone(),
-                batch: vec![finished_req],
+                version: batch_start_version,
+                batch,
             },
             AppendResponseToExecution {
                 parent_execution_id,
@@ -357,7 +396,7 @@ async fn append_finish_cancelled(
         )
         .await?;
     } else {
-        conn.append(log.execution_id.clone(), finished_version, finished_req)
+        conn.append_batch(now, batch, log.execution_id.clone(), batch_start_version)
             .await?;
     }
     debug!(execution_id = %log.execution_id, "Cancellation finished");
@@ -493,6 +532,147 @@ mod tests {
                 "{id} should be cancelled"
             );
         }
+        assert!(conn.get_cancelling(10).await.unwrap().is_empty());
+        drop(conn);
+        db_close.close().await;
+    }
+
+    /// A cancelling workflow with an unawaited join-set member gets a synthetic
+    /// closing `JoinNext` appended alongside `Finished(Cancelled)`, so every response
+    /// driven during cancellation pairs 1:1 with a `JoinNext` (what the UI zips on).
+    #[tokio::test]
+    async fn driver_appends_closing_join_next_for_unawaited_member() {
+        let sim_clock = SimClock::default();
+        let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
+        let conn = db_pool.connection().await.unwrap();
+        let cancel_registry = CancelRegistry::new();
+        let now = sim_clock.now();
+
+        let create = |execution_id: ExecutionId| CreateRequest {
+            created_at: now,
+            execution_id,
+            ffqn: CANCELLABLE_FFQN,
+            params: Params::empty(),
+            parent: None,
+            metadata: concepts::ExecutionMetadata::empty(),
+            scheduled_at: now,
+            component_id: ComponentId::dummy_workflow(),
+            deployment_id: DEPLOYMENT_ID_DUMMY,
+            scheduled_by: None,
+            paused: false,
+        };
+
+        // Parent with two cancellable children in one join set, awaiting only the
+        // first: the second is unawaited, so its Cancelled response has no `JoinNext`.
+        let parent_id = ExecutionId::generate();
+        let mut version = conn.create(create(parent_id.clone())).await.unwrap();
+        let join_set_id = JoinSetId::new(JoinSetKind::Named, StrVariant::from("js")).unwrap();
+        version = conn
+            .append(
+                parent_id.clone(),
+                version,
+                AppendRequest {
+                    created_at: now,
+                    event: ExecutionRequest::HistoryEvent {
+                        event: HistoryEvent::JoinSetCreate {
+                            join_set_id: join_set_id.clone(),
+                        },
+                    },
+                },
+            )
+            .await
+            .unwrap();
+        let child_ids = [
+            parent_id.next_level(&join_set_id),
+            parent_id.next_level(&join_set_id).get_incremented(),
+        ];
+        for child_id in &child_ids {
+            version = conn
+                .append(
+                    parent_id.clone(),
+                    version,
+                    AppendRequest {
+                        created_at: now,
+                        event: ExecutionRequest::HistoryEvent {
+                            event: HistoryEvent::JoinSetRequest {
+                                join_set_id: join_set_id.clone(),
+                                request: JoinSetRequest::ChildExecutionRequest {
+                                    child_execution_id: child_id.clone(),
+                                    target_ffqn: CANCELLABLE_FFQN,
+                                    params: Params::empty(),
+                                    result: Ok(()),
+                                },
+                            },
+                        },
+                    },
+                )
+                .await
+                .unwrap();
+            conn.create(create(ExecutionId::Derived(child_id.clone())))
+                .await
+                .unwrap();
+        }
+        // Await only the first child.
+        conn.append(
+            parent_id.clone(),
+            version,
+            AppendRequest {
+                created_at: now,
+                event: ExecutionRequest::HistoryEvent {
+                    event: HistoryEvent::JoinNext {
+                        join_set_id: join_set_id.clone(),
+                        run_expires_at: now,
+                        closing: false,
+                        requested_ffqn: Some(CANCELLABLE_FFQN),
+                    },
+                },
+            },
+        )
+        .await
+        .unwrap();
+        conn.cancel_workflow(&parent_id, now).await.unwrap();
+
+        let mut cancellation_requested = HashSet::new();
+        for _ in 0..10 {
+            tick(
+                conn.as_ref(),
+                &cancel_registry,
+                now,
+                10,
+                &mut cancellation_requested,
+            )
+            .await;
+        }
+
+        let log = conn.get(&parent_id).await.unwrap();
+        assert_matches::assert_matches!(log.pending_state, PendingState::Finished(_));
+        assert_matches::assert_matches!(
+            log.as_finished_result(),
+            Some(SupportedFunctionReturnValue::ExecutionFailure(
+                FinishedExecutionFailure {
+                    kind: ExecutionFailureKind::Cancelled,
+                    ..
+                }
+            ))
+        );
+
+        // Both children responded, and each response pairs with a `JoinNext`: the
+        // pre-existing `closing:false` await plus one synthetic `closing:true`.
+        let join_next_count = log
+            .event_history()
+            .filter(|(event, _)| matches!(event, HistoryEvent::JoinNext { .. }))
+            .count();
+        let closing_join_next_count = log
+            .event_history()
+            .filter(|(event, _)| matches!(event, HistoryEvent::JoinNext { closing: true, .. }))
+            .count();
+        assert_eq!(2, log.responses.len(), "both children responded");
+        assert_eq!(
+            2, join_next_count,
+            "one JoinNext per response for UI pairing"
+        );
+        assert_eq!(1, closing_join_next_count, "one synthetic closing JoinNext");
+
         assert!(conn.get_cancelling(10).await.unwrap().is_empty());
         drop(conn);
         db_close.close().await;

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -175,7 +175,7 @@ async fn close_workflow_step(
     // A resolution failure fails the whole step (retried next tick) rather than guessing
     // a type: mis-classifying an activity as an uncancellable workflow would silently
     // strand it as a permanent await barrier.
-    let child_component_types = resolve_child_component_types(conn, &log).await?;
+    let child_component_types = resolve_child_component_types(conn, log).await?;
 
     let fold = JoinSetFold::reconstruct(
         log.event_history().map(|(event, _version)| event),

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -310,7 +310,7 @@ async fn signal_cancellable_child_workflow(
         return;
     }
     let child = ExecutionId::Derived(child_id.clone());
-    match conn.request_cancellation_with_retries(&child, now).await {
+    match conn.cancel_workflow_with_retries(&child, now).await {
         Ok(_) => {
             cancellation_requested.insert(response_id);
         }
@@ -459,7 +459,7 @@ mod tests {
         )
         .await
         .unwrap();
-        conn.request_cancellation(&parent_id, now).await.unwrap();
+        conn.cancel_workflow(&parent_id, now).await.unwrap();
 
         // A handful of ticks drives: parent signals child, child finishes and responds,
         // parent then finishes.

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -25,7 +25,7 @@ use concepts::{
     },
     time::{ClockFn, Sleep},
 };
-use db_common::{JoinSetFold, JoinSetFoldError, JoinSetResponseId};
+use db_common::{JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId};
 use executor::AbortOnDropHandle;
 use std::{collections::HashMap, collections::HashSet, sync::Arc, time::Duration};
 use tracing::{Instrument, debug, info_span, warn};
@@ -36,8 +36,8 @@ enum CloseStepError {
     Read(#[from] DbErrorRead),
     #[error(transparent)]
     Write(#[from] DbErrorWrite),
-    #[error("fold reconstruction failed: {0}")]
-    Fold(#[from] JoinSetFoldError),
+    #[error("open join-set reconstruction failed: {0}")]
+    OpenTracker(#[from] JoinSetOpenTrackerError),
 }
 
 pub struct CancellationDriver;
@@ -177,7 +177,7 @@ async fn close_workflow_step(
     // strand it as a permanent await barrier.
     let child_component_types = resolve_child_component_types(conn, log).await?;
 
-    let fold = JoinSetFold::reconstruct(
+    let tracker = JoinSetOpenTracker::reconstruct(
         log.event_history().map(|(event, _version)| event),
         responses,
         |child_id| {
@@ -194,7 +194,7 @@ async fn close_workflow_step(
     let mut all_responded = true;
     let mut activity_and_delay_ids = Vec::new();
     let mut cancellable_child_ids = Vec::new();
-    for members in fold.open_join_sets().values() {
+    for members in tracker.open_join_sets().values() {
         for (response_id, member) in members {
             if responded.contains(response_id) {
                 // Response landed: this child/delay is done, drop it from the
@@ -236,7 +236,7 @@ async fn close_workflow_step(
         // UI/API can zip responses to `JoinNext`s positionally. `reconstruct` already
         // consumed responses matched by pre-existing awaits, so the members left open
         // are exactly the unpaired ones.
-        let closing_join_nexts = build_closing_join_nexts(&fold, now);
+        let closing_join_nexts = build_closing_join_nexts(&tracker, now);
         append_finish_cancelled(conn, log, closing_join_nexts, now).await?;
     }
     Ok(())
@@ -244,9 +244,12 @@ async fn close_workflow_step(
 
 /// One closing `JoinNext` per still-open join-set member, matching the per-member
 /// count a worker-run close appends so responses pair 1:1.
-fn build_closing_join_nexts(fold: &JoinSetFold, now: DateTime<Utc>) -> Vec<AppendRequest> {
+fn build_closing_join_nexts(
+    tracker: &JoinSetOpenTracker,
+    now: DateTime<Utc>,
+) -> Vec<AppendRequest> {
     let mut reqs = Vec::new();
-    for (join_set_id, members) in fold.open_join_sets() {
+    for (join_set_id, members) in tracker.open_join_sets() {
         for _ in 0..members.len() {
             reqs.push(AppendRequest {
                 created_at: now,

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -17,7 +17,7 @@ use concepts::storage::{
     AppendRequest, BacktraceInfo, CreateRequest, DbConnection, DbErrorGeneric, DbErrorRead,
     DbErrorReadWithTimeout, DbErrorWrite, DbPool, ExecutionRequest, HistoryEvent,
     HistoryEventScheduleAt, JoinSetRequest, LogInfoAppendRow, LogLevel, LogStreamType,
-    PendingState, PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateSuspended,
+    PendingState, PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateCancelling,
     TimeoutOutcome, Version, http_client_trace::HttpClientTrace,
 };
 use concepts::time::{ClockFn, Sleep};
@@ -1096,13 +1096,13 @@ impl WebhookSupportHost for WebhookEndpointCtx {
         let pending_state = self.get_status_pending_state(&execution_id).await?;
         let status = match pending_state {
             PendingState::PendingAt(state)
-            | PendingState::Cancelling(PendingStateSuspended::PendingAt(state)) => {
+            | PendingState::Cancelling(PendingStateCancelling::PendingAt(state)) => {
                 ExecutionStatus::PendingAt(datetime_from_scheduled_at(&state.scheduled_at))
             }
             PendingState::Locked(_)
-            | PendingState::Cancelling(PendingStateSuspended::Locked(_)) => ExecutionStatus::Locked,
+            | PendingState::Cancelling(PendingStateCancelling::Locked(_)) => ExecutionStatus::Locked,
             PendingState::BlockedByJoinSet(_)
-            | PendingState::Cancelling(PendingStateSuspended::BlockedByJoinSet(_)) => {
+            | PendingState::Cancelling(PendingStateCancelling::BlockedByJoinSet(_)) => {
                 ExecutionStatus::BlockedByJoinSet
             }
             PendingState::Paused(_) => ExecutionStatus::Paused,

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -1099,7 +1099,8 @@ impl WebhookSupportHost for WebhookEndpointCtx {
             | PendingState::Cancelling(PendingStateSuspended::PendingAt(state)) => {
                 ExecutionStatus::PendingAt(datetime_from_scheduled_at(&state.scheduled_at))
             }
-            PendingState::Locked(_) => ExecutionStatus::Locked,
+            PendingState::Locked(_)
+            | PendingState::Cancelling(PendingStateSuspended::Locked(_)) => ExecutionStatus::Locked,
             PendingState::BlockedByJoinSet(_)
             | PendingState::Cancelling(PendingStateSuspended::BlockedByJoinSet(_)) => {
                 ExecutionStatus::BlockedByJoinSet

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -17,8 +17,8 @@ use concepts::storage::{
     AppendRequest, BacktraceInfo, CreateRequest, DbConnection, DbErrorGeneric, DbErrorRead,
     DbErrorReadWithTimeout, DbErrorWrite, DbPool, ExecutionRequest, HistoryEvent,
     HistoryEventScheduleAt, JoinSetRequest, LogInfoAppendRow, LogLevel, LogStreamType,
-    PendingState, PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateCancelling,
-    TimeoutOutcome, Version, http_client_trace::HttpClientTrace,
+    PendingState, PendingStateCancelling, PendingStateFinishedError,
+    PendingStateFinishedResultKind, TimeoutOutcome, Version, http_client_trace::HttpClientTrace,
 };
 use concepts::time::{ClockFn, Sleep};
 use concepts::{
@@ -1100,7 +1100,9 @@ impl WebhookSupportHost for WebhookEndpointCtx {
                 ExecutionStatus::PendingAt(datetime_from_scheduled_at(&state.scheduled_at))
             }
             PendingState::Locked(_)
-            | PendingState::Cancelling(PendingStateCancelling::Locked(_)) => ExecutionStatus::Locked,
+            | PendingState::Cancelling(PendingStateCancelling::Locked(_)) => {
+                ExecutionStatus::Locked
+            }
             PendingState::BlockedByJoinSet(_)
             | PendingState::Cancelling(PendingStateCancelling::BlockedByJoinSet(_)) => {
                 ExecutionStatus::BlockedByJoinSet

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -404,12 +404,12 @@ impl WorkflowDbConnection for CachingDbConnection {
                     }
                 }
             }
-            // Signal cancellable children (already classified, so guard-free); the
-            // driver drives their close and the `Cancelled` response wakes our await.
+            // Signal cancellable children; the driver drives their close and the
+            // `Cancelled` response wakes our await.
             for child_id in cancellations.cancellable_child_ids() {
                 let res = self
                     .db_connection
-                    .request_cancellation_with_retries(
+                    .cancel_workflow_with_retries(
                         &ExecutionId::Derived(child_id.clone()),
                         cancellations.cancelled_at,
                     )

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -47,7 +47,7 @@ use concepts::storage::{
 use concepts::storage::{HistoryEvent, JoinNextTryOutcome, JoinSetRequest};
 use concepts::{ExecutionId, StrVariant};
 use concepts::{FunctionFqn, Params};
-use db_common::{JoinSetFold, JoinSetFoldError, JoinSetResponseId};
+use db_common::{JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId};
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use indexmap::indexmap;
@@ -121,7 +121,7 @@ impl From<DbErrorWriteOrReplayInterrupt> for ApplyError {
     }
 }
 
-fn join_set_fold_error_to_constraint(err: &JoinSetFoldError) -> StrVariant {
+fn join_set_open_tracker_error_to_constraint(err: &JoinSetOpenTrackerError) -> StrVariant {
     err.to_string().into()
 }
 
@@ -157,7 +157,7 @@ pub(crate) struct EventHistory {
     subscription_interruption: Option<Duration>,
 
     // Tracks join set contents for closing. One-offs are ignored, response id is removed when the response is processed.
-    join_set_fold: JoinSetFold,
+    join_set_open_tracker: JoinSetOpenTracker,
 }
 
 #[derive(Debug)]
@@ -208,7 +208,7 @@ impl EventHistory {
             locked_event,
             lock_extension: lock_extension.unwrap_or_default(),
             subscription_interruption,
-            join_set_fold: JoinSetFold::new(),
+            join_set_open_tracker: JoinSetOpenTracker::new(),
         }
     }
 
@@ -508,10 +508,10 @@ impl EventHistory {
         wasm_backtrace: Option<storage::WasmBacktrace>,
     ) -> Result<(), ApplyError> {
         let response_ids = self
-            .join_set_fold
+            .join_set_open_tracker
             .close_join_set(join_set_id)
             .map_err(|err| {
-                ApplyError::ConstraintViolation(join_set_fold_error_to_constraint(&err))
+                ApplyError::ConstraintViolation(join_set_open_tracker_error_to_constraint(&err))
             })?;
         debug!("Closing `{join_set_id}` with unawaited {response_ids:?}");
 
@@ -562,18 +562,18 @@ impl EventHistory {
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(), ApplyError> {
-        while let Some(join_set_id) =
-            self.join_set_fold
-                .open_join_sets()
-                .iter()
-                .rev()
-                .find_map(|(js, remaining)| {
-                    if !remaining.is_empty() {
-                        Some(js.clone())
-                    } else {
-                        None
-                    }
-                })
+        while let Some(join_set_id) = self
+            .join_set_open_tracker
+            .open_join_sets()
+            .iter()
+            .rev()
+            .find_map(|(js, remaining)| {
+                if !remaining.is_empty() {
+                    Some(js.clone())
+                } else {
+                    None
+                }
+            })
         {
             self.join_set_close_inner(&join_set_id, db_connection, called_at, None)
                 .await?;
@@ -1531,7 +1531,7 @@ impl EventHistory {
                 let outcome = if self.has_unprocessed_response_for_join_set(&join_set_id) {
                     JoinNextTryOutcome::Found
                 } else if self
-                    .join_set_fold
+                    .join_set_open_tracker
                     .open_join_sets()
                     .get(&join_set_id)
                     .is_some_and(|requests| !requests.is_empty())
@@ -2218,7 +2218,7 @@ impl JoinSetCreate {
             ChildReturnValue::JoinSetCreate(join_set_id) => join_set_id);
         assert_eq!(join_set_id, value);
         event_history
-            .join_set_fold
+            .join_set_open_tracker
             .create_join_set(join_set_id)
             .expect("conflict check must have been performed by the caller");
         Ok(value)
@@ -2271,7 +2271,7 @@ impl SubmitChildExecution {
             && let Some(component_type) = component_type
         {
             event_history
-                .join_set_fold
+                .join_set_open_tracker
                 .insert_child(
                     &join_set_id,
                     child_execution_id,
@@ -2279,9 +2279,9 @@ impl SubmitChildExecution {
                     target_ffqn,
                 )
                 .map_err(|err| {
-                    WorkflowFunctionError::ConstraintViolation(join_set_fold_error_to_constraint(
-                        &err,
-                    ))
+                    WorkflowFunctionError::ConstraintViolation(
+                        join_set_open_tracker_error_to_constraint(&err),
+                    )
                 })?;
         }
 
@@ -2320,10 +2320,12 @@ impl SubmitDelay {
             .await?;
         assert_matches!(value, ChildReturnValue::SubmitDelay);
         event_history
-            .join_set_fold
+            .join_set_open_tracker
             .insert_delay(&join_set_id, delay_id.clone())
             .map_err(|err| {
-                WorkflowFunctionError::ConstraintViolation(join_set_fold_error_to_constraint(&err))
+                WorkflowFunctionError::ConstraintViolation(
+                    join_set_open_tracker_error_to_constraint(&err),
+                )
             })?;
         Ok(delay_id)
     }
@@ -2476,14 +2478,14 @@ impl JoinNextRequestingFfqn {
                     wast_val_result,
                 ])))));
                 event_history
-                    .join_set_fold
+                    .join_set_open_tracker
                     .remove_response(
                         &join_set_id,
                         &JoinSetResponseId::ChildExecutionId(child_execution_id),
                     )
                     .map_err(|err| {
                         WorkflowFunctionError::ConstraintViolation(
-                            join_set_fold_error_to_constraint(&err),
+                            join_set_open_tracker_error_to_constraint(&err),
                         )
                     })?;
                 wast_val_res
@@ -2492,14 +2494,14 @@ impl JoinNextRequestingFfqn {
                 if let AwaitNextExtensionError::FunctionMismatch { actual_id, .. } = &await_ext_err
                 {
                     event_history
-                        .join_set_fold
+                        .join_set_open_tracker
                         .remove_response(&join_set_id, actual_id)
                         .map_err(|err| {
                             WorkflowFunctionError::ConstraintViolation(
-                                join_set_fold_error_to_constraint(&err),
+                                join_set_open_tracker_error_to_constraint(&err),
                             )
                         })?;
-                } // all-processed does not change the join-set fold
+                } // all-processed does not change the join-set open-tracker
                 await_ext_err.as_wast_val_result()
             }
         }
@@ -2540,12 +2542,12 @@ impl JoinNext {
         let value = assert_matches!(value,ChildReturnValue::JoinNext(value) => value);
         if let Ok((response_id, _)) = &value {
             event_history
-                .join_set_fold
+                .join_set_open_tracker
                 .remove_response(&join_set_id, response_id)
                 .map_err(|err| {
-                    WorkflowFunctionError::ConstraintViolation(join_set_fold_error_to_constraint(
-                        &err,
-                    ))
+                    WorkflowFunctionError::ConstraintViolation(
+                        join_set_open_tracker_error_to_constraint(&err),
+                    )
                 })?;
         }
         let value = value
@@ -2593,12 +2595,12 @@ impl JoinNextTry {
         let value = assert_matches!(value, ChildReturnValue::JoinNextTry(value) => value);
         if let Ok((response_id, _)) = &value {
             event_history
-                .join_set_fold
+                .join_set_open_tracker
                 .remove_response(&join_set_id, response_id)
                 .map_err(|err| {
-                    WorkflowFunctionError::ConstraintViolation(join_set_fold_error_to_constraint(
-                        &err,
-                    ))
+                    WorkflowFunctionError::ConstraintViolation(
+                        join_set_open_tracker_error_to_constraint(&err),
+                    )
                 })?;
         } // else it is JoinNextTryError
         let value = value

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@execute_workflow_fn_with_single_delay-testing_stub-workflow__workflow.join-next-in-scope.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@execute_workflow_fn_with_single_delay-testing_stub-workflow__workflow.join-next-in-scope.snap
@@ -487,7 +487,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.n:a_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"
@@ -503,7 +503,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.n:c_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"
@@ -532,7 +532,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.n:f_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@sleep_activity_submit_should_cancel_the_activity-testing_sleep-workflow__workflow.sleep-activity-submit.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@sleep_activity_submit_should_cancel_the_activity-testing_sleep-workflow__workflow.sleep-activity-submit.snap
@@ -146,7 +146,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.g:1_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@sleep_activity_submit_then_trap_should_cancel_the_activity-testing_sleep-workflow__workflow.sleep-activity-submit-then-trap.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@sleep_activity_submit_then_trap_should_cancel_the_activity-testing_sleep-workflow__workflow.sleep-activity-submit-then-trap.snap
@@ -125,7 +125,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.g:1_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_delay-testing_stub-workflow__workflow.submit-race-join-next-delay.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_delay-testing_stub-workflow__workflow.submit-race-join-next-delay.snap
@@ -220,7 +220,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.g:1_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_log_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_log_1.snap
@@ -83,30 +83,14 @@ expression: "ExecutionLogSanitized::from(log)"
       "version": 4
     }
   ],
-  "responses": [
-    {
-      "created_at": "1970-01-01T00:00:00.200Z",
-      "event": {
-        "join_set_id": "g:1",
-        "event": {
-          "type": "child_execution_finished",
-          "child_execution_id": "E_0000000000000000000000000A.g:1_1",
-          "finished_version": 1,
-          "result": {
-            "execution_failure": {
-              "kind": "cancelled"
-            }
-          }
-        }
-      }
-    }
-  ],
+  "responses": [],
   "next_version": 5,
   "pending_state": {
     "status": "paused",
-    "PendingAt": {
-      "scheduled_at": "1970-01-01T00:00:00.200Z",
-      "last_lock": null
+    "BlockedByJoinSet": {
+      "join_set_id": "g:1",
+      "lock_expires_at": "1970-01-01T00:00:00.200Z",
+      "closing": true
     }
   },
   "component_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_log_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_log_2.snap
@@ -100,13 +100,13 @@ expression: "ExecutionLogSanitized::from(log)"
   ],
   "responses": [
     {
-      "created_at": "1970-01-01T00:00:00.200Z",
+      "created_at": "1970-01-01T00:00:00.300Z",
       "event": {
         "join_set_id": "g:1",
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_0000000000000000000000000A.g:1_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_log_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_log_3.snap
@@ -83,30 +83,14 @@ expression: "ExecutionLogSanitized::from(log)"
       "version": 4
     }
   ],
-  "responses": [
-    {
-      "created_at": "1970-01-01T00:00:00.600Z",
-      "event": {
-        "join_set_id": "g:1",
-        "event": {
-          "type": "child_execution_finished",
-          "child_execution_id": "E_0000000000000000000000000B.g:1_1",
-          "finished_version": 1,
-          "result": {
-            "execution_failure": {
-              "kind": "cancelled"
-            }
-          }
-        }
-      }
-    }
-  ],
+  "responses": [],
   "next_version": 5,
   "pending_state": {
     "status": "paused",
-    "PendingAt": {
-      "scheduled_at": "1970-01-01T00:00:00.600Z",
-      "last_lock": null
+    "BlockedByJoinSet": {
+      "join_set_id": "g:1",
+      "lock_expires_at": "1970-01-01T00:00:00.600Z",
+      "closing": true
     }
   },
   "component_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_log_4.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_log_4.snap
@@ -100,13 +100,13 @@ expression: "ExecutionLogSanitized::from(log)"
   ],
   "responses": [
     {
-      "created_at": "1970-01-01T00:00:00.600Z",
+      "created_at": "1970-01-01T00:00:00.700Z",
       "event": {
         "join_set_id": "g:1",
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_0000000000000000000000000B.g:1_1",
-          "finished_version": 1,
+          "finished_version": 2,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -2805,6 +2805,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::activity::cancel_registry::CancelRegistry;
+    use crate::cancellation_driver;
     use crate::testing_fn_registry::fn_registry_dummy;
     use crate::workflow::caching_db_connection::{CachingBuffer, CachingDbConnection};
     use crate::workflow::deadline_tracker::{
@@ -3556,6 +3557,7 @@ pub(crate) mod tests {
                     executor_close_watcher: tokio::sync::watch::channel(false).1,
                 })
                 .await;
+            let cancel_registry = CancelRegistry::new();
             // Run it SUBMITS times to close all join sets.
             for run in 0..SUBMITS {
                 info!("Run {run}");
@@ -3563,6 +3565,12 @@ pub(crate) mod tests {
                     worker_result,
                     WorkerResult::Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
                 );
+                cancellation_driver::tick_test(
+                    db_connection.as_ref(),
+                    &cancel_registry,
+                    sim_clock.now(),
+                )
+                .await;
                 let execution_log = db_connection.get(&execution_id).await.unwrap();
                 let closing_join_nexts: hashbrown::HashSet<_> = execution_log
                     .event_history()
@@ -3828,6 +3836,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let mut processed = Vec::new();
+        let cancel_registry = CancelRegistry::new();
         loop {
             workflow_exec
                 .tick_test(
@@ -3840,6 +3849,12 @@ pub(crate) mod tests {
                 .await
                 .wait_for_tasks()
                 .await;
+            cancellation_driver::tick_test(
+                db_connection.as_ref(),
+                &cancel_registry,
+                sim_clock.now(),
+            )
+            .await;
             let pending_state = db_connection
                 .get_pending_state(&execution_id)
                 .await

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -590,6 +590,7 @@ mod tests {
     use crate::RunnableComponent;
     use crate::activity::activity_worker::test::compile_activity;
     use crate::activity::activity_worker::tests::new_activity_fibo;
+    use crate::cancellation_driver;
     use crate::engines::{EngineConfig, Engines};
     use crate::testing_fn_registry::TestingFnRegistry;
     use crate::workflow::deadline_tracker::DeadlineTrackerFactoryTokio;
@@ -1388,6 +1389,7 @@ mod tests {
 
         let (workflow_exec, _workflow_close_tx) =
             new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
+        let cancel_registry = CancelRegistry::new();
 
         let execution_id = ExecutionId::generate();
         let created_at = sim_clock.now();
@@ -1467,13 +1469,15 @@ mod tests {
                 .len()
         );
 
-        info!("Step 4: Resume workflow - should close the join set");
-        assert_eq!(
-            1,
+        info!("Step 4: Finish cancelled loser and resume workflow if still pending");
+        cancellation_driver::tick_test(db_connection.as_ref(), &cancel_registry, sim_clock.now())
+            .await;
+        assert!(
             workflow_exec
                 .tick_test_await(sim_clock.now(), RunId::generate())
                 .await
                 .len()
+                <= 1
         );
 
         let res = db_connection
@@ -1612,6 +1616,7 @@ mod tests {
         execution_id: ExecutionId,
         db_connection: Box<dyn DbConnectionTest>,
         sim_clock: SimClock,
+        cancel_registry: CancelRegistry,
     }
 
     impl JsWorkflowTestHarness {
@@ -1698,6 +1703,7 @@ mod tests {
                 execution_id,
                 db_connection,
                 sim_clock,
+                cancel_registry: CancelRegistry::new(),
             }
         }
 
@@ -1705,6 +1711,12 @@ mod tests {
             self.workflow_exec
                 .tick_test_await(self.sim_clock.now(), RunId::generate())
                 .await;
+            cancellation_driver::tick_test(
+                self.db_connection.as_ref(),
+                &self.cancel_registry,
+                self.sim_clock.now(),
+            )
+            .await;
         }
 
         /// Move time forward and process expired timers.
@@ -3580,10 +3592,17 @@ mod tests {
     ) -> SupportedFunctionReturnValue {
         let mut steps = 0;
         let mut saw_trimmed_preview = false;
+        let cancel_registry = CancelRegistry::new();
         loop {
             harness
                 .sim_clock
                 .move_time_forward(Duration::from_millis(100));
+            cancellation_driver::tick_test(
+                db_connection,
+                &cancel_registry,
+                harness.sim_clock.now(),
+            )
+            .await;
             let replay = harness
                 .replay_worker
                 .replay(harness.execution_id.clone())

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1551,6 +1551,7 @@ pub(crate) mod tests {
     };
     use crate::activity::activity_worker::tests::{new_activity, new_activity_with_config};
     use crate::activity::cancel_registry::CancelRegistry;
+    use crate::cancellation_driver;
     use crate::testing_fn_registry::{TestingFnRegistry, fn_registry_dummy};
     use crate::workflow::deadline_tracker::{
         DeadlineTrackerFactoryForReplay, DeadlineTrackerFactoryTokio,
@@ -2116,7 +2117,7 @@ pub(crate) mod tests {
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
             &fn_registry,
-            cancel_registry,
+            cancel_registry.clone(),
             LockingStrategy::ByComponentDigest,
         )
         .await;
@@ -2184,7 +2185,7 @@ pub(crate) mod tests {
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
             &fn_registry,
-            cancel_registry,
+            cancel_registry.clone(),
             LockingStrategy::ByComponentDigest,
         )
         .await;
@@ -2250,7 +2251,7 @@ pub(crate) mod tests {
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
             &fn_registry,
-            cancel_registry,
+            cancel_registry.clone(),
             LockingStrategy::ByComponentDigest,
         )
         .await;
@@ -2284,21 +2285,9 @@ pub(crate) mod tests {
             .tick_test_await(sim_clock.now(), RunId::generate())
             .await;
 
-        // The workflow submitted an activity and called join_set_close which internally
-        // calls JoinNext(closing: true). This interrupts and the workflow is scheduled to run again.
-        // We need to run the activity executor to cancel/complete the activity.
-
-        info!("Running activity executor to process the child activity");
-        let (activity_exec, _activity_close_tx) = new_activity_fibo(
-            db_pool.clone(),
-            sim_clock.clone_box(),
-            TokioSleep,
-            LockingStrategy::ByComponentDigest,
-        )
-        .await;
-        // The activity may be cancelled or run - either way we process it
-        activity_exec
-            .tick_test_await(sim_clock.now(), RunId::generate())
+        // The workflow submitted an activity and called join_set_close. The cancellation
+        // driver finalizes the cancelled child before the workflow resumes.
+        cancellation_driver::tick_test(db_connection.as_ref(), &cancel_registry, sim_clock.now())
             .await;
 
         info!("Second workflow tick - receives response and completes");
@@ -3644,13 +3633,14 @@ pub(crate) mod tests {
             compile_workflow(workflow_wasm_path).await,
         ]);
 
+        let cancel_registry = CancelRegistry::new();
         let worker = compile_workflow_worker(
             workflow_wasm_path,
             db_pool.clone(),
             sim_clock.clone_box(),
             JoinNextBlockingStrategy::Interrupt,
             &fn_registry,
-            CancelRegistry::new(),
+            cancel_registry.clone(),
         )
         .await;
         let execution_id = ExecutionId::from_parts(0, 0);
@@ -3729,8 +3719,22 @@ pub(crate) mod tests {
             }
         }
 
-        // Keep running exec ticks.
+        // Keep running cancellation driver and exec ticks.
         loop {
+            cancellation_driver::tick_test(
+                db_connection.as_ref(),
+                &cancel_registry,
+                sim_clock.now(),
+            )
+            .await;
+            let pending_state = db_connection
+                .get_pending_state(&execution_id)
+                .await
+                .unwrap()
+                .pending_state;
+            if matches!(pending_state, PendingState::Finished(_)) {
+                break;
+            }
             let run = run_id();
             assert!(run.random_part() < MAX_RUNS);
             let executed = exec_task
@@ -3739,10 +3743,7 @@ pub(crate) mod tests {
                 .wait_for_tasks()
                 .await
                 .len();
-            if executed == 0 {
-                break;
-            }
-            assert_eq!(1, executed);
+            assert!(executed <= 1);
         }
 
         let pending_state = db_connection
@@ -3771,9 +3772,11 @@ pub(crate) mod tests {
         max_steps: usize,
     ) -> ExecutionLog {
         let mut steps = 0;
+        let cancel_registry = CancelRegistry::new();
 
         loop {
             sim_clock.move_time_forward(Duration::from_millis(100));
+            cancellation_driver::tick_test(db_connection, &cancel_registry, sim_clock.now()).await;
             let replay = harness
                 .replay_worker
                 .replay(harness.execution_id.clone())
@@ -3812,33 +3815,6 @@ pub(crate) mod tests {
                 "execution did not finish after {steps} replay+advance steps",
             );
         }
-    }
-
-    fn normalized_cancellable_request_order(execution_log: &ExecutionLog) -> Vec<String> {
-        execution_log
-            .events
-            .iter()
-            .filter_map(|event| match &event.event {
-                ExecutionRequest::HistoryEvent {
-                    event:
-                        HistoryEvent::JoinSetRequest {
-                            request:
-                                JoinSetRequest::ChildExecutionRequest {
-                                    child_execution_id, ..
-                                },
-                            ..
-                        },
-                } => Some(format!("child:{child_execution_id}")),
-                ExecutionRequest::HistoryEvent {
-                    event:
-                        HistoryEvent::JoinSetRequest {
-                            request: JoinSetRequest::DelayRequest { delay_id, .. },
-                            ..
-                        },
-                } => Some(format!("delay:{delay_id}")),
-                _ => None,
-            })
-            .collect()
     }
 
     fn normalized_response_order(execution_log: &ExecutionLog) -> Vec<String> {
@@ -3939,6 +3915,7 @@ pub(crate) mod tests {
             let sim_clock = SimClock::epoch();
             let (_guard, db_pool, db_close) = db.set_up().await;
             let db_connection = db_pool.connection_test().await.unwrap();
+            let cancel_registry = CancelRegistry::new();
 
             let direct_worker = compile_workflow_worker(
                 test_programs_stub_workflow_builder::TEST_PROGRAMS_STUB_WORKFLOW,
@@ -3946,7 +3923,7 @@ pub(crate) mod tests {
                 sim_clock.clone_box(),
                 JoinNextBlockingStrategy::Interrupt,
                 &fn_registry,
-                CancelRegistry::new(),
+                cancel_registry.clone(),
             )
             .await;
 
@@ -3986,6 +3963,20 @@ pub(crate) mod tests {
             );
 
             loop {
+                cancellation_driver::tick_test(
+                    db_connection.as_ref(),
+                    &cancel_registry,
+                    sim_clock.now(),
+                )
+                .await;
+                let pending_state = db_connection
+                    .get_pending_state(&execution_id)
+                    .await
+                    .unwrap()
+                    .pending_state;
+                if matches!(pending_state, PendingState::Finished(_)) {
+                    break;
+                }
                 let executed = direct_exec_task
                     .tick_test(sim_clock.now(), RunId::generate())
                     .await
@@ -4058,13 +4049,8 @@ pub(crate) mod tests {
             advance_execution_log
         };
 
-        let expected_cancellation_order =
-            normalized_cancellable_request_order(&direct_execution_log)
-                .into_iter()
-                .rev()
-                .collect::<Vec<_>>();
         assert_eq!(
-            expected_cancellation_order,
+            normalized_response_order(&direct_execution_log),
             normalized_response_order(&advance_execution_log),
             "stepped replay+advance must match direct cancellation order",
         );
@@ -4922,9 +4908,11 @@ pub(crate) mod tests {
     ) -> (usize, bool, SupportedFunctionReturnValue) {
         let mut steps = 0;
         let mut saw_trimmed_preview = false; // at least one replay got trimmed
+        let cancel_registry = CancelRegistry::new();
 
         loop {
             sim_clock.move_time_forward(Duration::from_millis(100));
+            cancellation_driver::tick_test(db_connection, &cancel_registry, sim_clock.now()).await;
             let replay = harness
                 .replay_worker
                 .replay(harness.execution_id.clone())

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2753,7 +2753,11 @@ async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
         .await
         .unwrap_err();
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
-    assert!(status.message().contains("must be marked cancellable"));
+    assert!(
+        status
+            .message()
+            .contains("cannot cancel, execution is not a cancellable workflow")
+    );
 
     server.shutdown().await;
 }
@@ -2861,7 +2865,7 @@ async fn cancel_execution_webapi_routes_activities_and_cancellable_workflows() {
     assert_eq!(resp.status().as_u16(), 422);
     assert_eq!(
         resp.json::<Value>().await.unwrap(),
-        json!({ "err": "cancelled workflow must be marked cancellable" })
+        json!({ "err": "cannot cancel, execution is not a cancellable workflow" })
     );
 
     server.shutdown().await;
@@ -3644,7 +3648,7 @@ async fn webhook_js_get_status_cancelling() {
         conn.create(create(ExecutionId::Derived(child_id), CHILD_FFQN))
             .await
             .unwrap();
-        conn.request_cancellation_with_retries(&parent_id, now)
+        conn.cancel_workflow_with_retries(&parent_id, now)
             .await
             .unwrap();
         pool.close().await;

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2662,6 +2662,7 @@ async fn submit_workflow_and_replay() {
 }
 
 #[tokio::test]
+#[ignore = "requires activity cancellation implementation"]
 async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
     let server = TestServer::start(test_addr!(83)).await;
     let mut grpc_client =
@@ -2758,6 +2759,7 @@ async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
 }
 
 #[tokio::test]
+#[ignore = "requires activity cancellation implementation"]
 async fn cancel_execution_webapi_routes_activities_and_cancellable_workflows() {
     let server = TestServer::start(test_addr!(84)).await;
 

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1149,8 +1149,13 @@ impl TestServer {
 async fn deploy_local_wasm_to_empty_server() {
     let server = TestServer::start_empty(test_addr!(78)).await;
 
-    let toml_path = get_workspace_dir().join("obelisk-testing-wasm-local.toml");
-    let deployment_id = server.grpc_upload_and_submit_manifest(&toml_path).await;
+    let fixture = crate::command::test_support::target_aware_deployment_fixture(
+        &get_workspace_dir(),
+        "obelisk-testing-wasm-local.toml",
+    )
+    .await
+    .unwrap();
+    let deployment_id = server.grpc_upload_and_submit_manifest(fixture.path()).await;
     server.grpc_switch_hot_redeploy(deployment_id).await;
 
     // The WASM components from the manifest are now live.

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2662,7 +2662,6 @@ async fn submit_workflow_and_replay() {
 }
 
 #[tokio::test]
-#[ignore = "requires activity cancellation implementation"]
 async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
     let server = TestServer::start(test_addr!(83)).await;
     let mut grpc_client =
@@ -2691,14 +2690,24 @@ async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
         resp.outcome(),
         CancelExecutionOutcome::CancellationRequested
     );
-    let summary = server.get_status_summary_grpc(&activity_id).await;
-    assert!(matches!(
-        summary
-            .current_status
-            .as_ref()
-            .and_then(|status| status.status.as_ref()),
-        Some(grpc::grpc_gen::execution_status::Status::Finished(_))
-    ));
+    // Cancelling a paused activity is async: the driver finalizes it to
+    // Finished(Cancelled) on a later tick, so poll rather than asserting immediately.
+    let mut activity_finished = false;
+    for _ in 0..100 {
+        let summary = server.get_status_summary_grpc(&activity_id).await;
+        if matches!(
+            summary
+                .current_status
+                .as_ref()
+                .and_then(|status| status.status.as_ref()),
+            Some(grpc::grpc_gen::execution_status::Status::Finished(_))
+        ) {
+            activity_finished = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(activity_finished, "cancelled paused activity must finish");
 
     let cancellable_workflow_id = server
         .seed_cancellable_parent_blocked_on_uncancellable_child()
@@ -2763,7 +2772,6 @@ async fn cancel_execution_grpc_routes_activities_and_cancellable_workflows() {
 }
 
 #[tokio::test]
-#[ignore = "requires activity cancellation implementation"]
 async fn cancel_execution_webapi_routes_activities_and_cancellable_workflows() {
     let server = TestServer::start(test_addr!(84)).await;
 
@@ -2790,14 +2798,24 @@ async fn cancel_execution_webapi_routes_activities_and_cancellable_workflows() {
         resp.json::<Value>().await.unwrap(),
         json!({ "ok": "cancellation requested" })
     );
-    let summary = server.get_status_summary_grpc(&activity_id).await;
-    assert!(matches!(
-        summary
-            .current_status
-            .as_ref()
-            .and_then(|status| status.status.as_ref()),
-        Some(grpc::grpc_gen::execution_status::Status::Finished(_))
-    ));
+    // Cancelling a paused activity is async: the driver finalizes it to
+    // Finished(Cancelled) on a later tick, so poll rather than asserting immediately.
+    let mut activity_finished = false;
+    for _ in 0..100 {
+        let summary = server.get_status_summary_grpc(&activity_id).await;
+        if matches!(
+            summary
+                .current_status
+                .as_ref()
+                .and_then(|status| status.status.as_ref()),
+            Some(grpc::grpc_gen::execution_status::Status::Finished(_))
+        ) {
+            activity_finished = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(activity_finished, "cancelled paused activity must finish");
 
     let cancellable_workflow_id = server
         .seed_cancellable_parent_blocked_on_uncancellable_child()

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -7,3 +7,5 @@ pub(crate) mod termination_notifier;
 
 #[cfg(test)]
 mod integration_tests;
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -4850,7 +4850,12 @@ mod tests {
             ConfigHolder::new(project_dirs, base_dirs, Some(workspace.join(server_toml)))?;
         let config = config_holder.load_config().await?;
 
-        let deployment = load_deployment_canonical(&workspace.join(deployment_toml)).await?;
+        let fixture = crate::command::test_support::target_aware_deployment_fixture(
+            &workspace,
+            deployment_toml,
+        )
+        .await?;
+        let deployment = load_deployment_canonical(fixture.path()).await?;
 
         let prepared_dirs = prepare_dirs(
             &config,
@@ -4912,8 +4917,12 @@ mod tests {
         )?;
         let config = config_holder.load_config().await?;
 
-        let mut deployment =
-            load_deployment_canonical(&workspace.join("obelisk-testing-wasm-local.toml")).await?;
+        let fixture = crate::command::test_support::target_aware_deployment_fixture(
+            &workspace,
+            "obelisk-testing-wasm-local.toml",
+        )
+        .await?;
+        let mut deployment = load_deployment_canonical(fixture.path()).await?;
         let shared_digest: ComponentDigest =
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 .parse()

--- a/src/command/test_support.rs
+++ b/src/command/test_support.rs
@@ -1,0 +1,43 @@
+//! Shared helpers for tests in the `command` submodules.
+
+use std::path::{Path, PathBuf};
+
+/// The workspace target directory *relative to the workspace root*, honoring
+/// `CARGO_TARGET_DIR`. Deployment manifests forbid absolute local paths, so the value is
+/// kept relative: a relative `CARGO_TARGET_DIR` is already workspace-relative; an absolute
+/// one under the workspace is stripped to its suffix; the default is `target`.
+fn target_dir_relative(workspace: &Path) -> String {
+    match std::env::var("CARGO_TARGET_DIR") {
+        Ok(dir) => {
+            let path = PathBuf::from(&dir);
+            if path.is_relative() {
+                dir
+            } else if let Ok(stripped) = path.strip_prefix(workspace) {
+                stripped.to_string_lossy().into_owned()
+            } else {
+                panic!(
+                    "`CARGO_TARGET_DIR` must be under workspace dir {workspace:?}, but is set to {dir:?}"
+                )
+            }
+        }
+        Err(std::env::VarError::NotPresent) => "target".to_owned(),
+        Err(err) => panic!("CARGO_TARGET_DIR set to an invalid value - {err:?}"),
+    }
+}
+
+pub(crate) async fn target_aware_deployment_fixture(
+    workspace: &Path,
+    deployment_toml: &str,
+) -> Result<tempfile::NamedTempFile, anyhow::Error> {
+    let text = tokio::fs::read_to_string(workspace.join(deployment_toml)).await?;
+    let rewritten = text.replace(
+        "target/wasm-cache",
+        &format!("{}/wasm-cache", target_dir_relative(workspace)),
+    );
+    let tmp = tempfile::Builder::new()
+        .prefix(".deployment-target-aware-")
+        .suffix(".toml")
+        .tempfile_in(workspace)?;
+    tokio::fs::write(tmp.path(), rewritten).await?;
+    Ok(tmp)
+}

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -130,13 +130,10 @@ impl GrpcServer {
                 .cancel_activity(conn.as_ref(), execution_id, executed_at)
                 .await
                 .to_status(),
-            ComponentType::Workflow if create_req.ffqn.is_cancellable() => conn
+            ComponentType::Workflow => conn
                 .cancel_workflow_with_retries(execution_id, executed_at)
                 .await
                 .to_status(),
-            ComponentType::Workflow => Err(tonic::Status::invalid_argument(
-                "cancelled workflow must be marked cancellable",
-            )),
             _ => Err(tonic::Status::invalid_argument(
                 "cancelled execution must be an activity or cancellable workflow",
             )),

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -653,16 +653,9 @@ async fn execution_cancel(
                 .cancel_activity(conn.as_ref(), &execution_id, executed_at)
                 .await
         }
-        ComponentType::Workflow if create_req.ffqn.is_cancellable() => {
+        ComponentType::Workflow => {
             conn.cancel_workflow_with_retries(&execution_id, executed_at)
                 .await
-        }
-        ComponentType::Workflow => {
-            return Err(HttpResponse {
-                status: StatusCode::UNPROCESSABLE_ENTITY,
-                message: "cancelled workflow must be marked cancellable".to_string(),
-                accept,
-            });
         }
         _ => {
             return Err(HttpResponse {
@@ -4178,21 +4171,32 @@ impl From<ErrorWrapper<DbErrorWriteNonRetriable>> for HttpResponse {
     fn from(value: ErrorWrapper<DbErrorWriteNonRetriable>) -> Self {
         let err = value.0;
         let accept = value.1;
-        if err == DbErrorWriteNonRetriable::Conflict {
-            HttpResponse {
+        match err {
+            DbErrorWriteNonRetriable::ValidationFailed(reason) => HttpResponse {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                message: reason.to_string(),
+                accept,
+            },
+            DbErrorWriteNonRetriable::IllegalState { reason, .. } => HttpResponse {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                message: reason.to_string(),
+                accept,
+            },
+            DbErrorWriteNonRetriable::Conflict => HttpResponse {
                 status: StatusCode::CONFLICT,
                 message: "conflict".to_string(),
                 accept,
-            }
-        } else {
-            let loc = std::panic::Location::caller();
-            let (loc_file, loc_line) = (loc.file(), loc.line());
+            },
+            err => {
+                let loc = std::panic::Location::caller();
+                let (loc_file, loc_line) = (loc.file(), loc.line());
 
-            warn!(loc_file, loc_line, "{err:?}");
-            HttpResponse {
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                message: "database error".to_string(),
-                accept,
+                warn!(loc_file, loc_line, "{err:?}");
+                HttpResponse {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: "database error".to_string(),
+                    accept,
+                }
             }
         }
     }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -4172,12 +4172,8 @@ impl From<ErrorWrapper<DbErrorWriteNonRetriable>> for HttpResponse {
         let err = value.0;
         let accept = value.1;
         match err {
-            DbErrorWriteNonRetriable::ValidationFailed(reason) => HttpResponse {
-                status: StatusCode::UNPROCESSABLE_ENTITY,
-                message: reason.to_string(),
-                accept,
-            },
-            DbErrorWriteNonRetriable::IllegalState { reason, .. } => HttpResponse {
+            DbErrorWriteNonRetriable::ValidationFailed(reason)
+            | DbErrorWriteNonRetriable::IllegalState { reason, .. } => HttpResponse {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
                 message: reason.to_string(),
                 accept,


### PR DESCRIPTION
- **refactor: Prepare activity cancellation request path**
- **refactor: Rename `cancel_activity` to `append_activity_cancellation_requested`**
- **refactor: Allow `Paused` -> `CancellationRequested` for activities**
- **refactor: Allow `Paused` -> `CancellationRequested` for workflows**
- **refactor: Allow `Locked` -> `CancellationRequested` for workflows**
- **refactor: Remove `CancelWorkflowPlan`**
- **refactor: Extract `reject_locked_activities`**
- **refactor: Split `PendingStatePaused`, `PendingStateCancelling`**
- **refactor(db): Do not send response wakeup signal when workflow is being cancelled**
- **test: Update tests after `CancellationRequested` transition changes**
- **refactor: Split activity/workflow handling in `cancellation_driver`**
- **refactor: Cancel delays and activities in reverse, then signal cancellable workflows**
- **refactor: Collapse `request_cancellation` to `cancel_workflow`**
- **style: Address clippy lints**
- **refactor: Append `JoinNext**
- **refactor: Append `JoinNext`-s in cancellation driver**
- **feat(activity): Kill activity run before reporting cancelling finished**
- **test: Correct the `wasm-cache` path if `CARGO_TARGET_DIR` is present**
- **refactor: Rename `JoinSetFold` to `JoinSetOpenTracker`**
