### PR TITLE
fix: back workflow Date with the deterministic Obelisk clock

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,6 +57,17 @@ jobs:
               exit 1
           fi
 
+  check-js-runtime-freshness:
+    name: JS runtime pins up to date
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+
+      - name: Check JS runtime version pins are newer than their sources
+        run: ./scripts/check-js-runtime-freshness.sh
+
   deny:
     name: cargo deny
     runs-on: ubuntu-24.04

--- a/assets/activity-js-runtime-version.txt
+++ b/assets/activity-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/activity-js-runtime:2026-07-10@sha256:6d347784056d76376dcdcbbd26b66c0eb5ec56ccdc3d8c642df5c3994179eace
+oci://docker.io/getobelisk/activity-js-runtime:2026-07-21@sha256:3615bbf3dda76466f59ebdcd0f4a3bf2f9517f201658d71a2e66ee7657c5d5e2

--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-07-15@sha256:c0f7a883972c242e98d78be5875c15d3e24af1d4a58e4dcb6d58e964c59b819d
+oci://docker.io/getobelisk/webhook-js-runtime:2026-07-21@sha256:688f71c8aba0f0604f79a0de8b75b3d0ab5d7e3a3c9e25c3f3fd7b51026b0322

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-07-15@sha256:59f36f5f0f9cc00c42bdbb7740b8cd378132c52bea96a4ef64c40c5d5e34be29
+oci://docker.io/getobelisk/workflow-js-runtime:2026-07-21@sha256:d91dd3592b41643984326a7aac6ae095549bfd0db23c09a36f75a2a4957b5c5a

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2301,6 +2301,59 @@ mod tests {
         db_close.close().await;
     }
 
+    /// Test: `new Date()` resolves to the same deterministic Obelisk clock as
+    /// `Date.now()` (both go through `ObeliskClock::system_time_millis`). In 0.40.0
+    /// the workflow runtime wired a `FixedClock(0)`, so `new Date()` returned epoch 0
+    /// while `Date.now()` returned the real clock; this asserts they now agree.
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_new_date(database: Database) {
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+
+        let js_source = r"
+        export default function test_new_date(params) {
+            const now = new Date().getTime();
+            return JSON.stringify({ now });
+        }";
+
+        let harness =
+            JsWorkflowTestHarness::with_no_activities(db_pool.clone(), js_source, "test-new-date")
+                .await;
+        harness.advance_time(Duration::from_millis(42)).await;
+        harness.tick().await; // workflow yields at sleep_bt(Now), expires_at=42ms
+        harness.advance_time(Duration::ZERO).await; // fire the timer (42ms ≤ 42ms)
+        harness.tick().await; // workflow resumes, clock read returns 42ms
+
+        let result = harness.get_result_json().await;
+        assert_eq!(
+            json!(42),
+            result["now"],
+            "new Date() should return the simulated clock time (42ms): {result}"
+        );
+
+        // Same as Date.now(): the clock read goes through sleep_bt(Now), which
+        // creates a JoinSetRequest::DelayRequest event.
+        let db_conn = db_pool.connection_test().await.unwrap();
+        let log = db_conn.get(&harness.execution_id).await.unwrap();
+        assert!(
+            log.events.iter().any(|e| matches!(
+                e.event,
+                ExecutionRequest::HistoryEvent {
+                    event: HistoryEvent::JoinSetRequest {
+                        request: JoinSetRequest::DelayRequest { .. },
+                        ..
+                    }
+                }
+            )),
+            "expected a JoinSetRequest::DelayRequest event for new Date()"
+        );
+        drop(harness);
+        drop(db_conn);
+        db_close.close().await;
+    }
+
     /// Test: `obelisk.sleep()` returns a `Date` object representing the wake-up time.
     /// - `advance_time(42ms)` → clock=42ms
     /// - `tick()` → workflow calls `sleep({ milliseconds: 100 })`, yields at `expires_at=142ms`

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1005,6 +1005,37 @@ mod tests {
         assert_eq!(extract_string(&err_val.value), "something went wrong");
     }
 
