### PR TITLE
feat(api)!: Add token based auth, deny unauthenticated requests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** *(api)* The API port now denies unauthenticated requests by default (HTTP `401`, gRPC
   `UNAUTHENTICATED`), where previously it accepted anything. Clients must present an accepted token; the
-  `--allow-all` server flag restores the old behavior for dev or recovery. Webhook `http_server`s are unaffected
+  `--allow-unauthenticated-api` server flag restores the old behavior for dev or recovery. Webhook `http_server`s are unaffected
   and stay open
 - **Breaking:** *(api)* Renamed the runtime-config availability policy from "missing" to "unavailable" so it also covers
   server capabilities (such as exec activities), not only environment variables and secrets. The CLI flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(server)* Gate `activity_exec` behind a new `allow_exec_activities` server.toml flag (default disabled), since exec
   activities run host processes outside the WASM sandbox. Deployments that declare exec activities fail verification
   unless the operator enables the flag (or `OBELISK__ALLOW_EXEC_ACTIVITIES=true`)
+- *(server)* `allow_exec_activities` now also accepts an allowlist of exec script content digests
+  (`["sha256:..."]`), so only reviewed scripts may run; a rejected deployment logs the digest line to copy into
+  server.toml after review
+- *(server)* Bearer token authentication on the API port, covering the web API, gRPC, and gRPC-web uniformly. An
+  ephemeral startup token is always generated and printed to the console (again on a denied request), so there is
+  no lockout. Persistent tokens are configured in server.toml as sha256 hashes (`api.token_hashes`, safe to commit)
+  or injected as plaintext via `OBELISK__API__TOKEN` (`api.token`); revocation is deleting a hash line and
+  restarting
+- *(cli)* `obelisk generate token` prints a fresh random API token once, plus its ready-to-paste
+  `api.token_hashes` entry
+- *(cli)* Global `--api-token` flag, with fallback to `OBELISK_API_TOKEN`, then `OBELISK__API__TOKEN`, presented as
+  `Authorization: Bearer` on all gRPC and web API calls
 
 ### Changed
 
+- **Breaking:** *(api)* The API port now denies unauthenticated requests by default (HTTP `401`, gRPC
+  `UNAUTHENTICATED`), where previously it accepted anything. Clients must present an accepted token; the
+  `--allow-all` server flag restores the old behavior for dev or recovery. Webhook `http_server`s are unaffected
+  and stay open
 - **Breaking:** *(api)* Renamed the runtime-config availability policy from "missing" to "unavailable" so it also covers
   server capabilities (such as exec activities), not only environment variables and secrets. The CLI flag
   `--allow-missing-runtime-config` (and `server verify --ignore-missing-env-vars`) is now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.9",
  "strum 0.28.0",
+ "subtle",
  "tempfile",
  "test-programs-fibo-workflow-outer-builder",
  "test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 serde.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
@@ -326,6 +327,7 @@ serde_json = { version = "1.0.150", features = ["preserve_order"] }
 serde_with = "3.21.0"
 hmac = "0.12.1"
 sha2 = "0.10.9"
+subtle = "2.6.1"
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "2", features = ["full"] }
 tempfile = "3.27"

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -3,6 +3,10 @@
   "about": "Obelisk: deterministic workflow engine",
   "options": [
     {
+      "name": "--api-token",
+      "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`, then `$OBELISK__API__TOKEN`"
+    },
+    {
       "name": "--version",
       "short": "v",
       "help": "Print version"
@@ -56,6 +60,10 @@
               "name": "--suppress-type-checking-errors",
               "short": "s",
               "help": "Do not fail startup when a component's imports/exports fail type checking against the current deployment"
+            },
+            {
+              "name": "--allow-all",
+              "help": "Disable API authentication, accepting all requests. Dev/recovery override"
             }
           ]
         },
