### PR TITLE
fix(workflow): Start `DelayId` indexing from 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(js)* A cancelled `obelisk.sleep` now throws `obelisk.ChildError` (with `cancelled: true` and
+  `failureKind: "cancelled"`) instead of a plain `Error`; the message stays `Sleep was cancelled`.
+  Its `.value` is `undefined`, indicating that the cancellation has no business error payload.
+  Re-throwing the caught error serializes that value as a `null` workflow err payload, like any
+  other payload-less `ChildError`, instead of propagating the message string.
+- *(js)* A delay cancelled inside a join set now also sets `failureKind: "cancelled"` on the
+  `ChildError` thrown by `joinNext`/`joinNextTry` (previously only `cancelled: true` was set).
+
+### Deprecated
+
+- *(js)* Renamed `obelisk.ChildExecutionError` to `obelisk.ChildError`, which now also covers
+  cancelled delays and sleeps. The old name stays as a deprecated alias for the same constructor,
+  so `instanceof` checks against either name keep working; instances now report
+  `name: "ChildError"`.
+
 ## [0.40.0](https://github.com/obeli-sk/obelisk/compare/v0.39.5...v0.40.0)
 
 This release secures access to host executable activities and the Obelisk API. Exec activities are

--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-07-11-1@sha256:8ca9476b27513d58672a0d4fb0fbcd73d939fcafa0ac96f894ddc5822a711975
+oci://docker.io/getobelisk/webhook-js-runtime:2026-07-15@sha256:c0f7a883972c242e98d78be5875c15d3e24af1d4a58e4dcb6d58e964c59b819d

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-07-11-1@sha256:43110a1841c4eec0ef80c2d77c14a71bac2611cdfb72b435d4d2968efa128edb
+oci://docker.io/getobelisk/workflow-js-runtime:2026-07-15@sha256:59f36f5f0f9cc00c42bdbb7740b8cd378132c52bea96a4ef64c40c5d5e34be29

--- a/crates/boa-common/src/child_error.rs
+++ b/crates/boa-common/src/child_error.rs
@@ -1,5 +1,5 @@
-//! `obelisk.ChildExecutionError` — the single catchable type thrown when an
-//! awaited child execution (or a cancelled delay) fails.
+//! `obelisk.ChildError`: the single catchable type thrown when an awaited
+//! child execution, a cancelled delay, or a cancelled `obelisk.sleep` fails.
 //!
 //! It replaces the earlier "throw the raw err value / `throw null`" behavior:
 //! - Always truthy and `instanceof Error` (its prototype is spliced onto
@@ -10,10 +10,14 @@
 //!   instance via the native brand (`downcast_ref`) and re-serializes `.value`,
 //!   so `throw e` behaves like `throw e.value`.
 //!
