### PR TITLE
 feat(js): Unify `joinNext` with `joinNextTry` and other throwing fns

### DIFF
--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-07-10@sha256:bd0ef4d00c0f3f71e62905ba9fea161b66beb9e8ce10406a5f42008283317a7a
+oci://docker.io/getobelisk/webhook-js-runtime:2026-07-11@sha256:6d207a66b2a83661be373ce66165e0eb43364eaae42233d42885691c959fa23c

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-07-10@sha256:9653ab166704bb6d7936aab023e058fcc017bbeaac97911b6d91a1646af9cde9
+oci://docker.io/getobelisk/workflow-js-runtime:2026-07-11@sha256:dfca8bb143f546fb18f7dbcedbafee9057d8f9000a1298746a240a481b4e4505

--- a/crates/boa-common/src/child_execution_error.rs
+++ b/crates/boa-common/src/child_execution_error.rs
@@ -1,0 +1,184 @@
+//! `obelisk.ChildExecutionError` — the single catchable type thrown when an
+//! awaited child execution (or a cancelled delay) fails.
+//!
+//! It replaces the earlier "throw the raw err value / `throw null`" behavior:
+//! - Always truthy and `instanceof Error` (its prototype is spliced onto
+//!   `Error.prototype`), with a legible `message` and a JS stack.
+//! - Carries the err payload on `.value` plus metadata (`.childId`,
+//!   `.cancelled`, `.failureKind`).
+//! - Re-propagates transparently: the producer runtime detects a re-thrown
+//!   instance via the native brand (`downcast_ref`) and re-serializes `.value`,
+//!   so `throw e` behaves like `throw e.value`.
+//!
+//! The native data ([`ChildExecutionError`]) is intentionally empty: every
+//! user-visible field lives as an ordinary JS own property. The Rust struct
+//! exists only as a brand that the producer can detect via `downcast_ref`,
+//! rather than sniffing a spoofable `.name`/prototype.
+
+use boa_engine::{
+    Context, JsError, JsNativeError, JsObject, JsResult, JsValue, Source,
+    class::{Class, ClassBuilder},
+    js_string,
+};
+use boa_gc::{Finalize, Trace};
+
+/// Native brand stored inside every `obelisk.ChildExecutionError` instance.
+#[derive(Debug, Trace, Finalize, boa_engine::JsData)]
+pub struct ChildExecutionError;
+
+impl Class for ChildExecutionError {
+    const NAME: &'static str = "ChildExecutionError";
+    const LENGTH: usize = 1;
+
+    fn data_constructor(
+        _new_target: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<Self> {
+        Ok(ChildExecutionError)
+    }
+
+    fn object_constructor(
+        instance: &JsObject<Self>,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<()> {
+        let obj = instance.clone().upcast();
+        let message = args.first().cloned().unwrap_or(JsValue::undefined());
+        obj.set(js_string!("message"), message, false, context)?;
+        obj.set(
+            js_string!("name"),
+            js_string!("ChildExecutionError"),
+            false,
+            context,
+        )?;
+        Ok(())
+    }
+
+    fn init(_class: &mut ClassBuilder<'_>) -> JsResult<()> {
+        Ok(())
+    }
+}
+
+/// Register `obelisk.ChildExecutionError`.
+///
+/// Must run after the global `obelisk` object has been installed. Registers the
+/// native class, moves the constructor under `obelisk` (off the global
+/// namespace), and splices its prototype chain onto `Error` so that
+/// `instanceof Error` holds and instances inherit `Error.prototype`.
+pub fn register(context: &mut Context) -> JsResult<()> {
+    context.register_global_class::<ChildExecutionError>()?;
+    context.eval(Source::from_bytes(
+        "obelisk.ChildExecutionError = globalThis.ChildExecutionError;\n\
+         delete globalThis.ChildExecutionError;\n\
+         Object.setPrototypeOf(obelisk.ChildExecutionError.prototype, Error.prototype);\n\
+         Object.setPrototypeOf(obelisk.ChildExecutionError, Error);",
+    ))?;
+    Ok(())
+}
+
+/// Resolved pieces of a child-execution failure, gathered by each runtime from
+/// its own host bindings before delegating message/object construction here.
+pub struct ChildExecutionErrorParts<'a> {
+    /// Completed child execution id; `None` for a delay.
+    pub child_id: Option<&'a str>,
+    /// Cancelled delay id; `Some` only for a cancelled delay.
+    pub delay_id: Option<&'a str>,
+    /// Business `err` payload as a JSON string; `None` for a unit err or a
+    /// platform failure.
+    pub value_json: Option<&'a str>,
+    /// Execution-failure kind as a kebab string (mirrors the WIT
+    /// `execution-failure-kind` enum) for a platform failure; `None` for a
+    /// business err or a cancelled delay.
+    pub failure_kind: Option<&'a str>,
+    /// Whether the child or delay was cancelled.
+    pub cancelled: bool,
+}
+
+/// Build a `ChildExecutionError` and wrap it as a throwable [`JsError`].
+pub fn make_child_execution_error(
+    parts: &ChildExecutionErrorParts,
+    context: &mut Context,
+) -> JsResult<JsError> {
+    // `.value` is the parsed business payload, and `undefined` for a platform
+    // failure (kind set, synthesized sentinel dropped) or a unit err.
+    let value = match (parts.failure_kind, parts.value_json) {
+        (Some(_), _) | (None, None) => JsValue::undefined(),
+        (None, Some(json)) => context.eval(Source::from_bytes(&format!("({json})")))?,
+    };
+
+    let message = build_message(parts, &value);
+
+    // Construct via the registered constructor so the instance carries the
+    // native brand and the (Error-spliced) prototype.
+    let ctor = ctor(context)?;
+    let instance = ctor.construct(
+        &[JsValue::from(js_string!(message.as_str()))],
+        None,
+        context,
+    )?;
+
+    instance.set(js_string!("value"), value, false, context)?;
+    instance.set(
+        js_string!("childId"),
+        parts
+            .child_id
+            .map_or(JsValue::undefined(), |id| js_string!(id).into()),
+        false,
+        context,
+    )?;
+    instance.set(
+        js_string!("cancelled"),
+        JsValue::from(parts.cancelled),
+        false,
+        context,
+    )?;
+    instance.set(
+        js_string!("failureKind"),
+        parts
+            .failure_kind
+            .map_or(JsValue::undefined(), |k| js_string!(k).into()),
+        false,
+        context,
+    )?;
+    // Best-effort JS stack captured at the throw site.
+    if let Ok(stack) = context.eval(Source::from_bytes("new Error().stack")) {
+        instance.set(js_string!("stack"), stack, false, context)?;
+    }
+
+    Ok(JsError::from_opaque(instance.into()))
+}
+
+/// A human-facing one-liner; programmatic access always goes through `.value`.
+fn build_message(parts: &ChildExecutionErrorParts, value: &JsValue) -> String {
+    if let Some(delay_id) = parts.delay_id {
+        return format!("delay {delay_id} cancelled");
+    }
+    let mut msg = match parts.child_id {
+        Some(id) => format!("child execution {id} failed"),
+        None => "child execution failed".to_string(),
+    };
+    if let Some(kind) = parts.failure_kind {
+        msg.push_str(&format!(": {kind}"));
+    } else if let Some(s) = value.as_string() {
+        msg.push_str(&format!(": {}", s.to_std_string_escaped()));
+    }
+    msg
+}
+
+/// Fetch the `obelisk.ChildExecutionError` constructor.
+fn ctor(context: &mut Context) -> JsResult<JsObject> {
+    let global = context.global_object();
+    let obelisk = global
+        .get(js_string!("obelisk"), context)?
+        .as_object()
+        .ok_or_else(|| JsNativeError::error().with_message("global obelisk object missing"))?;
+    obelisk
+        .get(js_string!("ChildExecutionError"), context)?
+        .as_object()
+        .ok_or_else(|| {
+            JsNativeError::error()
+                .with_message("obelisk.ChildExecutionError missing")
+                .into()
+        })
+}

--- a/crates/boa-common/src/lib.rs
+++ b/crates/boa-common/src/lib.rs
@@ -1,5 +1,6 @@
 //! Common utilities for Boa JS engine-based Obelisk runtimes.
 
+pub mod child_execution_error;
 pub mod console;
 pub mod crypto;
 pub mod esm;

--- a/crates/testing/test-programs/js/workflow/add_via_activity.js
+++ b/crates/testing/test-programs/js/workflow/add_via_activity.js
@@ -3,11 +3,10 @@ export default function add_via_activity(a, b) {
     const js = createJoinSet();
     const execId = js.submit('testing:integration/activity.add', [a, b]);
     console.log('Submitted add activity, execId:', execId);
-    const response = js.joinNext();
-    if (!response.ok) {
-        throw 'activity failed';
+    const result = js.joinNext();
+    if (js.lastId !== execId) {
+        throw 'unexpected completed execution';
     }
-    const result = obelisk.getResult(response.id);
     console.log('Got result:', JSON.stringify(result));
     return result;
 }

--- a/crates/testing/test-programs/js/workflow/call_stub.js
+++ b/crates/testing/test-programs/js/workflow/call_stub.js
@@ -4,6 +4,5 @@ export default function call_stub(id) {
     const execId = js.submit('testing:integration/stubs.my-stub', [id]);
     console.log("stubbed id", execId);
     obelisk.stub(execId, { 'ok': 'stub-ok' });
-    js.joinNext();
-    return obelisk.getResult(execId);
+    return js.joinNext();
 }

--- a/crates/testing/test-programs/js/workflow/cancel_child_error.js
+++ b/crates/testing/test-programs/js/workflow/cancel_child_error.js
@@ -1,0 +1,30 @@
+// Await a child execution that is cancelled out-of-band. The child's cancellation
+// is a platform failure (not a business err), so `joinNext` throws a
+// `ChildExecutionError` whose `.cancelled` is true, `.failureKind` is `cancelled`
+// and `.value` is undefined (no err payload to carry).
+export default function cancel_child_error() {
+    // A named join set gives the child a well-known id the test can reconstruct.
+    const js = obelisk.createJoinSet({ name: 'cancel-set' });
+    const childId = js.submit('testing:integration/workflow-sleep.sleep-cancellable', []);
+    try {
+        js.joinNext();
+    } catch (e) {
+        if (!(e instanceof obelisk.ChildExecutionError)) {
+            throw `expected ChildExecutionError, got: ${e}`;
+        }
+        if (e.cancelled !== true) {
+            throw `expected cancelled=true, got: ${e.cancelled}`;
+        }
+        if (e.failureKind !== 'cancelled') {
+            throw `expected failureKind=cancelled, got: ${e.failureKind}`;
+        }
+        if (e.childId !== childId) {
+            throw `expected childId=${childId}, got: ${e.childId}`;
+        }
+        if (e.value !== undefined) {
+            throw `expected value=undefined, got: ${JSON.stringify(e.value)}`;
+        }
+        return 'cancelled-child-observed';
+    }
+    throw 'joinNext did not throw for a cancelled child';
+}

--- a/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
+++ b/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
@@ -1,5 +1,5 @@
 // Exercise JS joinNextTry() semantics: pending -> undefined, success -> value,
-// failure -> throw err value, exhausted -> host error class.
+// failure -> throw ChildExecutionError, exhausted -> host error class.
 import { addSubmit } from 'testing:integration-obelisk-ext/activity';
 import { myStubSubmit } from 'testing:integration-obelisk-ext/stubs';
 import { myStubStub } from 'testing:integration-obelisk-stub/stubs';
@@ -55,8 +55,14 @@ export default function join_next_try_semantics(id) {
         errJs.joinNextTry();
         throw 'expected stub error';
     } catch (e) {
-        if (e !== 'stub-err') {
-            throw `unexpected thrown err value: ${e}`;
+        if (!(e instanceof obelisk.ChildExecutionError)) {
+            throw `expected ChildExecutionError, got: ${e}`;
+        }
+        if (e.value !== 'stub-err') {
+            throw `unexpected child err value: ${e.value}`;
+        }
+        if (e.childId !== errExecId) {
+            throw `unexpected childId: ${e.childId} !== ${errExecId}`;
         }
     }
 
@@ -68,8 +74,11 @@ export default function join_next_try_semantics(id) {
         blockingErrJs.joinNext();
         throw 'expected blocking stub error';
     } catch (e) {
-        if (e !== 'stub-err-blocking') {
-            throw `unexpected blocking thrown err value: ${e}`;
+        if (!(e instanceof obelisk.ChildExecutionError)) {
+            throw `expected ChildExecutionError, got: ${e}`;
+        }
+        if (e.value !== 'stub-err-blocking') {
+            throw `unexpected blocking child err value: ${e.value}`;
         }
     }
 

--- a/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
+++ b/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
@@ -55,8 +55,21 @@ export default function join_next_try_semantics(id) {
         errJs.joinNextTry();
         throw 'expected stub error';
     } catch (e) {
-        if (!String(e).includes('stub-err')) {
+        if (e !== 'stub-err') {
             throw `unexpected thrown err value: ${e}`;
+        }
+    }
+
+    const blockingErrJs = obelisk.createJoinSet();
+    const blockingErrExecId = myStubSubmit(blockingErrJs, id + 2);
+    myStubStub(blockingErrExecId, { err: 'stub-err-blocking' });
+    obelisk.sleep({ milliseconds: 1 });
+    try {
+        blockingErrJs.joinNext();
+        throw 'expected blocking stub error';
+    } catch (e) {
+        if (e !== 'stub-err-blocking') {
+            throw `unexpected blocking thrown err value: ${e}`;
         }
     }
 

--- a/crates/testing/test-programs/js/workflow/rethrow_child_error.js
+++ b/crates/testing/test-programs/js/workflow/rethrow_child_error.js
@@ -1,0 +1,20 @@
+// Catch a child execution's string err as a ChildExecutionError and re-throw it.
+// The transparent re-propagation must reproduce the original err payload as the
+// workflow's own err value (i.e. `throw e` behaves like `throw e.value`).
+import { myStubSubmit } from 'testing:integration-obelisk-ext/stubs';
+import { myStubStub } from 'testing:integration-obelisk-stub/stubs';
+
+export default function rethrow_child_error(id) {
+    const js = obelisk.createJoinSet();
+    const execId = myStubSubmit(js, id);
+    myStubStub(execId, { err: 'boom' });
+    try {
+        js.joinNext();
+    } catch (e) {
+        if (!(e instanceof obelisk.ChildExecutionError)) {
+            throw `expected ChildExecutionError, got: ${e}`;
+        }
+        throw e; // transparent re-propagation -> workflow err 'boom'
+    }
+    return 'unreachable';
+}

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -3592,14 +3592,22 @@ pub(crate) mod tests {
         async fn webhook_js_call_with_error() {
             test_utils::set_up();
             // fibo(50) returns err in the test activity (n > 40 returns error).
-            // fibo returns result<u64> (no err type), so the unit err is thrown as null.
+            // fibo returns result<u64> (no err type), so the child fails with a unit
+            // err: a ChildExecutionError whose `.value` is undefined.
             let js_source = r#"
                 export default function handle(request) {
                     try {
                         obelisk.call("testing:fibo/fibo.fibo", [50]);
                         return Response.json({ threw: false });
                     } catch (e) {
-                        return Response.json({ threw: true, caughtNull: e === null });
+                        return Response.json({
+                            threw: true,
+                            isChildErr: e instanceof obelisk.ChildExecutionError,
+                            isError: e instanceof Error,
+                            valueIsUndefined: e.value === undefined,
+                            cancelled: e.cancelled,
+                            hasChildId: typeof e.childId === "string",
+                        });
                     }
                 }
             "#;
@@ -3621,9 +3629,14 @@ pub(crate) mod tests {
             let resp = fetch_task.await.unwrap();
             assert_eq!(resp.status().as_u16(), 200);
             let body: serde_json::Value = resp.json().await.unwrap();
-            // Should have caught the error, thrown as null for a unit err.
+            // Should have caught a ChildExecutionError with an undefined value
+            // (unit err), which is a business err (not cancelled), and a child id.
             assert_eq!(body["threw"], serde_json::json!(true));
-            assert_eq!(body["caughtNull"], serde_json::json!(true));
+            assert_eq!(body["isChildErr"], serde_json::json!(true));
+            assert_eq!(body["isError"], serde_json::json!(true));
+            assert_eq!(body["valueIsUndefined"], serde_json::json!(true));
+            assert_eq!(body["cancelled"], serde_json::json!(false));
+            assert_eq!(body["hasChildId"], serde_json::json!(true));
         }
     }
 

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -3591,14 +3591,15 @@ pub(crate) mod tests {
         #[tokio::test]
         async fn webhook_js_call_with_error() {
             test_utils::set_up();
-            // fibo(50) returns Err(()) in the test activity (n > 40 returns error)
+            // fibo(50) returns err in the test activity (n > 40 returns error).
+            // fibo returns result<u64> (no err type), so the unit err is thrown as null.
             let js_source = r#"
                 export default function handle(request) {
                     try {
                         obelisk.call("testing:fibo/fibo.fibo", [50]);
-                        return Response.json({ result: "unexpected success" });
+                        return Response.json({ threw: false });
                     } catch (e) {
-                        return Response.json({ error: e.message });
+                        return Response.json({ threw: true, caughtNull: e === null });
                     }
                 }
             "#;
@@ -3620,8 +3621,9 @@ pub(crate) mod tests {
             let resp = fetch_task.await.unwrap();
             assert_eq!(resp.status().as_u16(), 200);
             let body: serde_json::Value = resp.json().await.unwrap();
-            // Should have caught the error
-            assert!(body["error"].is_string());
+            // Should have caught the error, thrown as null for a unit err.
+            assert_eq!(body["threw"], serde_json::json!(true));
+            assert_eq!(body["caughtNull"], serde_json::json!(true));
         }
     }
 

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_2.snap
@@ -93,8 +93,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
                     {
                       "func_name": null,
                       "file": null,
-                      "line": 6,
-                      "col": 41
+                      "line": 2,
+                      "col": 45
                     }
                   ]
                 }

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_4.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_4.snap
@@ -93,8 +93,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
                     {
                       "func_name": null,
                       "file": null,
-                      "line": 6,
-                      "col": 41
+                      "line": 2,
+                      "col": 45
                     }
                   ]
                 }

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_5.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_5.snap
@@ -41,8 +41,8 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
                     {
                       "func_name": null,
                       "file": null,
-                      "line": 6,
-                      "col": 41
+                      "line": 2,
+                      "col": 45
                     }
                   ]
                 }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1781,13 +1781,15 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-param']);
             obelisk.stub(execId, {'err': null}); // result<string> has no error type
-            let caughtErr = 'none';
+            let threw = false;
+            let caughtErr = 'unset';
             try {
                 js.joinNext();
             } catch (e) {
-                caughtErr = e.message;
+                threw = true;
+                caughtErr = e;
             }
-            return JSON.stringify({ lastId: js.lastId, caughtErr: caughtErr });
+            return JSON.stringify({ lastId: js.lastId, threw: threw, caughtErr: caughtErr });
         }";
 
         let harness =