@@ -1090,6 +1098,17 @@
         {
           "name": "deployment-id",
           "about": "Generate a fresh random deployment ID and print it to stdout",
+          "options": [
+            {
+              "name": "--json",
+              "short": "j",
+              "help": "Output as JSON instead of plain text"
+            }
+          ]
+        },
+        {
+          "name": "token",
+          "about": "Generate a random API token plus the `sha256:` hash entry accepted in `server.toml` `api.token_hashes`",
           "options": [
             {
               "name": "--json",

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -35,6 +35,7 @@
             },
             {
               "name": "--server-config",
+              "short": "s",
               "help": "Path to the server configuration file (server.toml). If omitted, built-in defaults are used",
               "accepts": {
                 "path": true
@@ -81,6 +82,7 @@
             },
             {
               "name": "--server-config",
+              "short": "s",
               "help": "Path to the server configuration file (server.toml). If omitted, built-in defaults are used",
               "accepts": {
                 "path": true

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -63,8 +63,8 @@
               "help": "Do not fail startup when a component's imports/exports fail type checking against the current deployment"
             },
             {
-              "name": "--allow-all",
-              "help": "Disable API authentication, accepting all requests. Dev/recovery override"
+              "name": "--allow-unauthenticated-api",
+              "help": "Accept unauthenticated requests on the API port. Dev/recovery override"
             }
           ]
         },

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -83,6 +83,21 @@
         "listening_addr": {
           "type": "string",
           "default": "127.0.0.1:5005"
+        },
+        "token_hashes": {
+          "description": "Accepted API bearer tokens as `sha256:<hex>` digests of the token text.\nHashes are not secrets, so this file stays safe to commit.\nGenerate an entry with `obelisk generate token`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "token": {
+          "description": "Plaintext accepted token, intended for env injection only\n(`OBELISK__API__TOKEN`); do not write it into the config file.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/obelisk-help-server.toml
+++ b/obelisk-help-server.toml
@@ -7,7 +7,19 @@
 # webui.listening_addr = "127.0.0.1:8080"        # Address and port on which the webui will listen.
 # external.enabled = true                        # Disable the external HTTP server (enabled by default).
 # external.listening_addr = "127.0.0.1:9090"     # Address and port on which the external HTTP server will listen.
-# Note: listening on all interfaces using [::]:port is not advised, as there is no auth yet.
+# Note: the external HTTP server (webhooks) has no auth; listening on all interfaces using [::]:port is not advised.
+
+## API authentication. The API port denies requests without a valid `Authorization: Bearer <token>` header.
+## An ephemeral startup token is always generated and printed to the console.
+## Persistent tokens are configured as sha256 hashes of the token text; hashes are not secrets,
+## so this file stays safe to commit. Generate a token plus its hash with `obelisk generate token`.
+# api.token_hashes = [
+#   "sha256:...",   # agent
+#   "sha256:...",   # laptop
+# ]
+## Plaintext accepted token, intended for env injection only (`OBELISK__API__TOKEN`);
+## do not write it into this file.
+# api.token = "..."
 
 ## Semver version requirement for the Obelisk binary.
 ## If set, the server will fail to start if the binary version doesn't match.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,26 @@
+use concepts::component_id::Digest;
+use rand::Rng as _;
+use sha2::{Digest as _, Sha256};
+use std::fmt::Write as _;
+
+/// Maximum encoded gRPC message size for deployment repository requests and responses.
+pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
+
+pub(crate) fn token_digest(token: &str) -> [u8; 32] {
+    Sha256::digest(token.as_bytes()).into()
+}
+
+/// Digest of a token as accepted in `api.token_hashes`; displays as `sha256:<hex>`.
+pub(crate) fn token_hash(token: &str) -> Digest {
+    Digest(token_digest(token))
+}
+
+/// Generate a high-entropy random token (64 hex chars).
+pub(crate) fn generate_token() -> String {
+    let bytes = rand::rng().random::<[u8; 32]>();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(&mut out, "{b:02x}").expect("writing to string");
+    }
+    out
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -32,6 +32,10 @@ fn parse_oci_reference(s: &str) -> Result<oci_client::Reference, String> {
     oci_client::Reference::from_str(s).map_err(|e| e.to_string())
 }
 
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "clap function value parsers must return Result"
+)]
 fn parse_secret_string(value: &str) -> Result<SecretString, std::convert::Infallible> {
     Ok(SecretString::from(value.to_owned()))
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -420,7 +420,7 @@ pub(crate) enum Server {
         #[arg(long)]
         clean_codegen_cache: bool,
         /// Path to the server configuration file (server.toml). If omitted, built-in defaults are used.
-        #[arg(long)]
+        #[arg(short, long)]
         server_config: Option<PathBuf>,
         /// Path to the deployment TOML file. If provided, the deployment is inserted and activated on startup,
         /// overriding any existing Enqueued or Active deployment in the database.
@@ -449,7 +449,7 @@ pub(crate) enum Server {
         #[arg(long)]
         clean_codegen_cache: bool,
         /// Path to the server configuration file (server.toml). If omitted, built-in defaults are used.
-        #[arg(long)]
+        #[arg(short, long)]
         server_config: Option<PathBuf>,
         /// Path to the deployment TOML file. If omitted, the database's Enqueued deployment is used,
         /// falling back to the Active deployment. Errors if neither is found.

--- a/src/args.rs
+++ b/src/args.rs
@@ -436,9 +436,9 @@ pub(crate) enum Server {
         /// Do not fail startup when a component's imports/exports fail type checking against the current deployment.
         #[arg(long, short)]
         suppress_type_checking_errors: bool,
-        /// Disable API authentication, accepting all requests. Dev/recovery override.
+        /// Accept unauthenticated requests on the API port. Dev/recovery override.
         #[arg(long)]
-        allow_all: bool,
+        allow_unauthenticated_api: bool,
     },
     /// Read the configuration, compile the components, verify their imports and exit without starting the server.
     Verify {

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,7 @@ use concepts::{
     ComponentType, ExecutionId, FunctionFqn, FunctionFqnParseError,
     prefixed_ulid::{DelayId, DeploymentId, ExecutionIdDerived},
 };
+use secrecy::SecretString;
 
 /// Deployment TOML section names, used as the key in the deployment TOML file.
 #[derive(
@@ -29,6 +30,10 @@ fn parse_oci_reference(s: &str) -> Result<oci_client::Reference, String> {
         .strip_prefix("oci://")
         .ok_or_else(|| format!("OCI reference must start with `oci://`, got: {s}"))?;
     oci_client::Reference::from_str(s).map_err(|e| e.to_string())
+}
+
+fn parse_secret_string(value: &str) -> Result<SecretString, std::convert::Infallible> {
+    Ok(SecretString::from(value.to_owned()))
 }
 
 /// A deployment source: either a path to a TOML file or an existing deployment ID.
@@ -63,6 +68,16 @@ about = "Obelisk: deterministic workflow engine", disable_version_flag = true, d
 pub(crate) struct Args {
     #[command(subcommand)]
     pub(crate) command: Subcommand,
+
+    /// API token presented to the server as `Authorization: Bearer <token>`.
+    /// Falls back to `$OBELISK_API_TOKEN`, then `$OBELISK__API__TOKEN`.
+    #[arg(
+        long,
+        global = true,
+        value_name = "TOKEN",
+        value_parser = parse_secret_string
+    )]
+    pub(crate) api_token: Option<SecretString>,
 
     /// Print version
     #[arg(short, long, action = clap::ArgAction::Version)]
@@ -367,6 +382,16 @@ pub(crate) enum Generate {
         #[arg(short, long)]
         json: bool,
     },
+    /// Generate a random API token plus the `sha256:` hash entry accepted in
+    /// `server.toml` `api.token_hashes`.
+    ///
+    /// The plaintext token is printed once and never stored; revoke it by
+    /// deleting its hash line and restarting the server.
+    Token {
+        /// Output as JSON instead of plain text.
+        #[arg(short, long)]
+        json: bool,
+    },
     /// Print a prompt context for authoring an Obelisk application with a coding agent.
     ///
     /// Usage: obelisk generate prompt description of what to build | claude
@@ -411,6 +436,9 @@ pub(crate) enum Server {
         /// Do not fail startup when a component's imports/exports fail type checking against the current deployment.
         #[arg(long, short)]
         suppress_type_checking_errors: bool,
+        /// Disable API authentication, accepting all requests. Dev/recovery override.
+        #[arg(long)]
+        allow_all: bool,
     },
     /// Read the configuration, compile the components, verify their imports and exit without starting the server.
     Verify {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,142 @@
+use grpc::{grpc_gen, injector::TracingInjector};
+use secrecy::{ExposeSecret as _, SecretString};
+use tonic::{codec::CompressionEncoding, transport::Channel};
+
+/// Token this CLI invocation presents to the server, resolved once from
+/// `--api-token` > `OBELISK_API_TOKEN` > `OBELISK__API__TOKEN`.
+static API_TOKEN: std::sync::OnceLock<Option<SecretString>> = std::sync::OnceLock::new();
+
+pub(crate) fn init_api_token(flag: Option<SecretString>) {
+    API_TOKEN
+        .set(resolve_api_token(flag))
+        .expect("API_TOKEN is only set here");
+}
+
+fn resolve_api_token(flag: Option<SecretString>) -> Option<SecretString> {
+    flag.or_else(|| {
+        std::env::var("OBELISK_API_TOKEN")
+            .ok()
+            .map(SecretString::from)
+    })
+    .or_else(|| {
+        std::env::var("OBELISK__API__TOKEN")
+            .ok()
+            .map(SecretString::from)
+    })
+    .filter(|token| !token.expose_secret().is_empty())
+}
+
+fn api_token() -> Option<&'static SecretString> {
+    API_TOKEN.get_or_init(|| None).as_ref()
+}
+
+/// Client interceptor for all gRPC calls: injects tracing metadata and, if a
+/// token is configured, the `authorization` header.
+#[derive(Clone)]
+pub(crate) struct ClientInterceptor {
+    authorization: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl ClientInterceptor {
+    fn new() -> Result<Self, anyhow::Error> {
+        let authorization = if let Some(token) = api_token() {
+            let mut authorization: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
+                format!("Bearer {}", token.expose_secret())
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
+            authorization.set_sensitive(true);
+            Some(authorization)
+        } else {
+            None
+        };
+        Ok(Self { authorization })
+    }
+}
+
+impl tonic::service::Interceptor for ClientInterceptor {
+    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        let mut request = tonic::service::Interceptor::call(&mut TracingInjector, request)?;
+        if let Some(authorization) = &self.authorization {
+            request
+                .metadata_mut()
+                .insert("authorization", authorization.clone());
+        }
+        Ok(request)
+    }
+}
+
+/// HTTP client for web-API calls, presenting the API token as a default header.
+pub(crate) fn web_api_client() -> Result<reqwest::Client, anyhow::Error> {
+    Ok(web_api_client_builder()?.build()?)
+}
+
+pub(crate) fn web_api_client_builder() -> Result<reqwest::ClientBuilder, anyhow::Error> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Some(token) = api_token() {
+        let mut value =
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))
+                .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
+        value.set_sensitive(true);
+        headers.insert(reqwest::header::AUTHORIZATION, value);
+    }
+    Ok(reqwest::Client::builder().default_headers(headers))
+}
+
+pub(crate) type ExecutionRepositoryClient =
+    grpc_gen::execution_repository_client::ExecutionRepositoryClient<
+        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
+    >;
+
+pub(crate) async fn get_execution_repository_client(
+    channel: Channel,
+) -> Result<ExecutionRepositoryClient, anyhow::Error> {
+    Ok(
+        grpc_gen::execution_repository_client::ExecutionRepositoryClient::with_interceptor(
+            channel,
+            ClientInterceptor::new()?,
+        )
+        .send_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip),
+    )
+}
+
+type DeploymentRepositoryClient =
+    grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
+        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
+    >;
+
+pub(crate) async fn get_deployment_repository_client(
+    channel: Channel,
+) -> Result<DeploymentRepositoryClient, anyhow::Error> {
+    Ok(
+        grpc_gen::deployment_repository_client::DeploymentRepositoryClient::with_interceptor(
+            channel,
+            ClientInterceptor::new()?,
+        )
+        .send_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE),
+    )
+}
+
+pub(crate) type FunctionRepositoryClient =
+    grpc_gen::function_repository_client::FunctionRepositoryClient<
+        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
+    >;
+
+pub(crate) async fn get_fn_repository_client(
+    channel: Channel,
+) -> Result<FunctionRepositoryClient, anyhow::Error> {
+    Ok(
+        grpc_gen::function_repository_client::FunctionRepositoryClient::with_interceptor(
+            channel,
+            ClientInterceptor::new()?,
+        )
+        .send_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Zstd)
+        .accept_compressed(CompressionEncoding::Gzip),
+    )
+}

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -1,7 +1,8 @@
 use crate::FunctionMetadataVerbosity;