+    /// A schedule object with more than one of the mutually-exclusive keys is
+    /// rejected (rather than silently picking one). The JS catches the thrown
+    /// `TypeError` and returns its message so we can assert on it.
+    #[tokio::test]
+    async fn workflow_js_schedule_rejects_multiple_keys() {
+        test_utils::set_up();
+        let ffqn = FunctionFqn::new_static("test:pkg/ifc", "fail");
+        let js_source = r#"
+            export default function fail() {
+                try {
+                    obelisk.sleep({ seconds: 5, minutes: 3 });
+                    return 'no-throw';
+                } catch (e) {
+                    return String(e.message ?? e);
+                }
+            }
+        "#;
+
+        let (worker, _guard, _db_close) = new_js_workflow_worker(js_source, &ffqn).await;
+        let ctx = make_worker_context(ffqn, &[]);
+
+        let result = worker.run(ctx).await.expect("worker should succeed");
+        let retval = assert_matches!(result, WorkerResultOk::RunFinished(RunFinished { retval, .. }) => retval);
+        let output = assert_matches!(retval, SupportedFunctionReturnValue::Ok(ok) => ok);
+        let msg = extract_string(&output.expect("should have ok value").value);
+        assert!(
+            msg.contains("multiple keys") && msg.contains("seconds") && msg.contains("minutes"),
+            "expected a multiple-keys rejection naming the conflicting keys, got: {msg}"
+        );
+    }
+
     #[tokio::test]
     async fn workflow_js_syntax_error_should_fail_to_link() {
         test_utils::set_up();

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2393,6 +2393,43 @@ mod tests {
         db_close.close().await;
     }
 
+    /// Test: `obelisk.sleep` accepts a JS `Date` as an absolute wake-up time
+    /// (symmetric with the `Date` it returns). `new Date(142)` is 142ms since epoch,
+    /// so with the clock at 42ms the sleep must resolve at the absolute 142ms.
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_sleep_accepts_date(database: Database) {
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+
+        let js_source = r"
+        export default function test_sleep_date_arg(params) {
+            const wakeUp = obelisk.sleep(new Date(142));
+            return JSON.stringify({ ms: wakeUp.getTime() });
+        }";
+
+        let harness = JsWorkflowTestHarness::with_no_activities(
+            db_pool.clone(),
+            js_source,
+            "test-sleep-date-arg",
+        )
+        .await;
+        harness.advance_time(Duration::from_millis(42)).await;
+        harness.tick().await; // workflow yields at sleep, expires_at=142ms absolute
+        harness.advance_time(Duration::from_millis(100)).await; // clock=142ms, fire the timer
+        harness.tick().await; // workflow resumes
+
+        let result = harness.get_result_json().await;
+        assert_eq!(
+            json!(142),
+            result["ms"],
+            "sleep(new Date(142)) should wake at the absolute 142ms: {result}"
+        );
+        drop(harness);
+        db_close.close().await;
+    }
+
     #[expand_enum_database]
     #[rstest]
     #[tokio::test]

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1012,7 +1012,7 @@ mod tests {
     async fn workflow_js_schedule_rejects_multiple_keys() {
         test_utils::set_up();
         let ffqn = FunctionFqn::new_static("test:pkg/ifc", "fail");
-        let js_source = r#"
+        let js_source = r"
             export default function fail() {
                 try {
                     obelisk.sleep({ seconds: 5, minutes: 3 });
@@ -1021,7 +1021,7 @@ mod tests {
                     return String(e.message ?? e);
                 }
             }
-        "#;
+        ";
 
         let (worker, _guard, _db_close) = new_js_workflow_worker(js_source, &ffqn).await;
         let ctx = make_worker_context(ffqn, &[]);

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -889,5 +889,9 @@ fn parse_schedule_at(value: &JsValue, ctx: &mut Context) -> JsResult<ScheduleAt>
         }));
     }
 
-    Ok(ScheduleAt::Now)
+    Err(JsNativeError::typ()
+        .with_message(
+            "schedule object has no recognized key (milliseconds, seconds, minutes, hours, days, at) and is not a Date",
+        )
+        .into())
 }

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -856,6 +856,25 @@ fn parse_schedule_at(value: &JsValue, ctx: &mut Context) -> JsResult<ScheduleAt>
         }));
     }
 