@@ -1800,7 +1802,9 @@ mod tests {
             result["lastId"].as_str().unwrap().starts_with("E_"),
             "lastId should be set before throwing child err, got {result}"
         );
-        assert_eq!(json!("child execution failed"), result["caughtErr"]);
+        assert_eq!(json!(true), result["threw"]);
+        // result<string> has no err type: unit err throws null, mirroring Ok(None).
+        assert_eq!(json!(null), result["caughtErr"]);
         drop(harness);
         db_close.close().await;
     }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1337,21 +1337,13 @@ mod tests {
             const tryPending = js1.joinNextTry();
             console.log('joinNextTry pending:', JSON.stringify(tryPending));
 
-            /* Join next - should get fibo result first (activity completes before delay) */
+            /* Join next - should get fibo result first if the activity wins */
             const response1 = js1.joinNext();
-            console.log('joinNext response 1:', JSON.stringify(response1));
+            console.log('joinNext response 1:', JSON.stringify(response1), 'lastId:', js1.lastId);
 
-            /* Get the fibo result */
-            let fiboResult = null;
-            let loser = null;
-            if (response1.type === 'execution') {
-                const result = obelisk.getResult(response1.id);
-                console.log('Got fibo result:', JSON.stringify(result));
-                fiboResult = result;
-                loser = delayId;
-            } else {
-                loser = execId;
-            }
+            let fiboResult = response1;
+            const response1WasExecution = js1.lastId === execId;
+            const loser = response1WasExecution ? delayId : execId;
             if (explicit_close) {
                 js1.close();
                 js2.close();
@@ -1362,7 +1354,7 @@ mod tests {
                 rand2InRange: rand2 >= 1n && rand2 <= 10n,
                 randStrLenOk: randStr.length >= 5 && randStr.length < 10,
                 fiboResult: fiboResult,
-                response1Type: response1.type,
+                response1WasExecution,
                 loser,
                 joinNextTryEmptyErrorCode: tryEmptyErrorCode,
                 joinNextTryPendingIsUndefined: tryPending === undefined
@@ -1518,8 +1510,8 @@ mod tests {
         );
         if activity_should_win {
             assert_eq!(
-                json!("execution"),
-                result["response1Type"],
+                json!(true),
+                result["response1WasExecution"],
                 "first response should be execution"
             );
             assert_eq!(
@@ -1529,8 +1521,8 @@ mod tests {
             );
         } else {
             assert_eq!(
-                json!("delay"),
-                result["response1Type"],
+                json!(false),
+                result["response1WasExecution"],
                 "first response should be delay"
             );
         }
@@ -1754,11 +1746,9 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-param']);
             obelisk.stub(execId, {'ok': 'stubbed-result-42'});
-            const response = js.joinNext();
-            const result = obelisk.getResult(execId);
+            const result = js.joinNext();
             return JSON.stringify({
-                responseType: response.type,
-                responseOk: response.ok,
+                lastId: js.lastId,
                 result: result
             });
         }";
@@ -1769,8 +1759,10 @@ mod tests {
         harness.tick().await; // resume, complete
 
         let result = harness.get_result_json().await;
-        assert_eq!(json!("execution"), result["responseType"]);
-        assert_eq!(json!(true), result["responseOk"]);
+        assert!(
+            result["lastId"].as_str().unwrap().starts_with("E_"),
+            "lastId should be a child execution id, got {result}"
+        );
         assert_eq!(json!("stubbed-result-42"), result["result"]);
         drop(harness);
         db_close.close().await;
@@ -1789,14 +1781,13 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-param']);
             obelisk.stub(execId, {'err': null}); // result<string> has no error type
-            const response = js.joinNext();
             let caughtErr = 'none';
             try {
-                obelisk.getResult(execId);
+                js.joinNext();
             } catch (e) {
                 caughtErr = e.message;
             }
-            return JSON.stringify({ responseOk: response.ok, caughtErr: caughtErr });
+            return JSON.stringify({ lastId: js.lastId, caughtErr: caughtErr });
         }";
 
         let harness =
@@ -1805,7 +1796,10 @@ mod tests {
         harness.tick().await;
 
         let result = harness.get_result_json().await;
-        assert_eq!(json!(false), result["responseOk"]);
+        assert!(
+            result["lastId"].as_str().unwrap().starts_with("E_"),
+            "lastId should be set before throwing child err, got {result}"
+        );
         assert_eq!(json!("child execution failed"), result["caughtErr"]);
         drop(harness);
         db_close.close().await;
@@ -1859,9 +1853,8 @@ mod tests {
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-param']);
             obelisk.stub(execId, {'ok': 'same-value'});
             obelisk.stub(execId, {'ok': 'same-value'}); // same value - should succeed
-            const response = js.joinNext();
-            const result = obelisk.getResult(execId);
-            return JSON.stringify({ responseOk: response.ok, result: result });
+            const result = js.joinNext();
+            return JSON.stringify({ lastId: js.lastId, result: result });
         }";
 
         let harness =
@@ -1870,7 +1863,10 @@ mod tests {
         harness.tick().await;
 
         let result = harness.get_result_json().await;
-        assert_eq!(json!(true), result["responseOk"]);
+        assert!(
+            result["lastId"].as_str().unwrap().starts_with("E_"),
+            "lastId should be a child execution id, got {result}"
+        );
         assert_eq!(json!("same-value"), result["result"]);
         drop(harness);
         db_close.close().await;
@@ -1889,9 +1885,8 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.noret', []);
             obelisk.stub(execId, {'ok': null}); // result has no payload
-            const response = js.joinNext();
-            const result = obelisk.getResult(execId);
-            return JSON.stringify({ responseOk: response.ok, result: result });
+            const result = js.joinNext();
+            return JSON.stringify({ lastId: js.lastId, result: result });
         }";
 
         let harness =
@@ -1900,7 +1895,10 @@ mod tests {
         harness.tick().await;
 
         let result = harness.get_result_json().await;
-        assert_eq!(json!(true), result["responseOk"]);
+        assert!(
+            result["lastId"].as_str().unwrap().starts_with("E_"),
+            "lastId should be a child execution id, got {result}"
+        );
         assert_eq!(json!(null), result["result"]);
         drop(harness);
         db_close.close().await;
@@ -1923,12 +1921,11 @@ mod tests {
                 obelisk.stub(execId, {'ok': 'different-value'}); // must fail
                 return JSON.stringify({ error: 'expected-conflict-but-stub-succeeded' });
             } catch (e) {
-                const response = js.joinNext();
-                const result = obelisk.getResult(execId);
+                const result = js.joinNext();
                 return JSON.stringify({
                     conflictDetected: true,
                     errorMessage: e.message,
-                    responseOk: response.ok,
+                    lastId: js.lastId,
                     result: result
                 });
             }
@@ -1951,7 +1948,10 @@ mod tests {
             error_msg.contains("Conflict"),
             "Expected 'Conflict' in error, got: {error_msg}"
         );
-        assert_eq!(json!(true), result["responseOk"]);
+        assert!(
+            result["lastId"].as_str().unwrap().starts_with("E_"),
+            "lastId should be a child execution id, got {result}"
+        );
         assert_eq!(json!("first-value"), result["result"]);
         drop(harness);
         db_close.close().await;
@@ -2767,9 +2767,7 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
             obelisk.stub(execId, { 'ok': 'stubbed-by-upgrade' });
-            const response = js.joinNext();
-            if (!response.ok) throw 'stub failed';
-            return obelisk.getResult(execId);
+            return js.joinNext();
         }";
 
         let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
@@ -3072,9 +3070,7 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
             obelisk.stub(execId, { 'ok': 'hello' });
-            const response = js.joinNext();
-            if (!response.ok) throw 'stub failed';
-            return obelisk.getResult(execId);
+            return js.joinNext();
         }";
 
         let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");
@@ -3193,9 +3189,7 @@ mod tests {
             const js = obelisk.createJoinSet();
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
             obelisk.stub(execId, { 'ok': 'hello' });
-            const response = js.joinNext();
-            if (!response.ok) throw 'stub failed';
-            return obelisk.getResult(execId);
+            return js.joinNext();
         }";
 
         let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1782,14 +1782,33 @@ mod tests {
             const execId = js.submit('testing:stub-activity/activity.foo', ['test-param']);
             obelisk.stub(execId, {'err': null}); // result<string> has no error type
             let threw = false;
-            let caughtErr = 'unset';
+            let isChildErr = false;
+            let isError = false;
+            let valueIsUndefined = null;
+            let cancelled = null;
+            let failureKind = 'unset';
+            let childId = null;
             try {
                 js.joinNext();
             } catch (e) {
                 threw = true;
-                caughtErr = e;
+                isChildErr = e instanceof obelisk.ChildExecutionError;
+                isError = e instanceof Error;
+                valueIsUndefined = e.value === undefined;
+                cancelled = e.cancelled;
+                failureKind = e.failureKind ?? null;
+                childId = e.childId;
             }
-            return JSON.stringify({ lastId: js.lastId, threw: threw, caughtErr: caughtErr });
+            return JSON.stringify({
+                lastId: js.lastId,
+                threw,
+                isChildErr,
+                isError,
+                valueIsUndefined,
+                cancelled,
+                failureKind,
+                childId,
+            });
         }";
 
         let harness =
@@ -1803,8 +1822,15 @@ mod tests {
             "lastId should be set before throwing child err, got {result}"
         );
         assert_eq!(json!(true), result["threw"]);
-        // result<string> has no err type: unit err throws null, mirroring Ok(None).
-        assert_eq!(json!(null), result["caughtErr"]);
+        // A unit err (result<string> has no err type) throws a ChildExecutionError
+        // (also an Error) whose `.value` is undefined; it is a business err, not a
+        // platform failure, so `.cancelled` is false and `.failureKind` is absent.
+        assert_eq!(json!(true), result["isChildErr"]);
+        assert_eq!(json!(true), result["isError"]);
+        assert_eq!(json!(true), result["valueIsUndefined"]);
+        assert_eq!(json!(false), result["cancelled"]);
+        assert_eq!(json!(null), result["failureKind"]);
+        assert_eq!(result["lastId"], result["childId"]);
         drop(harness);
         db_close.close().await;
     }

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -117,8 +117,8 @@ use boa_common::wasi_job_executor::WasiJobExecutor;
 use boa_engine::class::Class;
 use boa_engine::module::MapModuleLoader;
 use boa_engine::{
-    Context, JsArgs, JsNativeError, JsResult, JsString, JsValue, NativeFunction, Source, js_string,
-    property::Attribute,
+    Context, JsArgs, JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction, Source,
+    js_string, property::Attribute,
 };
 use boa_runtime::extensions::FetchExtension;
 use boa_runtime::fetch::request::JsRequest;
@@ -240,7 +240,7 @@ fn create_direct_call_proxy(
             match webhook_support::call_json(&function, &params_json, Some(&backtrace)) {
                 Ok(Ok(Some(json_str))) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
                 Ok(Ok(None)) => Ok(JsValue::null()),
-                Ok(Err(Some(err_str))) => Err(JsNativeError::error().with_message(err_str).into()),
+                Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
                 Ok(Err(None)) => Err(JsNativeError::error()
                     .with_message("child execution failed")
                     .into()),
@@ -472,11 +472,16 @@ fn unwrap_result(
     match inner_result {
         Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
         Ok(None) => Ok(JsValue::null()),
-        Err(Some(err_str)) => Err(JsNativeError::error().with_message(err_str).into()),
+        Err(Some(err_str)) => throw_json_value(&err_str, ctx),
         Err(None) => Err(JsNativeError::error()
             .with_message("child execution failed")
             .into()),
     }
+}
+
+fn throw_json_value(json_str: &str, ctx: &mut Context) -> JsResult<JsValue> {
+    let value = ctx.eval(Source::from_bytes(&format!("({json_str})")))?;
+    Err(JsError::from_opaque(value))
 }
 
 /// Set up the global `obelisk` object with webhook support functions.
@@ -719,7 +724,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                 Ok(parsed)
             }
             Ok(Ok(None)) => Ok(JsValue::null()),
-            Ok(Err(Some(err_str))) => Err(JsNativeError::error().with_message(err_str).into()),
+            Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
             Ok(Err(None)) => Err(JsNativeError::error()
                 .with_message("child execution failed")
                 .into()),

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -241,9 +241,8 @@ fn create_direct_call_proxy(
                 Ok(Ok(Some(json_str))) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
                 Ok(Ok(None)) => Ok(JsValue::null()),
                 Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-                Ok(Err(None)) => Err(JsNativeError::error()
-                    .with_message("child execution failed")
-                    .into()),
+                // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
+                Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
                 Err(e) => Err(JsNativeError::error()
                     .with_message(format!("call failed: {:?}", e))
                     .into()),
@@ -473,9 +472,8 @@ fn unwrap_result(
         Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
         Ok(None) => Ok(JsValue::null()),
         Err(Some(err_str)) => throw_json_value(&err_str, ctx),
-        Err(None) => Err(JsNativeError::error()
-            .with_message("child execution failed")
-            .into()),
+        // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
+        Err(None) => Err(JsError::from_opaque(JsValue::null())),
     }
 }
 
@@ -725,9 +723,8 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
             }
             Ok(Ok(None)) => Ok(JsValue::null()),
             Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-            Ok(Err(None)) => Err(JsNativeError::error()
-                .with_message("child execution failed")
-                .into()),
+            // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
+            Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("call failed: {:?}", e))
                 .into()),

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -102,11 +102,12 @@
 
 use crate::generated::obelisk::log::log;
 use crate::generated::obelisk::types::backtrace::{FrameInfo, FrameSymbol, WasmBacktrace};