-use crate::FunctionRepositoryClient;
 use crate::args;
 use crate::args::TomlComponentType;
+use crate::client::FunctionRepositoryClient;
+use crate::client::get_fn_repository_client;
 use crate::config::config_holder::{ConfigHolder, OBELISK_HELP_DEPLOYMENT_TOML};
 use crate::config::env_var::EnvVarConfig;
 use crate::config::toml::ComponentLocationToml;
@@ -11,7 +12,6 @@ use crate::config::toml::DurationConfig;
 use crate::config::toml::JsLocationToml;
 use crate::config::toml::OCI_SCHEMA_PREFIX;
 use crate::config::wasm_cache_metadata_dir;
-use crate::get_fn_repository_client;
 use crate::oci;
 use crate::oci::ComponentMetadataAnnotation;
 use crate::project_dirs;

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -7,7 +7,6 @@ use chrono::DateTime;
 use concepts::prefixed_ulid::DeploymentId;
 use grpc::grpc_gen;
 use grpc::grpc_gen::switch_deployment_response::Outcome;
-use grpc::injector::TracingInjector;
 use grpc::to_channel;
 use std::path::PathBuf;
 use tonic::transport::Channel;
@@ -301,7 +300,7 @@ async fn write_new_file(
 }
 
 type DeploymentClient = grpc::grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, TracingInjector>,
+    tonic::service::interceptor::InterceptedService<Channel, crate::ClientInterceptor>,
 >;
 
 /// If the source is a file, submit it and return the new ID. If it's an ID, return it directly.

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -1,7 +1,7 @@
 use crate::args::{self, DeploymentSource};
+use crate::client::get_deployment_repository_client;
 use crate::config::manifest::{PreparedDeploymentManifest, prepare_deployment_manifest_from_disk};
 use crate::config::toml::sanitize_deployment_relative_path;
-use crate::get_deployment_repository_client;
 use anyhow::{Context as _, bail};
 use chrono::DateTime;
 use concepts::prefixed_ulid::DeploymentId;
@@ -300,7 +300,7 @@ async fn write_new_file(
 }
 
 type DeploymentClient = grpc::grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, crate::ClientInterceptor>,
