### PR TITLE
feat(server,api)!: Gate exec activities behind a server.toml flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(server)* Gate `activity_exec` behind a new `allow_exec_activities` server.toml flag (default disabled), since exec
+  activities run host processes outside the WASM sandbox. Deployments that declare exec activities fail verification
+  unless the operator enables the flag (or `OBELISK__ALLOW_EXEC_ACTIVITIES=true`)
+
+### Changed
+
+- **Breaking:** *(api)* Renamed the runtime-config availability policy from "missing" to "unavailable" so it also covers
+  server capabilities (such as exec activities), not only environment variables and secrets. The CLI flag
+  `--allow-missing-runtime-config` (and `server verify --ignore-missing-env-vars`) is now
+  `--allow-unavailable-runtime-config`, the REST field `allow_missing_runtime_config` is now
+  `allow_unavailable_runtime_config`, and the gRPC enum value `RUNTIME_CONFIG_CHECK_ALLOW_MISSING` is now
+  `RUNTIME_CONFIG_CHECK_ALLOW_UNAVAILABLE` (numeric tag `2` is unchanged, so the gRPC wire format is compatible). The REST
+  field keeps a serde alias for `allow_missing_runtime_config`, so 0.39.x HTTP clients keep working for now
+
 ## [0.39.5](https://github.com/obeli-sk/obelisk/compare/v0.39.4...v0.39.5)
 
 This release introduces execution cancellation, enforcing the structured-concurrency guarantee that a

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -87,9 +87,9 @@
               }
             },
             {
-              "name": "--ignore-missing-env-vars",
-              "short": "i",
-              "help": "Skip the check that every environment variable referenced by the deployment is set"
+              "name": "--allow-unavailable-runtime-config",
+              "short": "a",
+              "help": "Tolerate runtime requirements unavailable on this server while verifying"
             },
             {
               "name": "--suppress-type-checking-errors",
@@ -637,8 +637,8 @@
               "help": "Submit an empty deployment with no components"
             },
             {
-              "name": "--allow-missing-runtime-config",
-              "help": "Tolerate missing environment variables / secrets while verifying the deployment before persisting it (default: missing config fails)"
+              "name": "--allow-unavailable-runtime-config",
+              "help": "Tolerate runtime requirements unavailable on this server while verifying the deployment before persisting it"
             },
             {
               "name": "--description",
@@ -673,8 +673,8 @@
               "help": "Enqueue an empty deployment with no components"
             },
             {
-              "name": "--allow-missing-runtime-config",
-              "help": "Tolerate missing environment variables / secrets while verifying the deployment before enqueuing it (default: missing config fails)"
+              "name": "--allow-unavailable-runtime-config",
+              "help": "Tolerate runtime requirements unavailable on this server while verifying the deployment before enqueuing it"
             },
             {
               "name": "--description",

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -2205,9 +2205,9 @@
           "deployment_toml"
         ],
         "properties": {
-          "allow_missing_runtime_config": {
+          "allow_unavailable_runtime_config": {
             "type": "boolean",
-            "description": "Tolerate missing environment variables / secrets while verifying the\ndeployment before persisting it. Defaults to strict (missing config fails)."
+            "description": "Tolerate runtime requirements unavailable on this server while verifying\nthe deployment before persisting it."
           },
           "deployment_id": {
             "type": [
@@ -2244,9 +2244,9 @@
         "type": "object",
         "description": "Request payload for switching deployment",
         "properties": {
-          "allow_missing_runtime_config": {
+          "allow_unavailable_runtime_config": {
             "type": "boolean",
-            "description": "Tolerate missing environment variables / secrets while verifying. Rejected\nfor a hot redeploy, which requires all runtime config to be available."
+            "description": "Tolerate runtime requirements unavailable on this server while verifying.\nRejected for a hot redeploy."
           },
           "hot_redeploy": {
             "type": "boolean",

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -10,6 +10,11 @@
       ],
       "default": null
     },
+    "allow_exec_activities": {
+      "description": "Permit deployments to run host processes through `activity_exec`.",
+      "type": "boolean",
+      "default": false
+    },
     "api": {
       "$ref": "#/$defs/ApiConfig"
     },

--- a/obelisk-help-server.toml
+++ b/obelisk-help-server.toml
@@ -13,6 +13,9 @@
 ## If set, the server will fail to start if the binary version doesn't match.
 # obelisk-version = 0.1
 
+## Exec activities run host processes outside the WASM sandbox and are disabled by default.
+# allow_exec_activities = true
+
 ## SQLite configuration (enabled by default)
 # database.sqlite.directory = "${DATA_DIR}/obelisk-sqlite" # Path to sqlite directory. Supports path prefixes.
 ## Customize PRAGMA statements.

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -1157,8 +1157,8 @@ message GetCurrentDeploymentIdResponse {
     DeploymentId deployment_id = 1;
 }
 
-// Policy for runtime configuration (environment variables and secrets) that a
-// deployment references but that may be absent from the server's environment.
+// Policy for runtime requirements that may be unavailable on the current server,
+// including environment variables, secrets, and server capabilities.
 // Structural, file, compile, and link validation are always performed regardless
 // of this value.
 enum RuntimeConfigCheck {
@@ -1166,14 +1166,14 @@ enum RuntimeConfigCheck {
     RUNTIME_CONFIG_CHECK_UNSPECIFIED = 0;
     // Missing environment variables or secrets fail the operation.
     RUNTIME_CONFIG_CHECK_STRICT = 1;
-    // Missing environment variables or secrets are tolerated.
-    RUNTIME_CONFIG_CHECK_ALLOW_MISSING = 2;
+    // Unavailable environment variables, secrets, or server capabilities are tolerated.
+    RUNTIME_CONFIG_CHECK_ALLOW_UNAVAILABLE = 2;
 }
 
 message SwitchDeploymentRequest {
     DeploymentId deployment_id = 1;
     // Runtime config availability policy applied while verifying the deployment.
-    // A hot redeploy rejects RUNTIME_CONFIG_CHECK_ALLOW_MISSING.
+    // A hot redeploy rejects RUNTIME_CONFIG_CHECK_ALLOW_UNAVAILABLE.
     RuntimeConfigCheck runtime_config_check = 2;
     // Perform a hot redeployment (reload running components without restart).
     bool hot_redeploy = 3;

--- a/src/args.rs
+++ b/src/args.rs
@@ -102,10 +102,10 @@ pub(crate) enum Deployment {
         /// Submit an empty deployment with no components.
         #[arg(long)]
         empty: bool,
-        /// Tolerate missing environment variables / secrets while verifying the
-        /// deployment before persisting it (default: missing config fails).
+        /// Tolerate runtime requirements unavailable on this server while verifying
+        /// the deployment before persisting it.
         #[arg(long)]
-        allow_missing_runtime_config: bool,
+        allow_unavailable_runtime_config: bool,
         /// Optional human-readable description.
         #[arg(long)]
         description: Option<String>,
@@ -132,10 +132,10 @@ pub(crate) enum Deployment {
         /// Enqueue an empty deployment with no components.
         #[arg(long)]
         empty: bool,
-        /// Tolerate missing environment variables / secrets while verifying the
-        /// deployment before enqueuing it (default: missing config fails).
+        /// Tolerate runtime requirements unavailable on this server while verifying
+        /// the deployment before enqueuing it.
         #[arg(long)]
-        allow_missing_runtime_config: bool,
+        allow_unavailable_runtime_config: bool,
         /// Optional human-readable description for a newly submitted deployment.
         #[arg(long)]
         description: Option<String>,
@@ -427,9 +427,9 @@ pub(crate) enum Server {
         /// falling back to the Active deployment. Errors if neither is found.
         #[arg(short, long)]
         deployment: Option<PathBuf>,
-        /// Skip the check that every environment variable referenced by the deployment is set.
+        /// Tolerate runtime requirements unavailable on this server while verifying.
         #[arg(long, short)]
-        ignore_missing_env_vars: bool,
+        allow_unavailable_runtime_config: bool,
         /// Do not fail when a component's imports/exports fail type checking against the deployment.
         #[arg(long, short)]
         suppress_type_checking_errors: bool,

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -12,10 +12,10 @@ use grpc::to_channel;
 use std::path::PathBuf;
 use tonic::transport::Channel;
 
-/// Map the CLI `--allow-missing-runtime-config` flag to the wire enum.
-fn runtime_config_check_from_bool(allow_missing: bool) -> grpc_gen::RuntimeConfigCheck {
-    if allow_missing {
-        grpc_gen::RuntimeConfigCheck::AllowMissing
+/// Map the CLI `--allow-unavailable-runtime-config` flag to the wire enum.
+fn runtime_config_check_from_bool(allow_unavailable: bool) -> grpc_gen::RuntimeConfigCheck {
+    if allow_unavailable {
+        grpc_gen::RuntimeConfigCheck::AllowUnavailable
     } else {
         grpc_gen::RuntimeConfigCheck::Strict
     }
@@ -27,7 +27,7 @@ impl args::Deployment {
             args::Deployment::Submit {
                 file,
                 empty,
-                allow_missing_runtime_config,
+                allow_unavailable_runtime_config,
                 description,
                 deployment_id,
                 api_url,
@@ -38,7 +38,7 @@ impl args::Deployment {
                 let id = upload_and_submit_manifest(
                     &mut client,
                     prepared,
-                    runtime_config_check_from_bool(allow_missing_runtime_config),
+                    runtime_config_check_from_bool(allow_unavailable_runtime_config),
                     description,
                     deployment_id,
                 )
@@ -50,13 +50,13 @@ impl args::Deployment {
             args::Deployment::Enqueue {
                 source,
                 empty,
-                allow_missing_runtime_config,
+                allow_unavailable_runtime_config,
                 description,
                 deployment_id,
                 api_url,
             } => {
                 let runtime_config_check =
-                    runtime_config_check_from_bool(allow_missing_runtime_config);
+                    runtime_config_check_from_bool(allow_unavailable_runtime_config);
                 let channel = to_channel(&api_url).await?;
                 let mut client = get_deployment_repository_client(channel).await?;
                 let id = submit_deployment(

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -1,8 +1,8 @@
 use crate::args::Generate;
 use crate::args::shadow::PKG_VERSION;
 use crate::command::server::{
-    PrepareDirsParams, VerifyParams, create_engines, deployment_compile_link,
-    deployment_verify_config, prepare_dirs, server_verify,
+    PrepareDirsParams, RuntimeConfigAvailability, VerifyParams, create_engines,
+    deployment_compile_link, deployment_verify_config, prepare_dirs, server_verify,
 };
 use crate::command::termination_notifier::termination_notifier;
 use crate::config::config_holder::{ConfigHolder, load_deployment_validated};
@@ -598,7 +598,7 @@ async fn generate_wit_deps(
             clean_cache: false,
             clean_codegen_cache: false,
         },
-        ignore_missing_env_vars: true,
+        runtime_config_availability: RuntimeConfigAvailability::AllowUnavailable, // Just extracting WITs, not running components
         suppress_type_checking_errors: true, // Just extracting WITs, not running components
         suppress_linking_errors: true,       // Just extracting WITs, not running components
     };

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -159,6 +159,7 @@ fn write_test_configs(ip: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
     copy_dir_recursive(&fixture_src.join("exec"), &fixture_dst.join("exec"));
     let server_contents = format!(
         r#"api.listening_addr = "{ip}:{API_PORT}"
+allow_exec_activities = true
 webui.enabled = false
 external.listening_addr = "{ip}:{WEBHOOK_PORT}"
 
@@ -674,7 +675,10 @@ impl TestServer {
         let (termination_sender, termination_watcher) = watch::channel(());
 
         let params = RunParams {
-            dir_params: PrepareDirsParams::default(),
+            dir_params: PrepareDirsParams {
+                clean_cache: false,
+                clean_codegen_cache: false,
+            },
             clean_sqlite_directory: false,
             suppress_type_checking_errors: false,
         };
@@ -2231,8 +2235,8 @@ ffqn = "testing:integration/deferred.run"
 }
 
 /// Phase 5: `RuntimeConfigCheck` governs whether missing env vars / secrets fail
-/// verification. Submit is strict by default and tolerant under `ALLOW_MISSING`; a
-/// hot redeploy is always strict and rejects `ALLOW_MISSING` outright.
+/// verification. Submit is strict by default and tolerant under `ALLOW_UNAVAILABLE`; a
+/// hot redeploy is always strict and rejects `ALLOW_UNAVAILABLE` outright.
 #[tokio::test]
 async fn submit_runtime_config_check_grpc() {
     let server = TestServer::start(test_addr!(79)).await;
@@ -2281,8 +2285,8 @@ env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
         status.message()
     );
 
-    // ALLOW_MISSING submit tolerates the missing env var and persists.
-    let stored_id = submit(RuntimeConfigCheck::AllowMissing, None)
+    // ALLOW_UNAVAILABLE submit tolerates the missing env var and persists.
+    let stored_id = submit(RuntimeConfigCheck::AllowUnavailable, None)
         .await
         .expect("allow-missing submit must persist")
         .into_inner()
@@ -2291,18 +2295,18 @@ env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
         .id;
     let stored_grpc_id = GrpcDeploymentId { id: stored_id };
 
-    // A hot redeploy with ALLOW_MISSING is rejected outright.
+    // A hot redeploy with ALLOW_UNAVAILABLE is rejected outright.
     let status = grpc_client
         .clone()
         .switch_deployment(SwitchDeploymentRequest {
             deployment_id: Some(stored_grpc_id.clone()),
-            runtime_config_check: RuntimeConfigCheck::AllowMissing as i32,
+            runtime_config_check: RuntimeConfigCheck::AllowUnavailable as i32,
             hot_redeploy: true,
         })
         .await
-        .expect_err("hot redeploy must reject allow-missing-runtime-config");
+        .expect_err("hot redeploy must reject allow-unavailable-runtime-config");
     assert_eq!(
-        "argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_MISSING` cannot be used with `hot_redeploy = true`",
+        "argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_UNAVAILABLE` cannot be used with `hot_redeploy = true`",
         status.message()
     );
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -432,7 +432,7 @@ impl Server {
                 clean_codegen_cache,
                 server_config,
                 deployment,
-                ignore_missing_env_vars,
+                allow_unavailable_runtime_config,
                 suppress_type_checking_errors,
                 skip_db,
             } => {
@@ -446,7 +446,11 @@ impl Server {
                             clean_cache,
                             clean_codegen_cache,
                         },
-                        ignore_missing_env_vars,
+                        runtime_config_availability: if allow_unavailable_runtime_config {
+                            RuntimeConfigAvailability::AllowUnavailable
+                        } else {
+                            RuntimeConfigAvailability::Strict
+                        },
                         suppress_type_checking_errors,
                         suppress_linking_errors: false,
                     },
@@ -661,10 +665,28 @@ pub(crate) async fn run(
     Ok(())
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeConfigAvailability {
+    Strict,
+    AllowUnavailable,
+}
+impl RuntimeConfigAvailability {
+    fn allows_unavailable(self) -> bool {
+        self == Self::AllowUnavailable
+    }
+
+    fn assert_strict(self) {
+        assert!(
+            self == Self::Strict,
+            "cannot activate a deployment verified with unavailable runtime config allowed"
+        );
+    }
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct VerifyParams {
     pub(crate) dir_params: PrepareDirsParams,
-    pub(crate) ignore_missing_env_vars: bool,
+    pub(crate) runtime_config_availability: RuntimeConfigAvailability,
     pub(crate) suppress_type_checking_errors: bool,
     pub(crate) suppress_linking_errors: bool,
 }
@@ -788,7 +810,7 @@ async fn verify_db_schema(
     Ok(result)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct PrepareDirsParams {
     pub(crate) clean_cache: bool,
     pub(crate) clean_codegen_cache: bool,
@@ -938,6 +960,22 @@ pub(crate) async fn deployment_verify_config(
     params: VerifyParams,
     termination_watcher: &mut watch::Receiver<()>,
 ) -> Result<DeploymentVerified, anyhow::Error> {
+    if !server_verified.allow_exec_activities
+        && !params.runtime_config_availability.allows_unavailable()
+        && !deployment.activities_exec.is_empty()
+    {
+        let component_names = deployment
+            .activities_exec
+            .iter()
+            .map(|activity| activity.name.to_string())
+            .collect::<Vec<_>>()
+            .join("`, `");
+        bail!(
+            "deployment contains exec activities (`{component_names}`), which run outside the \
+             WASM sandbox; enable them with `allow_exec_activities = true` in server.toml or \
+             `OBELISK__ALLOW_EXEC_ACTIVITIES=true`"
+        );
+    }
     // Materialize deployment-owned WASM blobs from the CAS onto disk before compiling.
     let deployment =
         DeploymentRunnable::resolve(deployment, cas.as_deref(), &prepared_dirs.wasm_cache_dir)
@@ -947,7 +985,7 @@ pub(crate) async fn deployment_verify_config(
         server_verified.http_servers.clone(),
         prepared_dirs.wasm_cache_dir.clone(),
         prepared_dirs.metadata_dir.clone(),
-        params.ignore_missing_env_vars,
+        params.runtime_config_availability,
         server_verified.global_backtrace_persist,
         server_verified.global_executor_instance_limiter.clone(),
         server_verified.fuel,
@@ -1488,7 +1526,7 @@ pub(crate) async fn run_internal(
                 clean_cache: params.dir_params.clean_cache,
                 clean_codegen_cache: params.dir_params.clean_codegen_cache,
             },
-            ignore_missing_env_vars: false,
+            runtime_config_availability: RuntimeConfigAvailability::Strict,
             suppress_type_checking_errors: params.suppress_type_checking_errors,
             suppress_linking_errors: false,
         },
@@ -1671,6 +1709,7 @@ fn make_span<B>(request: &axum::http::Request<B>) -> Span {
 #[derive(Clone)]
 pub(crate) struct ServerVerified {
     launch: ServerVerifiedLaunch,
+    allow_exec_activities: bool,
     http_servers: Vec<HttpServer>,
     fuel: Option<u64>,
     global_backtrace_persist: bool,
@@ -1731,6 +1770,7 @@ impl ServerVerified {
                 build_semaphore,
                 workflows_lock_extension_leeway,
             },
+            allow_exec_activities: config.allow_exec_activities,
             http_servers,
             fuel,
             global_backtrace_persist,
@@ -1756,6 +1796,7 @@ pub(crate) type HttpServersToWebhooksAndState = Vec<(
 )>;
 
 pub(crate) struct ServerCompiledLinked {
+    runtime_config_availability: RuntimeConfigAvailability,
     engines: Engines,
     pub(crate) component_registry_ro: ComponentConfigRegistryRO,
     pub(crate) workers_linked: Vec<WorkerLinked>,
@@ -1775,6 +1816,7 @@ impl ServerCompiledLinked {
     ) -> Result<Self, anyhow::Error> {
         trace!("Verified deployment: {deployment_verified:#?}");
         let DeploymentVerified {
+            runtime_config_availability,
             activities_wasm,
             activities_js,
             activities_exec,
@@ -1843,6 +1885,7 @@ impl ServerCompiledLinked {
         );
 
         Ok(ServerCompiledLinked {
+            runtime_config_availability,
             workers_linked: linked.workers,
             component_registry_ro: linked.component_registry_ro,
             engines: server_verified.engines,
@@ -2294,7 +2337,7 @@ pub(crate) async fn submit_deployment(
                 clean_cache: false,
                 clean_codegen_cache: false,
             },
-            ignore_missing_env_vars: runtime_config_check.ignore_missing_env_vars(),
+            runtime_config_availability: runtime_config_check.availability(),
             suppress_type_checking_errors: false,
             suppress_linking_errors: false,
         },
@@ -2338,10 +2381,10 @@ pub(crate) async fn submit_deployment(
     upsert_backtrace_sources(conn.as_ref(), cas.as_ref(), &compiled_linked).await;
 
     // Only cache strict-verified artifacts. A hot redeploy is always strict, so an
-    // artifact compiled while tolerating missing env vars (AllowMissing) must not be
+    // artifact compiled while tolerating unavailable runtime config must not be
     // reused to satisfy a later strict switch; a strict artifact satisfies any consumer.
     if let Some(manager) = deployment_switch_manager
-        && !runtime_config_check.ignore_missing_env_vars()
+        && runtime_config_check.availability() == RuntimeConfigAvailability::Strict
     {
         manager
             .store_latest_prepared(PreparedDeploymentSwitch {
@@ -2386,19 +2429,21 @@ impl From<anyhow::Error> for SwitchError {
     }
 }
 
-/// Policy for runtime configuration (environment variables and secrets) that a
-/// deployment references but that may be absent from the server's environment.
+/// Policy for runtime requirements that may be unavailable on the current server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum RuntimeConfigCheck {
     /// Missing environment variables or secrets fail the operation.
     #[default]
     Strict,
-    /// Missing environment variables or secrets are tolerated.
-    AllowMissing,
+    /// Unavailable environment variables, secrets, or server capabilities are tolerated.
+    AllowUnavailable,
 }
 impl RuntimeConfigCheck {
-    fn ignore_missing_env_vars(self) -> bool {
-        self == RuntimeConfigCheck::AllowMissing
+    fn availability(self) -> RuntimeConfigAvailability {
+        match self {
+            Self::Strict => RuntimeConfigAvailability::Strict,
+            Self::AllowUnavailable => RuntimeConfigAvailability::AllowUnavailable,
+        }
     }
 }
 
@@ -2408,10 +2453,10 @@ pub(crate) enum SwitchDeploymentAction {
     Enqueue(RuntimeConfigCheck),
 }
 impl SwitchDeploymentAction {
-    fn ignore_missing_env_vars(self) -> bool {
+    fn runtime_config_availability(self) -> RuntimeConfigAvailability {
         match self {
-            SwitchDeploymentAction::Enqueue(check) => check.ignore_missing_env_vars(),
-            SwitchDeploymentAction::Activate => false,
+            SwitchDeploymentAction::Enqueue(check) => check.availability(),
+            SwitchDeploymentAction::Activate => RuntimeConfigAvailability::Strict,
         }
     }
 }
@@ -2575,7 +2620,7 @@ async fn prepare_switch_deployment(
             clean_cache: false,
             clean_codegen_cache: false,
         },
-        ignore_missing_env_vars: action.ignore_missing_env_vars(),
+        runtime_config_availability: action.runtime_config_availability(),
         suppress_type_checking_errors: false,
         suppress_linking_errors: false,
     };
@@ -2646,6 +2691,9 @@ async fn switch_hot_redeploy(
     cancel_registry: CancelRegistry,
     log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
 ) -> Result<SwitchOutcome, SwitchError> {
+    server_compiled_linked
+        .runtime_config_availability
+        .assert_strict();
     let mut write_guard_ctx = deployment_ctx.write().await;
     if write_guard_ctx.closed {
         return Err(SwitchError::Other(anyhow::anyhow!(
@@ -2753,6 +2801,9 @@ async fn spawn_tasks_and_threads(
     termination_watcher: &watch::Receiver<()>,
     prepared_dirs: PreparedDirs,
 ) -> Result<ServerInit, anyhow::Error> {
+    server_compiled_linked
+        .runtime_config_availability
+        .assert_strict();
     upsert_backtrace_sources(
         db_pool.external_api_conn().await?.as_ref(),
         db_pool.cas_conn().await?.as_ref(),
@@ -3014,6 +3065,7 @@ async fn start_http_servers(
 
 #[derive(Debug)]
 pub(crate) struct DeploymentVerified {
+    runtime_config_availability: RuntimeConfigAvailability, // Allows asserting strictness on startup and hot redeploy.
     activities_wasm: Vec<ActivityWasmConfigVerified>,
     activities_js: Vec<ActivityJsConfigVerified>,
     activities_exec: Vec<ActivityExecConfigVerified>,
@@ -3148,7 +3200,7 @@ impl DeploymentVerified {
         http_servers: Vec<webhook::HttpServer>,
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
-        ignore_missing_env_vars: bool,
+        runtime_config_availability: RuntimeConfigAvailability,
         global_backtrace_persist: bool,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -3156,6 +3208,7 @@ impl DeploymentVerified {
         subscription_interruption: Option<Duration>,
         api_addr_if_webui_enabled: Option<String>,
     ) -> Result<DeploymentVerified, anyhow::Error> {
+        let ignore_missing_env_vars = runtime_config_availability.allows_unavailable();
         let mut deployment = deployment.into_canonical();
         trace!("Using deployment toml: {deployment:#?}");
         // Check uniqueness of http_server names.
@@ -3477,6 +3530,7 @@ impl DeploymentVerified {
                 }
 
                 let deployment_verified = DeploymentVerified {
+                    runtime_config_availability,
                     activities_wasm,
                     activities_js: activities_js_verified,
                     activities_exec: activities_exec_verified,
@@ -4773,9 +4827,9 @@ pub(crate) fn gen_trace_id() -> String {
 mod tests {
     use crate::{
         command::server::{
-            DeploymentRunnable, DeploymentVerified, PrepareDirsParams, ServerCompiledLinked,
-            ServerVerified, VerifyParams, compile_activity_inline, create_engines,
-            deployment_verify_config, prepare_dirs,
+            DeploymentRunnable, DeploymentVerified, PrepareDirsParams, RuntimeConfigAvailability,
+            ServerCompiledLinked, ServerVerified, VerifyParams, compile_activity_inline,
+            create_engines, deployment_verify_config, prepare_dirs,
         },
         config::config_holder::{ConfigHolder, load_deployment_canonical},
     };
@@ -4859,7 +4913,10 @@ mod tests {
 
         let prepared_dirs = prepare_dirs(
             &config,
-            &PrepareDirsParams::default(),
+            &PrepareDirsParams {
+                clean_cache: false,
+                clean_codegen_cache: false,
+            },
             &config_holder.path_prefixes,
         )
         .await?;
@@ -4867,7 +4924,15 @@ mod tests {
         let (_termination_sender, mut termination_watcher) = watch::channel(());
         let engines = create_engines(&config, &prepared_dirs)?;
         let server_verified = Box::pin(ServerVerified::new(engines, config)).await?;
-        let params = VerifyParams::default();
+        let params = VerifyParams {
+            dir_params: PrepareDirsParams {
+                clean_cache: false,
+                clean_codegen_cache: false,
+            },
+            runtime_config_availability: RuntimeConfigAvailability::Strict,
+            suppress_type_checking_errors: false,
+            suppress_linking_errors: false,
+        };
         let webui_enabled = None;
 
         // Verify deployment. The current disk-authored canonical holds internal absolute
@@ -4879,7 +4944,7 @@ mod tests {
             server_verified.http_servers,
             prepared_dirs.wasm_cache_dir.clone(),
             prepared_dirs.metadata_dir.clone(),
-            params.ignore_missing_env_vars,
+            params.runtime_config_availability,
             server_verified.global_backtrace_persist,
             server_verified.global_executor_instance_limiter,
             server_verified.fuel,
@@ -4932,7 +4997,10 @@ mod tests {
 
         let prepared_dirs = prepare_dirs(
             &config,
-            &PrepareDirsParams::default(),
+            &PrepareDirsParams {
+                clean_cache: false,
+                clean_codegen_cache: false,
+            },
             &config_holder.path_prefixes,
         )
         .await?;
@@ -4945,13 +5013,94 @@ mod tests {
             &prepared_dirs,
             deployment,
             None,
-            VerifyParams::default(),
+            VerifyParams {
+                dir_params: PrepareDirsParams {
+                    clean_cache: false,
+                    clean_codegen_cache: false,
+                },
+                runtime_config_availability: RuntimeConfigAvailability::Strict,
+                suppress_type_checking_errors: false,
+                suppress_linking_errors: false,
+            },
             &mut termination_watcher,
         )
         .await
         .unwrap_err();
 
         assert!(err.to_string().contains("shared between component types"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn deployment_verify_rejects_exec_activities_unless_allowed_or_deferred()
+    -> Result<(), anyhow::Error> {
+        test_utils::set_up();
+
+        let workspace = get_workspace_dir();
+        let config_holder = ConfigHolder::new(
+            crate::project_dirs(),
+            BaseDirs::new(),
+            Some(workspace.join("server-sqlite.toml")),
+        )?;
+        let config = config_holder.load_config().await?;
+        assert!(!config.allow_exec_activities);
+        let deployment =
+            load_deployment_canonical(&workspace.join("obelisk-testing-exec.toml")).await?;
+        let prepared_dirs = prepare_dirs(
+            &config,
+            &PrepareDirsParams {
+                clean_cache: false,
+                clean_codegen_cache: false,
+            },
+            &config_holder.path_prefixes,
+        )
+        .await?;
+        let engines = create_engines(&config, &prepared_dirs)?;
+        let server_verified = Box::pin(ServerVerified::new(engines, config)).await?;
+        let (_termination_sender, mut termination_watcher) = watch::channel(());
+
+        let err = deployment_verify_config(
+            &server_verified,
+            &prepared_dirs,
+            deployment.clone(),
+            None,
+            VerifyParams {
+                dir_params: PrepareDirsParams {
+                    clean_cache: false,
+                    clean_codegen_cache: false,
+                },
+                runtime_config_availability: RuntimeConfigAvailability::Strict,
+                suppress_type_checking_errors: false,
+                suppress_linking_errors: false,
+            },
+            &mut termination_watcher,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("run outside the WASM sandbox"));
+        assert!(err.to_string().contains("exec-stream"));
+
+        let verified = deployment_verify_config(
+            &server_verified,
+            &prepared_dirs,
+            deployment,
+            None,
+            VerifyParams {
+                dir_params: PrepareDirsParams {
+                    clean_cache: false,
+                    clean_codegen_cache: false,
+                },
+                runtime_config_availability: RuntimeConfigAvailability::AllowUnavailable,
+                suppress_type_checking_errors: false,
+                suppress_linking_errors: false,
+            },
+            &mut termination_watcher,
+        )
+        .await?;
+        assert_eq!(
+            verified.runtime_config_availability,
+            RuntimeConfigAvailability::AllowUnavailable
+        );
         Ok(())
     }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -416,6 +416,9 @@ impl DeploymentToml {
 pub(crate) struct ServerConfigToml {
     #[serde(default, rename = "obelisk-version")]
     pub(crate) obelisk_version: Option<String>,
+    /// Permit deployments to run host processes through `activity_exec`.
+    #[serde(default)]
+    pub(crate) allow_exec_activities: bool,
     #[serde(default)]
     pub(crate) api: ApiConfig,
     #[serde(default)]

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1733,8 +1733,8 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             .try_into()?;
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         let action = if request.hot_redeploy {
-            if check == RuntimeConfigCheck::AllowMissing {
-                return Err(tonic::Status::invalid_argument("argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_MISSING` cannot be used with `hot_redeploy = true`".to_string()));
+            if check == RuntimeConfigCheck::AllowUnavailable {
+                return Err(tonic::Status::invalid_argument("argument `runtime_config_check = RUNTIME_CONFIG_CHECK_ALLOW_UNAVAILABLE` cannot be used with `hot_redeploy = true`".to_string()));
             }
             SwitchDeploymentAction::Activate
         } else {
@@ -1911,7 +1911,9 @@ fn runtime_config_check_from_grpc(
     check: grpc_gen::RuntimeConfigCheck,
 ) -> server::RuntimeConfigCheck {
     match check {
-        grpc_gen::RuntimeConfigCheck::AllowMissing => server::RuntimeConfigCheck::AllowMissing,
+        grpc_gen::RuntimeConfigCheck::AllowUnavailable => {
+            server::RuntimeConfigCheck::AllowUnavailable
+        }
         grpc_gen::RuntimeConfigCheck::Unspecified | grpc_gen::RuntimeConfigCheck::Strict => {
             server::RuntimeConfigCheck::Strict
         }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3034,10 +3034,10 @@ mod deployment {
     };
     use http::header;
 
-    /// Map the REST `allow_missing_runtime_config` flag to the runtime config policy.
-    fn runtime_config_check_from_bool(allow_missing: bool) -> RuntimeConfigCheck {
-        if allow_missing {
-            RuntimeConfigCheck::AllowMissing
+    /// Map the REST `allow_unavailable_runtime_config` flag to the runtime config policy.
+    fn runtime_config_check_from_bool(allow_unavailable: bool) -> RuntimeConfigCheck {
+        if allow_unavailable {
+            RuntimeConfigCheck::AllowUnavailable
         } else {
             RuntimeConfigCheck::Strict
         }
@@ -3354,10 +3354,11 @@ mod deployment {
         pub deployment_toml: String,
         /// Optional human-readable deployment description
         pub description: Option<String>,
-        /// Tolerate missing environment variables / secrets while verifying the
-        /// deployment before persisting it. Defaults to strict (missing config fails).
-        #[serde(default)]
-        pub allow_missing_runtime_config: bool,
+        /// Tolerate runtime requirements unavailable on this server while verifying
+        /// the deployment before persisting it.
+        // backcompat: 0.39.x accepted `allow_missing_runtime_config`; drop the alias after a couple of majors.
+        #[serde(default, alias = "allow_missing_runtime_config")]
+        pub allow_unavailable_runtime_config: bool,
         /// Optional client-supplied deployment ID for idempotent submission.
         /// If a deployment with this ID already exists and its content digest
         /// matches, the submission is a no-op; a digest mismatch is rejected.
@@ -3436,13 +3437,13 @@ mod deployment {
     struct SubmitInputs {
         deployment_toml: String,
         description: Option<String>,
-        allow_missing_runtime_config: bool,
+        allow_unavailable_runtime_config: bool,
         deployment_id: Option<String>,
         files: Vec<server::SuppliedFile>,
     }
 
     /// Parse a `multipart/form-data` submit package. Text fields `deployment_toml`,
-    /// `description`, `allow_missing_runtime_config`, and `deployment_id` carry the
+    /// `description`, `allow_unavailable_runtime_config`, and `deployment_id` carry the
     /// manifest and options. Every other part is a deployment-owned file blob: its
     /// `filename` is the deployment-relative path and its form-field `name` is the
     /// claimed `sha256:...` content digest (or `file` when unknown).
@@ -3457,7 +3458,7 @@ mod deployment {
         };
         let mut deployment_toml = None;
         let mut description = None;
-        let mut allow_missing_runtime_config = false;
+        let mut allow_unavailable_runtime_config = false;
         let mut deployment_id = None;
         let mut files = Vec::new();
         while let Some(field) = multipart
@@ -3482,13 +3483,14 @@ mod deployment {
                             .map_err(|err| bad(format!("invalid `description` field: {err}")))?,
                     );
                 }
-                "allow_missing_runtime_config" => {
+                // backcompat: 0.39.x accepted `allow_missing_runtime_config`; drop the alias after a couple of majors.
+                "allow_unavailable_runtime_config" | "allow_missing_runtime_config" => {
                     let value = field.text().await.map_err(|err| {
                         bad(format!(
-                            "invalid `allow_missing_runtime_config` field: {err}"
+                            "invalid `allow_unavailable_runtime_config` field: {err}"
                         ))
                     })?;
-                    allow_missing_runtime_config = value.trim() == "true";
+                    allow_unavailable_runtime_config = value.trim() == "true";
                 }
                 "deployment_id" => {
                     deployment_id = Some(
@@ -3519,7 +3521,7 @@ mod deployment {
             deployment_toml: deployment_toml
                 .ok_or_else(|| bad("missing `deployment_toml` field".to_string()))?,
             description,
-            allow_missing_runtime_config,
+            allow_unavailable_runtime_config,
             deployment_id,
             files,
         })
@@ -3577,7 +3579,7 @@ mod deployment {
             SubmitInputs {
                 deployment_toml: payload.deployment_toml,
                 description: payload.description,
-                allow_missing_runtime_config: payload.allow_missing_runtime_config,
+                allow_unavailable_runtime_config: payload.allow_unavailable_runtime_config,
                 deployment_id: payload.deployment_id,
                 files: Vec::new(),
             }
@@ -3597,7 +3599,7 @@ mod deployment {
         let result = Box::pin(crate::command::server::submit_deployment(
             state.server_verified.clone(),
             &inputs.deployment_toml,
-            runtime_config_check_from_bool(inputs.allow_missing_runtime_config),
+            runtime_config_check_from_bool(inputs.allow_unavailable_runtime_config),
             Some("web-api".to_string()),
             inputs.description,
             requested_deployment_id,
@@ -3696,10 +3698,11 @@ mod deployment {
     /// Request payload for switching deployment
     #[derive(Deserialize, ToSchema)]
     pub struct DeploymentSwitchPayload {
-        /// Tolerate missing environment variables / secrets while verifying. Rejected
-        /// for a hot redeploy, which requires all runtime config to be available.
-        #[serde(default)]
-        pub allow_missing_runtime_config: bool,
+        /// Tolerate runtime requirements unavailable on this server while verifying.
+        /// Rejected for a hot redeploy.
+        // backcompat: 0.39.x accepted `allow_missing_runtime_config`; drop the alias after a couple of majors.
+        #[serde(default, alias = "allow_missing_runtime_config")]
+        pub allow_unavailable_runtime_config: bool,
         /// Hot redeploy without restart
         #[serde(default)]
         pub hot_redeploy: bool,
@@ -3729,17 +3732,17 @@ mod deployment {
     ) -> Result<Response, HttpResponse> {
         tracing::Span::current().record("deployment_id", tracing::field::display(&deployment_id));
         let action = if payload.hot_redeploy {
-            if payload.allow_missing_runtime_config {
+            if payload.allow_unavailable_runtime_config {
                 return Err(HttpResponse::bad_request(
                     accept,
-                    "`allow_missing_runtime_config = true` not allowed with `hot_redeploy = true`"
+                    "`allow_unavailable_runtime_config = true` not allowed with `hot_redeploy = true`"
                         .to_string(),
                 ));
             }
             SwitchDeploymentAction::Activate
         } else {
             SwitchDeploymentAction::Enqueue(runtime_config_check_from_bool(
-                payload.allow_missing_runtime_config,
+                payload.allow_unavailable_runtime_config,
             ))
         };
         let outcome = crate::command::server::switch_deployment(


### PR DESCRIPTION
Do not allow running deployments with exec activities unless
`allow_exec_activities` server.toml flag (or `OBELISK__ALLOW_EXEC_ACTIVITIES=true`)
is set.