+    // The duration keys and `at` are mutually exclusive: they are not summed, so
+    // more than one is a mistake. Reject it instead of silently picking one by
+    // precedence order.
+    let present: Vec<&str> = ["milliseconds", "seconds", "minutes", "hours", "days", "at"]
+        .into_iter()
+        .filter(|key| {
+            obj.get(JsString::from(*key), ctx)
+                .is_ok_and(|v| !v.is_undefined())
+        })
+        .collect();
+    if present.len() > 1 {
+        return Err(JsNativeError::typ()
+            .with_message(format!(
+                "schedule object has multiple keys ({}); specify exactly one of milliseconds, seconds, minutes, hours, days, or at",
+                present.join(", ")
+            ))
+            .into());
+    }
+
     // Check for different duration types
     if let Ok(ms) = obj.get(js_string!("milliseconds"), ctx)
         && !ms.is_undefined()

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -120,7 +120,7 @@ use boa_engine::class::Class;
 use boa_engine::module::MapModuleLoader;
 use boa_engine::{
     Context, JsArgs, JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction, Source,
-    js_string, property::Attribute,
+    js_string, object::builtins::JsDate, property::Attribute,
 };
 use boa_runtime::extensions::FetchExtension;
 use boa_runtime::fetch::request::JsRequest;
@@ -837,6 +837,24 @@ fn parse_schedule_at(value: &JsValue, ctx: &mut Context) -> JsResult<ScheduleAt>
     let obj = value
         .as_object()
         .ok_or_else(|| JsNativeError::typ().with_message("schedule must be an object"))?;
+
+    // A JS `Date` is accepted as an absolute wake-up time; `sleep` also returns a
+    // `Date`, making the API symmetric.
+    if let Ok(date) = JsDate::from_object(obj.clone()) {
+        let millis = date.get_time(ctx)?.to_number(ctx)?;
+        if millis.is_nan() {
+            return Err(JsNativeError::typ()
+                .with_message("schedule Date is an Invalid Date")
+                .into());
+        }
+        let millis = millis as i64;
+        let seconds = (millis / 1000).max(0) as u64;
+        let nanoseconds = ((millis % 1000).max(0) * 1_000_000) as u32;
+        return Ok(ScheduleAt::At(Datetime {
+            seconds,
+            nanoseconds,
+        }));
+    }
 
     // Check for different duration types
     if let Ok(ms) = obj.get(js_string!("milliseconds"), ctx)

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -1548,6 +1548,25 @@ fn parse_schedule_at(value: &JsValue, ctx: &mut Context) -> JsResult<ScheduleAt>
         }));
     }
 
+    // The duration keys and `at` are mutually exclusive: they are not summed, so
+    // more than one is a mistake. Reject it instead of silently picking one by
+    // precedence order.
+    let present: Vec<&str> = ["milliseconds", "seconds", "minutes", "hours", "days", "at"]
+        .into_iter()
+        .filter(|key| {
+            obj.get(JsString::from(*key), ctx)
+                .is_ok_and(|v| !v.is_undefined())
+        })
+        .collect();
+    if present.len() > 1 {
+        return Err(JsNativeError::typ()
+            .with_message(format!(
+                "schedule object has multiple keys ({}); specify exactly one of milliseconds, seconds, minutes, hours, days, or at",
+                present.join(", ")
+            ))
+            .into());
+    }
+
     // Check for different duration types
     if let Ok(ms) = obj.get(js_string!("milliseconds"), ctx)
         && !ms.is_undefined()

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -1530,6 +1530,24 @@ fn parse_schedule_at(value: &JsValue, ctx: &mut Context) -> JsResult<ScheduleAt>
         .as_object()
         .ok_or_else(|| JsNativeError::typ().with_message("schedule must be an object"))?;
 