+    tonic::service::interceptor::InterceptedService<Channel, crate::client::ClientInterceptor>,
 >;
 
 /// If the source is a file, submit it and return the new ID. If it's an ID, return it directly.

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -341,7 +341,7 @@ pub(crate) async fn submit(
             follow,
             no_reconnect,
         } => {
-            let client = reqwest::Client::builder()
+            let client = crate::web_api_client_builder()?
                 .build()
                 .context("failed to build HTTP client")?;
 
@@ -773,7 +773,7 @@ async fn get_execution_status_json(
     follow: bool,
     no_reconnect: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let reconnect = !no_reconnect;
     let mut last_status: Option<serde_json::Value> = None;
 
@@ -812,7 +812,7 @@ async fn get_execution_result_json(
     follow: bool,
     no_reconnect: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let reconnect = follow && !no_reconnect;
 
     loop {
@@ -853,7 +853,7 @@ async fn send_and_print(req: reqwest::RequestBuilder) -> anyhow::Result<()> {
 }
 
 async fn replay(api_url: &str, execution_id: ExecutionId, json: bool) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {
@@ -870,7 +870,7 @@ async fn replay_json(
     api_url: &str,
     execution_id: &ExecutionId,
 ) -> anyhow::Result<serde_json::Value> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let resp = client
         .put(format!("{api_url}/v1/executions/{execution_id}/replay"))
         .header(ACCEPT, "application/json")
@@ -999,7 +999,7 @@ async fn advance(
     if opts.pause_delays {
         pause_delays_in_replay(&mut advance_request);
     }
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let accept = if opts.json {
         "application/json"
     } else {
@@ -1248,7 +1248,7 @@ async fn execution_list(
     limit: u16,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {
@@ -1473,7 +1473,7 @@ async fn execution_logs_cmd(
     after: Option<String>,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let logs_url = format!("{api_url}/v1/executions/{execution_id}/logs");
     let body = fetch_logs(&client, &logs_url, opts, None, after.as_deref(), "newer").await?;
     print_log_items(&body, json, opts.show_run_id, opts.show_derived)?;
@@ -1487,7 +1487,7 @@ async fn follow_logs(
     initial_after: Option<String>,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let logs_url = format!("{api_url}/v1/executions/{execution_id}/logs");
     let status_url = format!("{api_url}/v1/executions/{execution_id}/status");
     let mut cursor: Option<String> = None;
@@ -1547,7 +1547,7 @@ async fn execution_events_cmd(
     limit: u16,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {
@@ -1575,7 +1575,7 @@ async fn execution_responses_cmd(
     limit: u16,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = reqwest::Client::new();
+    let client = crate::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -1,10 +1,10 @@
-use crate::ExecutionRepositoryClient;
 use crate::args;
 use crate::args::CancelCommand;
 use crate::args::FunctionFqnOrShort;
 use crate::args::params::parse_params;
-use crate::get_execution_repository_client;
-use crate::get_fn_repository_client;
+use crate::client::ExecutionRepositoryClient;
+use crate::client::get_execution_repository_client;
+use crate::client::get_fn_repository_client;
 use crate::server::web_api_server::{AdvanceRequestSer, ExecutionSubmitPayload, ReplayResponseSer};
 use anyhow::Context as _;
 use anyhow::bail;
@@ -341,7 +341,7 @@ pub(crate) async fn submit(
             follow,
             no_reconnect,
         } => {
-            let client = crate::web_api_client_builder()?
+            let client = crate::client::web_api_client_builder()?
                 .build()
                 .context("failed to build HTTP client")?;
 
@@ -773,7 +773,7 @@ async fn get_execution_status_json(
     follow: bool,
     no_reconnect: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let reconnect = !no_reconnect;
     let mut last_status: Option<serde_json::Value> = None;
 
@@ -812,7 +812,7 @@ async fn get_execution_result_json(
     follow: bool,
     no_reconnect: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let reconnect = follow && !no_reconnect;
 
     loop {
@@ -853,7 +853,7 @@ async fn send_and_print(req: reqwest::RequestBuilder) -> anyhow::Result<()> {
 }
 
 async fn replay(api_url: &str, execution_id: ExecutionId, json: bool) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {
@@ -870,7 +870,7 @@ async fn replay_json(
     api_url: &str,
     execution_id: &ExecutionId,
 ) -> anyhow::Result<serde_json::Value> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let resp = client
         .put(format!("{api_url}/v1/executions/{execution_id}/replay"))
         .header(ACCEPT, "application/json")
@@ -999,7 +999,7 @@ async fn advance(
     if opts.pause_delays {
         pause_delays_in_replay(&mut advance_request);
     }
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let accept = if opts.json {
         "application/json"
     } else {
@@ -1248,7 +1248,7 @@ async fn execution_list(
     limit: u16,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {
@@ -1473,7 +1473,7 @@ async fn execution_logs_cmd(
     after: Option<String>,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let logs_url = format!("{api_url}/v1/executions/{execution_id}/logs");
     let body = fetch_logs(&client, &logs_url, opts, None, after.as_deref(), "newer").await?;
     print_log_items(&body, json, opts.show_run_id, opts.show_derived)?;
@@ -1487,7 +1487,7 @@ async fn follow_logs(
     initial_after: Option<String>,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let logs_url = format!("{api_url}/v1/executions/{execution_id}/logs");
     let status_url = format!("{api_url}/v1/executions/{execution_id}/status");
     let mut cursor: Option<String> = None;
@@ -1547,7 +1547,7 @@ async fn execution_events_cmd(
     limit: u16,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {
@@ -1575,7 +1575,7 @@ async fn execution_responses_cmd(
     limit: u16,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = crate::web_api_client()?;
+    let client = crate::client::web_api_client()?;
     let accept = if json {
         "application/json"
     } else {

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -140,8 +140,8 @@ impl Generate {
                 Ok(())
             }
             Generate::Token { json } => {
-                let token = crate::server::auth::generate_token();
-                let hash = crate::server::auth::token_hash(&token);
+                let token = crate::api::generate_token();
+                let hash = crate::api::token_hash(&token);
                 if json {
                     println!(
                         "{}",

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -139,6 +139,26 @@ impl Generate {
                 }
                 Ok(())
             }
+            Generate::Token { json } => {
+                let token = crate::server::auth::generate_token();
+                let hash = crate::server::auth::token_hash(&token);
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "token": token,
+                            "hash": hash.to_string(),
+                        }))?
+                    );
+                } else {
+                    println!("API token (shown only once, store it securely):");
+                    println!("{token}");
+                    println!();
+                    println!("Add its hash to `api.token_hashes` in server.toml:");
+                    println!("api.token_hashes = [\"{hash}\"]");
+                }
+                Ok(())
+            }
             Generate::Prompt { description } => {
                 let version = format!("v{PKG_VERSION}");
                 let description = description.join(" ");

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -150,7 +150,10 @@ pub(crate) use test_addr;
 /// Write separate server and deployment TOML configs to temp files and return their paths.
 /// The server config includes API, DB, and wasm settings.
 /// The deployment config references the JS fixtures from the workspace tree.
-fn write_test_configs(ip: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+fn write_test_configs(
+    ip: &str,
+    server_toml_api_lines: &str,
+) -> (tempfile::TempDir, PathBuf, PathBuf) {
     let workspace = get_workspace_dir();
     let db_dir = tempfile::tempdir().unwrap();
     let fixture_src = workspace.join("crates/testing/test-programs");
@@ -159,6 +162,7 @@ fn write_test_configs(ip: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
     copy_dir_recursive(&fixture_src.join("exec"), &fixture_dst.join("exec"));
     let server_contents = format!(
         r#"api.listening_addr = "{ip}:{API_PORT}"
+{server_toml_api_lines}
 allow_exec_activities = true
 webui.enabled = false
 external.listening_addr = "{ip}:{WEBHOOK_PORT}"
@@ -647,16 +651,24 @@ struct TestServer {
 
 impl TestServer {
     async fn start(ip: String) -> Self {
-        let (tmp_dir, server_path, deployment_path) = write_test_configs(&ip);
+        let (tmp_dir, server_path, deployment_path) = write_test_configs(&ip, "");
         let deployment = LocalDeployment::from_path(&deployment_path).await.unwrap();
-        Self::launch(ip, tmp_dir, server_path, deployment).await
+        Self::launch(ip, tmp_dir, server_path, deployment, true).await
     }
 
     /// Start a server with an empty deployment (no components, no CAS blobs), so a later
     /// `deployment apply` exercises the upload-then-submit path from a clean store.
     async fn start_empty(ip: String) -> Self {
-        let (tmp_dir, server_path, _deployment_path) = write_test_configs(&ip);
-        Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty()).await
+        let (tmp_dir, server_path, _deployment_path) = write_test_configs(&ip, "");
+        Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty(), true).await
+    }
+
+    /// Start an empty server with API auth enabled (no `allow_all`), accepting the
+    /// given extra top-level `server.toml` lines (e.g. `api.token = "..."`).
+    async fn start_empty_with_auth(ip: String, server_toml_api_lines: &str) -> Self {
+        let (tmp_dir, server_path, _deployment_path) =
+            write_test_configs(&ip, server_toml_api_lines);
+        Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty(), false).await
     }
 
     async fn launch(
@@ -664,6 +676,7 @@ impl TestServer {
         tmp_dir: tempfile::TempDir,
         server_path: PathBuf,
         deployment: LocalDeployment,
+        allow_all: bool,
     ) -> Self {
         test_utils::set_up();
 
@@ -681,6 +694,7 @@ impl TestServer {
             },
             clean_sqlite_directory: false,
             suppress_type_checking_errors: false,
+            allow_all,
         };
 
         let prepared_dirs = prepare_dirs(&config, &params.dir_params, &config_holder.path_prefixes)
@@ -726,7 +740,8 @@ impl TestServer {
                 .send()
                 .await;
             if let Ok(resp) = resp
-                && resp.status().is_success()
+                && (resp.status().is_success()
+                    || resp.status() == reqwest::StatusCode::UNAUTHORIZED)
             {
                 debug!("Pinging server OK");
                 break;
@@ -1156,6 +1171,71 @@ impl TestServer {
         let body: Value = resp.json().await.unwrap();
         assert_eq!(body["ok"], "switched", "unexpected switch outcome");
     }
+}
+
+/// v1 API token auth (`meta/designs/server-security-guard.md`): with auth active
+/// (tests otherwise run with `allow_all`), the API port denies requests without a
+/// valid bearer token and accepts both the plaintext `api.token` and an
+/// `api.token_hashes` entry, on the web API and at gRPC stream open.
+#[tokio::test]
+async fn api_auth_should_deny_unauthenticated_requests() {
+    fn list_components_request() -> ListComponentsRequest {
+        ListComponentsRequest {
+            function_name: None,
+            component_digest: None,
+            extensions: false,
+            deployment_id: None,
+        }
+    }
+
+    let plain_token = "plain-secret-token";
+    let hashed_token = "hashed-secret-token";
+    let server = TestServer::start_empty_with_auth(
+        test_addr!(89),
+        &format!(
+            "api.token = \"{plain_token}\"\napi.token_hashes = [\"{hash}\"]",
+            hash = crate::server::auth::token_hash(hashed_token)
+        ),
+    )
+    .await;
+
+    let url = format!("{}/v1/functions", server.base_url);
+    for wrong in [
+        server.client.get(&url),
+        server.client.get(&url).bearer_auth("wrong-token"),
+    ] {
+        assert_eq!(
+            wrong.send().await.unwrap().status(),
+            reqwest::StatusCode::UNAUTHORIZED
+        );
+    }
+    for accepted in [plain_token, hashed_token] {
+        let resp = server
+            .client
+            .get(&url)
+            .bearer_auth(accepted)
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success(), "status: {}", resp.status());
+    }
+
+    let mut fn_client = FunctionRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap();
+    let status = fn_client
+        .list_components(list_components_request())
+        .await
+        .unwrap_err();
+    assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    let mut authenticated = tonic::Request::new(list_components_request());
+    authenticated.metadata_mut().insert(
+        "authorization",
+        format!("Bearer {plain_token}").parse().unwrap(),
+    );
+    fn_client.list_components(authenticated).await.unwrap();
+
+    server.shutdown().await;
 }
 
 /// Regression test for hot-deploying local WASM files to a server that starts empty.

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1075,8 +1075,8 @@ impl TestServer {
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
                 .unwrap()
-                .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-                .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+                .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+                .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
 
         let submit = async |files| {
             grpc_client
@@ -1134,8 +1134,8 @@ impl TestServer {
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
                 .unwrap()
-                .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-                .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+                .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+                .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
         let resp = grpc_client
             .switch_deployment(SwitchDeploymentRequest {
                 deployment_id: Some(GrpcDeploymentId {
@@ -1194,7 +1194,7 @@ async fn api_auth_should_deny_unauthenticated_requests() {
         test_addr!(89),
         &format!(
             "api.token = \"{plain_token}\"\napi.token_hashes = [\"{hash}\"]",
-            hash = crate::server::auth::token_hash(hashed_token)
+            hash = crate::api::token_hash(hashed_token)
         ),
     )
     .await;
@@ -1307,8 +1307,8 @@ impl TestDeployClient {
                     DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
                         .await
                         .unwrap()
-                        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-                        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+                        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+                        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
                 let submit_resp = grpc_client
                     .submit_deployment(SubmitDeploymentRequest {
                         deployment_toml: new_deployment_toml,
@@ -2216,8 +2216,8 @@ ffqn = "testing:integration/deferred.run"
         DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
             .await
             .unwrap()
-            .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-            .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+            .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
     let submit = |files, id| {
         let mut client = grpc_client.clone();
         let toml = prepared.deployment_toml.clone();
@@ -2334,8 +2334,8 @@ env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
     let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
 
     let submit = |check: RuntimeConfigCheck, id: Option<GrpcDeploymentId>| {
         let mut client = grpc_client.clone();
@@ -2536,8 +2536,8 @@ async fn gc_orphan_files_grpc() {
     let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
 
     // Prepare a deployment-owned JS file (digest-enriched) from disk. `section` selects
     // `activity_js` or `workflow_js` (a JS workflow validates its source at link time, so

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -663,7 +663,7 @@ impl TestServer {
         Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty(), true).await
     }
 
-    /// Start an empty server with API auth enabled (no `allow_all`), accepting the
+    /// Start an empty server with API auth enabled (no `allow_unauthenticated_api`), accepting the
     /// given extra top-level `server.toml` lines (e.g. `api.token = "..."`).
     async fn start_empty_with_auth(ip: String, server_toml_api_lines: &str) -> Self {
         let (tmp_dir, server_path, _deployment_path) =
@@ -676,7 +676,7 @@ impl TestServer {
         tmp_dir: tempfile::TempDir,
         server_path: PathBuf,
         deployment: LocalDeployment,
-        allow_all: bool,
+        allow_unauthenticated_api: bool,
     ) -> Self {
         test_utils::set_up();
 
@@ -694,7 +694,7 @@ impl TestServer {
             },
             clean_sqlite_directory: false,
             suppress_type_checking_errors: false,
-            allow_all,
+            allow_unauthenticated_api,
         };
 
         let prepared_dirs = prepare_dirs(&config, &params.dir_params, &config_holder.path_prefixes)
@@ -1174,7 +1174,7 @@ impl TestServer {
 }
 
 /// v1 API token auth (`meta/designs/server-security-guard.md`): with auth active
-/// (tests otherwise run with `allow_all`), the API port denies requests without a
+/// (tests otherwise run with `allow_unauthenticated_api`), the API port denies requests without a
 /// valid bearer token and accepts both the plaintext `api.token` and an
 /// `api.token_hashes` entry, on the web API and at gRPC stream open.
 #[tokio::test]

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -410,7 +410,7 @@ impl Server {
                 empty: deployment_empty,
                 description,
                 suppress_type_checking_errors,
-                allow_all,
+                allow_unauthenticated_api,
             } => {
                 Box::pin(run(
                     project_dirs(),
@@ -426,7 +426,7 @@ impl Server {
                         },
                         clean_sqlite_directory,
                         suppress_type_checking_errors,
-                        allow_all,
+                        allow_unauthenticated_api,
                     },
                 ))
                 .await
@@ -626,8 +626,8 @@ pub(crate) struct RunParams {
     pub(crate) dir_params: PrepareDirsParams,
     pub(crate) clean_sqlite_directory: bool,
     pub(crate) suppress_type_checking_errors: bool,
-    /// Disable API authentication (`--allow-all`), accepting unauthenticated requests.
-    pub(crate) allow_all: bool,
+    /// Accept unauthenticated API requests (`--allow-unauthenticated-api`).
+    pub(crate) allow_unauthenticated_api: bool,
 }
 
 pub(crate) async fn run(
@@ -1727,8 +1727,10 @@ pub(crate) async fn run_internal(
     });
     if let Some(api_listening_addr) = api_listening_addr {
         let app = app_router.fallback_service(grpc_service);
-        let app_svc = if params.allow_all {
-            warn!("API authentication is disabled by --allow-all: accepting all requests");
+        let app_svc = if params.allow_unauthenticated_api {
+            warn!(
+                "API authentication is disabled by --allow-unauthenticated-api: accepting all API requests"
+            );
             app.into_make_service()
         } else {
             let api_auth = Arc::new(crate::server::auth::ApiAuth::new(&api_config));

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -409,6 +409,7 @@ impl Server {
                 empty: deployment_empty,
                 description,
                 suppress_type_checking_errors,
+                allow_all,
             } => {
                 Box::pin(run(
                     project_dirs(),
@@ -424,6 +425,7 @@ impl Server {
                         },
                         clean_sqlite_directory,
                         suppress_type_checking_errors,
+                        allow_all,
                     },
                 ))
                 .await
@@ -623,6 +625,8 @@ pub(crate) struct RunParams {
     pub(crate) dir_params: PrepareDirsParams,
     pub(crate) clean_sqlite_directory: bool,
     pub(crate) suppress_type_checking_errors: bool,
+    /// Disable API authentication (`--allow-all`), accepting unauthenticated requests.
+    pub(crate) allow_all: bool,
 }
 
 pub(crate) async fn run(
@@ -1442,6 +1446,8 @@ pub(crate) async fn run_internal(
     mut termination_watcher: watch::Receiver<()>,
 ) -> anyhow::Result<()> {
     let api_listening_addr = config.api.enabled.then_some(config.api.listening_addr);
+    // `config` is moved into `server_verify` below; keep the API auth config.
+    let api_config = config.api.clone();
 
     let global_webhook_instance_limiter = config
         .wasm_global_config
@@ -1718,7 +1724,24 @@ pub(crate) async fn run_internal(
         prepared_dirs: server_init.prepared_dirs.clone(),
         deployment_switch_manager,
     });
-    let app: axum::Router<()> = app_router.fallback_service(grpc_service);
+    let api_auth = Arc::new(crate::server::auth::ApiAuth::new(
+        &api_config,
+        params.allow_all,
+    ));
+    if api_listening_addr.is_some() {
+        if params.allow_all {
+            warn!("API authentication is disabled by --allow-all: accepting all requests");
+        } else {
+            info!("API startup token: {}", api_auth.startup_token());
+        }
+    }
+    let app: axum::Router<()> =
+        app_router
+            .fallback_service(grpc_service)
+            .layer(axum::middleware::from_fn_with_state(
+                api_auth,
+                crate::server::auth::auth_middleware,
+            ));
     let app_svc = app.into_make_service();
 
     if let Some(api_listening_addr) = api_listening_addr {
@@ -1746,7 +1769,10 @@ pub(crate) async fn run_internal(
 }
 
 fn make_span<B>(request: &axum::http::Request<B>) -> Span {
-    let headers = request.headers();
+    let mut headers = request.headers().clone();
+    if let Some(authorization) = headers.get_mut(axum::http::header::AUTHORIZATION) {
+        authorization.set_sensitive(true);
+    }
     info_span!(
         "gRPC request",
         "otel.name" = format!("gRPC request {}", request.uri().path()),

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -111,6 +111,7 @@ use grpc::extractor::accept_trace;
 use grpc::grpc_gen;
 use hashbrown::HashMap;
 use indexmap::IndexMap;
+use secrecy::ExposeSecret as _;
 use serde_json::json;
 use sha2::{Digest as _, Sha256};
 use std::fmt::Debug;
@@ -1724,27 +1725,23 @@ pub(crate) async fn run_internal(
         prepared_dirs: server_init.prepared_dirs.clone(),
         deployment_switch_manager,
     });
-    let api_auth = Arc::new(crate::server::auth::ApiAuth::new(
-        &api_config,
-        params.allow_all,
-    ));
-    if api_listening_addr.is_some() {
-        if params.allow_all {
+    if let Some(api_listening_addr) = api_listening_addr {
+        let app = app_router.fallback_service(grpc_service);
+        let app_svc = if params.allow_all {
             warn!("API authentication is disabled by --allow-all: accepting all requests");
+            app.into_make_service()
         } else {
-            info!("API startup token: {}", api_auth.startup_token());
-        }
-    }
-    let app: axum::Router<()> =
-        app_router
-            .fallback_service(grpc_service)
-            .layer(axum::middleware::from_fn_with_state(
+            let api_auth = Arc::new(crate::server::auth::ApiAuth::new(&api_config));
+            info!(
+                "API startup token: {}",
+                api_auth.startup_token().expose_secret()
+            );
+            app.layer(axum::middleware::from_fn_with_state(
                 api_auth,
                 crate::server::auth::auth_middleware,
-            ));
-    let app_svc = app.into_make_service();
-
-    if let Some(api_listening_addr) = api_listening_addr {
+            ))
+            .into_make_service()
+        };
         let listener = TcpListener::bind(api_listening_addr)
             .await
             .with_context(|| format!("cannot bind to {api_listening_addr}"))?;

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1695,8 +1695,8 @@ pub(crate) async fn run_internal(
         .accept_compressed(CompressionEncoding::Gzip)
         // Submit requests inline deployment-owned blobs; raise the decode limit
         // well above tonic's 4 MiB default. `GetFile` responses are likewise large.
-        .max_decoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(crate::MAX_GRPC_MESSAGE_SIZE),
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE),
     )
     .add_service(
         tonic_reflection::server::Builder::configure()

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -518,14 +518,31 @@ pub(crate) struct ApiConfig {
     pub(crate) enabled: bool,
     #[serde(default = "default_api_listening_addr")]
     pub(crate) listening_addr: SocketAddr,
+    /// Accepted API bearer tokens as `sha256:<hex>` digests of the token text.
+    /// Hashes are not secrets, so this file stays safe to commit.
+    /// Generate an entry with `obelisk generate token`.
+    #[serde(default)]
+    pub(crate) token_hashes: Vec<Digest>,
+    /// Plaintext accepted token, intended for env injection only
+    /// (`OBELISK__API__TOKEN`); do not write it into the config file.
+    #[serde(default, deserialize_with = "deserialize_opt_secret_string")]
+    #[schemars(with = "Option<String>")]
+    pub(crate) token: Option<SecretString>,
 }
 impl Default for ApiConfig {
     fn default() -> Self {
         Self {
             enabled: true,
             listening_addr: default_api_listening_addr(),
+            token_hashes: Vec::new(),
+            token: None,
         }
     }
+}
+fn deserialize_opt_secret_string<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<SecretString>, D::Error> {
+    Ok(Option::<String>::deserialize(deserializer)?.map(SecretString::from))
 }
 fn default_api_listening_addr() -> SocketAddr {
     "127.0.0.1:5005".parse().expect("valid default address")

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use args::{Args, Subcommand};
 use clap::Parser;
 use directories::ProjectDirs;
 use grpc::{grpc_gen, injector::TracingInjector};
+use secrecy::{ExposeSecret as _, SecretString};
 use tonic::{codec::CompressionEncoding, transport::Channel};
 use tracing::error;
 
@@ -24,7 +25,11 @@ async fn main() -> Result<(), anyhow::Error> {
     rustls::crypto::ring::default_provider()
         .install_default()
         .expect("default tls provider must be installed");
-    match Args::parse().command {
+    let args = Args::parse();
+    API_TOKEN
+        .set(resolve_api_token(args.api_token))
+        .expect("API_TOKEN is only set here");
+    match args.command {
         Subcommand::Server(server) => server
             .run()
             .await
@@ -40,6 +45,80 @@ pub(crate) fn project_dirs() -> Option<ProjectDirs> {
     ProjectDirs::from("", "obelisk", "obelisk")
 }
 
+/// Token this CLI invocation presents to the server, resolved once from
+/// `--api-token` > `OBELISK_API_TOKEN` > `OBELISK__API__TOKEN`.
+static API_TOKEN: std::sync::OnceLock<Option<SecretString>> = std::sync::OnceLock::new();
+
+fn resolve_api_token(flag: Option<SecretString>) -> Option<SecretString> {
+    flag.or_else(|| {
+        std::env::var("OBELISK_API_TOKEN")
+            .ok()
+            .map(SecretString::from)
+    })
+    .or_else(|| {
+        std::env::var("OBELISK__API__TOKEN")
+            .ok()
+            .map(SecretString::from)
+    })
+    .filter(|token| !token.expose_secret().is_empty())
+}
+
+pub(crate) fn api_token() -> Option<&'static SecretString> {
+    API_TOKEN.get_or_init(|| None).as_ref()
+}
+
+/// Client interceptor for all gRPC calls: injects tracing metadata and, if a
+/// token is configured, the `authorization` header.
+#[derive(Clone)]
+pub(crate) struct ClientInterceptor {
+    authorization: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
+}
+
+impl ClientInterceptor {
+    fn new() -> Result<Self, anyhow::Error> {
+        let authorization = if let Some(token) = api_token() {
+            let mut authorization: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
+                format!("Bearer {}", token.expose_secret())
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
+            authorization.set_sensitive(true);
+            Some(authorization)
+        } else {
+            None
+        };
+        Ok(Self { authorization })
+    }
+}
+
+impl tonic::service::Interceptor for ClientInterceptor {
+    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        let mut request = tonic::service::Interceptor::call(&mut TracingInjector, request)?;
+        if let Some(authorization) = &self.authorization {
+            request
+                .metadata_mut()
+                .insert("authorization", authorization.clone());
+        }
+        Ok(request)
+    }
+}
+
+/// HTTP client for web-API calls, presenting the API token as a default header.
+pub(crate) fn web_api_client() -> Result<reqwest::Client, anyhow::Error> {
+    Ok(web_api_client_builder()?.build()?)
+}
+
+pub(crate) fn web_api_client_builder() -> Result<reqwest::ClientBuilder, anyhow::Error> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Some(token) = api_token() {
+        let mut value =
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))
+                .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
+        value.set_sensitive(true);
+        headers.insert(reqwest::header::AUTHORIZATION, value);
+    }
+    Ok(reqwest::Client::builder().default_headers(headers))
+}
+
 /// Maximum encoded gRPC message size for the deployment repository service. Submit
 /// requests inline deployment-owned file blobs and `GetFile` returns them, so the
 /// default 4 MiB tonic limit is far too small. This caps both the server's decoding
@@ -47,7 +126,7 @@ pub(crate) fn project_dirs() -> Option<ProjectDirs> {
 pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
 
 type ExecutionRepositoryClient = grpc_gen::execution_repository_client::ExecutionRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, TracingInjector>,
+    tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
 >;
 
 async fn get_execution_repository_client(
@@ -56,7 +135,7 @@ async fn get_execution_repository_client(
     Ok(
         grpc_gen::execution_repository_client::ExecutionRepositoryClient::with_interceptor(
             channel,
-            TracingInjector,
+            ClientInterceptor::new()?,
         )
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)
@@ -65,7 +144,7 @@ async fn get_execution_repository_client(
 }
 type DeploymentRepositoryClient =
     grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
-        tonic::service::interceptor::InterceptedService<Channel, TracingInjector>,
+        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
     >;
 async fn get_deployment_repository_client(
     channel: Channel,
@@ -73,7 +152,7 @@ async fn get_deployment_repository_client(
     Ok(
         grpc_gen::deployment_repository_client::DeploymentRepositoryClient::with_interceptor(
             channel,
-            TracingInjector,
+            ClientInterceptor::new()?,
         )
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)
@@ -84,7 +163,7 @@ async fn get_deployment_repository_client(
 }
 
 type FunctionRepositoryClient = grpc_gen::function_repository_client::FunctionRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, TracingInjector>,
+    tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
 >;
 async fn get_fn_repository_client(
     channel: Channel,
@@ -92,7 +171,7 @@ async fn get_fn_repository_client(
     Ok(
         grpc_gen::function_repository_client::FunctionRepositoryClient::with_interceptor(
             channel,
-            TracingInjector,
+            ClientInterceptor::new()?,
         )
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "512"]
 
+mod api;
 mod args;
+mod client;
 mod command;
 mod config;
 mod env_vars;
@@ -12,9 +14,6 @@ mod wit_printer;
 use args::{Args, Subcommand};
 use clap::Parser;
 use directories::ProjectDirs;
-use grpc::{grpc_gen, injector::TracingInjector};
-use secrecy::{ExposeSecret as _, SecretString};
-use tonic::{codec::CompressionEncoding, transport::Channel};
 use tracing::error;
 
 #[global_allocator]
@@ -26,9 +25,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .install_default()
         .expect("default tls provider must be installed");
     let args = Args::parse();
-    API_TOKEN
-        .set(resolve_api_token(args.api_token))
-        .expect("API_TOKEN is only set here");
+    client::init_api_token(args.api_token);
     match args.command {
         Subcommand::Server(server) => server
             .run()
@@ -43,140 +40,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
 pub(crate) fn project_dirs() -> Option<ProjectDirs> {
     ProjectDirs::from("", "obelisk", "obelisk")
-}
-
-/// Token this CLI invocation presents to the server, resolved once from
-/// `--api-token` > `OBELISK_API_TOKEN` > `OBELISK__API__TOKEN`.
-static API_TOKEN: std::sync::OnceLock<Option<SecretString>> = std::sync::OnceLock::new();
-
-fn resolve_api_token(flag: Option<SecretString>) -> Option<SecretString> {
-    flag.or_else(|| {
-        std::env::var("OBELISK_API_TOKEN")
-            .ok()
-            .map(SecretString::from)
-    })
-    .or_else(|| {
-        std::env::var("OBELISK__API__TOKEN")
-            .ok()
-            .map(SecretString::from)
-    })
-    .filter(|token| !token.expose_secret().is_empty())
-}
-
-pub(crate) fn api_token() -> Option<&'static SecretString> {
-    API_TOKEN.get_or_init(|| None).as_ref()
-}
-
-/// Client interceptor for all gRPC calls: injects tracing metadata and, if a
-/// token is configured, the `authorization` header.
-#[derive(Clone)]
-pub(crate) struct ClientInterceptor {
-    authorization: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
-}
-
-impl ClientInterceptor {
-    fn new() -> Result<Self, anyhow::Error> {
-        let authorization = if let Some(token) = api_token() {
-            let mut authorization: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
-                format!("Bearer {}", token.expose_secret())
-                    .parse()
-                    .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
-            authorization.set_sensitive(true);
-            Some(authorization)
-        } else {
-            None
-        };
-        Ok(Self { authorization })
-    }
-}
-
-impl tonic::service::Interceptor for ClientInterceptor {
-    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
-        let mut request = tonic::service::Interceptor::call(&mut TracingInjector, request)?;
-        if let Some(authorization) = &self.authorization {
-            request
-                .metadata_mut()
-                .insert("authorization", authorization.clone());
-        }
-        Ok(request)
-    }
-}
-
-/// HTTP client for web-API calls, presenting the API token as a default header.
-pub(crate) fn web_api_client() -> Result<reqwest::Client, anyhow::Error> {
-    Ok(web_api_client_builder()?.build()?)
-}
-
-pub(crate) fn web_api_client_builder() -> Result<reqwest::ClientBuilder, anyhow::Error> {
-    let mut headers = reqwest::header::HeaderMap::new();
-    if let Some(token) = api_token() {
-        let mut value =
-            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))
-                .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
-        value.set_sensitive(true);
-        headers.insert(reqwest::header::AUTHORIZATION, value);
-    }
-    Ok(reqwest::Client::builder().default_headers(headers))
-}
-
-/// Maximum encoded gRPC message size for the deployment repository service. Submit
-/// requests inline deployment-owned file blobs and `GetFile` returns them, so the
-/// default 4 MiB tonic limit is far too small. This caps both the server's decoding
-/// and the client's encoding/decoding for that service.
-pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
-
-type ExecutionRepositoryClient = grpc_gen::execution_repository_client::ExecutionRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
->;
-
-async fn get_execution_repository_client(
-    channel: Channel,
-) -> Result<ExecutionRepositoryClient, anyhow::Error> {
-    Ok(
-        grpc_gen::execution_repository_client::ExecutionRepositoryClient::with_interceptor(
-            channel,
-            ClientInterceptor::new()?,
-        )
-        .send_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Gzip),
-    )
-}
-type DeploymentRepositoryClient =
-    grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
-        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
-    >;
-async fn get_deployment_repository_client(
-    channel: Channel,
-) -> Result<DeploymentRepositoryClient, anyhow::Error> {
-    Ok(
-        grpc_gen::deployment_repository_client::DeploymentRepositoryClient::with_interceptor(
-            channel,
-            ClientInterceptor::new()?,
-        )
-        .send_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Gzip)
-        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
-    )
-}
-
-type FunctionRepositoryClient = grpc_gen::function_repository_client::FunctionRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
->;
-async fn get_fn_repository_client(
-    channel: Channel,
-) -> Result<FunctionRepositoryClient, anyhow::Error> {
-    Ok(
-        grpc_gen::function_repository_client::FunctionRepositoryClient::with_interceptor(
-            channel,
-            ClientInterceptor::new()?,
-        )
-        .send_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Zstd)
-        .accept_compressed(CompressionEncoding::Gzip),
-    )
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd)]

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -12,11 +12,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use concepts::component_id::Digest;
-use rand::Rng as _;
 use secrecy::ExposeSecret as _;
-use sha2::{Digest as _, Sha256};
-use std::fmt::Write as _;
 use std::sync::Arc;
 use subtle::ConstantTimeEq as _;
 use tracing::{debug, warn};
@@ -31,14 +27,20 @@ pub(crate) struct ApiAuth {
 
 impl ApiAuth {
     pub(crate) fn new(config: &ApiConfig, allow_all: bool) -> Self {
-        let startup_token = generate_token();
-        let mut accepted = vec![(sha256(&startup_token), "startup-token".to_string())];
+        let startup_token = crate::api::generate_token();
+        let mut accepted = vec![(
+            crate::api::token_digest(&startup_token),
+            "startup-token".to_string(),
+        )];
         for digest in &config.token_hashes {
             accepted.push((digest.0, hash_prefix_label(digest)));
         }
         if let Some(token) = &config.token {
-            let digest = sha256(token.expose_secret());
-            accepted.push((digest, hash_prefix_label(&Digest(digest))));
+            let digest = crate::api::token_digest(token.expose_secret());
+            accepted.push((
+                digest,
+                hash_prefix_label(&concepts::component_id::Digest(digest)),
+            ));
         }
         Self {
             accepted,
@@ -68,7 +70,7 @@ impl ApiAuth {
         }
         // Hash-then-compare: digests of the secret are matched, so the comparison
         // cannot leak anything useful about accepted tokens.
-        let digest = sha256(token.trim());
+        let digest = crate::api::token_digest(token.trim());
         self.accepted
             .iter()
             .find(|(accepted, _)| accepted.ct_eq(&digest).into())
@@ -123,29 +125,7 @@ fn deny_response(headers: &HeaderMap) -> Response {
     }
 }
 
-fn sha256(token: &str) -> [u8; 32] {
-    Sha256::digest(token.as_bytes()).into()
-}
-
-/// Digest of a token as accepted in `api.token_hashes`; displays as `sha256:<hex>`.
-pub(crate) fn token_hash(token: &str) -> Digest {
-    Digest(sha256(token))
-}
-
-/// Generate a high-entropy random token (64 hex chars).
-pub(crate) fn generate_token() -> String {
-    hex(&rand::rng().random::<[u8; 32]>())
-}
-
-fn hex(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        write!(&mut out, "{b:02x}").expect("writing to string");
-    }
-    out
-}
-
 /// Audit-log identity of a `token_hashes` entry: the first 8 hex chars of its digest.
-fn hash_prefix_label(digest: &Digest) -> String {
-    format!("token:{}", &hex(&digest.0)[..8])
+fn hash_prefix_label(digest: &concepts::component_id::Digest) -> String {
+    format!("token:{}", &digest.to_string()["sha256:".len()..][..8])
 }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -12,7 +12,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use secrecy::ExposeSecret as _;
+use secrecy::{ExposeSecret as _, SecretString};
 use std::sync::Arc;
 use subtle::ConstantTimeEq as _;
 use tracing::{debug, warn};
@@ -20,16 +20,15 @@ use tracing::{debug, warn};
 pub(crate) struct ApiAuth {
     /// Accepted token digests with the identity label used in audit logs.
     accepted: Vec<([u8; 32], String)>,
-    /// Always-generated recovery token, printed to the console, valid until shutdown.
-    startup_token: String,
-    allow_all: bool,
+    /// Recovery token, printed to the console, valid until shutdown.
+    startup_token: SecretString,
 }
 
 impl ApiAuth {
-    pub(crate) fn new(config: &ApiConfig, allow_all: bool) -> Self {
-        let startup_token = crate::api::generate_token();
+    pub(crate) fn new(config: &ApiConfig) -> Self {
+        let startup_token = SecretString::from(crate::api::generate_token());
         let mut accepted = vec![(
-            crate::api::token_digest(&startup_token),
+            crate::api::token_digest(startup_token.expose_secret()),
             "startup-token".to_string(),
         )];
         for digest in &config.token_hashes {
@@ -45,18 +44,14 @@ impl ApiAuth {
         Self {
             accepted,
             startup_token,
-            allow_all,
         }
     }
 
-    pub(crate) fn startup_token(&self) -> &str {
+    pub(crate) fn startup_token(&self) -> &SecretString {
         &self.startup_token
     }
 
     fn check(&self, headers: &HeaderMap) -> Result<&str, &'static str> {
-        if self.allow_all {
-            return Ok("allow-all");
-        }
         let presented = headers
             .get(header::AUTHORIZATION)
             .ok_or("missing `authorization` header")?
@@ -95,7 +90,7 @@ pub(crate) async fn auth_middleware(
                 (CLI: `--api-token` or OBELISK_API_TOKEN). This server's startup token: {}",
                 req.method(),
                 req.uri().path(),
-                auth.startup_token
+                auth.startup_token.expose_secret()
             );
             deny_response(req.headers())
         }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -1,0 +1,151 @@
+//! Host-level bearer token check guarding the API port (web API, gRPC, gRPC-web).
+//!
+//! Applied as a middleware around the combined axum service before any routing,
+//! so all three surfaces are authenticated uniformly; gRPC streams are checked
+//! once at stream open. See `meta/designs/server-security-guard.md` (v1).
+
+use crate::config::toml::ApiConfig;
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::{HeaderMap, StatusCode, header},
+    middleware::Next,
+    response::Response,
+};
+use concepts::component_id::Digest;
+use rand::Rng as _;
+use secrecy::ExposeSecret as _;
+use sha2::{Digest as _, Sha256};
+use std::fmt::Write as _;
+use std::sync::Arc;
+use subtle::ConstantTimeEq as _;
+use tracing::{debug, warn};
+
+pub(crate) struct ApiAuth {
+    /// Accepted token digests with the identity label used in audit logs.
+    accepted: Vec<([u8; 32], String)>,
+    /// Always-generated recovery token, printed to the console, valid until shutdown.
+    startup_token: String,
+    allow_all: bool,
+}
+
+impl ApiAuth {
+    pub(crate) fn new(config: &ApiConfig, allow_all: bool) -> Self {
+        let startup_token = generate_token();
+        let mut accepted = vec![(sha256(&startup_token), "startup-token".to_string())];
+        for digest in &config.token_hashes {
+            accepted.push((digest.0, hash_prefix_label(digest)));
+        }
+        if let Some(token) = &config.token {
+            let digest = sha256(token.expose_secret());
+            accepted.push((digest, hash_prefix_label(&Digest(digest))));
+        }
+        Self {
+            accepted,
+            startup_token,
+            allow_all,
+        }
+    }
+
+    pub(crate) fn startup_token(&self) -> &str {
+        &self.startup_token
+    }
+
+    fn check(&self, headers: &HeaderMap) -> Result<&str, &'static str> {
+        if self.allow_all {
+            return Ok("allow-all");
+        }
+        let presented = headers
+            .get(header::AUTHORIZATION)
+            .ok_or("missing `authorization` header")?
+            .to_str()
+            .map_err(|_| "malformed `authorization` header")?;
+        let (scheme, token) = presented
+            .split_once(' ')
+            .ok_or("malformed `authorization` header")?;
+        if !scheme.eq_ignore_ascii_case("bearer") {
+            return Err("unsupported `authorization` scheme, expected `Bearer`");
+        }
+        // Hash-then-compare: digests of the secret are matched, so the comparison
+        // cannot leak anything useful about accepted tokens.
+        let digest = sha256(token.trim());
+        self.accepted
+            .iter()
+            .find(|(accepted, _)| accepted.ct_eq(&digest).into())
+            .map(|(_, identity)| identity.as_str())
+            .ok_or("unknown token")
+    }
+}
+
+pub(crate) async fn auth_middleware(
+    State(auth): State<Arc<ApiAuth>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    match auth.check(req.headers()) {
+        Ok(identity) => {
+            debug!(identity, path = %req.uri().path(), "Authorized API request");
+            next.run(req).await
+        }
+        Err(reason) => {
+            warn!(
+                "Denied {} {}: {reason}. Clients must send `Authorization: Bearer <token>` \
+                (CLI: `--api-token` or OBELISK_API_TOKEN). This server's startup token: {}",
+                req.method(),
+                req.uri().path(),
+                auth.startup_token
+            );
+            deny_response(req.headers())
+        }
+    }
+}
+
+fn deny_response(headers: &HeaderMap) -> Response {
+    let grpc_content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|content_type| content_type.to_str().ok())
+        .filter(|content_type| content_type.starts_with("application/grpc"));
+    if let Some(content_type) = grpc_content_type {
+        // Trailers-only gRPC response; 16 = UNAUTHENTICATED.
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, content_type)
+            .header("grpc-status", "16")
+            .header("grpc-message", "missing or invalid API token")
+            .body(Body::empty())
+            .expect("static response must build")
+    } else {
+        Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(header::WWW_AUTHENTICATE, "Bearer")
+            .body(Body::from("missing or invalid API token"))
+            .expect("static response must build")
+    }
+}
+
+fn sha256(token: &str) -> [u8; 32] {
+    Sha256::digest(token.as_bytes()).into()
+}
+
+/// Digest of a token as accepted in `api.token_hashes`; displays as `sha256:<hex>`.
+pub(crate) fn token_hash(token: &str) -> Digest {
+    Digest(sha256(token))
+}
+
+/// Generate a high-entropy random token (64 hex chars).
+pub(crate) fn generate_token() -> String {
+    hex(&rand::rng().random::<[u8; 32]>())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(&mut out, "{b:02x}").expect("writing to string");
+    }
+    out
+}
+
+/// Audit-log identity of a `token_hashes` entry: the first 8 hex chars of its digest.
+fn hash_prefix_label(digest: &Digest) -> String {
+    format!("token:{}", &hex(&digest.0)[..8])
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod auth;
 pub(crate) mod deployment_summary;
 pub(crate) mod grpc_server;
 pub(crate) mod web_api_server;


### PR DESCRIPTION
- **feat(api)!: Add token based auth, deny unauthenticated requests by default**
- **refactor: Split server and client auth**
- **refactor: Do not install auth layer on `--allow-all`**
- **refactor(cli): Add `-s` as a shorthand for `--server-config`**
- **refactor(cli): Rename `--allow-all` to `--allow-unauthenticated-api`**
- **style: Clippy**