-use crate::generated::obelisk::types::execution::{ExecutionId, Function};
+use crate::generated::obelisk::types::execution::{ExecutionFailureKind, ExecutionId, Function};
 use crate::generated::obelisk::types::time::{Datetime, Duration, ScheduleAt};
 use crate::generated::obelisk::webhook::webhook_support::{
     self, ExecutionStatus, ExecutionStatusFinished,
 };
+use boa_common::child_execution_error::{ChildExecutionErrorParts, make_child_execution_error};
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::crypto::setup_crypto;
 use boa_common::esm::{EsmError, get_default_export, resolve_promise};
@@ -240,9 +241,14 @@ fn create_direct_call_proxy(
             match webhook_support::call_json(&function, &params_json, Some(&backtrace)) {
                 Ok(Ok(Some(json_str))) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
                 Ok(Ok(None)) => Ok(JsValue::null()),
-                Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-                // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
-                Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
+                Ok(Err(payload)) => {
+                    let child = webhook_support::last_direct_call_id();
+                    Err(call_child_error(
+                        child.as_ref().map(|e| e.id.as_str()),
+                        payload,
+                        ctx,
+                    )?)
+                }
                 Err(e) => Err(JsNativeError::error()
                     .with_message(format!("call failed: {:?}", e))
                     .into()),
@@ -461,25 +467,90 @@ fn capture_backtrace(ctx: &Context) -> WasmBacktrace {
     WasmBacktrace { frames }
 }
 
-/// Unwrap a `Result<Option<String>, Option<String>>` into a JS value:
-/// returns the ok value, throws the err value.
-/// Matches the semantics of direct call proxies.
+/// Unwrap a `Result<Option<String>, Option<String>>` from a child outcome into a
+/// JS value: returns the ok value, or throws an [`obelisk.ChildExecutionError`]
+/// built from the given child `exec_id`.
 fn unwrap_result(
     inner_result: Result<Option<String>, Option<String>>,
+    exec_id: &str,
     ctx: &mut Context,
 ) -> JsResult<JsValue> {
     match inner_result {
         Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
         Ok(None) => Ok(JsValue::null()),
-        Err(Some(err_str)) => throw_json_value(&err_str, ctx),
-        // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
-        Err(None) => Err(JsError::from_opaque(JsValue::null())),
+        Err(payload) => Err(child_error(exec_id, payload, ctx)?),
     }
 }
 
-fn throw_json_value(json_str: &str, ctx: &mut Context) -> JsResult<JsValue> {
-    let value = ctx.eval(Source::from_bytes(&format!("({json_str})")))?;
-    Err(JsError::from_opaque(value))
+/// Kebab-case string for a WIT `execution-failure-kind`, used as
+/// `ChildExecutionError.failureKind`.
+fn exec_failure_kind_str(kind: ExecutionFailureKind) -> &'static str {
+    match kind {
+        ExecutionFailureKind::TimedOut => "timed-out",
+        ExecutionFailureKind::NondeterminismDetected => "nondeterminism-detected",
+        ExecutionFailureKind::OutOfFuel => "out-of-fuel",
+        ExecutionFailureKind::Cancelled => "cancelled",
+        ExecutionFailureKind::Uncategorized => "uncategorized",
+    }
+}
+
+/// Build a `ChildExecutionError` for a failed child execution, disambiguating a
+/// business `err` from a platform failure via `get-execution-failure-kind`.
+fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsResult<JsError> {
+    let backtrace = capture_backtrace(ctx);
+    let exec = ExecutionId {
+        id: exec_id.to_string(),
+    };
+    match webhook_support::get_execution_failure_kind(&exec, Some(&backtrace)) {
+        Ok(Some(kind)) => {
+            let cancelled = matches!(kind, ExecutionFailureKind::Cancelled);
+            make_child_execution_error(
+                &ChildExecutionErrorParts {
+                    child_id: Some(exec_id),
+                    delay_id: None,
+                    value_json: None,
+                    failure_kind: Some(exec_failure_kind_str(kind)),
+                    cancelled,
+                },
+                ctx,
+            )
+        }
+        Ok(None) => make_child_execution_error(
+            &ChildExecutionErrorParts {
+                child_id: Some(exec_id),
+                delay_id: None,
+                value_json: payload.as_deref(),
+                failure_kind: None,
+                cancelled: false,
+            },
+            ctx,
+        ),
+        Err(e) => Ok(JsNativeError::error()
+            .with_message(format!("failed to resolve child failure kind: {:?}", e))
+            .into()),
+    }
+}
+
+/// Build a `ChildExecutionError` for a failed direct call (`obelisk.call` / an
+/// import proxy), whose child id comes from `last-direct-call-id`.
+fn call_child_error(
+    child_id: Option<&str>,
+    payload: Option<String>,
+    ctx: &mut Context,
+) -> JsResult<JsError> {
+    match child_id {
+        Some(id) => child_error(id, payload, ctx),
+        None => make_child_execution_error(
+            &ChildExecutionErrorParts {
+                child_id: None,
+                delay_id: None,
+                value_json: payload.as_deref(),
+                failure_kind: None,
+                cancelled: false,
+            },
+            ctx,
+        ),
+    }
 }
 
 /// Set up the global `obelisk` object with webhook support functions.
@@ -652,11 +723,13 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
             .ok_or_else(|| JsNativeError::typ().with_message("executionId must be a string"))?
             .to_std_string_escaped();
 
-        let exec_id = ExecutionId { id: exec_id_str };
+        let exec_id = ExecutionId {
+            id: exec_id_str.clone(),
+        };
 
         let backtrace = capture_backtrace(ctx);
         match webhook_support::get(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => unwrap_result(inner_result, ctx),
+            Ok(inner_result) => unwrap_result(inner_result, &exec_id_str, ctx),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("get failed: {:?}", e))
                 .into()),
@@ -678,11 +751,13 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
             .ok_or_else(|| JsNativeError::typ().with_message("executionId must be a string"))?
             .to_std_string_escaped();
 
-        let exec_id = ExecutionId { id: exec_id_str };
+        let exec_id = ExecutionId {
+            id: exec_id_str.clone(),
+        };
 
         let backtrace = capture_backtrace(ctx);
         match webhook_support::try_get(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => unwrap_result(inner_result, ctx),
+            Ok(inner_result) => unwrap_result(inner_result, &exec_id_str, ctx),
             Err(webhook_support::TryGetError::NotFinishedYet) => Ok(JsValue::undefined()),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("tryGet failed: {:?}", e))
@@ -722,9 +797,14 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                 Ok(parsed)
             }
             Ok(Ok(None)) => Ok(JsValue::null()),