+    // A JS `Date` is accepted as an absolute wake-up time; `sleep` also returns a
+    // `Date`, making the API symmetric.
+    if let Ok(date) = JsDate::from_object(obj.clone()) {
+        let millis = date.get_time(ctx)?.to_number(ctx)?;
+        if millis.is_nan() {
+            return Err(JsNativeError::typ()
+                .with_message("schedule Date is an Invalid Date")
+                .into());
+        }
+        let millis = millis as i64;
+        let seconds = (millis / 1000).max(0) as u64;
+        let nanoseconds = ((millis % 1000).max(0) * 1_000_000) as u32;
+        return Ok(ScheduleAt::At(Datetime {
+            seconds,
+            nanoseconds,
+        }));
+    }
+
     // Check for different duration types
     if let Ok(ms) = obj.get(js_string!("milliseconds"), ctx)
         && !ms.is_undefined()

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -1587,5 +1587,9 @@ fn parse_schedule_at(value: &JsValue, ctx: &mut Context) -> JsResult<ScheduleAt>
         }));
     }
 
-    Ok(ScheduleAt::Now)
+    Err(JsNativeError::typ()
+        .with_message(
+            "schedule object has no recognized key (milliseconds, seconds, minutes, hours, days, at) and is not a Date",
+        )
+        .into())
 }

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -148,7 +148,7 @@ use boa_common::child_error::{ChildError, ChildErrorParts, make_child_error};
 use boa_common::console::{ObeliskLogger, json_stringify, setup_console};
 use boa_common::helpers::{new_object, parse_ffqn};
 use boa_common::imports::{self, ProxyKind};