-//! The native data ([`ChildExecutionError`]) is intentionally empty: every
-//! user-visible field lives as an ordinary JS own property. The Rust struct
-//! exists only as a brand that the producer can detect via `downcast_ref`,
-//! rather than sniffing a spoofable `.name`/prototype.
+//! `obelisk.ChildExecutionError` (the 0.40.0 name) stays as a deprecated alias
+//! for the same constructor, so `instanceof` checks against either name are
+//! identical.
+//!
+//! The native data ([`ChildError`]) is intentionally empty: every user-visible
+//! field lives as an ordinary JS own property. The Rust struct exists only as a
+//! brand that the producer can detect via `downcast_ref`, rather than sniffing
+//! a spoofable `.name`/prototype.
 
 use boa_engine::{
     Context, JsError, JsNativeError, JsObject, JsResult, JsValue, Source,
@@ -22,12 +26,12 @@ use boa_engine::{
 };
 use boa_gc::{Finalize, Trace};
 
-/// Native brand stored inside every `obelisk.ChildExecutionError` instance.
+/// Native brand stored inside every `obelisk.ChildError` instance.
 #[derive(Debug, Trace, Finalize, boa_engine::JsData)]
-pub struct ChildExecutionError;
+pub struct ChildError;
 
-impl Class for ChildExecutionError {
-    const NAME: &'static str = "ChildExecutionError";
+impl Class for ChildError {
+    const NAME: &'static str = "ChildError";
     const LENGTH: usize = 1;
 
     fn data_constructor(
@@ -35,7 +39,7 @@ impl Class for ChildExecutionError {
         _args: &[JsValue],
         _context: &mut Context,
     ) -> JsResult<Self> {
-        Ok(ChildExecutionError)
+        Ok(ChildError)
     }
 
     fn object_constructor(
@@ -46,12 +50,7 @@ impl Class for ChildExecutionError {
         let obj = instance.clone().upcast();
         let message = args.first().cloned().unwrap_or(JsValue::undefined());
         obj.set(js_string!("message"), message, false, context)?;
-        obj.set(
-            js_string!("name"),
-            js_string!("ChildExecutionError"),
-            false,
-            context,
-        )?;
+        obj.set(js_string!("name"), js_string!("ChildError"), false, context)?;
         Ok(())
     }
 
@@ -60,27 +59,31 @@ impl Class for ChildExecutionError {
     }
 }
 
-/// Register `obelisk.ChildExecutionError`.
+/// Register `obelisk.ChildError` (and its deprecated alias
+/// `obelisk.ChildExecutionError`).
 ///
 /// Must run after the global `obelisk` object has been installed. Registers the
 /// native class, moves the constructor under `obelisk` (off the global
 /// namespace), and splices its prototype chain onto `Error` so that
 /// `instanceof Error` holds and instances inherit `Error.prototype`.
 pub fn register(context: &mut Context) -> JsResult<()> {
-    context.register_global_class::<ChildExecutionError>()?;
+    context.register_global_class::<ChildError>()?;
+    // backcompat: 0.40.x apps catch obelisk.ChildExecutionError; keep the alias
+    // (same constructor, so `instanceof` is identical) until the old name is removed.
     context.eval(Source::from_bytes(
-        "obelisk.ChildExecutionError = globalThis.ChildExecutionError;\n\
-         delete globalThis.ChildExecutionError;\n\
-         Object.setPrototypeOf(obelisk.ChildExecutionError.prototype, Error.prototype);\n\
-         Object.setPrototypeOf(obelisk.ChildExecutionError, Error);",
+        "obelisk.ChildError = globalThis.ChildError;\n\
+         delete globalThis.ChildError;\n\
+         Object.setPrototypeOf(obelisk.ChildError.prototype, Error.prototype);\n\
+         Object.setPrototypeOf(obelisk.ChildError, Error);\n\
+         obelisk.ChildExecutionError = obelisk.ChildError;",
     ))?;
     Ok(())
 }
 
 /// Resolved pieces of a child-execution failure, gathered by each runtime from
 /// its own host bindings before delegating message/object construction here.
-pub struct ChildExecutionErrorParts<'a> {
-    /// Completed child execution id; `None` for a delay.
+pub struct ChildErrorParts<'a> {
+    /// Completed child execution id; `None` for a delay or a cancelled sleep.
     pub child_id: Option<&'a str>,
     /// Cancelled delay id; `Some` only for a cancelled delay.
     pub delay_id: Option<&'a str>,
@@ -88,18 +91,18 @@ pub struct ChildExecutionErrorParts<'a> {
     /// platform failure.
     pub value_json: Option<&'a str>,
     /// Execution-failure kind as a kebab string (mirrors the WIT
-    /// `execution-failure-kind` enum) for a platform failure; `None` for a
-    /// business err or a cancelled delay.
+    /// `execution-failure-kind` enum) for a platform failure or a cancelled
+    /// delay/sleep (`"cancelled"`); `None` for a business err.
     pub failure_kind: Option<&'a str>,
     /// Whether the child or delay was cancelled.
     pub cancelled: bool,
+    /// Verbatim `.message` override; when `None` the message is derived from
+    /// the other parts.
+    pub message: Option<&'a str>,
 }
 
-/// Build a `ChildExecutionError` and wrap it as a throwable [`JsError`].
-pub fn make_child_execution_error(
-    parts: &ChildExecutionErrorParts,
-    context: &mut Context,
-) -> JsResult<JsError> {
+/// Build a `ChildError` and wrap it as a throwable [`JsError`].
+pub fn make_child_error(parts: &ChildErrorParts, context: &mut Context) -> JsResult<JsError> {
     // `.value` is the parsed business payload, and `undefined` for a platform
     // failure (kind set, synthesized sentinel dropped) or a unit err.
     let value = match (parts.failure_kind, parts.value_json) {
@@ -107,7 +110,10 @@ pub fn make_child_execution_error(
         (None, Some(json)) => context.eval(Source::from_bytes(&format!("({json})")))?,
     };
 
-    let message = build_message(parts, &value);
+    let message = match parts.message {
+        Some(message) => message.to_string(),
+        None => build_message(parts, &value),
+    };
 
     // Construct via the registered constructor so the instance carries the
     // native brand and the (Error-spliced) prototype.
@@ -150,7 +156,7 @@ pub fn make_child_execution_error(
 }
 
 /// A human-facing one-liner; programmatic access always goes through `.value`.
-fn build_message(parts: &ChildExecutionErrorParts, value: &JsValue) -> String {
+fn build_message(parts: &ChildErrorParts, value: &JsValue) -> String {
     if let Some(delay_id) = parts.delay_id {
         return format!("delay {delay_id} cancelled");
     }
@@ -166,7 +172,7 @@ fn build_message(parts: &ChildExecutionErrorParts, value: &JsValue) -> String {
     msg
 }
 
-/// Fetch the `obelisk.ChildExecutionError` constructor.
+/// Fetch the `obelisk.ChildError` constructor.
 fn ctor(context: &mut Context) -> JsResult<JsObject> {
     let global = context.global_object();
     let obelisk = global
@@ -174,11 +180,11 @@ fn ctor(context: &mut Context) -> JsResult<JsObject> {
         .as_object()
         .ok_or_else(|| JsNativeError::error().with_message("global obelisk object missing"))?;
     obelisk
-        .get(js_string!("ChildExecutionError"), context)?
+        .get(js_string!("ChildError"), context)?
         .as_object()
         .ok_or_else(|| {
             JsNativeError::error()
-                .with_message("obelisk.ChildExecutionError missing")
+                .with_message("obelisk.ChildError missing")
                 .into()
         })
 }

--- a/crates/boa-common/src/lib.rs
+++ b/crates/boa-common/src/lib.rs
@@ -1,6 +1,6 @@
 //! Common utilities for Boa JS engine-based Obelisk runtimes.
 
-pub mod child_execution_error;
+pub mod child_error;
 pub mod console;
 pub mod crypto;
 pub mod esm;

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -1373,15 +1373,20 @@ pub mod prefixed_ulid {
     impl DelayId {
         #[must_use]
         pub fn new(execution_id: &ExecutionId, join_set_id: &JoinSetId) -> DelayId {
-            Self::new_with_index(execution_id, join_set_id, DELAY_ID_START_IDX)
+            Self::from_index(execution_id, join_set_id, DELAY_ID_START_IDX)
         }
 
+        #[cfg(any(test, feature = "test"))]
         #[must_use]
         pub fn new_with_index(
             execution_id: &ExecutionId,
             join_set_id: &JoinSetId,
             idx: u64,
         ) -> DelayId {
+            Self::from_index(execution_id, join_set_id, idx)
+        }
+
+        fn from_index(execution_id: &ExecutionId, join_set_id: &JoinSetId, idx: u64) -> DelayId {
             let ExecutionIdDerived {
                 top_level: PrefixedUlid { ulid, .. },
                 infix,
@@ -1396,11 +1401,21 @@ pub mod prefixed_ulid {
         }
 
         #[must_use]
+        pub fn index(&self) -> u64 {
+            self.idx
+        }
+
+        #[must_use]
         pub fn get_incremented(&self) -> Self {
+            self.get_incremented_by(1)
+        }
+
+        #[must_use]
+        pub fn get_incremented_by(&self, count: u64) -> Self {
             Self {
                 top_level: self.top_level,
                 infix: self.infix.clone(),
-                idx: self.idx + 1,
+                idx: self.idx + count,
             }
         }
 

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -805,8 +805,8 @@ impl SqlitePool {
                     // save result to be sent to the caller
                     *fn_res.lock().unwrap() = Some(func_res);
                     match tx_type {
-                        TxType::MultipleWrites => res,
-                        TxType::Other => Ok(()),
+                        TxType::MultipleWrites => res, // Rollback, skipping this on LTX replay.
+                        TxType::Other => Ok(()), // Failed single write should not rollback the PhyTx
                     }
                 }),
                 sent_at: Instant::now(),

--- a/crates/testing/db-tests/Cargo.toml
+++ b/crates/testing/db-tests/Cargo.toml
@@ -12,7 +12,7 @@ version.workspace = true
 test = ["concepts/test", "db-sqlite/test", "db-postgres/test"]
 
 [dependencies]
-concepts.workspace = true
+concepts = { workspace = true, features = ["test"] }
 db-sqlite = { workspace = true, features = ["tempfile"] }
 db-postgres.workspace = true
 test-utils.workspace = true

--- a/crates/testing/test-programs/js/workflow/cancel_child_error.js
+++ b/crates/testing/test-programs/js/workflow/cancel_child_error.js
@@ -1,16 +1,20 @@
 // Await a child execution that is cancelled out-of-band. The child's cancellation
 // is a platform failure (not a business err), so `joinNext` throws a
-// `ChildExecutionError` whose `.cancelled` is true, `.failureKind` is `cancelled`
+// `ChildError` whose `.cancelled` is true, `.failureKind` is `cancelled`
 // and `.value` is undefined (no err payload to carry).
 export default function cancel_child_error() {
+    // Deprecated alias must stay the very same constructor.
+    if (obelisk.ChildExecutionError !== obelisk.ChildError) {
+        throw 'expected obelisk.ChildExecutionError to alias obelisk.ChildError';
+    }
     // A named join set gives the child a well-known id the test can reconstruct.
     const js = obelisk.createJoinSet({ name: 'cancel-set' });
     const childId = js.submit('testing:integration/workflow-sleep.sleep-cancellable', []);
     try {
         js.joinNext();
     } catch (e) {
-        if (!(e instanceof obelisk.ChildExecutionError)) {
-            throw `expected ChildExecutionError, got: ${e}`;
+        if (!(e instanceof obelisk.ChildError)) {
+            throw `expected ChildError, got: ${e}`;
         }
         if (e.cancelled !== true) {
             throw `expected cancelled=true, got: ${e.cancelled}`;

--- a/crates/testing/test-programs/js/workflow/cancel_delay_error.js
+++ b/crates/testing/test-programs/js/workflow/cancel_delay_error.js
@@ -1,0 +1,23 @@
+// Validate the ChildError thrown by joinNext when a submitted delay is cancelled externally.
+export default function cancel_delay_error() {
+    const js = obelisk.createJoinSet({ name: 'cancel-delay' });
+    const delayId = js.submitDelay({ milliseconds: 100000 });
+    try {
+        js.joinNext();
+    } catch (e) {
+        if (!(e instanceof obelisk.ChildError) || !(e instanceof Error)) {
+            throw `expected ChildError, got: ${e}`;
+        }
+        if (e.name !== 'ChildError' || e.message !== `delay ${delayId} cancelled`) {
+            throw `unexpected error identity: ${e.name}: ${e.message}`;
+        }
+        if (e.cancelled !== true || e.failureKind !== 'cancelled') {
+            throw `unexpected cancellation metadata: ${e.cancelled}, ${e.failureKind}`;
+        }
+        if (e.value !== undefined || e.childId !== undefined) {
+            throw `unexpected payload metadata: ${e.value}, ${e.childId}`;
+        }
+        return 'cancelled-delay-observed';
+    }
+    throw 'delay was not cancelled';
+}

--- a/crates/testing/test-programs/js/workflow/cancel_sleep_error.js
+++ b/crates/testing/test-programs/js/workflow/cancel_sleep_error.js
@@ -1,0 +1,25 @@
+// Validate the ChildError thrown when a named durable sleep is cancelled externally,
+// then re-throw it to exercise transparent propagation of its undefined value.
+export default function cancel_sleep_error() {
+    try {
+        obelisk.sleep({ milliseconds: 100000 }, 'cancel-sleep');
+    } catch (e) {
+        if (!(e instanceof obelisk.ChildError) || !(e instanceof Error)) {
+            throw `expected ChildError, got: ${e}`;
+        }
+        if (obelisk.ChildExecutionError !== obelisk.ChildError) {
+            throw 'expected deprecated ChildExecutionError alias';
+        }
+        if (e.name !== 'ChildError' || e.message !== 'Sleep was cancelled') {
+            throw `unexpected error identity: ${e.name}: ${e.message}`;
+        }
+        if (e.cancelled !== true || e.failureKind !== 'cancelled') {
+            throw `unexpected cancellation metadata: ${e.cancelled}, ${e.failureKind}`;
+        }
+        if (e.value !== undefined || e.childId !== undefined) {
+            throw `unexpected payload metadata: ${e.value}, ${e.childId}`;
+        }
+        throw e;
+    }
+    throw 'sleep was not cancelled';
+}

--- a/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
+++ b/crates/testing/test-programs/js/workflow/join_next_try_semantics.js
@@ -1,5 +1,5 @@
 // Exercise JS joinNextTry() semantics: pending -> undefined, success -> value,
-// failure -> throw ChildExecutionError, exhausted -> host error class.
+// failure -> throw ChildError, exhausted -> host error class.
 import { addSubmit } from 'testing:integration-obelisk-ext/activity';
 import { myStubSubmit } from 'testing:integration-obelisk-ext/stubs';
 import { myStubStub } from 'testing:integration-obelisk-stub/stubs';
@@ -55,8 +55,8 @@ export default function join_next_try_semantics(id) {
         errJs.joinNextTry();
         throw 'expected stub error';
     } catch (e) {
-        if (!(e instanceof obelisk.ChildExecutionError)) {
-            throw `expected ChildExecutionError, got: ${e}`;
+        if (!(e instanceof obelisk.ChildError)) {
+            throw `expected ChildError, got: ${e}`;
         }
         if (e.value !== 'stub-err') {
             throw `unexpected child err value: ${e.value}`;
@@ -74,8 +74,8 @@ export default function join_next_try_semantics(id) {
         blockingErrJs.joinNext();
         throw 'expected blocking stub error';
     } catch (e) {
-        if (!(e instanceof obelisk.ChildExecutionError)) {
-            throw `expected ChildExecutionError, got: ${e}`;
+        if (!(e instanceof obelisk.ChildError)) {
+            throw `expected ChildError, got: ${e}`;
         }
         if (e.value !== 'stub-err-blocking') {
             throw `unexpected blocking child err value: ${e.value}`;

--- a/crates/testing/test-programs/js/workflow/rethrow_child_error.js
+++ b/crates/testing/test-programs/js/workflow/rethrow_child_error.js
@@ -1,4 +1,4 @@
-// Catch a child execution's string err as a ChildExecutionError and re-throw it.
+// Catch a child execution's string err as a ChildError and re-throw it.
 // The transparent re-propagation must reproduce the original err payload as the
 // workflow's own err value (i.e. `throw e` behaves like `throw e.value`).
 import { myStubSubmit } from 'testing:integration-obelisk-ext/stubs';
@@ -11,8 +11,8 @@ export default function rethrow_child_error(id) {
     try {
         js.joinNext();
     } catch (e) {
-        if (!(e instanceof obelisk.ChildExecutionError)) {
-            throw `expected ChildExecutionError, got: ${e}`;
+        if (!(e instanceof obelisk.ChildError)) {
+            throw `expected ChildError, got: ${e}`;
         }
         throw e; // transparent re-propagation -> workflow err 'boom'
     }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -3667,7 +3667,7 @@ pub(crate) mod tests {
             test_utils::set_up();
             // fibo(50) returns err in the test activity (n > 40 returns error).
             // fibo returns result<u64> (no err type), so the child fails with a unit
-            // err: a ChildExecutionError whose `.value` is undefined.
+            // err: a ChildError whose `.value` is undefined.
             let js_source = r#"
                 export default function handle(request) {
                     try {
@@ -3676,7 +3676,7 @@ pub(crate) mod tests {
                     } catch (e) {
                         return Response.json({
                             threw: true,
-                            isChildErr: e instanceof obelisk.ChildExecutionError,
+                            isChildErr: e instanceof obelisk.ChildError,
                             isError: e instanceof Error,
                             valueIsUndefined: e.value === undefined,
                             cancelled: e.cancelled,
@@ -3703,7 +3703,7 @@ pub(crate) mod tests {
             let resp = fetch_task.await.unwrap();
             assert_eq!(resp.status().as_u16(), 200);
             let body: serde_json::Value = resp.json().await.unwrap();
-            // Should have caught a ChildExecutionError with an undefined value
+            // Should have caught a ChildError with an undefined value
             // (unit err), which is a business err (not cancelled), and a child id.
             assert_eq!(body["threw"], serde_json::json!(true));
             assert_eq!(body["isChildErr"], serde_json::json!(true));

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -2106,12 +2106,11 @@ impl EventHistory {
         execution_id: &ExecutionId,
     ) -> DelayId {
         // TODO: Optimize
-        let idx = self
+        let offset = self
             .event_history
             .iter()
             .filter(|(event, processing_status, _version)| {
-                // Ignore unprocessed events, which happens only on replay where we need to produce "old" ids.
-                // Applying the `EventCall::SubmitDelay` will immediately mark this as processed.
+                // Applying `SubmitDelay` immediately marks the event as processed.
                 *processing_status == Processed &&
                 matches!(
                     event,
@@ -2120,11 +2119,33 @@ impl EventHistory {
                 )
             })
             .count();
-        DelayId::new_with_index(
-            execution_id,
-            join_set_id,
-            u64::try_from(idx).expect("too many delays in a join set"),
-        )
+        let offset = u64::try_from(offset).expect("too many delays in a join set");
+        let new_delay_id = DelayId::new(execution_id, join_set_id).get_incremented_by(offset);
+
+        // backcompat: 0.40.0 histories can contain delay indices starting at 0.
+        // Reuse the persisted id only when it follows the old or current sequence.
+        if let Some(found_delay_id) =
+            self.event_history
+                .iter()
+                .find_map(
+                    |(event, processing_status, _version)| match (event, processing_status) {
+                        (
+                            HistoryEvent::JoinSetRequest {
+                                join_set_id: found_join_set_id,
+                                request: JoinSetRequest::DelayRequest { delay_id, .. },
+                            },
+                            Unprocessed,
+                        ) if join_set_id == found_join_set_id => Some(delay_id),
+                        _ => None,
+                    },
+                )
+        {
+            // return the found DelayId if it is 0-based.
+            if found_delay_id.index() == offset {
+                return found_delay_id.clone();
+            }
+        }
+        new_delay_id
     }
 }
 

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@execute_workflow_fn_with_single_delay-testing_stub-workflow__workflow.join-next-in-scope.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@execute_workflow_fn_with_single_delay-testing_stub-workflow__workflow.join-next-in-scope.snap
@@ -93,7 +93,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "n:a",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.n:a_0",
+              "delay_id": "Delay_00000000000000000000000000.n:a_1",
               "expires_at": "1970-01-02T00:00:00Z",
               "schedule_at": {
                 "in": {
@@ -242,7 +242,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "n:f",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.n:f_0",
+              "delay_id": "Delay_00000000000000000000000000.n:f_1",
               "expires_at": "1970-01-02T00:00:00Z",
               "schedule_at": {
                 "in": {
@@ -473,7 +473,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "n:a",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.n:a_0",
+          "delay_id": "Delay_00000000000000000000000000.n:a_1",
           "result": {
             "Err": null
           }
@@ -518,7 +518,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "n:f",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.n:f_0",
+          "delay_id": "Delay_00000000000000000000000000.n:f_1",
           "result": {
             "Err": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@join_next_produces_all_processed_error-testing_sleep-workflow__workflow.join-next-produces-all-processed-error.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@join_next_produces_all_processed_error-testing_sleep-workflow__workflow.join-next-produces-all-processed-error.snap
@@ -70,7 +70,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:00.010Z",
               "schedule_at": {
                 "in": {
@@ -157,7 +157,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Ok": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@join_next_try_found-testing_sleep-workflow__workflow.join-next-try-found.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@join_next_try_found-testing_sleep-workflow__workflow.join-next-try-found.snap
@@ -70,7 +70,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:00.001Z",
               "schedule_at": {
                 "in": {
@@ -206,7 +206,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Ok": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@join_next_try_pending-testing_sleep-workflow__workflow.join-next-try-pending.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@join_next_try_pending-testing_sleep-workflow__workflow.join-next-try-pending.snap
@@ -70,7 +70,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:10Z",
               "schedule_at": {
                 "in": {
@@ -157,7 +157,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Err": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_delay-testing_stub-workflow__workflow.submit-race-join-next-delay.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_delay-testing_stub-workflow__workflow.submit-race-join-next-delay.snap
@@ -93,7 +93,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:00.010Z",
               "schedule_at": {
                 "in": {
@@ -206,7 +206,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Ok": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_stub-testing_stub-workflow__workflow.submit-race-join-next-stub-error.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_stub-testing_stub-workflow__workflow.submit-race-join-next-stub-error.snap
@@ -93,7 +93,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:00.010Z",
               "schedule_at": {
                 "in": {
@@ -236,7 +236,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Err": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_stub-testing_stub-workflow__workflow.submit-race-join-next-stub.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_stub-testing_stub-workflow__workflow.submit-race-join-next-stub.snap
@@ -93,7 +93,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:00.010Z",
               "schedule_at": {
                 "in": {
@@ -239,7 +239,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Err": null
           }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@two_delays_in_same_join_set-testing_sleep-workflow__workflow.two-delays-in-same-join-set.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@two_delays_in_same_join_set-testing_sleep-workflow__workflow.two-delays-in-same-join-set.snap
@@ -70,7 +70,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_0",
+              "delay_id": "Delay_00000000000000000000000000.g:1_1",
               "expires_at": "1970-01-01T00:00:10Z",
               "schedule_at": {
                 "in": {
@@ -94,7 +94,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
             "join_set_id": "g:1",
             "request": {
               "type": "delay_request",
-              "delay_id": "Delay_00000000000000000000000000.g:1_1",
+              "delay_id": "Delay_00000000000000000000000000.g:1_2",
               "expires_at": "1970-01-01T00:00:00.010Z",
               "schedule_at": {
                 "in": {
@@ -207,7 +207,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_1",
+          "delay_id": "Delay_00000000000000000000000000.g:1_2",
           "result": {
             "Ok": null
           }
@@ -220,7 +220,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "join_set_id": "g:1",
         "event": {
           "type": "delay_finished",
-          "delay_id": "Delay_00000000000000000000000000.g:1_0",
+          "delay_id": "Delay_00000000000000000000000000.g:1_1",
           "result": {
             "Err": null
           }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1792,7 +1792,7 @@ mod tests {
                 js.joinNext();
             } catch (e) {
                 threw = true;
-                isChildErr = e instanceof obelisk.ChildExecutionError;
+                isChildErr = e instanceof obelisk.ChildError;
                 isError = e instanceof Error;
                 valueIsUndefined = e.value === undefined;
                 cancelled = e.cancelled;
@@ -1822,7 +1822,7 @@ mod tests {
             "lastId should be set before throwing child err, got {result}"
         );
         assert_eq!(json!(true), result["threw"]);
-        // A unit err (result<string> has no err type) throws a ChildExecutionError
+        // A unit err (result<string> has no err type) throws a ChildError
         // (also an Error) whose `.value` is undefined; it is a business err, not a
         // platform failure, so `.cancelled` is false and `.failureKind` is absent.
         assert_eq!(json!(true), result["isChildErr"]);

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -108,7 +108,7 @@ use crate::generated::obelisk::webhook::webhook_support::{
     self, ExecutionStatus, ExecutionStatusFinished,
 };
 use crate::generated::obelisk::webhook::webhook_support_backtrace;
-use boa_common::child_execution_error::{ChildExecutionErrorParts, make_child_execution_error};
+use boa_common::child_error::{ChildErrorParts, make_child_error};
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::crypto::setup_crypto;
 use boa_common::esm::{EsmError, get_default_export, resolve_promise};
@@ -469,7 +469,7 @@ fn capture_backtrace(ctx: &Context) -> WasmBacktrace {
 }
 
 /// Unwrap a `Result<Option<String>, Option<String>>` from a child outcome into a
-/// JS value: returns the ok value, or throws an [`obelisk.ChildExecutionError`]
+/// JS value: returns the ok value, or throws an [`obelisk.ChildError`]
 /// built from the given child `exec_id`.
 fn unwrap_result(
     inner_result: Result<Option<String>, Option<String>>,
@@ -484,7 +484,7 @@ fn unwrap_result(
 }
 
 /// Kebab-case string for a WIT `execution-failure-kind`, used as
-/// `ChildExecutionError.failureKind`.
+/// `ChildError.failureKind`.
 fn exec_failure_kind_str(kind: ExecutionFailureKind) -> &'static str {
     match kind {
         ExecutionFailureKind::TimedOut => "timed-out",
@@ -495,7 +495,7 @@ fn exec_failure_kind_str(kind: ExecutionFailureKind) -> &'static str {
     }
 }
 
-/// Build a `ChildExecutionError` for a failed child execution, disambiguating a
+/// Build a `ChildError` for a failed child execution, disambiguating a
 /// business `err` from a platform failure via `get-execution-failure-kind`.
 fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsResult<JsError> {
     let exec = ExecutionId {
@@ -504,24 +504,26 @@ fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsR
     match webhook_support::get_execution_failure_kind(&exec) {
         Ok(Some(kind)) => {
             let cancelled = matches!(kind, ExecutionFailureKind::Cancelled);
-            make_child_execution_error(
-                &ChildExecutionErrorParts {
+            make_child_error(
+                &ChildErrorParts {
                     child_id: Some(exec_id),
                     delay_id: None,
                     value_json: None,
                     failure_kind: Some(exec_failure_kind_str(kind)),
                     cancelled,
+                    message: None,
                 },
                 ctx,
             )
         }
-        Ok(None) => make_child_execution_error(
-            &ChildExecutionErrorParts {
+        Ok(None) => make_child_error(
+            &ChildErrorParts {
                 child_id: Some(exec_id),
                 delay_id: None,
                 value_json: payload.as_deref(),
                 failure_kind: None,
                 cancelled: false,
+                message: None,
             },
             ctx,
         ),
@@ -531,7 +533,7 @@ fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsR
     }
 }
 
-/// Build a `ChildExecutionError` for a failed direct call (`obelisk.call` / an
+/// Build a `ChildError` for a failed direct call (`obelisk.call` / an
 /// import proxy), whose child id comes from `last-direct-call-id`.
 fn call_child_error(
     child_id: Option<&str>,
@@ -540,13 +542,14 @@ fn call_child_error(
 ) -> JsResult<JsError> {
     match child_id {
         Some(id) => child_error(id, payload, ctx),
-        None => make_child_execution_error(
-            &ChildExecutionErrorParts {
+        None => make_child_error(
+            &ChildErrorParts {
                 child_id: None,
                 delay_id: None,
                 value_json: payload.as_deref(),
                 failure_kind: None,
                 cancelled: false,
+                message: None,
             },
             ctx,
         ),
@@ -817,9 +820,10 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
     // Set obelisk as global
     context.register_global_property(js_string!("obelisk"), obelisk, Attribute::all())?;
 
-    // obelisk.ChildExecutionError — native, brand-safe error thrown for a failed
-    // child execution awaited via obelisk.call / obelisk.get / obelisk.tryGet.
-    boa_common::child_execution_error::register(context)?;
+    // obelisk.ChildError (plus the deprecated obelisk.ChildExecutionError alias):
+    // native, brand-safe error thrown for a failed child execution awaited via
+    // obelisk.call / obelisk.get / obelisk.tryGet.
+    boa_common::child_error::register(context)?;
 
     Ok(())
 }

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -86,6 +86,8 @@
 //! const wakeUp = obelisk.sleep({ milliseconds: 500 }); // Date
 //! const namedWakeUp = obelisk.sleep({ seconds: 30 }, "retry-timeout"); // Date
 //! console.log(wakeUp.toISOString()); // e.g. "2024-01-01T00:00:00.500Z"
+//! // A cancelled sleep throws an obelisk.ChildError with
+//! // cancelled=true and failureKind="cancelled".
 //! ```
 //!
 //! ## Random (Deterministic)
@@ -142,9 +144,7 @@ use crate::generated::obelisk::workflow::workflow_support_backtrace::{
     join_set_create_named, random_string, random_u64, random_u64_inclusive, schedule_json, sleep,
     stub_json, submit_delay, submit_json,
 };
-use boa_common::child_execution_error::{
-    ChildExecutionError, ChildExecutionErrorParts, make_child_execution_error,
-};
+use boa_common::child_error::{ChildError, ChildErrorParts, make_child_error};
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::helpers::{new_object, parse_ffqn};
 use boa_common::imports::{self, ProxyKind};
@@ -473,7 +473,7 @@ fn create_ext_get_proxy(context: &mut Context) -> JsValue {
 }
 
 /// Unwrap a `Result<Option<String>, Option<String>>` from a child outcome into a
-/// JS value: returns the ok value, or throws an [`obelisk.ChildExecutionError`]
+/// JS value: returns the ok value, or throws an [`obelisk.ChildError`]
 /// built from the given child `exec_id`.
 fn unwrap_result(
     inner_result: Result<Option<String>, Option<String>>,
@@ -488,7 +488,7 @@ fn unwrap_result(
 }
 
 /// Kebab-case string for a WIT `execution-failure-kind`, used as
-/// `ChildExecutionError.failureKind`.
+/// `ChildError.failureKind`.
 fn exec_failure_kind_str(kind: ExecutionFailureKind) -> &'static str {
     match kind {
         ExecutionFailureKind::TimedOut => "timed-out",
@@ -499,7 +499,7 @@ fn exec_failure_kind_str(kind: ExecutionFailureKind) -> &'static str {
     }
 }
 
-/// Build a `ChildExecutionError` for a failed child execution, disambiguating a
+/// Build a `ChildError` for a failed child execution, disambiguating a
 /// business `err` from a platform failure via `get-execution-failure-kind`.
 fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsResult<JsError> {
     let exec = ExecutionId {
@@ -508,36 +508,38 @@ fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsR
     match get_execution_failure_kind(&exec) {
         Ok(Some(kind)) => {
             let cancelled = matches!(kind, ExecutionFailureKind::Cancelled);
-            make_child_execution_error(
-                &ChildExecutionErrorParts {
+            make_child_error(
+                &ChildErrorParts {
                     child_id: Some(exec_id),
                     delay_id: None,
                     value_json: None,
                     failure_kind: Some(exec_failure_kind_str(kind)),
                     cancelled,
+                    message: None,
                 },
                 ctx,
             )
         }
-        Ok(None) => make_child_execution_error(
-            &ChildExecutionErrorParts {
+        Ok(None) => make_child_error(
+            &ChildErrorParts {
                 child_id: Some(exec_id),
                 delay_id: None,
                 value_json: payload.as_deref(),
                 failure_kind: None,
                 cancelled: false,
+                message: None,
             },
             ctx,
         ),
         // Failure kind is unresolvable (e.g. not-yet-processed): surface as a
-        // plain host error rather than a ChildExecutionError.
+        // plain host error rather than a ChildError.
         Err(e) => Ok(JsNativeError::error()
             .with_message(format!("failed to resolve child failure kind: {:?}", e))
             .into()),
     }
 }
 
-/// Build a `ChildExecutionError` for a failed direct call (`obelisk.call` / an
+/// Build a `ChildError` for a failed direct call (`obelisk.call` / an
 /// import proxy), whose child id comes from `last-direct-call-id`.
 fn call_child_error(
     child_id: Option<&str>,
@@ -546,40 +548,42 @@ fn call_child_error(
 ) -> JsResult<JsError> {
     match child_id {
         Some(id) => child_error(id, payload, ctx),
-        None => make_child_execution_error(
-            &ChildExecutionErrorParts {
+        None => make_child_error(
+            &ChildErrorParts {
                 child_id: None,
                 delay_id: None,
                 value_json: payload.as_deref(),
                 failure_kind: None,
                 cancelled: false,
+                message: None,
             },
             ctx,
         ),
     }
 }
 
-/// If `js_err` is a re-thrown [`obelisk.ChildExecutionError`], return its `.value`
+/// If `js_err` is a re-thrown [`obelisk.ChildError`], return its `.value`
 /// (the original business payload). Detection is brand-safe via `downcast_ref` on
 /// the native marker, not by sniffing `.name`/prototype.
-fn child_execution_error_rethrow_value(js_err: &JsError, ctx: &mut Context) -> Option<JsValue> {
+fn child_error_rethrow_value(js_err: &JsError, ctx: &mut Context) -> Option<JsValue> {
     let obj = js_err.as_opaque()?.as_object()?;
-    if obj.downcast_ref::<ChildExecutionError>().is_some() {
+    if obj.downcast_ref::<ChildError>().is_some() {
         obj.get(js_string!("value"), ctx).ok()
     } else {
         None
     }
 }
 
-/// Build a `ChildExecutionError` for a cancelled delay.
+/// Build a `ChildError` for a cancelled delay.
 fn delay_cancelled_error(delay_id: &str, ctx: &mut Context) -> JsResult<JsError> {
-    make_child_execution_error(
-        &ChildExecutionErrorParts {
+    make_child_error(
+        &ChildErrorParts {
             child_id: None,
             delay_id: Some(delay_id),
             value_json: None,
-            failure_kind: None,
+            failure_kind: Some("cancelled"),
             cancelled: true,
+            message: None,
         },
         ctx,
     )
@@ -778,20 +782,18 @@ pub fn execute(
         }
         Err(js_err) => {
             // JSON-encode the thrown value (consistent with ok branch).
-            // A re-thrown `ChildExecutionError` (`throw e`) is transparent: it
+            // A re-thrown `ChildError` (`throw e`) is transparent: it
             // re-serializes its `.value`, so it behaves like `throw e.value`.
             // `throw new Error("msg")` → JSON-encode the message string.
             // `throw expr` (null, string, number, object, …) → serialize via to_json.
-            let err_json = if let Some(value) =
-                child_execution_error_rethrow_value(&js_err, &mut context)
-            {
+            let err_json = if let Some(value) = child_error_rethrow_value(&js_err, &mut context) {
                 match value.to_json(&mut context) {
                     Ok(Some(json_val)) => serde_json::to_string(&json_val)
                         .expect("serde_json::Value must be serializable"),
                     Ok(None) => "null".to_string(), // undefined → null
                     Err(e) => {
                         return Err(JsRuntimeError::WrongThrownType(format!(
-                            "cannot serialize re-thrown ChildExecutionError value to JSON: {e:?}"
+                            "cannot serialize re-thrown ChildError value to JSON: {e:?}"
                         )));
                     }
                 }
@@ -995,9 +997,19 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
                 date.set_time(ms, ctx)?;
                 Ok(date.into())
             }
-            Err(()) => Err(JsNativeError::error()
-                .with_message("Sleep was cancelled")
-                .into()),
+            // A cancelled sleep throws a ChildError so it is catchable like any
+            // other cancellation, with the message kept stable.
+            Err(()) => Err(make_child_error(
+                &ChildErrorParts {
+                    child_id: None,
+                    delay_id: None,
+                    value_json: None,
+                    failure_kind: Some("cancelled"),
+                    cancelled: true,
+                    message: Some("Sleep was cancelled"),
+                },
+                ctx,
+            )?),
         }
     });
     obelisk.set(
@@ -1212,9 +1224,10 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         };",
     ))?;
 
-    // obelisk.ChildExecutionError — native, brand-safe error thrown for a failed
-    // awaited child execution or a cancelled delay.
-    boa_common::child_execution_error::register(context)?;
+    // obelisk.ChildError (plus the deprecated obelisk.ChildExecutionError alias):
+    // native, brand-safe error thrown for a failed awaited child execution, a
+    // cancelled delay, or a cancelled sleep.
+    boa_common::child_error::register(context)?;
 
     Ok(())
 }

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -3566,7 +3566,7 @@ async fn submit_workflow_cancelled_delay_surfaces_child_error() {
     let execution_id = server.generate_execution_id().await;
     let execution_id = execution_id.parse::<ExecutionId>().unwrap();
     let join_set_id = JoinSetId::new(JoinSetKind::Named, StrVariant::from("cancel-delay")).unwrap();
-    let delay_id = DelayId::new_with_index(&execution_id, &join_set_id, 0).to_string();
+    let delay_id = DelayId::new(&execution_id, &join_set_id).to_string();
     let execution_id = execution_id.to_string();
 
     let follow = server.submit_follow_with_id(

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -3438,7 +3438,7 @@ async fn submit_workflow_with_join_next_try_semantics() {
     server.shutdown().await;
 }
 
-/// A caught `ChildExecutionError` re-thrown with `throw e` transparently
+/// A caught `ChildError` re-thrown with `throw e` transparently
 /// reproduces the child's original err payload as the workflow's err.
 #[tokio::test]
 async fn submit_workflow_rethrows_child_execution_error() {
@@ -3457,7 +3457,7 @@ async fn submit_workflow_rethrows_child_execution_error() {
 }
 
 /// A child execution cancelled out-of-band surfaces to an awaiting JS parent as a
-/// `ChildExecutionError` with `.cancelled === true` and `.failureKind === "cancelled"`
+/// `ChildError` with `.cancelled === true` and `.failureKind === "cancelled"`
 /// (a platform failure with no err payload), not as a business err value.
 #[tokio::test]
 async fn submit_workflow_child_cancelled_surfaces_child_execution_error() {

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -414,6 +414,20 @@ params = []
 return_type = "result<string, string>"
 
 [[workflow_js]]
+name = "test_cancel_sleep_error_workflow"
+location = "{ws}/crates/testing/test-programs/js/workflow/cancel_sleep_error.js"
+ffqn = "testing:integration/workflow-cancel-sleep-error.cancel-sleep-error"
+params = []
+return_type = "result<string>"
+
+[[workflow_js]]
+name = "test_cancel_delay_error_workflow"
+location = "{ws}/crates/testing/test-programs/js/workflow/cancel_delay_error.js"
+ffqn = "testing:integration/workflow-cancel-delay-error.cancel-delay-error"
+params = []
+return_type = "result<string, string>"
+
+[[workflow_js]]
 name = "test_math_random_workflow"
 location = "{ws}/crates/testing/test-programs/js/workflow/math_random.js"
 ffqn = "testing:integration/workflow-math-random.math-random"
@@ -1723,6 +1737,24 @@ impl TestServer {
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
         panic!("execution {execution_id} was never cancellable");
+    }
+
+    /// Cancel a delay out-of-band, retrying until the workflow has submitted it.
+    async fn cancel_delay_with_retries(&self, delay_id: &str) {
+        for _ in 0..200 {
+            let resp = self
+                .client
+                .put(format!("{}/v1/delays/{delay_id}/cancel", self.base_url))
+                .header("Accept", "application/json")
+                .send()
+                .await
+                .expect("cancel delay request failed");
+            if resp.status().is_success() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("delay {delay_id} was never cancellable");
     }
 
     async fn step_execution_until_finished_grpc(
@@ -3490,6 +3522,66 @@ async fn submit_workflow_child_cancelled_surfaces_child_execution_error() {
     assert_eq!(resp.status().as_u16(), 201);
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body, json!({ "ok": "cancelled-child-observed" }));
+
+    server.shutdown().await;
+}
+
+/// A cancelled named sleep throws a payload-less `ChildError`; re-throwing it
+/// serializes its undefined `.value` as a null workflow err payload.
+#[tokio::test]
+async fn submit_workflow_cancelled_sleep_rethrows_null() {
+    use concepts::prefixed_ulid::DelayId;
+    use concepts::{ExecutionId, JoinSetId, JoinSetKind, StrVariant};
+
+    let server = TestServer::start(test_addr!(90)).await;
+    let execution_id = server.generate_execution_id().await;
+    let execution_id = execution_id.parse::<ExecutionId>().unwrap();
+    let join_set_id =
+        JoinSetId::new(JoinSetKind::OneOff, StrVariant::from("1-cancel-sleep")).unwrap();
+    let delay_id = DelayId::new(&execution_id, &join_set_id).to_string();
+    let execution_id = execution_id.to_string();
+
+    let follow = server.submit_follow_with_id(
+        &execution_id,
+        "testing:integration/workflow-cancel-sleep-error.cancel-sleep-error",
+        vec![],
+    );
+    let cancel = server.cancel_delay_with_retries(&delay_id);
+    let (resp, ()) = tokio::join!(follow, cancel);
+
+    assert_eq!(resp.status().as_u16(), 201);
+    assert_eq!(resp.json::<Value>().await.unwrap(), json!({ "err": null }));
+
+    server.shutdown().await;
+}
+
+/// A cancelled join-set delay throws a `ChildError` with cancellation metadata
+/// and no business error payload.
+#[tokio::test]
+async fn submit_workflow_cancelled_delay_surfaces_child_error() {
+    use concepts::prefixed_ulid::DelayId;
+    use concepts::{ExecutionId, JoinSetId, JoinSetKind, StrVariant};
+
+    let server = TestServer::start(test_addr!(91)).await;
+    let execution_id = server.generate_execution_id().await;
+    let execution_id = execution_id.parse::<ExecutionId>().unwrap();
+    let join_set_id = JoinSetId::new(JoinSetKind::Named, StrVariant::from("cancel-delay")).unwrap();
+    let delay_id = DelayId::new_with_index(&execution_id, &join_set_id, 0).to_string();
+    let execution_id = execution_id.to_string();
+
+    let follow = server.submit_follow_with_id(
+        &execution_id,
+        "testing:integration/workflow-cancel-delay-error.cancel-delay-error",
+        vec![],
+    );
+    let cancel = server.cancel_delay_with_retries(&delay_id);
+    let (resp, ()) = tokio::join!(follow, cancel);
+
+    assert_eq!(resp.status().as_u16(), 201);
+    assert_eq!(
+        resp.json::<Value>().await.unwrap(),
+        json!({ "ok": "cancelled-delay-observed" })
+    );
 
     server.shutdown().await;
 }

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -293,6 +293,20 @@ expression: components
   {
     "component_id": {
       "component_type": "workflow",
+      "name": "test_cancel_delay_error_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
+      "name": "test_cancel_sleep_error_workflow",
+      "component_digest": "sha256:<REDACTED>"
+    }
+  },
+  {
+    "component_id": {
+      "component_type": "workflow",
       "name": "test_date_now_workflow",
       "component_digest": "sha256:<REDACTED>"
     }

--- a/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_functions.snap
@@ -121,6 +121,12 @@ expression: functions
     "ffqn": "testing:integration/workflow-cancel-child-error.cancel-child-error"
   },
   {
+    "ffqn": "testing:integration/workflow-cancel-sleep-error.cancel-sleep-error"
+  },
+  {
+    "ffqn": "testing:integration/workflow-cancel-delay-error.cancel-delay-error"
+  },
+  {
     "ffqn": "testing:integration/workflow-math-random.math-random"
   },
   {


### PR DESCRIPTION
- **refactor(js): Add `ChildError`, deprecating `ChildExecutionError`, make `obelisk.sleep` throw it**
- **test: Migrate tests to `ChildError`**
- **doc: Add a changelog entry**
- **test(js): Test throwing of cancelled delays**
- **test: Update test snapshots**
- **chore: Push workflow and webhook JS components**
- **fix(workflow): Start `DelayId` indexing from 1**