-            Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-            // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
-            Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
+            Ok(Err(payload)) => {
+                let child = webhook_support::last_direct_call_id();
+                Err(call_child_error(
+                    child.as_ref().map(|e| e.id.as_str()),
+                    payload,
+                    ctx,
+                )?)
+            }
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("call failed: {:?}", e))
                 .into()),
@@ -739,6 +819,10 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
 
     // Set obelisk as global
     context.register_global_property(js_string!("obelisk"), obelisk, Attribute::all())?;
+
+    // obelisk.ChildExecutionError — native, brand-safe error thrown for a failed
+    // child execution awaited via obelisk.call / obelisk.get / obelisk.tryGet.
+    boa_common::child_execution_error::register(context)?;
 
     Ok(())
 }

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -129,13 +129,19 @@ use crate::generated::exports::obelisk_workflow::workflow_js_runtime::execute::{
 };
 use crate::generated::obelisk::log::log as obelisk_log;
 use crate::generated::obelisk::types::backtrace::{FrameInfo, FrameSymbol, WasmBacktrace};
-use crate::generated::obelisk::types::execution::{ExecutionId, Function, ResponseId};
+use crate::generated::obelisk::types::execution::{
+    ExecutionFailureKind, ExecutionId, Function, ResponseId,
+};
 use crate::generated::obelisk::types::join_set::JoinSet;
 use crate::generated::obelisk::types::time::{Datetime, Duration, ScheduleAt};
 use crate::generated::obelisk::workflow::workflow_support::{
-    self, JoinNextTryError, call_json, execution_id_generate, get_result_json, join_next,
-    join_next_try, join_set_close, join_set_create, join_set_create_named, random_string,
-    random_u64, random_u64_inclusive, schedule_json, sleep, stub_json, submit_delay, submit_json,
+    self, JoinNextTryError, call_json, execution_id_generate, get_execution_failure_kind,
+    get_result_json, join_next, join_next_try, join_set_close, join_set_create,
+    join_set_create_named, last_direct_call_id, random_string, random_u64, random_u64_inclusive,
+    schedule_json, sleep, stub_json, submit_delay, submit_json,
+};
+use boa_common::child_execution_error::{
+    ChildExecutionError, ChildExecutionErrorParts, make_child_execution_error,
 };
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::helpers::{new_object, parse_ffqn};
@@ -148,7 +154,7 @@ use boa_engine::{
     builtins::promise::PromiseState,
     js_string,
     object::builtins::{JsDate, JsFunction},
-    property::Attribute,
+    property::{Attribute, PropertyDescriptor},
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -281,9 +287,14 @@ fn create_direct_call_proxy(
             match call_json(&function, &params_json, Some(&backtrace)) {
                 Ok(Ok(Some(json_str))) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
                 Ok(Ok(None)) => Ok(JsValue::null()),
-                Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-                // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
-                Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
+                Ok(Err(payload)) => {
+                    let child = last_direct_call_id();
+                    Err(call_child_error(
+                        child.as_ref().map(|e| e.id.as_str()),
+                        payload,
+                        ctx,
+                    )?)
+                }
                 Err(e) => Err(JsNativeError::error()
                     .with_message(format!("call failed: {:?}", e))
                     .into()),
@@ -407,7 +418,8 @@ fn create_ext_await_next_proxy(context: &mut Context) -> JsValue {
         let idx = js_obj.get(js_string!(JOIN_SET_IDX_KEY), ctx)?.to_u32(ctx)? as usize;
 
         let backtrace = capture_backtrace(ctx);
-        // `join-next` now returns the value directly; the id is read via `last-id`.
+        // `join-next` now returns the value directly; the id is read via `last-id`
+        // (exposed to JS through the `lastId` accessor on the join set object).
         let (join_result, last_id) = with_join_set(idx, |js| {
             let result = join_next(js, Some(&backtrace));
             (result, js.last_id())
@@ -416,14 +428,7 @@ fn create_ext_await_next_proxy(context: &mut Context) -> JsValue {
         match join_result {
             Ok(inner_result) => match last_id {
                 Some(ResponseId::ExecutionId(exec_id)) => {
-                    // Store the execution ID on the join set object for later retrieval
-                    js_obj.set(
-                        js_string!("lastId"),
-                        js_string!(exec_id.id.as_str()),
-                        false,
-                        ctx,
-                    )?;
-                    unwrap_result(inner_result, ctx)
+                    unwrap_result(inner_result, exec_id.id.as_str(), ctx)
                 }
                 Some(ResponseId::DelayId(_)) => Err(JsNativeError::error()
                     .with_message("unexpected delay response in awaitNext")
@@ -451,11 +456,13 @@ fn create_ext_get_proxy(context: &mut Context) -> JsValue {
             .ok_or_else(|| JsNativeError::typ().with_message("executionId must be a string"))?
             .to_std_string_escaped();
 
-        let exec_id = ExecutionId { id: exec_id_str };
+        let exec_id = ExecutionId {
+            id: exec_id_str.clone(),
+        };
         let backtrace = capture_backtrace(ctx);
 
         match get_result_json(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => unwrap_result(inner_result, ctx),
+            Ok(inner_result) => unwrap_result(inner_result, &exec_id_str, ctx),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("get result failed: {:?}", e))
                 .into()),
@@ -464,25 +471,118 @@ fn create_ext_get_proxy(context: &mut Context) -> JsValue {
     native.to_js_function(context.realm()).into()
 }
 
-/// Unwrap a `Result<Option<String>, Option<String>>` from `get-result-json-bt`
-/// into a JS value: returns the ok value, throws the err value.
-/// Matches the semantics of direct call proxies.
+/// Unwrap a `Result<Option<String>, Option<String>>` from a child outcome into a
+/// JS value: returns the ok value, or throws an [`obelisk.ChildExecutionError`]
+/// built from the given child `exec_id`.
 fn unwrap_result(
     inner_result: Result<Option<String>, Option<String>>,
+    exec_id: &str,
     ctx: &mut Context,
 ) -> JsResult<JsValue> {
     match inner_result {
         Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
         Ok(None) => Ok(JsValue::null()),
-        Err(Some(err_str)) => throw_json_value(&err_str, ctx),
-        // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
-        Err(None) => Err(JsError::from_opaque(JsValue::null())),
+        Err(payload) => Err(child_error(exec_id, payload, ctx)?),
     }
 }
 
-fn throw_json_value(json_str: &str, ctx: &mut Context) -> JsResult<JsValue> {
-    let value = ctx.eval(Source::from_bytes(&format!("({json_str})")))?;
-    Err(JsError::from_opaque(value))
+/// Kebab-case string for a WIT `execution-failure-kind`, used as
+/// `ChildExecutionError.failureKind`.
+fn exec_failure_kind_str(kind: ExecutionFailureKind) -> &'static str {
+    match kind {
+        ExecutionFailureKind::TimedOut => "timed-out",
+        ExecutionFailureKind::NondeterminismDetected => "nondeterminism-detected",
+        ExecutionFailureKind::OutOfFuel => "out-of-fuel",
+        ExecutionFailureKind::Cancelled => "cancelled",
+        ExecutionFailureKind::Uncategorized => "uncategorized",
+    }
+}
+
+/// Build a `ChildExecutionError` for a failed child execution, disambiguating a
+/// business `err` from a platform failure via `get-execution-failure-kind`.
+fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsResult<JsError> {
+    let backtrace = capture_backtrace(ctx);
+    let exec = ExecutionId {
+        id: exec_id.to_string(),
+    };
+    match get_execution_failure_kind(&exec, Some(&backtrace)) {
+        Ok(Some(kind)) => {
+            let cancelled = matches!(kind, ExecutionFailureKind::Cancelled);
+            make_child_execution_error(
+                &ChildExecutionErrorParts {
+                    child_id: Some(exec_id),
+                    delay_id: None,
+                    value_json: None,
+                    failure_kind: Some(exec_failure_kind_str(kind)),
+                    cancelled,
+                },
+                ctx,
+            )
+        }
+        Ok(None) => make_child_execution_error(
+            &ChildExecutionErrorParts {
+                child_id: Some(exec_id),
+                delay_id: None,
+                value_json: payload.as_deref(),
+                failure_kind: None,
+                cancelled: false,
+            },
+            ctx,
+        ),
+        // Failure kind is unresolvable (e.g. not-yet-processed): surface as a
+        // plain host error rather than a ChildExecutionError.
+        Err(e) => Ok(JsNativeError::error()
+            .with_message(format!("failed to resolve child failure kind: {:?}", e))
+            .into()),
+    }
+}
+
+/// Build a `ChildExecutionError` for a failed direct call (`obelisk.call` / an
+/// import proxy), whose child id comes from `last-direct-call-id`.
+fn call_child_error(
+    child_id: Option<&str>,
+    payload: Option<String>,
+    ctx: &mut Context,
+) -> JsResult<JsError> {
+    match child_id {
+        Some(id) => child_error(id, payload, ctx),
+        None => make_child_execution_error(
+            &ChildExecutionErrorParts {
+                child_id: None,
+                delay_id: None,
+                value_json: payload.as_deref(),
+                failure_kind: None,
+                cancelled: false,
+            },
+            ctx,
+        ),
+    }
+}
+
+/// If `js_err` is a re-thrown [`obelisk.ChildExecutionError`], return its `.value`
+/// (the original business payload). Detection is brand-safe via `downcast_ref` on
+/// the native marker, not by sniffing `.name`/prototype.
+fn child_execution_error_rethrow_value(js_err: &JsError, ctx: &mut Context) -> Option<JsValue> {
+    let obj = js_err.as_opaque()?.as_object()?;
+    if obj.downcast_ref::<ChildExecutionError>().is_some() {
+        obj.get(js_string!("value"), ctx).ok()
+    } else {
+        None
+    }
+}
+
+/// Build a `ChildExecutionError` for a cancelled delay.
+fn delay_cancelled_error(delay_id: &str, ctx: &mut Context) -> JsResult<JsError> {
+    make_child_execution_error(
+        &ChildExecutionErrorParts {
+            child_id: None,
+            delay_id: Some(delay_id),
+            value_json: None,
+            failure_kind: None,
+            cancelled: true,
+        },
+        ctx,
+    )
 }
 
 fn new_join_set_exhausted_error(ctx: &mut Context) -> JsError {
@@ -678,9 +778,24 @@ pub fn execute(
         }
         Err(js_err) => {
             // JSON-encode the thrown value (consistent with ok branch).
+            // A re-thrown `ChildExecutionError` (`throw e`) is transparent: it
+            // re-serializes its `.value`, so it behaves like `throw e.value`.
             // `throw new Error("msg")` → JSON-encode the message string.
             // `throw expr` (null, string, number, object, …) → serialize via to_json.
-            let err_json = if let Ok(native_err) = js_err.try_native(&mut context) {
+            let err_json = if let Some(value) =
+                child_execution_error_rethrow_value(&js_err, &mut context)
+            {
+                match value.to_json(&mut context) {
+                    Ok(Some(json_val)) => serde_json::to_string(&json_val)
+                        .expect("serde_json::Value must be serializable"),
+                    Ok(None) => "null".to_string(), // undefined → null
+                    Err(e) => {
+                        return Err(JsRuntimeError::WrongThrownType(format!(
+                            "cannot serialize re-thrown ChildExecutionError value to JSON: {e:?}"
+                        )));
+                    }
+                }
+            } else if let Ok(native_err) = js_err.try_native(&mut context) {
                 serde_json::to_string(&native_err.message().to_string())
                     .expect("string serialization is infallible")
             } else {
@@ -965,9 +1080,14 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                 Ok(parsed)
             }
             Ok(Ok(None)) => Ok(JsValue::null()),
-            Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-            // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
-            Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
+            Ok(Err(payload)) => {
+                let child = last_direct_call_id();
+                Err(call_child_error(
+                    child.as_ref().map(|e| e.id.as_str()),
+                    payload,
+                    ctx,
+                )?)
+            }
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("call failed: {:?}", e))
                 .into()),
@@ -988,11 +1108,13 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
             .ok_or_else(|| JsNativeError::typ().with_message("executionId must be a string"))?
             .to_std_string_escaped();
 
-        let exec_id = ExecutionId { id: exec_id_str };
+        let exec_id = ExecutionId {
+            id: exec_id_str.clone(),
+        };
         let backtrace = capture_backtrace(ctx);
 
         match get_result_json(&exec_id, Some(&backtrace)) {
-            Ok(inner_result) => unwrap_result(inner_result, ctx),
+            Ok(inner_result) => unwrap_result(inner_result, &exec_id_str, ctx),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("Failed to get result: {:?}", e))
                 .into()),
@@ -1091,6 +1213,10 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         };",
     ))?;
 
+    // obelisk.ChildExecutionError — native, brand-safe error thrown for a failed
+    // awaited child execution or a cancelled delay.
+    boa_common::child_execution_error::register(context)?;
+
     Ok(())
 }
 
@@ -1174,6 +1300,33 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
 
     // Store the ID as a string property
     obj.set(js_string!("__id__"), js_string!(js_id), false, ctx)?;
+
+    // joinSet.lastId — accessor over the WIT `join-set.last-id()`, the single
+    // source of truth for the id of the most recently processed response. Returns
+    // the execution/delay id string, or `undefined` if nothing has been processed
+    // yet or the join set has been closed. `last-id` is a non-logged deterministic
+    // in-memory read, so an accessor is replay-safe.
+    let last_id_getter = NativeFunction::from_fn_ptr(|this, _args, ctx| {
+        let this_obj = this
+            .as_object()
+            .ok_or_else(|| JsNativeError::typ().with_message("this is not an object"))?;
+        let idx = this_obj
+            .get(js_string!(JOIN_SET_IDX_KEY), ctx)?
+            .to_u32(ctx)? as usize;
+        match with_join_set(idx, |js| js.last_id()) {
+            Ok(Some(ResponseId::ExecutionId(exec_id))) => Ok(js_string!(exec_id.id).into()),
+            Ok(Some(ResponseId::DelayId(delay_id))) => Ok(js_string!(delay_id.id).into()),
+            Ok(None) | Err(_) => Ok(JsValue::undefined()),
+        }
+    });
+    obj.define_property_or_throw(
+        js_string!("lastId"),
+        PropertyDescriptor::builder()
+            .maybe_get(Some(last_id_getter.to_js_function(ctx.realm())))
+            .enumerable(true)
+            .configurable(true),
+        ctx,
+    )?;
 
     // joinSet.id()
     let id_fn = NativeFunction::from_fn_ptr(|this, _args, ctx| {
@@ -1277,21 +1430,12 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
         match join_result {
             Ok(inner_result) => match last_id {
                 Some(ResponseId::ExecutionId(exec_id)) => {
-                    this_obj.set(
-                        js_string!("lastId"),
-                        js_string!(exec_id.id.as_str()),
-                        false,
-                        ctx,
-                    )?;
-                    unwrap_result(inner_result, ctx)
+                    unwrap_result(inner_result, exec_id.id.as_str(), ctx)
                 }
-                Some(ResponseId::DelayId(delay_id)) => {
-                    this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
-                    match inner_result {
-                        Ok(_) => Ok(JsValue::null()),
-                        Err(_) => Err(JsNativeError::error().with_message("cancelled").into()),
-                    }
-                }
+                Some(ResponseId::DelayId(delay_id)) => match inner_result {
+                    Ok(_) => Ok(JsValue::null()),
+                    Err(_) => Err(delay_cancelled_error(delay_id.id.as_str(), ctx)?),
+                },
                 None => Err(JsNativeError::error()
                     .with_message("missing last-id after join-next")
                     .into()),
@@ -1324,21 +1468,12 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
         match join_result {
             Ok(inner_result) => match last_id {
                 Some(ResponseId::ExecutionId(exec_id)) => {
-                    this_obj.set(
-                        js_string!("lastId"),
-                        js_string!(exec_id.id.as_str()),
-                        false,
-                        ctx,
-                    )?;
-                    unwrap_result(inner_result, ctx)
+                    unwrap_result(inner_result, exec_id.id.as_str(), ctx)
                 }
-                Some(ResponseId::DelayId(delay_id)) => {
-                    this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
-                    match inner_result {
-                        Ok(_) => Ok(JsValue::null()),
-                        Err(_) => Err(JsNativeError::error().with_message("cancelled").into()),
-                    }
-                }
+                Some(ResponseId::DelayId(delay_id)) => match inner_result {
+                    Ok(_) => Ok(JsValue::null()),
+                    Err(_) => Err(delay_cancelled_error(delay_id.id.as_str(), ctx)?),
+                },
                 None => Err(JsNativeError::error()
                     .with_message("missing last-id after join-next-try")
                     .into()),

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -33,10 +33,10 @@
 //! // Submit a child execution
 //! const execId = js.submit("ns:pkg/ifc.func", [arg1, arg2]);
 //!
-//! // Wait for next result (blocks until a child completes)
-//! const response = js.joinNext();
-//! // response = { type: "execution"|"delay", id: string, ok: boolean }
-//! // js.lastId is also set to the id of the completed child
+//! // Wait for next result (blocks until a child or delay completes)
+//! const result = js.joinNext();
+//! // returns the child ok value, null for a completed delay, or throws on err
+//! // js.lastId is also set to the completed child or delay id
 //!
 //! // Non-blocking variant:
 //! const tryResponse = js.joinNextTry();
@@ -107,8 +107,8 @@
 //! const execId = js.submit("ns:pkg/ifc.slow_task", []);
 //! const delayId = js.submitDelay({ seconds: 30 }); // timeout
 //!
-//! const response = js.joinNext();
-//! if (response.type === "delay") {
+//! const result = js.joinNext();
+//! if (result === null && js.lastId === delayId) {
 //!     // Timeout fired before task completed
 //! } else {
 //!     // Task completed
@@ -281,7 +281,7 @@ fn create_direct_call_proxy(
             match call_json(&function, &params_json, Some(&backtrace)) {
                 Ok(Ok(Some(json_str))) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
                 Ok(Ok(None)) => Ok(JsValue::null()),
-                Ok(Err(Some(err_str))) => Err(JsNativeError::error().with_message(err_str).into()),
+                Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
                 Ok(Err(None)) => Err(JsNativeError::error()
                     .with_message("child execution failed")
                     .into()),
@@ -475,11 +475,16 @@ fn unwrap_result(
     match inner_result {
         Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
         Ok(None) => Ok(JsValue::null()),
-        Err(Some(err_str)) => Err(JsNativeError::error().with_message(err_str).into()),
+        Err(Some(err_str)) => throw_json_value(&err_str, ctx),
         Err(None) => Err(JsNativeError::error()
             .with_message("child execution failed")
             .into()),
     }
+}
+
+fn throw_json_value(json_str: &str, ctx: &mut Context) -> JsResult<JsValue> {
+    let value = ctx.eval(Source::from_bytes(&format!("({json_str})")))?;
+    Err(JsError::from_opaque(value))
 }
 
 fn new_join_set_exhausted_error(ctx: &mut Context) -> JsError {
@@ -962,7 +967,7 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                 Ok(parsed)
             }
             Ok(Ok(None)) => Ok(JsValue::null()),
-            Ok(Err(Some(err_str))) => Err(JsNativeError::error().with_message(err_str).into()),
+            Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
             Ok(Err(None)) => Err(JsNativeError::error()
                 .with_message("child execution failed")
                 .into()),
@@ -1273,44 +1278,28 @@ fn create_join_set_object(js: JoinSet, ctx: &mut Context) -> JsResult<JsValue> {
         })?;
 
         match join_result {
-            Ok(inner_result) => {
-                let result_obj = new_object(ctx);
-                let is_ok = inner_result.is_ok();
-                match last_id {
-                    Some(ResponseId::ExecutionId(exec_id)) => {
-                        result_obj.set(js_string!("type"), js_string!("execution"), false, ctx)?;
-                        result_obj.set(
-                            js_string!("id"),
-                            js_string!(exec_id.id.clone()),
-                            false,
-                            ctx,
-                        )?;
-                        result_obj.set(js_string!("ok"), is_ok, false, ctx)?;
-                        this_obj.set(js_string!("lastId"), js_string!(exec_id.id), false, ctx)?;
-                    }
-                    Some(ResponseId::DelayId(delay_id)) => {
-                        result_obj.set(js_string!("type"), js_string!("delay"), false, ctx)?;
-                        result_obj.set(
-                            js_string!("id"),
-                            js_string!(delay_id.id.clone()),
-                            false,
-                            ctx,
-                        )?;
-                        result_obj.set(js_string!("ok"), is_ok, false, ctx)?;
-                        this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
-                    }
-                    None => {
-                        return Err(JsNativeError::error()
-                            .with_message("missing last-id after join-next")
-                            .into());
+            Ok(inner_result) => match last_id {
+                Some(ResponseId::ExecutionId(exec_id)) => {
+                    this_obj.set(
+                        js_string!("lastId"),
+                        js_string!(exec_id.id.as_str()),
+                        false,
+                        ctx,
+                    )?;
+                    unwrap_result(inner_result, ctx)
+                }
+                Some(ResponseId::DelayId(delay_id)) => {
+                    this_obj.set(js_string!("lastId"), js_string!(delay_id.id), false, ctx)?;
+                    match inner_result {
+                        Ok(_) => Ok(JsValue::null()),
+                        Err(_) => Err(JsNativeError::error().with_message("cancelled").into()),
                     }
                 }
-
-                Ok(result_obj.into())
-            }
-            Err(_) => Err(JsNativeError::error()
-                .with_message("JoinSetEmpty: all responses processed")
-                .into()),
+                None => Err(JsNativeError::error()
+                    .with_message("missing last-id after join-next")
+                    .into()),
+            },
+            Err(_) => Err(new_join_set_exhausted_error(ctx)),
         }
     });
     obj.set(

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -282,9 +282,8 @@ fn create_direct_call_proxy(
                 Ok(Ok(Some(json_str))) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
                 Ok(Ok(None)) => Ok(JsValue::null()),
                 Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-                Ok(Err(None)) => Err(JsNativeError::error()
-                    .with_message("child execution failed")
-                    .into()),
+                // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
+                Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
                 Err(e) => Err(JsNativeError::error()
                     .with_message(format!("call failed: {:?}", e))
                     .into()),
@@ -476,9 +475,8 @@ fn unwrap_result(
         Ok(Some(json_str)) => ctx.eval(Source::from_bytes(&format!("({})", json_str))),
         Ok(None) => Ok(JsValue::null()),
         Err(Some(err_str)) => throw_json_value(&err_str, ctx),
-        Err(None) => Err(JsNativeError::error()
-            .with_message("child execution failed")
-            .into()),
+        // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
+        Err(None) => Err(JsError::from_opaque(JsValue::null())),
     }
 }
 
@@ -968,9 +966,8 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
             }
             Ok(Ok(None)) => Ok(JsValue::null()),
             Ok(Err(Some(err_str))) => throw_json_value(&err_str, ctx),
-            Ok(Err(None)) => Err(JsNativeError::error()
-                .with_message("child execution failed")
-                .into()),
+            // Unit err (result<T> or execution failure with no err type): throw null, mirroring Ok(None).
+            Ok(Err(None)) => Err(JsError::from_opaque(JsValue::null())),
             Err(e) => Err(JsNativeError::error()
                 .with_message(format!("call failed: {:?}", e))
                 .into()),

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -393,6 +393,22 @@ params = [
 return_type = "result<string, string>"
 
 [[workflow_js]]
+name = "test_rethrow_child_error_workflow"
+location = "{ws}/crates/testing/test-programs/js/workflow/rethrow_child_error.js"
+ffqn = "testing:integration/workflow-rethrow-child-error.rethrow-child-error"
+params = [
+  {{ name = "id", type = "u64" }},
+]
+return_type = "result<string, string>"
+
+[[workflow_js]]
+name = "test_cancel_child_error_workflow"
+location = "{ws}/crates/testing/test-programs/js/workflow/cancel_child_error.js"
+ffqn = "testing:integration/workflow-cancel-child-error.cancel-child-error"
+params = []
+return_type = "result<string, string>"
+
+[[workflow_js]]
 name = "test_math_random_workflow"
 location = "{ws}/crates/testing/test-programs/js/workflow/math_random.js"
 ffqn = "testing:integration/workflow-math-random.math-random"
@@ -1599,6 +1615,30 @@ impl TestServer {
             .unwrap();
         pool.close().await;
         parent_id
+    }
+
+    /// Cancel an execution out-of-band via gRPC, retrying until it exists and the
+    /// request is accepted (a parent submits its child lazily while running).
+    async fn cancel_execution_with_retries(&self, execution_id: &str) {
+        let mut grpc_client =
+            ExecutionRepositoryClient::connect(format!("http://{}", self.api_addr()))
+                .await
+                .unwrap();
+        for _ in 0..200 {
+            if let Ok(resp) = grpc_client
+                .cancel_execution(CancelExecutionRequest {
+                    execution_id: Some(GrpcExecutionId {
+                        id: execution_id.to_string(),
+                    }),
+                })
+                .await
+                && resp.into_inner().outcome() == CancelExecutionOutcome::CancellationRequested
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("execution {execution_id} was never cancellable");
     }
 
     async fn step_execution_until_finished_grpc(
@@ -3310,6 +3350,62 @@ async fn submit_workflow_with_join_next_try_semantics() {
     assert_eq!(resp.status().as_u16(), 201);
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body, json!({ "ok": "stub-ok" }));
+
+    server.shutdown().await;
+}
+
+/// A caught `ChildExecutionError` re-thrown with `throw e` transparently
+/// reproduces the child's original err payload as the workflow's err.
+#[tokio::test]
+async fn submit_workflow_rethrows_child_execution_error() {
+    let server = TestServer::start(test_addr!(87)).await;
+    let resp = server
+        .submit_follow(
+            "testing:integration/workflow-rethrow-child-error.rethrow-child-error",
+            vec![json!(7u64)],
+        )
+        .await;
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body, json!({ "err": "boom" }));
+
+    server.shutdown().await;
+}
+
+/// A child execution cancelled out-of-band surfaces to an awaiting JS parent as a
+/// `ChildExecutionError` with `.cancelled === true` and `.failureKind === "cancelled"`
+/// (a platform failure with no err payload), not as a business err value.
+#[tokio::test]
+async fn submit_workflow_child_cancelled_surfaces_child_execution_error() {
+    use concepts::{ExecutionId, JoinSetId, JoinSetKind, StrVariant};
+
+    let server = TestServer::start(test_addr!(88)).await;
+    let parent_id = server.generate_execution_id().await;
+
+    // The child id is deterministic either way, but the parent's named join set makes it
+    // a well-known string (first child of `n:cancel-set`) we can reconstruct here instead
+    // of replaying the parent's generated join-set id.
+    let join_set_id = JoinSetId::new(JoinSetKind::Named, StrVariant::from("cancel-set")).unwrap();
+    let child_id = ExecutionId::Derived(
+        parent_id
+            .parse::<ExecutionId>()
+            .unwrap()
+            .next_level(&join_set_id),
+    )
+    .to_string();
+
+    // Cancel concurrently with the follow so the parent is still blocked on joinNext.
+    let follow = server.submit_follow_with_id(
+        &parent_id,
+        "testing:integration/workflow-cancel-child-error.cancel-child-error",
+        vec![],
+    );
+    let cancel = server.cancel_execution_with_retries(&child_id);
+    let (resp, ()) = tokio::join!(follow, cancel);
+
+    assert_eq!(resp.status().as_u16(), 201);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body, json!({ "ok": "cancelled-child-observed" }));
 
     server.shutdown().await;
 }

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -286,6 +286,13 @@ expression: components
   {
     "component_id": {
       "component_type": "workflow",
+      "name": "test_cancel_child_error_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
       "name": "test_date_now_workflow",
       "component_digest": "sha256:<REDACTED>"
     }
@@ -343,6 +350,13 @@ expression: components
     "component_id": {
       "component_type": "workflow",
       "name": "test_math_random_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_rethrow_child_error_workflow",
       "component_digest": "sha256:<REDACTED>"
     }
   },

--- a/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
@@ -115,6 +115,12 @@ expression: functions
     "ffqn": "testing:integration/workflow-join-next-try-semantics.join-next-try-semantics"
   },
   {
+    "ffqn": "testing:integration/workflow-rethrow-child-error.rethrow-child-error"
+  },
+  {
+    "ffqn": "testing:integration/workflow-cancel-child-error.cancel-child-error"
+  },
+  {
     "ffqn": "testing:integration/workflow-math-random.math-random"
   },
   {


### PR DESCRIPTION
- **feat(js): Unify `joinNext` with `joinNextTry` and other throwing fns**
- **feat(js): throw null for unit child err, mirroring Ok(None)**
- **feat(js): wrap awaited-child failures in obelisk.ChildExecutionError**