-use boa_engine::context::time::FixedClock;
+use boa_engine::context::time::{Clock, JsInstant};
 use boa_engine::module::MapModuleLoader;
 use boa_engine::{
     Context, JsArgs, JsError, JsNativeError, JsResult, JsString, JsValue, Module, NativeFunction,
@@ -709,7 +709,7 @@ pub fn execute(
     let loader = Rc::new(MapModuleLoader::new());
     let mut context = Context::builder()
         .job_executor(executor.clone())
-        .clock(Rc::new(FixedClock::from_millis(0)))
+        .clock(Rc::new(ObeliskClock))
         .module_loader(loader.clone())
         .build()
         .expect("building context must work");
@@ -723,9 +723,6 @@ pub fn execute(
 
     // Override Math.random() to use deterministic random source
     setup_math_random(&mut context).expect("Math.random setup must work");
-
-    // Override Date.now() to use the Obelisk clock via sleep(0)
-    setup_date_now(&mut context).expect("Date.now setup must work");
 
     // Register synthetic modules for WIT-style imports (e.g., 'ns:pkg/ifc').
     // Each imported function becomes a NativeFunction proxy to the appropriate
@@ -993,8 +990,11 @@ fn setup_obelisk_api(context: &mut Context) -> JsResult<()> {
         match sleep(schedule, name.as_deref(), Some(&backtrace)) {
             Ok(dt) => {
                 let ms = (dt.seconds as f64) * 1000.0 + (dt.nanoseconds as f64) / 1_000_000.0;
-                let date = JsDate::new(ctx);
-                date.set_time(ms, ctx)?;
+                // Construct `new Date(ms)` directly. Passing the timestamp avoids the
+                // clock read that `JsDate::new` triggers via `ObeliskClock`, which would
+                // append a spurious extra delay on every `obelisk.sleep`.
+                let date_ctor = ctx.intrinsics().constructors().date().constructor();
+                let date = date_ctor.construct(&[JsValue::from(ms)], Some(&date_ctor), ctx)?;
                 Ok(date.into())
             }
             // A cancelled sleep throws a ChildError so it is catchable like any
@@ -1262,31 +1262,25 @@ fn setup_math_random(context: &mut Context) -> JsResult<()> {
     Ok(())
 }
 
-/// Override `Date.now()` to return the current Obelisk clock time via
-/// `sleep(0, None)`.
-///
-/// Returns milliseconds since Unix epoch as f64 (matching the JS spec).
-fn setup_date_now(context: &mut Context) -> JsResult<()> {
-    let date_now_fn = NativeFunction::from_fn_ptr(|_this, _args, ctx| {
-        let backtrace = capture_backtrace(ctx);
-        let dt = sleep(ScheduleAt::Now, None, Some(&backtrace))
-            .map_err(|()| JsNativeError::error().with_message("sleep failed"))?;
-        let ms = (dt.seconds as f64) * 1000.0 + (dt.nanoseconds as f64) / 1_000_000.0;
-        Ok(JsValue::from(ms))
-    });
+/// Backs every wall-clock `Date` read (`new Date()`, `Date()`, `Date.now()`) with the
+/// deterministic Obelisk clock via `sleep(Now)`, so time is stable across replay. Boa's
+/// `Date` builtin reads `system_time_millis()` for all three paths.
+struct ObeliskClock;
 
-    let global = context.global_object();
-    let date = global
-        .get(js_string!("Date"), context)
-        .expect("global Date object must be found");
-    let date_obj = date.as_object().expect("global Date must be an object");
-    date_obj.set(
-        js_string!("now"),
-        date_now_fn.to_js_function(context.realm()),
-        false,
-        context,
-    )?;
-    Ok(())
+impl Clock for ObeliskClock {
+    fn now(&self) -> JsInstant {
+        // The monotonic clock is only consumed by timeout jobs (`setTimeout`), which
+        // `DeterministicJobExecutor` already rejects. Reaching here would mean a
+        // non-deterministic time source slipped into a workflow, so fail loudly.
+        obelisk_log::error("Workflow must be deterministic, monotonic clock is not supported");
+        panic!("monotonic clock is not supported in workflows")
+    }
+
+    fn system_time_millis(&self) -> i64 {
+        let dt =
+            sleep(ScheduleAt::Now, None, None).expect("clock read via sleep(Now) must not fail");
+        (dt.seconds as i64) * 1000 + (dt.nanoseconds as i64) / 1_000_000
+    }
 }
 
 // Property key for storing join set index

--- a/scripts/check-js-runtime-freshness.sh
+++ b/scripts/check-js-runtime-freshness.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Fail if a published JS runtime pin is older than the sources it is built from.
+#
+# Each JS runtime is published out-of-band by the manual `push-js-runtime` workflow,
+# which records the pushed OCI reference in `assets/<name>-js-runtime-version.txt`.
+# Tests run via `scripts/test.sh` and real deployments load that published image, so
+# if a runtime's sources change without the pin being refreshed, they silently run an
+# outdated runtime (only `scripts/test-js-local.sh` builds the runtime locally).
+#
+# This check enforces the invariant: the commit that last touched each pin file must
+# be at or after every commit that touches the sources that runtime is built from.
+# When it fails, republish the runtime (Actions -> push-js-runtime) which updates the
+# pin, then rebase/merge.
+#
+# Note: boa version bumps in the root Cargo.toml/Cargo.lock also change the runtimes
+# but are intentionally not tracked here to avoid false positives from unrelated
+# dependency churn.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Sources embedded in every JS runtime.
+COMMON="crates/boa-common"
+
+status=0
+
+check() {
+    local name="$1"
+    local pin="assets/${name}-js-runtime-version.txt"
+    local sources=("crates/${name}-js-runtime" "$COMMON")
+
+    local pin_commit
+    pin_commit=$(git rev-list -1 HEAD -- "$pin")
+    if [ -z "$pin_commit" ]; then
+        echo "::error::${pin} is not tracked or has no commit history"
+        status=1
+        return
+    fi
+
+    local newer
+    newer=$(git rev-list "${pin_commit}..HEAD" -- "${sources[@]}")
+    if [ -n "$newer" ]; then
+        echo "::error::${pin} is stale: sources changed after the pin was last updated. Republish the ${name} JS runtime (Actions -> push-js-runtime) to refresh it."
+        echo "Commits touching ${sources[*]} since ${pin_commit}:" >&2
+        git --no-pager log --oneline "${pin_commit}..HEAD" -- "${sources[@]}" >&2
+        status=1
+    else
+        echo "${pin} is up to date."
+    fi
+}
+
+check activity
+check workflow
+check webhook
+
+exit "$status"


### PR DESCRIPTION
- **fix: reject schedule objects with no recognized key**
- **fix: back workflow Date with the deterministic Obelisk clock**
- **feat: accept a Date as an absolute schedule time**
- **fix: reject schedule objects with multiple keys**
- **ci: fail PRs when a JS runtime pin is older than its sources**
