### PR TITLE
feat!: capture workflow backtraces lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(api, cli)* Added the idempotent `PersistExecutionBacktraces` RPC and
+  `obelisk execution persist-backtraces` command. They replay a workflow and persist only newly
+  eligible call-site backtraces in one transaction.
+
 ### Changed
 
+- **Breaking:** *(server)* Workflow backtraces are now captured lazily by user-issued replay and
+  advance operations instead of during normal execution or internal component-upgrade replay. The
+  global `wasm.backtrace.persist` setting was removed. Webhook components can opt in independently
+  with `backtrace_persist = true`, which defaults to `false`.
 - *(cli)* `obelisk generate token` now prints only the token to stdout, so it composes with env
   injection: `OBELISK__API__TOKEN=$(obelisk generate token)`. When stdout is a terminal, the
   ready-to-paste `api.token_hashes` entry is still printed, on stderr. The `sha256:` hash is also

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "execution",
-      "about": "Submit, inspect, stub, cancel, pause, unpause, replay, or upgrade executions against a running server",
+      "about": "Submit, inspect, stub, cancel, pause, replay, persist backtraces, or upgrade executions",
       "subcommands": [
         {
           "name": "list",
@@ -472,6 +472,24 @@
             {
               "name": "execution_id",
               "help": "Execution ID to replay",
+              "required": true
+            }
+          ]
+        },
+        {
+          "name": "persist-backtraces",
+          "about": "Replay a workflow and persist its call-site backtraces",
+          "options": [
+            {
+              "name": "--api-url",
+              "short": "a",
+              "help": "Address of the obelisk server"
+            }
+          ],
+          "positionals": [
+            {
+              "name": "execution_id",
+              "help": "Execution ID whose backtraces should be persisted",
               "required": true
             }
           ]

--- a/assets/schemas/deployment-canonical.json
+++ b/assets/schemas/deployment-canonical.json
@@ -1075,6 +1075,10 @@
             "frame_files_to_sources": {}
           }
         },
+        "backtrace_persist": {
+          "type": "boolean",
+          "default": false
+        },
         "logs_store_min_level": {
           "$ref": "#/$defs/LogLevelToml",
           "default": "debug"
@@ -1168,6 +1172,10 @@
             "$ref": "#/$defs/EnvVarConfig"
           },
           "default": []
+        },
+        "backtrace_persist": {
+          "type": "boolean",
+          "default": false
         },
         "allowed_host": {
           "type": "array",

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -1608,6 +1608,10 @@
             "items": {
               "$ref": "#/components/schemas/CapturedWriteSer"
             }
+          },
+          "persist_backtrace": {
+            "type": "boolean",
+            "description": "Capture and persist call-site backtraces while advancing."
           }
         }
       },

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -1199,6 +1199,11 @@
             "sources": {}
           }
         },
+        "backtrace_persist": {
+          "description": "Capture and persist backtraces for requests handled by this webhook.",
+          "type": "boolean",
+          "default": false
+        },
         "logs_store_min_level": {
           "$ref": "#/$defs/LogLevelToml",
           "default": "debug"
@@ -1312,6 +1317,11 @@
             "$ref": "#/$defs/EnvVarConfig"
           },
           "default": []
+        },
+        "backtrace_persist": {
+          "description": "Capture and persist backtraces for requests handled by this webhook.",
+          "type": "boolean",
+          "default": false
         },
         "allowed_host": {
           "description": "Allowed outgoing HTTP hosts with optional method restrictions and secrets.",

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -376,9 +376,6 @@
         "codegen_cache": {
           "$ref": "#/$defs/CodegenCache"
         },
-        "backtrace": {
-          "$ref": "#/$defs/WasmGlobalBacktrace"
-        },
         "cache_directory": {
           "type": [
             "string",
@@ -430,16 +427,6 @@
             "null"
           ],
           "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "WasmGlobalBacktrace": {
-      "type": "object",
-      "properties": {
-        "persist": {
-          "type": "boolean",
-          "default": true
         }
       },
       "additionalProperties": false

--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-07-26@sha256:95f4ac159d49264fc99f55ee42849a66391fe10f4323c5ae36978a244489b7db
+oci://docker.io/getobelisk/webhook-js-runtime:2026-07-28@sha256:4d4fcba2854fc96eff9009ec12ec1935fa68f0abf3f0b5fb7faeb02bbf557b79

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-07-27@sha256:06c8b90eb7da20cd1a6bcf6ac2a1429f544ed4b25482cb950274f68b198e4de1
+oci://docker.io/getobelisk/workflow-js-runtime:2026-07-28@sha256:31e8c57f970981b72e77de88a0c29cc61d26256a16184901e2b970f6793c895f

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -194,7 +194,6 @@ mod bench {
                 WorkflowConfig {
                     component_id: component_id.clone(),
                     join_next_blocking_strategy,
-                    backtrace_persist: false,
                     stub_wasi: false,
                     fuel: None,
                     lock_extension: None,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -2041,7 +2041,10 @@ pub trait DbConnection: DbExecutor {
 
     async fn append_backtrace(&self, append: BacktraceInfo) -> Result<(), DbErrorWrite>;
 
-    async fn append_backtrace_batch(&self, batch: Vec<BacktraceInfo>) -> Result<(), DbErrorWrite>;
+    async fn append_backtrace_batch(
+        &self,
+        batch: Vec<BacktraceInfo>,
+    ) -> Result<usize, DbErrorWrite>;
 
     async fn append_log(&self, row: LogInfoAppendRow) -> Result<(), DbErrorWrite>;
 

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2894,7 +2894,7 @@ async fn append_response(
 async fn append_backtrace(
     tx: &Transaction<'_>,
     backtrace_info: &BacktraceInfo,
-) -> Result<(), DbErrorWrite> {
+) -> Result<u64, DbErrorWrite> {
     // Compute hash for deduplication
     let backtrace_hash = backtrace_info.wasm_backtrace.hash();
 
@@ -2914,7 +2914,8 @@ async fn append_backtrace(
     tx.execute(
         "INSERT INTO t_execution_backtrace \
          (execution_id, component_id, version_min_including, version_max_excluding, backtrace_hash) \
-         VALUES ($1, $2, $3, $4, $5)",
+         VALUES ($1, $2, $3, $4, $5) \
+         ON CONFLICT (execution_id, version_min_including, version_max_excluding) DO NOTHING",
         &[
             &backtrace_info.execution_id.to_string(),
             &Json(&backtrace_info.component_id),
@@ -2923,9 +2924,8 @@ async fn append_backtrace(
             &backtrace_hash.as_slice(),
         ],
     )
-    .await?;
-
-    Ok(())
+    .await
+    .map_err(DbErrorWrite::from)
 }
 
 async fn append_log(tx: &Transaction<'_>, row: &LogInfoAppendRow) -> Result<(), DbErrorWrite> {
@@ -4432,17 +4432,28 @@ impl DbConnection for PostgresConnection {
     }
 
     #[instrument(level = Level::DEBUG, skip_all)]
-    async fn append_backtrace_batch(&self, batch: Vec<BacktraceInfo>) -> Result<(), DbErrorWrite> {
+    async fn append_backtrace_batch(
+        &self,
+        batch: Vec<BacktraceInfo>,
+    ) -> Result<usize, DbErrorWrite> {
         debug!("append_backtrace_batch");
         let mut client_guard = self.client.lock().await;
         let tx = client_guard.transaction().await?;
 
+        let mut inserted = 0_u64;
         for append in batch {
-            append_backtrace(&tx, &append).await?;
+            inserted += append_backtrace(&tx, &append).await?;
         }
 
         tx.commit().await?;
-        Ok(())
+        usize::try_from(inserted).map_err(|_| {
+            DbErrorWrite::Generic(DbErrorGeneric::Uncategorized {
+                reason: "inserted backtrace count does not fit usize".into(),
+                context: SpanTrace::capture(),
+                source: None,
+                loc: Location::caller(),
+            })
+        })
     }
 
     #[instrument(level = Level::DEBUG, skip_all)]

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2607,7 +2607,7 @@ impl SqlitePool {
     fn append_backtrace(
         tx: &Transaction,
         backtrace_info: &BacktraceInfo,
-    ) -> Result<(), DbErrorWrite> {
+    ) -> Result<usize, DbErrorWrite> {
         let backtrace_hash = backtrace_info.wasm_backtrace.hash();
 
         tx.prepare("INSERT OR IGNORE INTO t_wasm_backtrace (backtrace_hash, wasm_backtrace) VALUES (:backtrace_hash, :wasm_backtrace)")?
@@ -2617,7 +2617,7 @@ impl SqlitePool {
         })?;
 
         tx.prepare(
-                "INSERT INTO t_execution_backtrace (execution_id, component_id, version_min_including, version_max_excluding, backtrace_hash) \
+                "INSERT OR IGNORE INTO t_execution_backtrace (execution_id, component_id, version_min_including, version_max_excluding, backtrace_hash) \
                     VALUES (:execution_id, :component_id, :version_min_including, :version_max_excluding, :backtrace_hash)",
         )?
         .execute(named_params! {
@@ -2626,9 +2626,8 @@ impl SqlitePool {
             ":version_min_including": backtrace_info.version_min_including.0,
             ":version_max_excluding": backtrace_info.version_max_excluding.0,
             ":backtrace_hash": backtrace_hash,
-        })?;
-
-        Ok(())
+        })
+        .map_err(DbErrorWrite::from)
     }
 
     fn append_log(tx: &Transaction, row: &LogInfoAppendRow) -> Result<(), DbErrorWrite> {
@@ -5619,7 +5618,7 @@ impl DbConnection for SqlitePool {
     async fn append_backtrace(&self, append: BacktraceInfo) -> Result<(), DbErrorWrite> {
         trace!("append_backtrace");
         self.transaction_fire_forget(
-            move |tx| Self::append_backtrace(tx, &append),
+            move |tx| Self::append_backtrace(tx, &append).map(drop),
             "append_backtrace",
         )
         .await;
@@ -5627,19 +5626,23 @@ impl DbConnection for SqlitePool {
     }
 
     #[instrument(level = Level::DEBUG, skip_all)]
-    async fn append_backtrace_batch(&self, batch: Vec<BacktraceInfo>) -> Result<(), DbErrorWrite> {
+    async fn append_backtrace_batch(
+        &self,
+        batch: Vec<BacktraceInfo>,
+    ) -> Result<usize, DbErrorWrite> {
         trace!("append_backtrace_batch");
-        self.transaction_fire_forget(
+        self.transaction(
             move |tx| {
+                let mut inserted = 0;
                 for append in &batch {
-                    Self::append_backtrace(tx, append)?;
+                    inserted += Self::append_backtrace(tx, append)?;
                 }
-                Ok::<_, DbErrorWrite>(())
+                Ok::<_, DbErrorWrite>(inserted)
             },
+            TxType::MultipleWrites,
             "append_backtrace_batch",
         )
-        .await;
-        Ok(())
+        .await
     }
 
     #[instrument(level = Level::DEBUG, skip_all)]

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -702,6 +702,8 @@ pub mod webhook {
         #[serde(default)]
         pub backtrace: ComponentBacktraceConfigResolved,
         #[serde(default)]
+        pub backtrace_persist: bool,
+        #[serde(default)]
         pub logs_store_min_level: LogLevelToml,
         #[serde(default, rename = "allowed_host")]
         pub allowed_hosts: Vec<AllowedHostToml>,
@@ -726,6 +728,8 @@ pub mod webhook {
         pub logs_store_min_level: LogLevelToml,
         #[serde(default)]
         pub env_vars: Vec<EnvVarConfig>,
+        #[serde(default)]
+        pub backtrace_persist: bool,
         #[serde(default, rename = "allowed_host")]
         pub allowed_hosts: Vec<AllowedHostToml>,
     }

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -3941,10 +3941,16 @@ async fn test_backtrace(database: Database) {
             }],
         },
     };
-    db_connection
-        .append_backtrace(backtrace_info_2.clone())
+    let inserted = db_connection
+        .append_backtrace_batch(vec![backtrace_info_1.clone(), backtrace_info_2.clone()])
         .await
         .unwrap();
+    assert_eq!(inserted, 1, "only the new backtrace should be inserted");
+    let inserted = db_connection
+        .append_backtrace_batch(vec![backtrace_info_1.clone(), backtrace_info_2.clone()])
+        .await
+        .unwrap();
+    assert_eq!(inserted, 0, "repeated backtrace batches must be idempotent");
 
     let api_conn = db_pool.external_api_conn().await.unwrap();
     let found = api_conn

--- a/crates/wasm-workers/src/registry.rs
+++ b/crates/wasm-workers/src/registry.rs
@@ -1,9 +1,13 @@
 //! Component registry for a single deployment.
 //!
+use crate::workflow::replay_advance::AdvanceResponse;
 use crate::workflow::workflow_js_worker::WorkflowJsWorker;
-use crate::workflow::workflow_worker::WorkflowWorker;
+use crate::workflow::workflow_worker::{
+    AdvanceError, ReplayAdvanceable, ReplayError, ReplayResponse, WorkflowWorker,
+};
 use concepts::ComponentId;
 use concepts::ComponentType;
+use concepts::ExecutionId;
 use concepts::FunctionFqn;
 use concepts::FunctionMetadata;
 use concepts::FunctionRegistry;
@@ -11,6 +15,7 @@ use concepts::IfcFqnName;
 use concepts::PackageIfcFns;
 use concepts::StrVariant;
 use concepts::component_id::ComponentDigest;
+use concepts::storage::BacktraceInfo;
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use std::fmt::Debug;
@@ -51,6 +56,49 @@ impl Debug for ReplayWorker {
         match self {
             ReplayWorker::Wasm(_) => f.write_str("ReplayWorker::Wasm(..)"),
             ReplayWorker::Js(_) => f.write_str("ReplayWorker::Js(..)"),
+        }
+    }
+}
+
+impl ReplayWorker {
+    pub async fn replay(
+        &self,
+        execution_id: ExecutionId,
+        backtrace_capture: bool,
+    ) -> Result<ReplayResponse, ReplayError> {
+        match self {
+            Self::Wasm(worker) => worker.replay(execution_id, backtrace_capture).await,
+            Self::Js(worker) => worker.replay(execution_id, backtrace_capture).await,
+        }
+    }
+
+    pub async fn capture_backtraces(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Vec<BacktraceInfo>, ReplayError> {
+        match self {
+            Self::Wasm(worker) => worker.capture_backtraces(execution_id).await,
+            Self::Js(worker) => worker.capture_backtraces(execution_id).await,
+        }
+    }
+
+    pub async fn advance(
+        &self,
+        execution_id: ExecutionId,
+        requested: ReplayAdvanceable,
+        backtrace_capture: bool,
+    ) -> Result<AdvanceResponse, AdvanceError> {
+        match self {
+            Self::Wasm(worker) => {
+                worker
+                    .advance(execution_id, requested, backtrace_capture)
+                    .await
+            }
+            Self::Js(worker) => {
+                worker
+                    .advance(execution_id, requested, backtrace_capture)
+                    .await
+            }
         }
     }
 }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -640,6 +640,7 @@ struct WebhookEndpointCtx {
     http_hooks: HttpHooks,
     // Execution id of the last `call-json`, for `last-direct-call-id`.
     last_direct_call_id: Option<ExecutionIdDerived>,
+    backtrace_persist: bool,
 }
 
 impl HostJoinSet for WebhookEndpointCtx {
@@ -877,14 +878,13 @@ impl types::obelisk::webhook::webhook_support_backtrace::Host for WebhookEndpoin
         params: String,
         backtrace: Option<types::obelisk::types::backtrace::WasmBacktrace>,
     ) -> Result<(), ScheduleJsonErrorTrappable> {
-        self.schedule_json_inner(
-            execution_id,
-            schedule_at,
-            function,
-            params,
-            backtrace.map(wit_backtrace_to_storage),
-        )
-        .await
+        let backtrace = if self.backtrace_persist {
+            backtrace.map(wit_backtrace_to_storage)
+        } else {
+            None
+        };
+        self.schedule_json_inner(execution_id, schedule_at, function, params, backtrace)
+            .await
     }
 
     async fn call_json(
@@ -893,8 +893,12 @@ impl types::obelisk::webhook::webhook_support_backtrace::Host for WebhookEndpoin
         params: String,
         backtrace: Option<types::obelisk::types::backtrace::WasmBacktrace>,
     ) -> Result<Result<Option<String>, Option<String>>, ScheduleJsonErrorTrappable> {
-        self.call_json_inner(function, params, backtrace.map(wit_backtrace_to_storage))
-            .await
+        let backtrace = if self.backtrace_persist {
+            backtrace.map(wit_backtrace_to_storage)
+        } else {
+            None
+        };
+        self.call_json_inner(function, params, backtrace).await
     }
 }
 
@@ -1804,6 +1808,9 @@ impl WebhookEndpointCtx {
         if let Some(js_config) = &config.js_config {
             wasi_ctx.env("__OBELISK_JS_SOURCE__", &js_config.source);
             wasi_ctx.env("__OBELISK_JS_FILE_NAME__", &js_config.file_name);
+            if config.backtrace_persist {
+                wasi_ctx.env("__OBELISK_BACKTRACE_ENABLED__", "true");
+            }
             if let Some(resolved_imports_json) = resolved_imports_json {
                 wasi_ctx.env("__OBELISK_RESOLVED_IMPORTS__", resolved_imports_json);
             }
@@ -1849,6 +1856,7 @@ impl WebhookEndpointCtx {
                 config_section_hint: config.config_section_hint,
             },
             last_direct_call_id: None,
+            backtrace_persist: config.backtrace_persist,
         };
         let mut store = Store::new(engine, ctx);
 
@@ -3420,6 +3428,10 @@ pub(crate) mod tests {
 
         impl JsWebhookWithActivitiesHarness {
             async fn new(js_source: &str) -> Self {
+                Self::new_with_backtrace(js_source, false).await
+            }
+
+            async fn new_with_backtrace(js_source: &str, backtrace_persist: bool) -> Self {
                 use crate::activity::activity_worker::test::compile_activity;
                 use crate::activity::activity_worker::tests::new_activity_fibo;
                 use concepts::time::TokioSleep;
@@ -3466,7 +3478,7 @@ pub(crate) mod tests {
                             forward_stderr: Some(StdOutputConfig::Stdout),
                             env_vars: Arc::from([]),
                             fuel: None,
-                            backtrace_persist: false,
+                            backtrace_persist,
                             subscription_interruption: None,
                             logs_store_min_level: None,
                             allowed_hosts: Arc::from([]),
@@ -3609,6 +3621,56 @@ pub(crate) mod tests {
                 "testing:fibo/fibo.fibo",
                 create_req.ffqn.to_string().as_str()
             );
+        }
+
+        #[tokio::test]
+        async fn webhook_js_backtrace_persistence_is_opt_in() {
+            use concepts::storage::BacktraceFilter;
+            use std::str::FromStr as _;
+
+            test_utils::set_up();
+            let js_source = r#"
+                export default function handle(request) {
+                    const execId = obelisk.executionIdGenerate();
+                    obelisk.schedule(execId, "testing:fibo/fibo.fibo", [10]);
+                    return Response.json({ execId });
+                }
+            "#;
+
+            for backtrace_persist in [false, true] {
+                let harness = JsWebhookWithActivitiesHarness::new_with_backtrace(
+                    js_source,
+                    backtrace_persist,
+                )
+                .await;
+                let resp = reqwest::get(format!("http://{}/", harness.server_addr))
+                    .await
+                    .unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+                let body: serde_json::Value = resp.json().await.unwrap();
+                let exec_id =
+                    concepts::ExecutionId::from_str(body["execId"].as_str().unwrap()).unwrap();
+
+                let conn = harness.db_pool.connection().await.unwrap();
+                let create_req = conn.get_create_request(&exec_id).await.unwrap();
+                let webhook_execution_id = create_req.scheduled_by.unwrap();
+                let conn = harness.db_pool.external_api_conn().await.unwrap();
+                let backtrace = conn
+                    .get_backtrace(&webhook_execution_id, BacktraceFilter::Last)
+                    .await;
+
+                if backtrace_persist {
+                    assert!(
+                        !backtrace.unwrap().wasm_backtrace.frames.is_empty(),
+                        "enabled webhook must persist a captured backtrace"
+                    );
+                } else {
+                    assert!(
+                        backtrace.is_err(),
+                        "webhook must not persist a backtrace by default"
+                    );
+                }
+            }
         }
 
         #[tokio::test]

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -28,9 +28,7 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
 
     fn execution_id(&self) -> &ExecutionId;
 
-    fn capture_application_log(&mut self, _row: LogInfoAppendRow) -> bool {
-        false
-    }
+    fn try_defer_application_log(&mut self, row: LogInfoAppendRow) -> bool;
 
     async fn append_backtrace(&mut self, backtrace: BacktraceInfo) -> Result<(), DbErrorWrite>;
 
@@ -216,6 +214,10 @@ impl WorkflowDbConnection for CachingDbConnection {
 
     fn execution_id(&self) -> &ExecutionId {
         &self.execution_id
+    }
+
+    fn try_defer_application_log(&mut self, _row: LogInfoAppendRow) -> bool {
+        false
     }
 
     async fn append_backtrace(&mut self, _backtrace: BacktraceInfo) -> Result<(), DbErrorWrite> {

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -28,11 +28,11 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
 
     fn execution_id(&self) -> &ExecutionId;
 
-    fn version(&self) -> &Version;
-
     fn capture_application_log(&mut self, _row: LogInfoAppendRow) -> bool {
         false
     }
+
+    async fn append_backtrace(&mut self, backtrace: BacktraceInfo) -> Result<(), DbErrorWrite>;
 
     async fn append_non_blocking(
         &mut self,
@@ -43,14 +43,17 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
     // Caller must trigger flushing before this call.
     async fn append_blocking(
         &mut self,
+        version: Version,
         execution_id: ExecutionId,
         req: AppendRequest,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite>;
 
+    #[expect(clippy::too_many_arguments)]
     async fn append_join_set_close(
         &mut self,
+        version: Version,
         cancel_registry: &CancelRegistry,
         execution_id: ExecutionId,
         req: AppendRequest,
@@ -61,6 +64,7 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
 
     async fn append_batch(
         &mut self,
+        version: Version,
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
@@ -68,8 +72,10 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite>;
 
+    #[expect(clippy::too_many_arguments)]
     async fn append_batch_create_new_execution(
         &mut self,
+        version: Version,
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
@@ -113,20 +119,17 @@ pub(crate) struct CachingDbConnection {
     db_connection: Box<dyn DbConnection>,
     execution_id: ExecutionId,
     pub(crate) caching_buffer: Option<CachingBuffer>,
-    version: Version,
 }
 impl CachingDbConnection {
     pub(crate) fn new(
         db_connection: Box<dyn DbConnection>,
         execution_id: ExecutionId,
         caching_buffer: Option<CachingBuffer>,
-        version: Version,
     ) -> CachingDbConnection {
         CachingDbConnection {
             db_connection,
             execution_id,
             caching_buffer,
-            version,
         }
     }
 }
@@ -215,8 +218,8 @@ impl WorkflowDbConnection for CachingDbConnection {
         &self.execution_id
     }
 
-    fn version(&self) -> &Version {
-        &self.version
+    async fn append_backtrace(&mut self, backtrace: BacktraceInfo) -> Result<(), DbErrorWrite> {
+        self.db_connection.append_backtrace(backtrace).await
     }
 
     async fn append_non_blocking(
@@ -224,14 +227,12 @@ impl WorkflowDbConnection for CachingDbConnection {
         non_blocking_event: CacheableDbEvent,
         called_at: DateTime<Utc>,
     ) -> Result<(), DbErrorWrite> {
-        self.version = if let Some(caching_buffer) = &mut self.caching_buffer {
-            let next_version = Version::new(self.version.0 + 1);
+        if let Some(caching_buffer) = &mut self.caching_buffer {
             caching_buffer
                 .non_blocking_event_batch
                 .push(non_blocking_event);
             self.flush_non_blocking_event_cache_if_full(called_at)
                 .await?;
-            next_version
         } else {
             // No caching_buffer here, so no flushing before the write.
             match non_blocking_event {
@@ -247,7 +248,8 @@ impl WorkflowDbConnection for CachingDbConnection {
                     child_req,
                     backtrace,
                 } => {
-                    self.db_connection
+                    let next_version = self
+                        .db_connection
                         .append_batch_create_new_execution(
                             called_at,
                             vec![request],
@@ -256,7 +258,8 @@ impl WorkflowDbConnection for CachingDbConnection {
                             vec![child_req],
                             backtrace.into_iter().collect(),
                         )
-                        .await?
+                        .await?;
+                    assert_eq!(version.increment(), next_version);
                 }
                 CacheableDbEvent::JoinSetCreate {
                     request,
@@ -302,16 +305,17 @@ impl WorkflowDbConnection for CachingDbConnection {
                                 debug!("Ignoring error while appending backtrace: {err:?}");
                             });
                     }
-                    next_version
+                    assert_eq!(version.increment(), next_version);
                 }
             }
-        };
+        }
         Ok(())
     }
 
     // Caller must trigger flushing before this call.
     async fn append_blocking(
         &mut self,
+        version: Version,
         execution_id: ExecutionId,
         req: AppendRequest,
         wasm_backtrace: Option<storage::WasmBacktrace>,
@@ -320,21 +324,17 @@ impl WorkflowDbConnection for CachingDbConnection {
         self.flush_non_blocking_event_cache(req.created_at).await?;
         let next_version = self
             .db_connection
-            .append(execution_id, self.version.clone(), req)
+            .append(execution_id, version.clone(), req)
             .await?;
-        self.persist_backtrace_blocking(
-            &self.version.clone(),
-            &next_version,
-            wasm_backtrace,
-            component_id,
-        )
-        .await;
-        self.version = next_version;
+        self.persist_backtrace_blocking(&version, &next_version, wasm_backtrace, component_id)
+            .await;
+        assert_eq!(version.increment(), next_version);
         Ok(())
     }
 
     async fn append_batch(
         &mut self,
+        version: Version,
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
@@ -344,21 +344,16 @@ impl WorkflowDbConnection for CachingDbConnection {
         self.flush_non_blocking_event_cache(current_time).await?;
         let next_version = self
             .db_connection
-            .append_batch(current_time, batch, execution_id, self.version.clone())
+            .append_batch(current_time, batch, execution_id, version.clone())
             .await?;
-        self.persist_backtrace_blocking(
-            &self.version.clone(),
-            &next_version,
-            wasm_backtrace,
-            component_id,
-        )
-        .await;
-        self.version = next_version;
+        self.persist_backtrace_blocking(&version, &next_version, wasm_backtrace, component_id)
+            .await;
         Ok(())
     }
 
     async fn append_join_set_close(
         &mut self,
+        version: Version,
         cancel_registry: &CancelRegistry,
         execution_id: ExecutionId,
         req: AppendRequest,
@@ -420,12 +415,13 @@ impl WorkflowDbConnection for CachingDbConnection {
             }
         }
 
-        self.append_blocking(execution_id, req, wasm_backtrace, component_id)
+        self.append_blocking(version, execution_id, req, wasm_backtrace, component_id)
             .await
     }
 
     async fn append_batch_create_new_execution(
         &mut self,
+        version: Version,
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
@@ -435,11 +431,11 @@ impl WorkflowDbConnection for CachingDbConnection {
     ) -> Result<(), DbErrorWrite> {
         self.flush_non_blocking_event_cache(current_time).await?;
         let expected_next_version =
-            Version(self.version.0 + u32::try_from(batch.len()).expect("max 3 won't overflow"));
+            Version(version.0 + u32::try_from(batch.len()).expect("max 3 won't overflow"));
         let backtrace_info = wasm_backtrace.map(|wasm_backtrace| BacktraceInfo {
             execution_id: execution_id.clone(),
             component_id: component_id.clone(),
-            version_min_including: self.version.clone(),
+            version_min_including: version.clone(),
             version_max_excluding: expected_next_version.clone(),
             wasm_backtrace,
         });
@@ -449,14 +445,13 @@ impl WorkflowDbConnection for CachingDbConnection {
                 current_time,
                 batch,
                 execution_id,
-                self.version.clone(),
+                version,
                 child_req,
                 backtrace_info.into_iter().collect(),
             )
             .await?;
         assert_eq!(next_version, expected_next_version); // must hold, assumed when creating the backtrace `version_max_excluding`
 
-        self.version = next_version;
         Ok(())
     }
 

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -218,8 +218,8 @@ impl WorkflowDbConnection for CachingDbConnection {
         &self.execution_id
     }
 
-    async fn append_backtrace(&mut self, backtrace: BacktraceInfo) -> Result<(), DbErrorWrite> {
-        self.db_connection.append_backtrace(backtrace).await
+    async fn append_backtrace(&mut self, _backtrace: BacktraceInfo) -> Result<(), DbErrorWrite> {
+        unreachable!("CachingDbConnection never captures backtraces")
     }
 
     async fn append_non_blocking(
@@ -240,13 +240,13 @@ impl WorkflowDbConnection for CachingDbConnection {
                     request,
                     version,
                     child_req,
-                    backtrace,
+                    backtrace: _,
                 }
                 | CacheableDbEvent::SubmitChildExecution {
                     request,
                     version,
                     child_req,
-                    backtrace,
+                    backtrace: _,
                 } => {
                     let next_version = self
                         .db_connection
@@ -256,7 +256,7 @@ impl WorkflowDbConnection for CachingDbConnection {
                             self.execution_id.clone(),
                             version.clone(),
                             vec![child_req],
-                            backtrace.into_iter().collect(),
+                            vec![],
                         )
                         .await?;
                     assert_eq!(version.increment(), next_version);
@@ -264,47 +264,37 @@ impl WorkflowDbConnection for CachingDbConnection {
                 CacheableDbEvent::JoinSetCreate {
                     request,
                     version,
-                    backtrace,
+                    backtrace: _,
                 }
                 | CacheableDbEvent::Persist {
                     request,
                     version,
-                    backtrace,
+                    backtrace: _,
                 }
                 | CacheableDbEvent::SubmitDelay {
                     request,
                     version,
-                    backtrace,
+                    backtrace: _,
                 }
                 | CacheableDbEvent::JoinNextTry {
                     request,
                     version,
-                    backtrace,
+                    backtrace: _,
                 }
                 | CacheableDbEvent::ScheduleError {
                     request,
                     version,
-                    backtrace,
+                    backtrace: _,
                 }
                 | CacheableDbEvent::SubmitChildExecutionError {
                     request,
                     version,
-                    backtrace,
+                    backtrace: _,
                 } => {
                     let next_version = self
                         .db_connection
                         .append(self.execution_id.clone(), version.clone(), request)
                         .await?;
-
-                    if let Some(backtrace) = backtrace {
-                        let _ = self
-                            .db_connection
-                            .append_backtrace(backtrace)
-                            .await
-                            .inspect_err(|err| {
-                                debug!("Ignoring error while appending backtrace: {err:?}");
-                            });
-                    }
                     assert_eq!(version.increment(), next_version);
                 }
             }
@@ -318,16 +308,14 @@ impl WorkflowDbConnection for CachingDbConnection {
         version: Version,
         execution_id: ExecutionId,
         req: AppendRequest,
-        wasm_backtrace: Option<storage::WasmBacktrace>,
-        component_id: &ComponentId,
+        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         self.flush_non_blocking_event_cache(req.created_at).await?;
         let next_version = self
             .db_connection
             .append(execution_id, version.clone(), req)
             .await?;
-        self.persist_backtrace_blocking(&version, &next_version, wasm_backtrace, component_id)
-            .await;
         assert_eq!(version.increment(), next_version);
         Ok(())
     }
@@ -338,16 +326,13 @@ impl WorkflowDbConnection for CachingDbConnection {
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
-        wasm_backtrace: Option<storage::WasmBacktrace>,
-        component_id: &ComponentId,
+        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         self.flush_non_blocking_event_cache(current_time).await?;
-        let next_version = self
-            .db_connection
-            .append_batch(current_time, batch, execution_id, version.clone())
+        self.db_connection
+            .append_batch(current_time, batch, execution_id, version)
             .await?;
-        self.persist_backtrace_blocking(&version, &next_version, wasm_backtrace, component_id)
-            .await;
         Ok(())
     }
 
@@ -426,19 +411,12 @@ impl WorkflowDbConnection for CachingDbConnection {
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
         child_req: Vec<CreateRequest>,
-        wasm_backtrace: Option<storage::WasmBacktrace>,
-        component_id: &ComponentId,
+        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         self.flush_non_blocking_event_cache(current_time).await?;
         let expected_next_version =
             Version(version.0 + u32::try_from(batch.len()).expect("max 3 won't overflow"));
-        let backtrace_info = wasm_backtrace.map(|wasm_backtrace| BacktraceInfo {
-            execution_id: execution_id.clone(),
-            component_id: component_id.clone(),
-            version_min_including: version.clone(),
-            version_max_excluding: expected_next_version.clone(),
-            wasm_backtrace,
-        });
         let next_version = self
             .db_connection
             .append_batch_create_new_execution(
@@ -447,7 +425,7 @@ impl WorkflowDbConnection for CachingDbConnection {
                 execution_id,
                 version,
                 child_req,
-                backtrace_info.into_iter().collect(),
+                vec![],
             )
             .await?;
         assert_eq!(next_version, expected_next_version); // must hold, assumed when creating the backtrace `version_max_excluding`
@@ -532,67 +510,60 @@ impl WorkflowDbConnection for CachingDbConnection {
             let mut batches = Vec::with_capacity(caching_buffer.non_blocking_event_batch.len());
             let mut childs = Vec::with_capacity(caching_buffer.non_blocking_event_batch.len());
             let mut first_version = None;
-            let mut backtraces = Vec::with_capacity(caching_buffer.non_blocking_event_batch.len());
             for non_blocking in caching_buffer.non_blocking_event_batch.drain(..) {
                 match non_blocking {
                     CacheableDbEvent::SubmitChildExecution {
                         request,
                         version,
                         child_req,
-                        backtrace,
+                        backtrace: _,
                     }
                     | CacheableDbEvent::Schedule {
                         request,
                         version,
                         child_req,
-                        backtrace,
+                        backtrace: _,
                     } => {
                         if first_version.is_none() {
                             first_version.replace(version);
                         }
                         childs.push(child_req);
                         batches.push(request);
-                        if let Some(backtrace) = backtrace {
-                            backtraces.push(backtrace);
-                        }
                     }
                     CacheableDbEvent::JoinSetCreate {
                         request,
                         version,
-                        backtrace,
+                        backtrace: _,
                     }
                     | CacheableDbEvent::Persist {
                         request,
                         version,
-                        backtrace,
+                        backtrace: _,
                     }
                     | CacheableDbEvent::SubmitDelay {
                         request,
                         version,
-                        backtrace,
+                        backtrace: _,
                     }
                     | CacheableDbEvent::JoinNextTry {
                         request,
                         version,
-                        backtrace,
+                        backtrace: _,
                     }
                     | CacheableDbEvent::ScheduleError {
                         request,
                         version,
-                        backtrace,
+                        backtrace: _,
                     }
                     | CacheableDbEvent::SubmitChildExecutionError {
                         request,
                         version,
-                        backtrace,
+                        backtrace: _,
                     } => {
                         if first_version.is_none() {
                             first_version.replace(version);
                         }
                         batches.push(request);
-                        if let Some(backtrace) = backtrace {
-                            backtraces.push(backtrace);
-                        }
                     }
                 }
             }
@@ -604,7 +575,7 @@ impl WorkflowDbConnection for CachingDbConnection {
                     self.execution_id.clone(),
                     first_version.expect("checked that !non_blocking_event_batch.is_empty()"),
                     childs,
-                    backtraces,
+                    vec![],
                 )
                 .await?;
 
@@ -641,36 +612,5 @@ impl CachingDbConnection {
             }
         }
         Ok(())
-    }
-
-    async fn persist_backtrace_blocking(
-        &mut self,
-        version: &Version,
-        next_version: &Version,
-        wasm_backtrace: Option<storage::WasmBacktrace>,
-        component_id: &ComponentId,
-    ) {
-        if let Some(wasm_backtrace) = wasm_backtrace {
-            assert_eq!(
-                self.caching_buffer
-                    .as_ref()
-                    .map(|caching_buffer| caching_buffer.non_blocking_event_batch.len())
-                    .unwrap_or_default(),
-                0,
-                "persist_backtrace_blocking must be called only after flushing `non_blocking_event_batch`"
-            );
-
-            let _ = self
-                .db_connection
-                .append_backtrace(BacktraceInfo {
-                    execution_id: self.execution_id.clone(),
-                    component_id: component_id.clone(),
-                    version_min_including: version.clone(),
-                    version_max_excluding: next_version.clone(),
-                    wasm_backtrace,
-                })
-                .await
-                .inspect_err(|err| debug!("Ignoring error while appending backtrace: {err:?}"));
-        }
     }
 }

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -50,6 +50,7 @@ use db_common::{JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId};
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use indexmap::indexmap;
+use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -169,14 +170,39 @@ pub(crate) struct EventHistory {
 
 #[derive(Debug)]
 enum FindMatchingResponse {
-    Found(ChildReturnValue),
+    Found {
+        value: ChildReturnValue,
+        version: Version,
+    },
     NotFound,
     FoundRequestButNotResponse {
-        join_next_idx: usize,
-        join_next_version: Version,
+        version: Version,
     },
 }
 
+#[derive(Debug)]
+enum ProcessEventResponse {
+    Found(ChildReturnValue),
+    FoundRequestButNotResponse,
+}
+
+#[derive(Debug)]
+enum FindMatchingAtomicResponse {
+    Found {
+        value: ChildReturnValue,
+        version_range: EventCallVersionRange,
+    },
+    NotFound,
+    FoundRequestButNotResponse {
+        version_range: EventCallVersionRange,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct EventCallVersionRange {
+    min_including: Version,
+    max_excluding: Version,
+}
 impl EventHistory {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -319,13 +345,38 @@ impl EventHistory {
     /// Returns `WorkflowFunctionError` that is interpreted for interrupt etc. by the worker.
     async fn apply(
         &mut self,
-        event_call: EventCall,
+        event_call: EventCallKind,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<ChildReturnValue, WorkflowFunctionError> {
         Ok(self
-            .apply_inner(event_call, db_connection, called_at)
+            .apply_event_call(event_call, event_call_cursor, db_connection, called_at)
             .await?)
+    }
+
+    async fn apply_event_call(
+        &mut self,
+        event_call_kind: EventCallKind,
+        event_call_cursor: &mut EventCallCursor,
+        db_connection: &mut dyn WorkflowDbConnection,
+        called_at: DateTime<Utc>,
+    ) -> Result<ChildReturnValue, ApplyError> {
+        match self.deadline_tracker.check_preempt() {
+            Ok(()) => {}
+            Err(PreemptRequested::ExecutorClosing) => {
+                info!("Executor closing detected in host function call");
+                return Err(ApplyError::ExecutorClosing);
+            }
+        }
+
+        if self.deadline_tracker.close_to_expired() && self.lock_extension > Duration::ZERO {
+            self.extend_lock(event_call_cursor, db_connection, called_at)
+                .await?;
+        }
+
+        let event_call = event_call_cursor.next(event_call_kind);
+        self.apply_inner(event_call, db_connection, called_at).await
     }
 
     /// Apply the event and wait if new, replay if already in the event history, or
@@ -337,65 +388,95 @@ impl EventHistory {
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<ChildReturnValue, ApplyError> {
-        debug!(
-            "applying {event_call:?}, Version:{}",
-            db_connection.version()
-        );
+        debug!("applying {event_call:?}");
 
-        match self.deadline_tracker.check_preempt() {
-            Ok(()) => {}
-            Err(PreemptRequested::ExecutorClosing) => {
-                info!("Executor closing detected in host function call");
-                return Err(ApplyError::ExecutorClosing);
-            }
-        }
-
-        if self.deadline_tracker.close_to_expired() && self.lock_extension > Duration::ZERO {
-            self.extend_lock(db_connection, called_at).await?;
-        }
-
+        let wasm_backtrace = event_call.wasm_backtrace().cloned();
         match self.find_matching_atomic(&event_call)? {
-            FindMatchingResponse::Found(resp) => {
-                trace!("found_atomic: {resp:?}");
-                return Ok(resp);
+            FindMatchingAtomicResponse::Found {
+                value,
+                version_range,
+            } => {
+                trace!("found_atomic: {value:?}");
+                if let Some(wasm_backtrace) = wasm_backtrace {
+                    self.persist_replayed_backtrace(db_connection, version_range, wasm_backtrace)
+                        .await?;
+                }
+                return Ok(value);
             }
-            FindMatchingResponse::NotFound => {} // continue
-            FindMatchingResponse::FoundRequestButNotResponse { .. } => {
+            FindMatchingAtomicResponse::NotFound => {} // continue
+            FindMatchingAtomicResponse::FoundRequestButNotResponse { version_range, .. } => {
                 assert!(self.replaying_unfinished_execution);
+                if let Some(wasm_backtrace) = wasm_backtrace {
+                    self.persist_replayed_backtrace(db_connection, version_range, wasm_backtrace)
+                        .await?;
+                }
                 return Err(ApplyError::ReplayInterrupt);
             }
         }
 
-        match event_call {
-            EventCall::NonBlocking(event_call) => {
+        let version_range = event_call.version_range.clone();
+        match event_call.kind {
+            EventCallKind::NonBlocking(event_call) => {
                 // Events that cannot block waiting for response.
                 let cloned_non_blocking = event_call.clone();
                 let (event, version) = self
-                    .append_to_db_non_blocking(event_call, db_connection, called_at)
+                    .append_to_db_non_blocking(
+                        event_call,
+                        version_range.min_including.clone(),
+                        db_connection,
+                        called_at,
+                    )
                     .await?;
                 self.event_history.push((event, Unprocessed, version));
                 trace!("find_matching_atomic must mark the non-blocking event as Processed");
+                let stored_event_call = EventCall::new(
+                    version_range.min_including.clone(),
+                    version_range,
+                    EventCallKind::NonBlocking(cloned_non_blocking),
+                );
                 let non_blocking_resp = assert_matches!(
-                    self
-                    .find_matching_atomic(&EventCall::NonBlocking(cloned_non_blocking))?,
-                    FindMatchingResponse::Found(resp) => resp, "just stored the event as Unprocessed, it must be found");
+                    self.find_matching_atomic(&stored_event_call)?,
+                    FindMatchingAtomicResponse::Found { value, .. } => value, "just stored the event as Unprocessed, it must be found");
                 Ok(non_blocking_resp)
             }
-            EventCall::Blocking(event_call) => {
+            EventCallKind::Blocking(event_call) => {
                 let lock_expires_at =
                     if self.join_next_blocking_strategy == JoinNextBlockingStrategy::Interrupt {
                         called_at
                     } else {
                         self.locked_event.lock_expires_at
                     };
-                self.apply_blocking(event_call, db_connection, lock_expires_at, called_at)
-                    .await
+                self.apply_blocking(
+                    event_call,
+                    version_range.min_including,
+                    db_connection,
+                    lock_expires_at,
+                    called_at,
+                )
+                .await
             }
         }
     }
 
+    async fn persist_replayed_backtrace(
+        &self,
+        db_connection: &mut dyn WorkflowDbConnection,
+        version_range: EventCallVersionRange,
+        wasm_backtrace: storage::WasmBacktrace,
+    ) -> Result<(), DbErrorWrite> {
+        let backtrace = BacktraceInfo {
+            execution_id: db_connection.execution_id().clone(),
+            component_id: self.locked_event.component_id.clone(),
+            version_min_including: version_range.min_including,
+            version_max_excluding: version_range.max_excluding,
+            wasm_backtrace,
+        };
+        db_connection.append_backtrace(backtrace).await
+    }
+
     async fn extend_lock(
         &mut self,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(), DbErrorWrite> {
@@ -406,23 +487,27 @@ impl EventHistory {
         };
         info!(
             "Extending the lock at version {version}",
-            version = db_connection.version()
+            version = event_call_cursor.version()
         );
 
+        let version = event_call_cursor.next_version.clone();
         db_connection
             .append_blocking(
+                version,
                 db_connection.execution_id().clone(),
                 append_req,
                 None,
                 &self.locked_event.component_id,
             )
             .await?;
+        event_call_cursor.next_version = event_call_cursor.next_version.increment();
         Ok(())
     }
 
     async fn apply_blocking(
         &mut self,
         event_call: EventCallBlocking,
+        version: Version,
         db_connection: &mut dyn WorkflowDbConnection,
         lock_expires_at: DateTime<Utc>,
         called_at: DateTime<Utc>,
@@ -431,7 +516,13 @@ impl EventHistory {
         let keys = event_call.as_keys();
         // Create and append HistoryEvents.
         let history_events = self
-            .append_to_db_blocking(event_call, db_connection, called_at, lock_expires_at)
+            .append_to_db_blocking(
+                event_call,
+                version,
+                db_connection,
+                called_at,
+                lock_expires_at,
+            )
             .await?;
         assert!(
             !history_events.is_empty(),
@@ -448,7 +539,7 @@ impl EventHistory {
         for (idx, key) in keys.into_iter().enumerate() {
             let res = self.process_event_by_key(&key)?;
             if idx == last_key_idx
-                && let FindMatchingResponse::Found(res) = res
+                && let FindMatchingResponse::Found { value: res, .. } = res
             {
                 // Last key was marked as processed.
                 assert_eq!(
@@ -502,8 +593,9 @@ impl EventHistory {
                         self.responses
                             .extend(next_responses.into_iter().map(|resp| (resp, Unprocessed)));
                         trace!("All responses: {:?}", self.responses);
-                        if let FindMatchingResponse::Found(accept_resp) =
-                            self.process_event_by_key(&key)?
+                        if let FindMatchingResponse::Found {
+                            value: accept_resp, ..
+                        } = self.process_event_by_key(&key)?
                         {
                             debug!(join_set_id = %join_next_variant.join_set_id(), "Got result");
                             return Ok(accept_resp);
@@ -532,18 +624,26 @@ impl EventHistory {
     pub(crate) async fn join_set_close(
         &mut self,
         join_set_id: &JoinSetId,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
         wasm_backtrace: Option<storage::WasmBacktrace>,
     ) -> Result<(), WorkflowFunctionError> {
-        self.join_set_close_inner(join_set_id, db_connection, called_at, wasm_backtrace)
-            .await
-            .map_err(WorkflowFunctionError::from)
+        self.join_set_close_inner(
+            join_set_id,
+            event_call_cursor,
+            db_connection,
+            called_at,
+            wasm_backtrace,
+        )
+        .await
+        .map_err(WorkflowFunctionError::from)
     }
     /// Deterministically cancel activites and delays, emit `JoinNext` and wait for the response.
     async fn join_set_close_inner(
         &mut self,
         join_set_id: &JoinSetId,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
         wasm_backtrace: Option<storage::WasmBacktrace>,
@@ -584,12 +684,13 @@ impl EventHistory {
                 ))
             };
         for _ in 0..join_next_count {
-            let event_call = EventCall::Blocking(EventCallBlocking::JoinSetClose(JoinSetClose {
-                join_set_id: join_set_id.clone(),
-                cancellations: std::mem::take(&mut cancellations), // First iterations takes all cancellations, so that the activities get the signal ASAP.
-                wasm_backtrace: wasm_backtrace.clone(),
-            }));
-            self.apply_inner(event_call, db_connection, called_at)
+            let event_call =
+                EventCallKind::Blocking(EventCallBlocking::JoinSetClose(JoinSetClose {
+                    join_set_id: join_set_id.clone(),
+                    cancellations: std::mem::take(&mut cancellations), // First iterations takes all cancellations, so that the activities get the signal ASAP.
+                    wasm_backtrace: wasm_backtrace.clone(),
+                }));
+            self.apply_event_call(event_call, event_call_cursor, db_connection, called_at)
                 .await?;
         }
         Ok(())
@@ -600,6 +701,7 @@ impl EventHistory {
     #[instrument(skip_all)]
     pub(crate) async fn finalize(
         &mut self,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(), ApplyError> {
@@ -616,8 +718,14 @@ impl EventHistory {
                 }
             })
         {
-            self.join_set_close_inner(&join_set_id, db_connection, called_at, None)
-                .await?;
+            self.join_set_close_inner(
+                &join_set_id,
+                event_call_cursor,
+                db_connection,
+                called_at,
+                None,
+            )
+            .await?;
         }
         if let Some((_found_idx, first_unprocessed, version)) = self.first_unprocessed_request() {
             return Err(ApplyError::NondeterminismDetected(format!(
@@ -631,34 +739,47 @@ impl EventHistory {
     fn find_matching_atomic(
         &mut self,
         event_call: &EventCall,
-    ) -> Result<FindMatchingResponse, ApplyError> {
+    ) -> Result<FindMatchingAtomicResponse, ApplyError> {
         let keys = event_call.as_keys();
         assert!(!keys.is_empty());
         let last_key_idx = keys.len() - 1;
         for (idx, key) in keys.into_iter().enumerate() {
-            let resp = self.process_event_by_key(&key)?;
-            match resp {
+            match self.process_event_by_key(&key)? {
                 FindMatchingResponse::NotFound => {
                     assert_eq!(idx, 0, "NotFound must be returned on the first key");
-                    return Ok(FindMatchingResponse::NotFound);
+                    return Ok(FindMatchingAtomicResponse::NotFound);
                 }
                 FindMatchingResponse::FoundRequestButNotResponse {
-                    join_next_idx,
-                    join_next_version,
+                    version: matched_version,
                 } => {
+                    let expected_version = Version::new(
+                        event_call.version.0
+                            + u32::try_from(idx).expect("an EventCall has at most three events"),
+                    );
+                    assert_eq!(expected_version, matched_version);
                     // JoinNext is still unprocessed. This can only happen on the last key (the JoinNext key).
                     assert_eq!(
                         last_key_idx, idx,
                         "FoundRequestButNotResponse must be returned on the last key"
                     );
-                    return Ok(FindMatchingResponse::FoundRequestButNotResponse {
-                        join_next_idx,
-                        join_next_version,
+                    return Ok(FindMatchingAtomicResponse::FoundRequestButNotResponse {
+                        version_range: event_call.version_range.clone(),
                     });
                 }
-                FindMatchingResponse::Found(found) => {
+                FindMatchingResponse::Found {
+                    value: found,
+                    version: matched_version,
+                } => {
+                    let expected_version = Version::new(
+                        event_call.version.0
+                            + u32::try_from(idx).expect("an EventCall has at most three events"),
+                    );
+                    assert_eq!(expected_version, matched_version);
                     if idx == last_key_idx {
-                        return Ok(FindMatchingResponse::Found(found));
+                        return Ok(FindMatchingAtomicResponse::Found {
+                            value: found,
+                            version_range: event_call.version_range.clone(),
+                        });
                     }
                 }
             }
@@ -769,430 +890,441 @@ impl EventHistory {
         trace!(
             "Finding match for {key:?}, [{found_idx}, v{found_version}] {found_request_event:?}"
         );
-        match (key, found_request_event) {
-            (
-                DeterministicKey::CreateJoinSet { join_set_id },
-                HistoryEvent::JoinSetCreate {
-                    join_set_id: found_join_set_id,
-                },
-            ) if *join_set_id == *found_join_set_id => {
-                trace!(%join_set_id, "Matched JoinSet");
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(
-                    ChildReturnValue::JoinSetCreate(join_set_id.clone()),
-                ))
-            }
+        let response = {
+            use ProcessEventResponse as FindMatchingResponse;
 
-            (
-                DeterministicKey::Persist { value, kind },
-                HistoryEvent::Persist {
-                    value: found_value,
-                    kind: found_kind,
-                },
-            ) if *value == *found_value && *kind == *found_kind => {
-                trace!("Matched Persist");
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::Persist))
-            }
-
-            (
-                DeterministicKey::ChildExecutionRequest {
-                    join_set_id,
-                    child_execution_id: execution_id,
-                    target_ffqn,
-                    params,
-                },
-                HistoryEvent::JoinSetRequest {
-                    join_set_id: found_join_set_id,
-                    request:
-                        JoinSetRequest::ChildExecutionRequest {
-                            child_execution_id,
-                            target_ffqn: stored_target_ffqn,
-                            params: stored_params,
-                            result: found_result,
-                        },
-                },
-            ) if *join_set_id == *found_join_set_id
-                && *execution_id == *child_execution_id
-                && target_ffqn == stored_target_ffqn
-                && params == stored_params =>
-            {
-                trace!(%child_execution_id, %join_set_id, "Matched JoinSetRequest::ChildExecutionRequest, result: {found_result:?}");
-                let found_result = found_result.clone();
-                // Only add to index if the result was Ok (child was actually created)
-                if found_result.is_ok() {
-                    self.index_child_exe_to_ffqn
-                        .insert(child_execution_id.clone(), target_ffqn.clone());
+            match (key, found_request_event) {
+                (
+                    DeterministicKey::CreateJoinSet { join_set_id },
+                    HistoryEvent::JoinSetCreate {
+                        join_set_id: found_join_set_id,
+                    },
+                ) if *join_set_id == *found_join_set_id => {
+                    trace!(%join_set_id, "Matched JoinSet");
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(
+                        ChildReturnValue::JoinSetCreate(join_set_id.clone()),
+                    ))
                 }
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::SubmitChild(
-                    found_result,
-                )))
-            }
 
-            (
-                DeterministicKey::DelayRequest {
-                    join_set_id,
-                    delay_id,
-                    schedule_at,
-                },
-                HistoryEvent::JoinSetRequest {
-                    join_set_id: found_join_set_id,
-                    request:
-                        JoinSetRequest::DelayRequest {
-                            delay_id: found_delay_id,
-                            expires_at,
-                            schedule_at: found_schedule_at,
-                            ..
-                        },
-                },
-            ) if *join_set_id == *found_join_set_id
-                && *delay_id == *found_delay_id
-                && schedule_at == found_schedule_at =>
-            {
-                trace!(%delay_id, %join_set_id, "Matched JoinSetRequest::DelayRequest");
-                self.index_delay_id_to_expires_at
-                    .insert(delay_id.clone(), *expires_at);
-                self.event_history[found_idx].1 = Processed;
-                // return delay id
-                Ok(FindMatchingResponse::Found(ChildReturnValue::SubmitDelay))
-            }
+                (
+                    DeterministicKey::Persist { value, kind },
+                    HistoryEvent::Persist {
+                        value: found_value,
+                        kind: found_kind,
+                    },
+                ) if *value == *found_value && *kind == *found_kind => {
+                    trace!("Matched Persist");
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::Persist))
+                }
 
-            (
-                DeterministicKey::JoinNextChild {
-                    join_set_id,
-                    kind: JoinNextChildKind::AwaitNext,
-                    requested_ffqn,
-                },
-                HistoryEvent::JoinNextTooMany {
-                    join_set_id: found_join_set_id,
-                    requested_ffqn: found_requested_ffqn,
-                },
-            ) if *join_set_id == *found_join_set_id
-                && Some(requested_ffqn) == found_requested_ffqn.as_ref() =>
-            {
-                trace!(%join_set_id, "matched JoinNextChild with JoinNextTooMany");
-                self.event_history[found_idx].1 = Processed;
+                (
+                    DeterministicKey::ChildExecutionRequest {
+                        join_set_id,
+                        child_execution_id: execution_id,
+                        target_ffqn,
+                        params,
+                    },
+                    HistoryEvent::JoinSetRequest {
+                        join_set_id: found_join_set_id,
+                        request:
+                            JoinSetRequest::ChildExecutionRequest {
+                                child_execution_id,
+                                target_ffqn: stored_target_ffqn,
+                                params: stored_params,
+                                result: found_result,
+                            },
+                    },
+                ) if *join_set_id == *found_join_set_id
+                    && *execution_id == *child_execution_id
+                    && target_ffqn == stored_target_ffqn
+                    && params == stored_params =>
+                {
+                    trace!(%child_execution_id, %join_set_id, "Matched JoinSetRequest::ChildExecutionRequest, result: {found_result:?}");
+                    let found_result = found_result.clone();
+                    // Only add to index if the result was Ok (child was actually created)
+                    if found_result.is_ok() {
+                        self.index_child_exe_to_ffqn
+                            .insert(child_execution_id.clone(), target_ffqn.clone());
+                    }
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::SubmitChild(
+                        found_result,
+                    )))
+                }
 
-                Ok(FindMatchingResponse::Found(
-                    ChildReturnValue::JoinNextRequestingFfqn(Err(
-                        AwaitNextExtensionError::AllProcessed,
-                    )),
-                ))
-            }
+                (
+                    DeterministicKey::DelayRequest {
+                        join_set_id,
+                        delay_id,
+                        schedule_at,
+                    },
+                    HistoryEvent::JoinSetRequest {
+                        join_set_id: found_join_set_id,
+                        request:
+                            JoinSetRequest::DelayRequest {
+                                delay_id: found_delay_id,
+                                expires_at,
+                                schedule_at: found_schedule_at,
+                                ..
+                            },
+                    },
+                ) if *join_set_id == *found_join_set_id
+                    && *delay_id == *found_delay_id
+                    && schedule_at == found_schedule_at =>
+                {
+                    trace!(%delay_id, %join_set_id, "Matched JoinSetRequest::DelayRequest");
+                    self.index_delay_id_to_expires_at
+                        .insert(delay_id.clone(), *expires_at);
+                    self.event_history[found_idx].1 = Processed;
+                    // return delay id
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::SubmitDelay))
+                }
 
-            (
-                DeterministicKey::JoinNextChild {
-                    join_set_id,
-                    kind,
-                    requested_ffqn,
-                },
-                HistoryEvent::JoinNext {
-                    join_set_id: found_join_set_id,
-                    requested_ffqn: Some(found_requested_ffqn),
-                    run_expires_at: _,
-                    closing: false, // JoinNextChild originates from user's code
-                },
-            ) if *join_set_id == *found_join_set_id && requested_ffqn == found_requested_ffqn => {
-                trace!(%join_set_id, "Peeked at JoinNext - Child");
-                match self.mark_next_unprocessed_response(found_idx, join_set_id) {
-                    Some(JoinSetResponseEnriched::ChildExecutionFinished(
-                        ChildExecutionFinished {
-                            child_execution_id,
-                            result,
-                            response_ffqn,
-                        },
-                    )) if requested_ffqn == response_ffqn => {
-                        trace!(%join_set_id, "Matched JoinNext & ChildExecutionFinished");
-                        let response_ffqn = response_ffqn.clone();
-                        let child_execution_id = child_execution_id.clone();
-                        let inner_res = result.clone().into_wast_val( || self.fn_registry.get_ret_type(&response_ffqn)
+                (
+                    DeterministicKey::JoinNextChild {
+                        join_set_id,
+                        kind: JoinNextChildKind::AwaitNext,
+                        requested_ffqn,
+                    },
+                    HistoryEvent::JoinNextTooMany {
+                        join_set_id: found_join_set_id,
+                        requested_ffqn: found_requested_ffqn,
+                    },
+                ) if *join_set_id == *found_join_set_id
+                    && Some(requested_ffqn) == found_requested_ffqn.as_ref() =>
+                {
+                    trace!(%join_set_id, "matched JoinNextChild with JoinNextTooMany");
+                    self.event_history[found_idx].1 = Processed;
+
+                    Ok(FindMatchingResponse::Found(
+                        ChildReturnValue::JoinNextRequestingFfqn(Err(
+                            AwaitNextExtensionError::AllProcessed,
+                        )),
+                    ))
+                }
+
+                (
+                    DeterministicKey::JoinNextChild {
+                        join_set_id,
+                        kind,
+                        requested_ffqn,
+                    },
+                    HistoryEvent::JoinNext {
+                        join_set_id: found_join_set_id,
+                        requested_ffqn: Some(found_requested_ffqn),
+                        run_expires_at: _,
+                        closing: false, // JoinNextChild originates from user's code
+                    },
+                ) if *join_set_id == *found_join_set_id
+                    && requested_ffqn == found_requested_ffqn =>
+                {
+                    trace!(%join_set_id, "Peeked at JoinNext - Child");
+                    match self.mark_next_unprocessed_response(found_idx, join_set_id) {
+                        Some(JoinSetResponseEnriched::ChildExecutionFinished(
+                            ChildExecutionFinished {
+                                child_execution_id,
+                                result,
+                                response_ffqn,
+                            },
+                        )) if requested_ffqn == response_ffqn => {
+                            trace!(%join_set_id, "Matched JoinNext & ChildExecutionFinished");
+                            let response_ffqn = response_ffqn.clone();
+                            let child_execution_id = child_execution_id.clone();
+                            let inner_res = result.clone().into_wast_val( || self.fn_registry.get_ret_type(&response_ffqn)
                                         .expect("response_ffqn must be no-ext, thus must be returned by get_ret_type"));
-                        match kind {
-                            JoinNextChildKind::DirectCall => Ok(FindMatchingResponse::Found(
-                                ChildReturnValue::WastVal(inner_res),
-                            )),
-                            JoinNextChildKind::AwaitNext => {
-                                // result<(execution-id, inner-res>, await-next-extension-error>
-                                Ok(FindMatchingResponse::Found(
-                                    ChildReturnValue::JoinNextRequestingFfqn(Ok((
-                                        child_execution_id,
-                                        inner_res,
-                                    ))),
-                                ))
+                            match kind {
+                                JoinNextChildKind::DirectCall => Ok(FindMatchingResponse::Found(
+                                    ChildReturnValue::WastVal(inner_res),
+                                )),
+                                JoinNextChildKind::AwaitNext => {
+                                    // result<(execution-id, inner-res>, await-next-extension-error>
+                                    Ok(FindMatchingResponse::Found(
+                                        ChildReturnValue::JoinNextRequestingFfqn(Ok((
+                                            child_execution_id,
+                                            inner_res,
+                                        ))),
+                                    ))
+                                }
                             }
                         }
-                    }
-                    Some(JoinSetResponseEnriched::ChildExecutionFinished(
-                        ChildExecutionFinished {
-                            child_execution_id,
+                        Some(JoinSetResponseEnriched::ChildExecutionFinished(
+                            ChildExecutionFinished {
+                                child_execution_id,
+                                result: _,
+                                response_ffqn, // mismatch between ffqns
+                            },
+                        )) => {
+                            let function_mismatch = AwaitNextExtensionError::FunctionMismatch {
+                                specified_function: requested_ffqn.clone(),
+                                actual_function: Some(response_ffqn.clone()),
+                                actual_id: JoinSetResponseId::ChildExecutionId(
+                                    child_execution_id.clone(),
+                                ),
+                            };
+                            Ok(FindMatchingResponse::Found(
+                                ChildReturnValue::JoinNextRequestingFfqn(Err(function_mismatch)),
+                            ))
+                        }
+                        Some(JoinSetResponseEnriched::DelayFinished {
+                            delay_id,
                             result: _,
-                            response_ffqn, // mismatch between ffqns
-                        },
-                    )) => {
-                        let function_mismatch = AwaitNextExtensionError::FunctionMismatch {
-                            specified_function: requested_ffqn.clone(),
-                            actual_function: Some(response_ffqn.clone()),
-                            actual_id: JoinSetResponseId::ChildExecutionId(
-                                child_execution_id.clone(),
-                            ),
-                        };
-                        Ok(FindMatchingResponse::Found(
-                            ChildReturnValue::JoinNextRequestingFfqn(Err(function_mismatch)),
-                        ))
+                            expires_at: _,
+                        }) => {
+                            let function_mismatch = AwaitNextExtensionError::FunctionMismatch {
+                                specified_function: requested_ffqn.clone(),
+                                actual_function: None,
+                                actual_id: JoinSetResponseId::DelayId(delay_id.clone()),
+                            };
+                            Ok(FindMatchingResponse::Found(
+                                ChildReturnValue::JoinNextRequestingFfqn(Err(function_mismatch)),
+                            ))
+                        }
+                        None => Ok(FindMatchingResponse::FoundRequestButNotResponse),
                     }
-                    Some(JoinSetResponseEnriched::DelayFinished {
-                        delay_id,
-                        result: _,
-                        expires_at: _,
-                    }) => {
-                        let function_mismatch = AwaitNextExtensionError::FunctionMismatch {
-                            specified_function: requested_ffqn.clone(),
-                            actual_function: None,
-                            actual_id: JoinSetResponseId::DelayId(delay_id.clone()),
-                        };
-                        Ok(FindMatchingResponse::Found(
-                            ChildReturnValue::JoinNextRequestingFfqn(Err(function_mismatch)),
-                        ))
-                    }
-                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse {
-                        join_next_idx: found_idx,
-                        join_next_version: found_version,
-                    }),
                 }
-            }
 
-            (
-                DeterministicKey::JoinNextDelay { join_set_id },
-                HistoryEvent::JoinNext {
-                    join_set_id: found_join_set_id,
-                    requested_ffqn: None,
-                    closing: false, // JoinNextDelay originates from user's code
-                    run_expires_at: _,
-                },
-            ) if *join_set_id == *found_join_set_id => {
-                trace!(
+                (
+                    DeterministicKey::JoinNextDelay { join_set_id },
+                    HistoryEvent::JoinNext {
+                        join_set_id: found_join_set_id,
+                        requested_ffqn: None,
+                        closing: false, // JoinNextDelay originates from user's code
+                        run_expires_at: _,
+                    },
+                ) if *join_set_id == *found_join_set_id => {
+                    trace!(
                     %join_set_id, "Peeked at JoinNext - Delay");
-                match self.mark_next_unprocessed_response(found_idx, join_set_id) {
-                    Some(JoinSetResponseEnriched::DelayFinished {
-                        expires_at: scheduled_at,
-                        result,
-                        delay_id: _, // one-shot
-                    }) => {
-                        trace!(%join_set_id, "Matched JoinNext & DelayFinished");
-                        Ok(FindMatchingResponse::Found(ChildReturnValue::OneOffDelay {
-                            scheduled_at,
+                    match self.mark_next_unprocessed_response(found_idx, join_set_id) {
+                        Some(JoinSetResponseEnriched::DelayFinished {
+                            expires_at: scheduled_at,
                             result,
-                        }))
-                    }
-                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse {
-                        join_next_idx: found_idx,
-                        join_next_version: found_version,
-                    }),
-                    Some(JoinSetResponseEnriched::ChildExecutionFinished { .. }) => unreachable!(
-                        "DeterministicKey::JoinNextDelay is emitted only on one-shot join sets"
-                    ),
-                }
-            }
-
-            (
-                DeterministicKey::JoinNext {
-                    join_set_id,
-                    closing,
-                },
-                HistoryEvent::JoinNext {
-                    join_set_id: found_join_set_id,
-                    requested_ffqn: None, // closing and `join-next` are agnostic of ffqn.
-                    run_expires_at: _,
-                    closing: found_closing,
-                },
-            ) if *join_set_id == *found_join_set_id && closing == found_closing => {
-                trace!(%join_set_id, "DeterministicKey::JoinNext(closing:{closing}): Peeked at JoinNext");
-                match self.mark_next_unprocessed_response(found_idx, join_set_id) {
-                    Some(JoinSetResponseEnriched::ChildExecutionFinished(
-                        ChildExecutionFinished {
-                            child_execution_id,
-                            result: res,
-                            response_ffqn: _,
-                        },
-                    )) => {
-                        trace!(%join_set_id, %child_execution_id, "DeterministicKey::JoinNext: Matched ChildExecutionFinished");
-                        Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNext(Ok(
-                            (
-                                JoinSetResponseId::ChildExecutionId(child_execution_id.clone()),
-                                res.as_pending_state_finished_result()
-                                    .as_result()
-                                    .map_err(|_| ()),
-                            ),
-                        ))))
-                    }
-                    Some(JoinSetResponseEnriched::DelayFinished {
-                        delay_id,
-                        result,
-                        expires_at: _,
-                    }) => {
-                        trace!(%join_set_id, %delay_id, "DeterministicKey::JoinNext: Matched DelayFinished");
-                        Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNext(Ok(
-                            (JoinSetResponseId::DelayId(delay_id.clone()), result),
-                        ))))
-                    }
-                    None => Ok(FindMatchingResponse::FoundRequestButNotResponse {
-                        join_next_idx: found_idx,
-                        join_next_version: found_version,
-                    }),
-                }
-            }
-
-            (
-                DeterministicKey::JoinNext {
-                    join_set_id,
-                    closing: false, // Runtime should never issue a bogus `JoinNext`.
-                },
-                HistoryEvent::JoinNextTooMany {
-                    join_set_id: found_join_set_id,
-                    requested_ffqn: None, // `join-next` is agnostic of ffqn.
-                },
-            ) if *join_set_id == *found_join_set_id => {
-                trace!(%join_set_id, "matched JoinNext with JoinNextTooMany");
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNext(
-                    Err(JoinNextError::AllProcessed),
-                )))
-            }
-
-            // JoinNextTry with outcome=Found: match with actual response
-            (
-                DeterministicKey::JoinNextTry { join_set_id },
-                HistoryEvent::JoinNextTry {
-                    join_set_id: found_join_set_id,
-                    outcome: JoinNextTryOutcome::Found,
-                },
-            ) if *join_set_id == *found_join_set_id => {
-                trace!(%join_set_id, "DeterministicKey::JoinNextTry(found): Peeked at JoinNextTry");
-                match self.mark_next_unprocessed_response(found_idx, join_set_id) {
-                    Some(JoinSetResponseEnriched::ChildExecutionFinished(
-                        ChildExecutionFinished {
-                            child_execution_id,
-                            result: res,
-                            response_ffqn: _,
-                        },
-                    )) => {
-                        trace!(%join_set_id, %child_execution_id, "DeterministicKey::JoinNextTry: Matched ChildExecutionFinished");
-                        Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
-                            Ok((
-                                JoinSetResponseId::ChildExecutionId(child_execution_id.clone()),
-                                res.as_pending_state_finished_result()
-                                    .as_result()
-                                    .map_err(|_| ()),
-                            )),
-                        )))
-                    }
-                    Some(JoinSetResponseEnriched::DelayFinished {
-                        delay_id,
-                        result,
-                        expires_at: _,
-                    }) => {
-                        trace!(%join_set_id, %delay_id, "DeterministicKey::JoinNextTry: Matched DelayFinished");
-                        Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
-                            Ok((JoinSetResponseId::DelayId(delay_id.clone()), result)),
-                        )))
-                    }
-                    None => {
-                        // This is a nondeterminism: history says outcome=Found but no response available
-                        Err(ApplyError::NondeterminismDetected(format!(
-                            "JoinNextTry recorded outcome=Found but no response available for join set `{join_set_id}`"
-                        )))
+                            delay_id: _, // one-shot
+                        }) => {
+                            trace!(%join_set_id, "Matched JoinNext & DelayFinished");
+                            Ok(FindMatchingResponse::Found(ChildReturnValue::OneOffDelay {
+                                scheduled_at,
+                                result,
+                            }))
+                        }
+                        None => Ok(FindMatchingResponse::FoundRequestButNotResponse),
+                        Some(JoinSetResponseEnriched::ChildExecutionFinished { .. }) => {
+                            unreachable!(
+                                "DeterministicKey::JoinNextDelay is emitted only on one-shot join sets"
+                            )
+                        }
                     }
                 }
-            }
 
-            // JoinNextTry with outcome=Pending: return Pending error
-            (
-                DeterministicKey::JoinNextTry { join_set_id },
-                HistoryEvent::JoinNextTry {
-                    join_set_id: found_join_set_id,
-                    outcome: JoinNextTryOutcome::Pending,
-                },
-            ) if *join_set_id == *found_join_set_id => {
-                trace!(%join_set_id, "DeterministicKey::JoinNextTry(pending): returning Pending error");
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
-                    Err(JoinNextTryError::Pending),
-                )))
-            }
+                (
+                    DeterministicKey::JoinNext {
+                        join_set_id,
+                        closing,
+                    },
+                    HistoryEvent::JoinNext {
+                        join_set_id: found_join_set_id,
+                        requested_ffqn: None, // closing and `join-next` are agnostic of ffqn.
+                        run_expires_at: _,
+                        closing: found_closing,
+                    },
+                ) if *join_set_id == *found_join_set_id && closing == found_closing => {
+                    trace!(%join_set_id, "DeterministicKey::JoinNext(closing:{closing}): Peeked at JoinNext");
+                    match self.mark_next_unprocessed_response(found_idx, join_set_id) {
+                        Some(JoinSetResponseEnriched::ChildExecutionFinished(
+                            ChildExecutionFinished {
+                                child_execution_id,
+                                result: res,
+                                response_ffqn: _,
+                            },
+                        )) => {
+                            trace!(%join_set_id, %child_execution_id, "DeterministicKey::JoinNext: Matched ChildExecutionFinished");
+                            Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNext(Ok(
+                                (
+                                    JoinSetResponseId::ChildExecutionId(child_execution_id.clone()),
+                                    res.as_pending_state_finished_result()
+                                        .as_result()
+                                        .map_err(|_| ()),
+                                ),
+                            ))))
+                        }
+                        Some(JoinSetResponseEnriched::DelayFinished {
+                            delay_id,
+                            result,
+                            expires_at: _,
+                        }) => {
+                            trace!(%join_set_id, %delay_id, "DeterministicKey::JoinNext: Matched DelayFinished");
+                            Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNext(Ok(
+                                (JoinSetResponseId::DelayId(delay_id.clone()), result),
+                            ))))
+                        }
+                        None => Ok(FindMatchingResponse::FoundRequestButNotResponse),
+                    }
+                }
 
-            // JoinNextTry with outcome=AllProcessed: return AllProcessed error
-            (
-                DeterministicKey::JoinNextTry { join_set_id },
-                HistoryEvent::JoinNextTry {
-                    join_set_id: found_join_set_id,
-                    outcome: JoinNextTryOutcome::AllProcessed,
-                },
-            ) if *join_set_id == *found_join_set_id => {
-                trace!(%join_set_id, "DeterministicKey::JoinNextTry(all_processed): returning AllProcessed error");
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
-                    Err(JoinNextTryError::AllProcessed),
-                )))
-            }
+                (
+                    DeterministicKey::JoinNext {
+                        join_set_id,
+                        closing: false, // Runtime should never issue a bogus `JoinNext`.
+                    },
+                    HistoryEvent::JoinNextTooMany {
+                        join_set_id: found_join_set_id,
+                        requested_ffqn: None, // `join-next` is agnostic of ffqn.
+                    },
+                ) if *join_set_id == *found_join_set_id => {
+                    trace!(%join_set_id, "matched JoinNext with JoinNextTooMany");
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNext(
+                        Err(JoinNextError::AllProcessed),
+                    )))
+                }
 
-            (
-                DeterministicKey::Schedule {
-                    target_execution_id,
-                    schedule_at,
-                },
-                HistoryEvent::Schedule {
-                    execution_id: found_execution_id,
-                    schedule_at: found_schedule_at,
-                    result: found_result,
-                },
-            ) if *target_execution_id == *found_execution_id
-                && schedule_at == found_schedule_at =>
-            {
-                trace!(%target_execution_id, "Matched Schedule, result: {:?}", found_result);
-                // Clone the result before mutating self
-                let found_result = found_result.clone();
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::Schedule(
-                    found_result,
-                )))
-            }
+                // JoinNextTry with outcome=Found: match with actual response
+                (
+                    DeterministicKey::JoinNextTry { join_set_id },
+                    HistoryEvent::JoinNextTry {
+                        join_set_id: found_join_set_id,
+                        outcome: JoinNextTryOutcome::Found,
+                    },
+                ) if *join_set_id == *found_join_set_id => {
+                    trace!(%join_set_id, "DeterministicKey::JoinNextTry(found): Peeked at JoinNextTry");
+                    match self.mark_next_unprocessed_response(found_idx, join_set_id) {
+                        Some(JoinSetResponseEnriched::ChildExecutionFinished(
+                            ChildExecutionFinished {
+                                child_execution_id,
+                                result: res,
+                                response_ffqn: _,
+                            },
+                        )) => {
+                            trace!(%join_set_id, %child_execution_id, "DeterministicKey::JoinNextTry: Matched ChildExecutionFinished");
+                            Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
+                                Ok((
+                                    JoinSetResponseId::ChildExecutionId(child_execution_id.clone()),
+                                    res.as_pending_state_finished_result()
+                                        .as_result()
+                                        .map_err(|_| ()),
+                                )),
+                            )))
+                        }
+                        Some(JoinSetResponseEnriched::DelayFinished {
+                            delay_id,
+                            result,
+                            expires_at: _,
+                        }) => {
+                            trace!(%join_set_id, %delay_id, "DeterministicKey::JoinNextTry: Matched DelayFinished");
+                            Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
+                                Ok((JoinSetResponseId::DelayId(delay_id.clone()), result)),
+                            )))
+                        }
+                        None => {
+                            // This is a nondeterminism: history says outcome=Found but no response available
+                            Err(ApplyError::NondeterminismDetected(format!(
+                                "JoinNextTry recorded outcome=Found but no response available for join set `{join_set_id}`"
+                            )))
+                        }
+                    }
+                }
 
-            (
-                DeterministicKey::Stub { intent, params },
-                HistoryEvent::Stub {
-                    target_execution_id: found_execution_id,
-                    retval_hash: found_retval_hash,
-                    result: found_result,
-                },
-            ) if params.target_execution_id == *found_execution_id
-                && params.retval_hash == *found_retval_hash =>
-            {
-                trace!(target_execution_id = %params.target_execution_id, "Matched Stub");
-                let found_result = found_result.clone();
-                self.event_history[found_idx].1 = Processed;
-                Ok(FindMatchingResponse::Found(ChildReturnValue::Stub(
-                    found_result,
-                )))
-            }
+                // JoinNextTry with outcome=Pending: return Pending error
+                (
+                    DeterministicKey::JoinNextTry { join_set_id },
+                    HistoryEvent::JoinNextTry {
+                        join_set_id: found_join_set_id,
+                        outcome: JoinNextTryOutcome::Pending,
+                    },
+                ) if *join_set_id == *found_join_set_id => {
+                    trace!(%join_set_id, "DeterministicKey::JoinNextTry(pending): returning Pending error");
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
+                        Err(JoinNextTryError::Pending),
+                    )))
+                }
 
-            (key, found) => {
-                let version = &self.event_history[found_idx].2;
-                Err(ApplyError::NondeterminismDetected(format!(
-                    "key does not match event stored at version {version}: key: {key}, event: {found}",
-                )))
+                // JoinNextTry with outcome=AllProcessed: return AllProcessed error
+                (
+                    DeterministicKey::JoinNextTry { join_set_id },
+                    HistoryEvent::JoinNextTry {
+                        join_set_id: found_join_set_id,
+                        outcome: JoinNextTryOutcome::AllProcessed,
+                    },
+                ) if *join_set_id == *found_join_set_id => {
+                    trace!(%join_set_id, "DeterministicKey::JoinNextTry(all_processed): returning AllProcessed error");
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::JoinNextTry(
+                        Err(JoinNextTryError::AllProcessed),
+                    )))
+                }
+
+                (
+                    DeterministicKey::Schedule {
+                        target_execution_id,
+                        schedule_at,
+                    },
+                    HistoryEvent::Schedule {
+                        execution_id: found_execution_id,
+                        schedule_at: found_schedule_at,
+                        result: found_result,
+                    },
+                ) if *target_execution_id == *found_execution_id
+                    && schedule_at == found_schedule_at =>
+                {
+                    trace!(%target_execution_id, "Matched Schedule, result: {:?}", found_result);
+                    // Clone the result before mutating self
+                    let found_result = found_result.clone();
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::Schedule(
+                        found_result,
+                    )))
+                }
+
+                (
+                    DeterministicKey::Stub { intent, params },
+                    HistoryEvent::Stub {
+                        target_execution_id: found_execution_id,
+                        retval_hash: found_retval_hash,
+                        result: found_result,
+                    },
+                ) if params.target_execution_id == *found_execution_id
+                    && params.retval_hash == *found_retval_hash =>
+                {
+                    trace!(target_execution_id = %params.target_execution_id, "Matched Stub");
+                    let found_result = found_result.clone();
+                    self.event_history[found_idx].1 = Processed;
+                    Ok(FindMatchingResponse::Found(ChildReturnValue::Stub(
+                        found_result,
+                    )))
+                }
+
+                (key, found) => {
+                    let version = &self.event_history[found_idx].2;
+                    Err(ApplyError::NondeterminismDetected(format!(
+                        "key does not match event stored at version {version}: key: {key}, event: {found}",
+                    )))
+                }
             }
-        }
+        }?;
+        Ok(match response {
+            ProcessEventResponse::Found(value) => FindMatchingResponse::Found {
+                value,
+                version: found_version,
+            },
+            ProcessEventResponse::FoundRequestButNotResponse => {
+                FindMatchingResponse::FoundRequestButNotResponse {
+                    version: found_version,
+                }
+            }
+        })
     }
 
     #[instrument(level = Level::DEBUG, skip_all)]
     async fn append_to_db_non_blocking(
         &mut self,
         event_call: EventCallNonBlocking,
+        version: Version,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(HistoryEvent, Version), DbErrorWriteOrReplayInterrupt> {
-        trace!("append_to_db_non_blocking {}", db_connection.version());
+        trace!("append_to_db_non_blocking {}", version);
         match event_call {
             EventCallNonBlocking::JoinSetCreate(JoinSetCreate {
                 join_set_id,
@@ -1201,20 +1333,20 @@ impl EventHistory {
                 // Cacheable event.
                 debug!(%join_set_id, "CreateJoinSet: Creating new JoinSet");
                 let event = HistoryEvent::JoinSetCreate { join_set_id };
-                let history_event = (event.clone(), db_connection.version().clone());
+                let history_event = (event.clone(), version.clone());
                 let join_set_create = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
                 };
                 let cacheable_event = CacheableDbEvent::JoinSetCreate {
                     request: join_set_create,
-                    version: db_connection.version().clone(),
+                    version: version.clone(),
                     backtrace: wasm_backtrace.map(|wasm_backtrace| BacktraceInfo {
                         execution_id: db_connection.execution_id().clone(),
                         component_id: self.locked_event.component_id.clone(),
                         wasm_backtrace,
-                        version_min_including: db_connection.version().clone(),
-                        version_max_excluding: Version::new(db_connection.version().0 + 1),
+                        version_min_including: version.clone(),
+                        version_max_excluding: Version::new(version.0 + 1),
                     }),
                 };
                 db_connection
@@ -1230,20 +1362,20 @@ impl EventHistory {
             }) => {
                 // Cacheable event.
                 let event = HistoryEvent::Persist { value, kind };
-                let history_event = (event.clone(), db_connection.version().clone());
+                let history_event = (event.clone(), version.clone());
                 let request = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
                 };
                 let cacheable_event = CacheableDbEvent::Persist {
                     request,
-                    version: db_connection.version().clone(),
+                    version: version.clone(),
                     backtrace: wasm_backtrace.map(|wasm_backtrace| BacktraceInfo {
                         execution_id: db_connection.execution_id().clone(),
                         component_id: self.locked_event.component_id.clone(),
                         wasm_backtrace,
-                        version_min_including: db_connection.version().clone(),
-                        version_max_excluding: Version::new(db_connection.version().0 + 1),
+                        version_min_including: version.clone(),
+                        version_max_excluding: Version::new(version.0 + 1),
                     }),
                 };
                 db_connection
@@ -1299,7 +1431,7 @@ impl EventHistory {
                         result,
                     },
                 };
-                let history_event = (event.clone(), db_connection.version().clone());
+                let history_event = (event.clone(), version.clone());
                 let append_req = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
@@ -1309,15 +1441,15 @@ impl EventHistory {
                     execution_id: db_connection.execution_id().clone(),
                     component_id: self.locked_event.component_id.clone(),
                     wasm_backtrace,
-                    version_min_including: db_connection.version().clone(),
-                    version_max_excluding: Version::new(db_connection.version().0 + 1),
+                    version_min_including: version.clone(),
+                    version_max_excluding: Version::new(version.0 + 1),
                 });
 
                 // If we have a child_req, use SubmitChildExecution event; otherwise just persist the history event
                 if let Some(child_req) = maybe_child_req {
                     let cacheable_event = CacheableDbEvent::SubmitChildExecution {
                         request: append_req,
-                        version: db_connection.version().clone(),
+                        version: version.clone(),
                         child_req,
                         backtrace,
                     };
@@ -1328,7 +1460,7 @@ impl EventHistory {
                     // Error case: only persist the history event, no child creation
                     let cacheable_event = CacheableDbEvent::SubmitChildExecutionError {
                         request: append_req,
-                        version: db_connection.version().clone(),
+                        version: version.clone(),
                         backtrace,
                     };
                     db_connection
@@ -1358,20 +1490,20 @@ impl EventHistory {
                         paused: false,
                     },
                 };
-                let history_event = (event.clone(), db_connection.version().clone());
+                let history_event = (event.clone(), version.clone());
                 let delay_req = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
                 };
                 let cacheable_event = CacheableDbEvent::SubmitDelay {
                     request: delay_req,
-                    version: db_connection.version().clone(),
+                    version: version.clone(),
                     backtrace: wasm_backtrace.map(|wasm_backtrace| BacktraceInfo {
                         execution_id: db_connection.execution_id().clone(),
                         component_id: self.locked_event.component_id.clone(),
                         wasm_backtrace,
-                        version_min_including: db_connection.version().clone(),
-                        version_max_excluding: Version::new(db_connection.version().0 + 1),
+                        version_min_including: version.clone(),
+                        version_max_excluding: Version::new(version.0 + 1),
                     }),
                 };
                 db_connection
@@ -1418,7 +1550,7 @@ impl EventHistory {
                     result,
                 };
 
-                let history_event = (event.clone(), db_connection.version().clone());
+                let history_event = (event.clone(), version.clone());
                 let append_req = AppendRequest {
                     event: ExecutionRequest::HistoryEvent { event },
                     created_at: called_at,
@@ -1429,15 +1561,15 @@ impl EventHistory {
                     execution_id: db_connection.execution_id().clone(),
                     component_id: self.locked_event.component_id.clone(),
                     wasm_backtrace,
-                    version_min_including: db_connection.version().clone(),
-                    version_max_excluding: Version::new(db_connection.version().0 + 1),
+                    version_min_including: version.clone(),
+                    version_max_excluding: Version::new(version.0 + 1),
                 });
 
                 // If we have a child_req, use Schedule event; otherwise just persist the history event
                 if let Some(child_req) = maybe_child_req {
                     let non_blocking_event = CacheableDbEvent::Schedule {
                         request: append_req,
-                        version: db_connection.version().clone(),
+                        version: version.clone(),
                         child_req,
                         backtrace,
                     };
@@ -1448,7 +1580,7 @@ impl EventHistory {
                     // Error case: only persist the history event, no child creation
                     let non_blocking_event = CacheableDbEvent::ScheduleError {
                         request: append_req,
-                        version: db_connection.version().clone(),
+                        version: version.clone(),
                         backtrace,
                     };
                     db_connection
@@ -1477,13 +1609,14 @@ impl EventHistory {
                             retval_hash: params.retval_hash,
                             result: Err(err.into()),
                         };
-                        let history_event = (event.clone(), db_connection.version().clone());
+                        let history_event = (event.clone(), version.clone());
                         let history_event_req = AppendRequest {
                             created_at: called_at,
                             event: ExecutionRequest::HistoryEvent { event },
                         };
                         db_connection
                             .append_batch(
+                                version.clone(),
                                 called_at,
                                 vec![history_event_req],
                                 db_connection.execution_id().clone(),
@@ -1544,7 +1677,7 @@ impl EventHistory {
                             retval_hash: params.retval_hash.clone(),
                             result,
                         };
-                        let history_event = (event.clone(), db_connection.version().clone());
+                        let history_event = (event.clone(), version.clone());
                         let history_event_req = AppendRequest {
                             created_at: called_at,
                             event: ExecutionRequest::HistoryEvent { event },
@@ -1552,6 +1685,7 @@ impl EventHistory {
 
                         db_connection
                             .append_batch(
+                                version.clone(),
                                 called_at,
                                 vec![history_event_req],
                                 db_connection.execution_id().clone(),
@@ -1587,7 +1721,7 @@ impl EventHistory {
                     join_set_id,
                     outcome,
                 };
-                let history_event = (event.clone(), db_connection.version().clone());
+                let history_event = (event.clone(), version.clone());
                 let request = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
@@ -1597,13 +1731,13 @@ impl EventHistory {
                     .append_non_blocking(
                         CacheableDbEvent::JoinNextTry {
                             request,
-                            version: db_connection.version().clone(),
+                            version: version.clone(),
                             backtrace: wasm_backtrace.map(|wasm_backtrace| BacktraceInfo {
                                 execution_id: db_connection.execution_id().clone(),
                                 component_id: self.locked_event.component_id.clone(),
                                 wasm_backtrace,
-                                version_min_including: db_connection.version().clone(),
-                                version_max_excluding: Version::new(db_connection.version().0 + 1),
+                                version_min_including: version.clone(),
+                                version_max_excluding: Version::new(version.0 + 1),
                             }),
                         },
                         called_at,
@@ -1618,11 +1752,12 @@ impl EventHistory {
     async fn append_to_db_blocking(
         &mut self,
         event_call: EventCallBlocking,
+        version: Version,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
         lock_expires_at: DateTime<Utc>,
     ) -> Result<Vec<(HistoryEvent, Version)>, DbErrorWrite> {
-        trace!("append_to_db_blocking {}", db_connection.version());
+        trace!("append_to_db_blocking {}", version);
         match event_call {
             EventCallBlocking::JoinNext(JoinNext {
                 join_set_id,
@@ -1643,13 +1778,14 @@ impl EventHistory {
                             requested_ffqn: None,
                         }
                     };
-                let history_events = vec![(event.clone(), db_connection.version().clone())];
+                let history_events = vec![(event.clone(), version.clone())];
                 let join_next = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
                 };
                 db_connection
                     .append_blocking(
+                        version.clone(),
                         db_connection.execution_id().clone(),
                         join_next,
                         wasm_backtrace,
@@ -1682,13 +1818,14 @@ impl EventHistory {
                             requested_ffqn: None,
                         }
                     };
-                let history_events = vec![(event.clone(), db_connection.version().clone())];
+                let history_events = vec![(event.clone(), version.clone())];
                 let join_next = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
                 };
                 db_connection
                     .append_join_set_close(
+                        version.clone(),
                         &self.cancel_registry,
                         db_connection.execution_id().clone(),
                         join_next,
@@ -1720,7 +1857,7 @@ impl EventHistory {
                             requested_ffqn: Some(requested_ffqn),
                         }
                     };
-                let history_events = vec![(event.clone(), db_connection.version().clone())];
+                let history_events = vec![(event.clone(), version.clone())];
                 let append_request = AppendRequest {
                     created_at: called_at,
                     event: ExecutionRequest::HistoryEvent { event },
@@ -1728,6 +1865,7 @@ impl EventHistory {
 
                 db_connection
                     .append_blocking(
+                        version.clone(),
                         db_connection.execution_id().clone(),
                         append_request,
                         wasm_backtrace,
@@ -1752,7 +1890,7 @@ impl EventHistory {
                 let event = HistoryEvent::JoinSetCreate {
                     join_set_id: join_set_id.clone(),
                 };
-                let mut version = db_connection.version().clone();
+                let mut version = version.clone();
                 history_events.push((event.clone(), version.clone()));
                 let join_set = AppendRequest {
                     event: ExecutionRequest::HistoryEvent { event },
@@ -1802,6 +1940,11 @@ impl EventHistory {
 
                 db_connection
                     .append_batch_create_new_execution(
+                        history_events
+                            .first()
+                            .expect("direct call has three events")
+                            .1
+                            .clone(),
                         called_at,
                         vec![join_set, child_exec_req, join_next],
                         db_connection.execution_id().clone(),
@@ -1826,7 +1969,7 @@ impl EventHistory {
                 let event = HistoryEvent::JoinSetCreate {
                     join_set_id: join_set_id.clone(),
                 };
-                let mut version = db_connection.version().clone();
+                let mut version = version.clone();
                 history_events.push((event.clone(), version.clone()));
                 let join_set = AppendRequest {
                     created_at: called_at,
@@ -1862,6 +2005,11 @@ impl EventHistory {
 
                 db_connection
                     .append_batch(
+                        history_events
+                            .first()
+                            .expect("blocking delay has three events")
+                            .1
+                            .clone(),
                         called_at,
                         vec![join_set, delay_req, join_next],
                         db_connection.execution_id().clone(),
@@ -2265,8 +2413,56 @@ impl JoinNextVariant {
     }
 }
 
+#[derive(derive_more::Debug)]
+struct EventCall {
+    version: Version,
+    version_range: EventCallVersionRange,
+    kind: EventCallKind,
+}
+
+pub(crate) struct EventCallCursor {
+    next_version: Version,
+    replay_versions: VecDeque<Version>,
+}
+
+impl EventCallCursor {
+    pub(crate) fn new(next_version: Version, event_history: &[(HistoryEvent, Version)]) -> Self {
+        Self {
+            next_version,
+            replay_versions: event_history
+                .iter()
+                .map(|(_, version)| version.clone())
+                .collect(),
+        }
+    }
+
+    pub(crate) fn version(&self) -> &Version {
+        &self.next_version
+    }
+
+    fn next(&mut self, kind: EventCallKind) -> EventCall {
+        let event_count =
+            u32::try_from(kind.as_keys().len()).expect("an EventCall has at most three events");
+        let version = if let Some(version) = self.replay_versions.pop_front() {
+            for _ in 1..event_count {
+                self.replay_versions.pop_front();
+            }
+            version
+        } else {
+            let version = self.next_version.clone();
+            self.next_version = Version::new(self.next_version.0 + event_count);
+            version
+        };
+        let version_range = EventCallVersionRange {
+            min_including: version.clone(),
+            max_excluding: Version::new(version.0 + event_count),
+        };
+        EventCall::new(version, version_range, kind)
+    }
+}
+
 #[derive(derive_more::Debug, Clone)]
-pub(crate) enum EventCall {
+pub(crate) enum EventCallKind {
     Blocking(EventCallBlocking),
     NonBlocking(EventCallNonBlocking),
 }
@@ -2292,6 +2488,43 @@ pub(crate) enum EventCallNonBlocking {
     Persist(Persist),
 }
 
+impl EventCall {
+    fn new(version: Version, version_range: EventCallVersionRange, kind: EventCallKind) -> Self {
+        Self {
+            version,
+            version_range,
+            kind,
+        }
+    }
+
+    fn wasm_backtrace(&self) -> Option<&storage::WasmBacktrace> {
+        match &self.kind {
+            EventCallKind::Blocking(event) => match event {
+                EventCallBlocking::JoinNextRequestingFfqn(event) => event.wasm_backtrace.as_ref(),
+                EventCallBlocking::JoinNext(event) => event.wasm_backtrace.as_ref(),
+                EventCallBlocking::JoinSetClose(event) => event.wasm_backtrace.as_ref(),
+                EventCallBlocking::OneOffChildExecutionRequest(event) => {
+                    event.wasm_backtrace.as_ref()
+                }
+                EventCallBlocking::OneOffDelayRequest(event) => event.wasm_backtrace.as_ref(),
+            },
+            EventCallKind::NonBlocking(event) => match event {
+                EventCallNonBlocking::JoinSetCreate(event) => event.wasm_backtrace.as_ref(),
+                EventCallNonBlocking::SubmitChildExecution(event) => event.wasm_backtrace.as_ref(),
+                EventCallNonBlocking::SubmitDelay(event) => event.wasm_backtrace.as_ref(),
+                EventCallNonBlocking::JoinNextTry(event) => event.wasm_backtrace.as_ref(),
+                EventCallNonBlocking::Schedule(event) => event.wasm_backtrace.as_ref(),
+                EventCallNonBlocking::Stub(event) => event.wasm_backtrace.as_ref(),
+                EventCallNonBlocking::Persist(event) => event.wasm_backtrace.as_ref(),
+            },
+        }
+    }
+
+    fn as_keys(&self) -> Vec<DeterministicKey> {
+        self.kind.as_keys()
+    }
+}
+
 #[derive(derive_more::Debug, Clone)]
 pub(crate) struct JoinSetCreate {
     pub(crate) join_set_id: JoinSetId,
@@ -2303,14 +2536,16 @@ impl JoinSetCreate {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<JoinSetId, ApplyError> {
         assert!(self.join_set_id.kind != JoinSetKind::OneOff);
         let join_set_id = self.join_set_id.clone();
         let value = event_history
-            .apply_inner(
-                EventCall::NonBlocking(EventCallNonBlocking::JoinSetCreate(self)),
+            .apply_event_call(
+                EventCallKind::NonBlocking(EventCallNonBlocking::JoinSetCreate(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2341,6 +2576,7 @@ impl SubmitChildExecution {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<Result<(), ChildExecutionRequestError>, WorkflowFunctionError> {
@@ -2360,7 +2596,8 @@ impl SubmitChildExecution {
         };
         let value = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::SubmitChildExecution(self)),
+                EventCallKind::NonBlocking(EventCallNonBlocking::SubmitChildExecution(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2403,6 +2640,7 @@ impl SubmitDelay {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<DelayId, WorkflowFunctionError> {
@@ -2414,7 +2652,8 @@ impl SubmitDelay {
         let delay_id = self.delay_id.clone();
         let value = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::SubmitDelay(self)),
+                EventCallKind::NonBlocking(EventCallNonBlocking::SubmitDelay(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2449,12 +2688,14 @@ impl Schedule {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<Result<(), ScheduleRequestError>, WorkflowFunctionError> {
         let value = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::Schedule(self)),
+                EventCallKind::NonBlocking(EventCallNonBlocking::Schedule(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2523,12 +2764,14 @@ impl Stub {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<Result<(), StubError>, WorkflowFunctionError> {
         let value = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::Stub(self)),
+                EventCallKind::NonBlocking(EventCallNonBlocking::Stub(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2551,6 +2794,7 @@ impl JoinNextRequestingFfqn {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<
@@ -2564,7 +2808,8 @@ impl JoinNextRequestingFfqn {
         let join_set_id = self.join_set_id.clone();
         let value = event_history
             .apply(
-                EventCall::Blocking(EventCallBlocking::JoinNextRequestingFfqn(self)),
+                EventCallKind::Blocking(EventCallBlocking::JoinNextRequestingFfqn(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2625,6 +2870,7 @@ impl JoinNext {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<
@@ -2637,8 +2883,9 @@ impl JoinNext {
         );
         let join_set_id = self.join_set_id.clone();
         let value = event_history
-            .apply_inner(
-                EventCall::Blocking(EventCallBlocking::JoinNext(self)),
+            .apply_event_call(
+                EventCallKind::Blocking(EventCallBlocking::JoinNext(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2679,6 +2926,7 @@ impl JoinNextTry {
     pub(crate) async fn apply(
         self,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<
@@ -2691,8 +2939,9 @@ impl JoinNextTry {
         );
         let join_set_id = self.join_set_id.clone();
         let value = event_history
-            .apply_inner(
-                EventCall::NonBlocking(EventCallNonBlocking::JoinNextTry(self)),
+            .apply_event_call(
+                EventCallKind::NonBlocking(EventCallNonBlocking::JoinNextTry(self)),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2727,12 +2976,14 @@ pub(crate) struct OneOffChildExecutionRequest {
     wasm_backtrace: Option<storage::WasmBacktrace>,
 }
 impl OneOffChildExecutionRequest {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn apply(
         ffqn: FunctionFqn,
         fn_component_id: ComponentId,
         params: Params,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<Val, WorkflowFunctionError> {
@@ -2740,7 +2991,7 @@ impl OneOffChildExecutionRequest {
             .next_join_set_one_off_named(&ffqn.function_name)
             .expect("no illegal chars are allowed in fn name by WIT, only alphanumeric and dash");
         let child_execution_id = db_connection.execution_id().next_level(&join_set_id);
-        let event = EventCall::Blocking(EventCallBlocking::OneOffChildExecutionRequest(
+        let event = EventCallKind::Blocking(EventCallBlocking::OneOffChildExecutionRequest(
             OneOffChildExecutionRequest {
                 ffqn,
                 fn_component_id,
@@ -2751,7 +3002,9 @@ impl OneOffChildExecutionRequest {
             },
         ));
 
-        let value = event_history.apply(event, db_connection, called_at).await?;
+        let value = event_history
+            .apply(event, event_call_cursor, db_connection, called_at)
+            .await?;
         event_history
             .record_last_oneoff_id(JoinSetResponseId::ChildExecutionId(child_execution_id));
         let value = assert_matches!(value,
@@ -2770,12 +3023,14 @@ pub(crate) struct OneOffDelayRequest {
     wasm_backtrace: Option<storage::WasmBacktrace>,
 }
 impl OneOffDelayRequest {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn apply(
         schedule_at: HistoryEventScheduleAt,
         name: Option<String>,
         expires_at_if_new: DateTime<Utc>,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<Result<DateTime<Utc>, ()>, WorkflowFunctionError> {
@@ -2795,13 +3050,16 @@ impl OneOffDelayRequest {
             result,
         } = event_history
             .apply(
-                EventCall::Blocking(EventCallBlocking::OneOffDelayRequest(OneOffDelayRequest {
-                    join_set_id,
-                    delay_id: delay_id.clone(),
-                    schedule_at,
-                    expires_at_if_new,
-                    wasm_backtrace,
-                })),
+                EventCallKind::Blocking(EventCallBlocking::OneOffDelayRequest(
+                    OneOffDelayRequest {
+                        join_set_id,
+                        delay_id: delay_id.clone(),
+                        schedule_at,
+                        expires_at_if_new,
+                        wasm_backtrace,
+                    },
+                )),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2823,18 +3081,20 @@ pub(crate) struct Persist {
     pub(crate) wasm_backtrace: Option<storage::WasmBacktrace>,
 }
 impl Persist {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn apply_string(
         value: &str,
         min_length: u64,
         max_length_exclusive: u64,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(), WorkflowFunctionError> {
         let ret = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::Persist(Persist {
+                EventCallKind::NonBlocking(EventCallNonBlocking::Persist(Persist {
                     value: Vec::from_iter(value.bytes()),
                     kind: PersistKind::RandomString {
                         min_length,
@@ -2842,6 +3102,7 @@ impl Persist {
                     },
                     wasm_backtrace,
                 })),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2850,22 +3111,25 @@ impl Persist {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn apply_u64(
         value: u64,
         min: u64,
         max_inclusive: u64,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(), WorkflowFunctionError> {
         let ret = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::Persist(Persist {
+                EventCallKind::NonBlocking(EventCallNonBlocking::Persist(Persist {
                     value: Vec::from(storage::from_u64_to_bytes(value)),
                     kind: PersistKind::RandomU64 { min, max_inclusive },
                     wasm_backtrace,
                 })),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -2878,16 +3142,18 @@ impl Persist {
         value: &ExecutionIdTopLevel,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
     ) -> Result<(), WorkflowFunctionError> {
         let ret = event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::Persist(Persist {
+                EventCallKind::NonBlocking(EventCallNonBlocking::Persist(Persist {
                     value: Vec::from(value.ulid().0.to_be_bytes()),
                     kind: PersistKind::ExecutionId,
                     wasm_backtrace,
                 })),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -3020,11 +3286,11 @@ enum JoinNextChildKind {
     DirectCall,
 }
 
-impl EventCall {
+impl EventCallKind {
     fn as_keys(&self) -> Vec<DeterministicKey> {
         match self {
-            EventCall::Blocking(inner) => inner.as_keys(),
-            EventCall::NonBlocking(inner) => vec![inner.as_key()],
+            EventCallKind::Blocking(inner) => inner.as_keys(),
+            EventCallKind::NonBlocking(inner) => vec![inner.as_key()],
         }
     }
 }
@@ -3170,7 +3436,7 @@ impl EventCallNonBlocking {
 #[cfg(test)]
 mod tests {
     use super::super::event_history::{
-        EventCall, EventCallBlocking, EventCallNonBlocking, EventHistory,
+        EventCallBlocking, EventCallCursor, EventCallKind, EventCallNonBlocking, EventHistory,
     };
     use super::super::workflow_worker::JoinNextBlockingStrategy;
     use super::SubmitChildExecution;
@@ -3232,16 +3498,17 @@ mod tests {
 
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
 
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt, // first run needs to interrupt
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt, // first run needs to interrupt
+                fn_registry.clone(),
+            )
+            .await;
 
         let join_set_id =
             JoinSetId::new(concepts::JoinSetKind::OneOff, StrVariant::empty()).unwrap();
@@ -3253,6 +3520,7 @@ mod tests {
                 MOCK_FFQN,
                 child_execution_id.clone(),
                 &mut event_history,
+                &mut event_call_cursor,
                 join_set_id.clone(),
                 sim_clock.now()
             )
@@ -3285,21 +3553,23 @@ mod tests {
             .unwrap();
 
         info!("Second run");
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id,
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            second_run_strategy,
-            fn_registry,
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id,
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                second_run_strategy,
+                fn_registry,
+            )
+            .await;
         apply_create_join_set_start_async_await_next(
             &mut *caching_db_connection,
             MOCK_FFQN,
             child_execution_id,
             &mut event_history,
+            &mut event_call_cursor,
             join_set_id,
             sim_clock.now(),
         )
@@ -3307,7 +3577,11 @@ mod tests {
         .expect("response was appended, should finish successfuly");
 
         event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap();
 
@@ -3333,16 +3607,17 @@ mod tests {
         // Create an execution.
         let execution_id = create_execution(db_connection.as_ref(), &sim_clock).await;
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            join_next_blocking_strategy,
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                join_next_blocking_strategy,
+                fn_registry.clone(),
+            )
+            .await;
 
         let join_set_id =
             JoinSetId::new(concepts::JoinSetKind::OneOff, StrVariant::empty()).unwrap();
@@ -3351,6 +3626,7 @@ mod tests {
         apply_create_join_set_start_async(
             &mut *caching_db_connection,
             &mut event_history,
+            &mut event_call_cursor,
             join_set_id.clone(),
             MOCK_FFQN,
             child_execution_id.clone(),
@@ -3388,20 +3664,22 @@ mod tests {
 
         info!("Second run");
 
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id,
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            join_next_blocking_strategy,
-            fn_registry,
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id,
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                join_next_blocking_strategy,
+                fn_registry,
+            )
+            .await;
 
         apply_create_join_set_start_async(
             &mut *caching_db_connection,
             &mut event_history,
+            &mut event_call_cursor,
             join_set_id.clone(),
             MOCK_FFQN,
             child_execution_id.clone(),
@@ -3411,13 +3689,14 @@ mod tests {
         // issue BlockingChildJoinNext
         let res = event_history
             .apply(
-                EventCall::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
+                EventCallKind::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
                     JoinNextRequestingFfqn {
                         join_set_id,
                         wasm_backtrace: None,
                         requested_ffqn: MOCK_FFQN,
                     },
                 )),
+                &mut event_call_cursor,
                 &mut *caching_db_connection,
                 sim_clock.now(),
             )
@@ -3429,7 +3708,11 @@ mod tests {
         assert_eq!((child_execution_id, expected_child_res), res);
 
         event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap();
 
@@ -3472,16 +3755,17 @@ mod tests {
         // Create an execution.
         let execution_id = create_execution(db_connection.as_ref(), &sim_clock).await;
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt, // First blocking strategy is always Interrupt
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt, // First blocking strategy is always Interrupt
+                fn_registry.clone(),
+            )
+            .await;
 
         let join_set_id =
             JoinSetId::new(concepts::JoinSetKind::Generated, StrVariant::empty()).unwrap();
@@ -3494,6 +3778,7 @@ mod tests {
             apply_create_join_set_two_start_asyncs_await_next_a(
                 &mut *caching_db_connection,
                 &mut event_history,
+                &mut event_call_cursor,
                 join_set_id.clone(),
                 submit_ffqn_1.clone(),
                 child_execution_id_a.clone(),
@@ -3563,20 +3848,22 @@ mod tests {
 
         info!("Second run");
 
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id,
-            sim_clock.now(),
-            Duration::ZERO, // deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt,
-            fn_registry,
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id,
+                sim_clock.now(),
+                Duration::ZERO, // deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt,
+                fn_registry,
+            )
+            .await;
 
         let res = apply_create_join_set_two_start_asyncs_await_next_a(
             &mut *caching_db_connection,
             &mut event_history,
+            &mut event_call_cursor,
             join_set_id.clone(),
             submit_ffqn_1.clone(),
             child_execution_id_a.clone(),
@@ -3604,13 +3891,14 @@ mod tests {
             // second child result should be found
             let res = event_history
                 .apply(
-                    EventCall::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
+                    EventCallKind::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
                         JoinNextRequestingFfqn {
                             join_set_id,
                             wasm_backtrace: None,
                             requested_ffqn: submit_ffqn_2.clone(),
                         },
                     )),
+                    &mut event_call_cursor,
                     &mut *caching_db_connection,
                     sim_clock.now(),
                 )
@@ -3623,7 +3911,11 @@ mod tests {
         }
 
         event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap();
         db_close.close().await;
@@ -3640,20 +3932,21 @@ mod tests {
         // Create an execution.
         let execution_id = create_execution(db_connection, &sim_clock).await;
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt, // does not matter, there are no blocking events
-            fn_registry,
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt, // does not matter, there are no blocking events
+                fn_registry,
+            )
+            .await;
 
         event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::Schedule(Schedule {
+                EventCallKind::NonBlocking(EventCallNonBlocking::Schedule(Schedule {
                     schedule_at: HistoryEventScheduleAt::Now,
                     scheduled_at_if_new: sim_clock.now(),
                     execution_id: ExecutionId::generate(),
@@ -3664,6 +3957,7 @@ mod tests {
                     },
                     wasm_backtrace: None,
                 })),
+                &mut event_call_cursor,
                 &mut *caching_db_connection,
                 sim_clock.now(),
             )
@@ -3674,10 +3968,11 @@ mod tests {
             JoinSetId::new(concepts::JoinSetKind::OneOff, StrVariant::empty()).unwrap();
         event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::JoinSetCreate(JoinSetCreate {
+                EventCallKind::NonBlocking(EventCallNonBlocking::JoinSetCreate(JoinSetCreate {
                     join_set_id: join_set_id.clone(),
                     wasm_backtrace: None,
                 })),
+                &mut event_call_cursor,
                 &mut *caching_db_connection,
                 sim_clock.now(),
             )
@@ -3685,7 +3980,11 @@ mod tests {
             .unwrap();
 
         event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap();
         db_close.close().await;
@@ -3706,22 +4005,24 @@ mod tests {
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
         for run_id in 0..=1 {
             info!("Run {run_id}");
-            let (mut event_history, mut caching_db_connection) = load_event_history(
-                db_pool.connection_test().await.unwrap(),
-                execution_id.clone(),
-                sim_clock.now(),
-                Duration::from_secs(1), // execution deadline
-                deadline_tracker_factory_test(&sim_clock),
-                JoinNextBlockingStrategy::Await {
-                    non_blocking_event_batching: 0,
-                },
-                fn_registry.clone(),
-            )
-            .await;
+            let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+                load_event_history(
+                    db_pool.connection_test().await.unwrap(),
+                    execution_id.clone(),
+                    sim_clock.now(),
+                    Duration::from_secs(1), // execution deadline
+                    deadline_tracker_factory_test(&sim_clock),
+                    JoinNextBlockingStrategy::Await {
+                        non_blocking_event_batching: 0,
+                    },
+                    fn_registry.clone(),
+                )
+                .await;
 
             apply_create_join_set_start_async(
                 &mut *caching_db_connection,
                 &mut event_history,
+                &mut event_call_cursor,
                 join_set_id.clone(),
                 MOCK_FFQN,
                 child_execution_id.clone(),
@@ -3731,7 +4032,7 @@ mod tests {
 
             event_history
                 .apply(
-                    EventCall::NonBlocking(EventCallNonBlocking::Stub(Stub {
+                    EventCallKind::NonBlocking(EventCallNonBlocking::Stub(Stub {
                         intent: StubIntent::StubTypeChecked(SUPPORTED_RETURN_VALUE_OK_EMPTY),
                         params: StubParams {
                             target_execution_id: child_execution_id.clone(),
@@ -3739,6 +4040,7 @@ mod tests {
                         },
                         wasm_backtrace: None,
                     })),
+                    &mut event_call_cursor,
                     &mut *caching_db_connection,
                     sim_clock.now(),
                 )
@@ -3747,13 +4049,14 @@ mod tests {
 
             let child_return_value = event_history
                 .apply(
-                    EventCall::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
+                    EventCallKind::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
                         JoinNextRequestingFfqn {
                             join_set_id: join_set_id.clone(),
                             wasm_backtrace: None,
                             requested_ffqn: MOCK_FFQN,
                         },
                     )),
+                    &mut event_call_cursor,
                     &mut *caching_db_connection,
                     sim_clock.now(),
                 )
@@ -3773,7 +4076,11 @@ mod tests {
             );
 
             event_history
-                .finalize(&mut *caching_db_connection, sim_clock.now())
+                .finalize(
+                    &mut event_call_cursor,
+                    &mut *caching_db_connection,
+                    sim_clock.now(),
+                )
                 .await
                 .unwrap();
         }
@@ -3799,21 +4106,23 @@ mod tests {
         // First execution creates `target_activity_stub` and stubs its return value.
         for run_id in 0..=1 {
             info!("Run {run_id}");
-            let (mut event_history, mut caching_db_connection) = load_event_history(
-                db_pool.connection_test().await.unwrap(),
-                execution_id.clone(),
-                sim_clock.now(),
-                Duration::from_secs(1),
-                deadline_tracker_factory_test(&sim_clock),
-                JoinNextBlockingStrategy::Await {
-                    non_blocking_event_batching: 0,
-                },
-                fn_registry.clone(),
-            )
-            .await;
+            let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+                load_event_history(
+                    db_pool.connection_test().await.unwrap(),
+                    execution_id.clone(),
+                    sim_clock.now(),
+                    Duration::from_secs(1),
+                    deadline_tracker_factory_test(&sim_clock),
+                    JoinNextBlockingStrategy::Await {
+                        non_blocking_event_batching: 0,
+                    },
+                    fn_registry.clone(),
+                )
+                .await;
             apply_create_join_set_start_async(
                 &mut *caching_db_connection,
                 &mut event_history,
+                &mut event_call_cursor,
                 join_set_id.clone(),
                 MOCK_FFQN,
                 target_activity_stub.clone(),
@@ -3824,7 +4133,7 @@ mod tests {
                 // In the same execution we can ask many times to stub the same value to target_activity_stub
                 event_history
                     .apply(
-                        EventCall::NonBlocking(EventCallNonBlocking::Stub(Stub {
+                        EventCallKind::NonBlocking(EventCallNonBlocking::Stub(Stub {
                             intent: StubIntent::StubTypeChecked(SUPPORTED_RETURN_VALUE_OK_EMPTY),
                             params: StubParams {
                                 target_execution_id: target_activity_stub.clone(),
@@ -3833,6 +4142,7 @@ mod tests {
                             },
                             wasm_backtrace: None,
                         })),
+                        &mut event_call_cursor,
                         &mut *caching_db_connection,
                         sim_clock.now(),
                     )
@@ -3841,7 +4151,11 @@ mod tests {
             }
 
             event_history
-                .finalize(&mut *caching_db_connection, sim_clock.now())
+                .finalize(
+                    &mut event_call_cursor,
+                    &mut *caching_db_connection,
+                    sim_clock.now(),
+                )
                 .await
                 .unwrap();
         }
@@ -3849,23 +4163,24 @@ mod tests {
         // Second execution
         {
             let execution_id = create_execution(db_connection.as_ref(), &sim_clock).await;
-            let (mut event_history, mut caching_db_connection) = load_event_history(
-                db_pool.connection_test().await.unwrap(),
-                execution_id.clone(),
-                sim_clock.now(),
-                Duration::from_secs(1),
-                deadline_tracker_factory_test(&sim_clock),
-                JoinNextBlockingStrategy::Await {
-                    non_blocking_event_batching: 0,
-                },
-                fn_registry.clone(),
-            )
-            .await;
+            let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+                load_event_history(
+                    db_pool.connection_test().await.unwrap(),
+                    execution_id.clone(),
+                    sim_clock.now(),
+                    Duration::from_secs(1),
+                    deadline_tracker_factory_test(&sim_clock),
+                    JoinNextBlockingStrategy::Await {
+                        non_blocking_event_batching: 0,
+                    },
+                    fn_registry.clone(),
+                )
+                .await;
             for _ in 0..=1 {
                 // In the same execution we can ask many times to stub the same value to target_activity_stub
                 event_history
                     .apply(
-                        EventCall::NonBlocking(EventCallNonBlocking::Stub(Stub {
+                        EventCallKind::NonBlocking(EventCallNonBlocking::Stub(Stub {
                             intent: StubIntent::StubTypeChecked(SUPPORTED_RETURN_VALUE_OK_EMPTY),
                             params: StubParams {
                                 target_execution_id: target_activity_stub.clone(),
@@ -3874,6 +4189,7 @@ mod tests {
                             },
                             wasm_backtrace: None,
                         })),
+                        &mut event_call_cursor,
                         &mut *caching_db_connection,
                         sim_clock.now(),
                     )
@@ -3882,7 +4198,11 @@ mod tests {
             }
 
             event_history
-                .finalize(&mut *caching_db_connection, sim_clock.now())
+                .finalize(
+                    &mut event_call_cursor,
+                    &mut *caching_db_connection,
+                    sim_clock.now(),
+                )
                 .await
                 .unwrap();
         }
@@ -3906,16 +4226,17 @@ mod tests {
 
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
 
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt, // first run needs to interrupt
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt, // first run needs to interrupt
+                fn_registry.clone(),
+            )
+            .await;
 
         let join_set_id =
             JoinSetId::new(concepts::JoinSetKind::OneOff, StrVariant::empty()).unwrap();
@@ -3927,6 +4248,7 @@ mod tests {
                 MOCK_FFQN,
                 child_execution_id.clone(),
                 &mut event_history,
+                &mut event_call_cursor,
                 join_set_id.clone(),
                 sim_clock.now()
             )
@@ -3959,20 +4281,25 @@ mod tests {
             .unwrap();
 
         info!("Second run attemts to finish with no requests");
-        let (mut event_history, _caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id,
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            second_run_strategy,
-            fn_registry,
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, _caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id,
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                second_run_strategy,
+                fn_registry,
+            )
+            .await;
 
         // finish the execution
         let err = event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap_err();
         let reason = assert_matches!(err, ApplyError::NondeterminismDetected(reason) => reason);
@@ -4049,23 +4376,25 @@ mod tests {
         deadline_factory: Arc<dyn DeadlineTrackerFactory>,
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         fn_registry: Arc<dyn FunctionRegistry>,
-    ) -> (EventHistory, Box<dyn WorkflowDbConnection>) {
+    ) -> (EventHistory, EventCallCursor, Box<dyn WorkflowDbConnection>) {
         let execution_deadline = now + lock_expires_at;
         let deadline_tracker = deadline_factory
             .create(execution_deadline, tokio::sync::watch::channel(false).1)
             .unwrap();
 
         let exec_log = db_connection.get(&execution_id).await.unwrap();
+        let version = exec_log.next_version.clone();
+        let history_events: Vec<_> = exec_log.event_history().collect();
+        let event_call_cursor = EventCallCursor::new(version, &history_events);
         let caching_db_connection = CachingDbConnection::new(
             db_connection,
             execution_id,
             CachingBuffer::new(join_next_blocking_strategy),
-            exec_log.next_version.clone(),
         );
         let cancel_registry = CancelRegistry::new();
         let event_history = EventHistory::new(
             DEPLOYMENT_ID_DUMMY,
-            exec_log.event_history().collect(),
+            history_events,
             exec_log.responses,
             join_next_blocking_strategy,
             fn_registry,
@@ -4085,7 +4414,11 @@ mod tests {
             false, // replaying_unfinished_execution
         );
 
-        (event_history, Box::new(caching_db_connection))
+        (
+            event_history,
+            event_call_cursor,
+            Box::new(caching_db_connection),
+        )
     }
 
     async fn apply_create_join_set_start_async_await_next(
@@ -4093,12 +4426,14 @@ mod tests {
         ffqn: FunctionFqn,
         child_execution_id: ExecutionIdDerived,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         join_set_id: JoinSetId,
         called_at: DateTime<Utc>,
     ) -> Result<ChildReturnValue, ApplyError> {
         apply_create_join_set_start_async(
             db_connection,
             event_history,
+            event_call_cursor,
             join_set_id.clone(),
             ffqn.clone(),
             child_execution_id,
@@ -4106,14 +4441,15 @@ mod tests {
         )
         .await;
         event_history
-            .apply_inner(
-                EventCall::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
+            .apply_event_call(
+                EventCallKind::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
                     JoinNextRequestingFfqn {
                         join_set_id,
                         wasm_backtrace: None,
                         requested_ffqn: ffqn,
                     },
                 )),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -4123,6 +4459,7 @@ mod tests {
     async fn apply_create_join_set_start_async(
         db_connection: &mut dyn WorkflowDbConnection,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         join_set_id: JoinSetId,
         ffqn: FunctionFqn,
         child_execution_id: ExecutionIdDerived,
@@ -4130,10 +4467,11 @@ mod tests {
     ) {
         event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::JoinSetCreate(JoinSetCreate {
+                EventCallKind::NonBlocking(EventCallNonBlocking::JoinSetCreate(JoinSetCreate {
                     join_set_id: join_set_id.clone(),
                     wasm_backtrace: None,
                 })),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -4141,7 +4479,7 @@ mod tests {
             .unwrap();
         event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::SubmitChildExecution(
+                EventCallKind::NonBlocking(EventCallNonBlocking::SubmitChildExecution(
                     SubmitChildExecution {
                         target_ffqn: ffqn,
                         join_set_id,
@@ -4153,6 +4491,7 @@ mod tests {
                         wasm_backtrace: None,
                     },
                 )),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -4164,6 +4503,7 @@ mod tests {
     async fn apply_create_join_set_two_start_asyncs_await_next_a(
         db_connection: &mut dyn WorkflowDbConnection,
         event_history: &mut EventHistory,
+        event_call_cursor: &mut EventCallCursor,
         join_set_id: JoinSetId,
         ffqn_a: FunctionFqn,
         child_execution_id_a: ExecutionIdDerived,
@@ -4174,6 +4514,7 @@ mod tests {
         apply_create_join_set_start_async(
             db_connection,
             event_history,
+            event_call_cursor,
             join_set_id.clone(),
             ffqn_a.clone(),
             child_execution_id_a,
@@ -4182,7 +4523,7 @@ mod tests {
         .await;
         event_history
             .apply(
-                EventCall::NonBlocking(EventCallNonBlocking::SubmitChildExecution(
+                EventCallKind::NonBlocking(EventCallNonBlocking::SubmitChildExecution(
                     SubmitChildExecution {
                         target_ffqn: ffqn_b,
                         join_set_id: join_set_id.clone(),
@@ -4194,20 +4535,22 @@ mod tests {
                         wasm_backtrace: None,
                     },
                 )),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
             .await
             .unwrap();
         event_history
-            .apply_inner(
-                EventCall::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
+            .apply_event_call(
+                EventCallKind::Blocking(EventCallBlocking::JoinNextRequestingFfqn(
                     JoinNextRequestingFfqn {
                         join_set_id,
                         wasm_backtrace: None,
                         requested_ffqn: ffqn_a,
                     },
                 )),
+                event_call_cursor,
                 db_connection,
                 called_at,
             )
@@ -4236,16 +4579,17 @@ mod tests {
 
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
 
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt,
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt,
+                fn_registry.clone(),
+            )
+            .await;
 
         // Create a join set using JoinSetCreate::apply which updates the index
         let join_set_id =
@@ -4256,6 +4600,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4275,6 +4620,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4288,6 +4634,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4312,16 +4659,17 @@ mod tests {
             .unwrap();
 
         // Reload event history to pick up the response
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1),
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt,
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1),
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt,
+                fn_registry.clone(),
+            )
+            .await;
 
         // Replay the join set creation and delay submission (updates index)
         JoinSetCreate {
@@ -4330,6 +4678,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4345,6 +4694,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4358,6 +4708,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4376,6 +4727,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4397,6 +4749,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4409,7 +4762,11 @@ mod tests {
         );
 
         event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap();
 
@@ -4429,16 +4786,17 @@ mod tests {
 
         let fn_registry = TestingFnRegistry::new_from_components(vec![]);
 
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1), // execution deadline
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt,
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1), // execution deadline
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt,
+                fn_registry.clone(),
+            )
+            .await;
 
         // Create a join set
         let join_set_id =
@@ -4449,6 +4807,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4462,6 +4821,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4471,21 +4831,26 @@ mod tests {
 
         // no new events should be appended.
         event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap();
 
         // Replay without the buggy join-next-try should trigger nondeterminism error.
-        let (mut event_history, mut caching_db_connection) = load_event_history(
-            db_pool.connection_test().await.unwrap(),
-            execution_id.clone(),
-            sim_clock.now(),
-            Duration::from_secs(1),
-            deadline_tracker_factory_test(&sim_clock),
-            JoinNextBlockingStrategy::Interrupt,
-            fn_registry.clone(),
-        )
-        .await;
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1),
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Interrupt,
+                fn_registry.clone(),
+            )
+            .await;
         let join_set_id =
             JoinSetId::new(concepts::JoinSetKind::Named, StrVariant::Arc("test".into())).unwrap();
         JoinSetCreate {
@@ -4494,6 +4859,7 @@ mod tests {
         }
         .apply(
             &mut event_history,
+            &mut event_call_cursor,
             &mut *caching_db_connection,
             sim_clock.now(),
         )
@@ -4501,7 +4867,11 @@ mod tests {
         .unwrap();
 
         let err = event_history
-            .finalize(&mut *caching_db_connection, sim_clock.now())
+            .finalize(
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
             .await
             .unwrap_err();
 

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -48,13 +48,14 @@ impl InternalCapturedWrite {
 #[derive(Debug, Default)]
 struct ReplayEventCollector {
     preview: Vec<InternalCapturedWrite>,
+    backtraces: Vec<BacktraceInfo>,
     // Logs emitted during replay belong to the next captured write, which
     // corresponds to the next user-code step that would be persisted.
     pending_logs: Vec<LogInfoAppendRow>,
 }
 
 impl ReplayEventCollector {
-    fn into_writes(self) -> Vec<InternalCapturedWrite> {
+    fn into_parts(self) -> (Vec<InternalCapturedWrite>, Vec<BacktraceInfo>) {
         if !self.pending_logs.is_empty() {
             let pending_messages: Vec<_> = self
                 .pending_logs
@@ -72,7 +73,7 @@ impl ReplayEventCollector {
             "replay must not finish with unattached application logs: {:?}",
             self.pending_logs
         );
-        self.preview
+        (self.preview, self.backtraces)
     }
 
     fn push_write(&mut self, write: CapturedDbWrite) {
@@ -97,6 +98,10 @@ impl ReplayEventCollector {
 
     fn push_log(&mut self, row: LogInfoAppendRow) {
         self.pending_logs.push(row);
+    }
+
+    fn push_backtrace(&mut self, backtrace: BacktraceInfo) {
+        self.backtraces.push(backtrace);
     }
 }
 
@@ -323,7 +328,6 @@ async fn apply_captured_write(
 pub(crate) struct ReplayWorkflowDbConnection {
     execution_id: ExecutionId,
     collector: ReplayEventCollector,
-    version: Version,
     real_connection: Box<dyn DbConnection>,
     parent: Option<(ExecutionId, JoinSetId)>,
 }
@@ -331,23 +335,28 @@ pub(crate) struct ReplayWorkflowDbConnection {
 impl ReplayWorkflowDbConnection {
     pub(crate) fn new(
         execution_id: ExecutionId,
-        version: Version,
         real_connection: Box<dyn DbConnection>,
         parent: Option<(ExecutionId, JoinSetId)>,
     ) -> Self {
         Self {
             execution_id,
             collector: ReplayEventCollector::default(),
-            version,
             real_connection,
             parent,
         }
     }
-    pub(crate) fn into_parts(self) -> (Vec<InternalCapturedWrite>, Box<dyn DbConnection>) {
-        (self.collector.into_writes(), self.real_connection)
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Vec<InternalCapturedWrite>,
+        Vec<BacktraceInfo>,
+        Box<dyn DbConnection>,
+    ) {
+        let (writes, backtraces) = self.collector.into_parts();
+        (writes, backtraces, self.real_connection)
     }
 
-    /// Push a captured write and advance the version.
+    /// Push a captured write.
     pub(crate) fn push_write(&mut self, write: CapturedDbWrite) {
         self.collector.push_write(write);
     }
@@ -356,8 +365,8 @@ impl ReplayWorkflowDbConnection {
         self.collector.push_log(row);
     }
 
-    pub(crate) fn version(&self) -> &Version {
-        &self.version
+    pub(crate) fn push_backtrace(&mut self, backtrace: BacktraceInfo) {
+        self.collector.push_backtrace(backtrace);
     }
 
     pub(crate) fn execution_id(&self) -> &ExecutionId {
@@ -461,13 +470,14 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         &self.execution_id
     }
 
-    fn version(&self) -> &Version {
-        &self.version
-    }
-
     fn capture_application_log(&mut self, row: LogInfoAppendRow) -> bool {
         self.push_log(row);
         true
+    }
+
+    async fn append_backtrace(&mut self, backtrace: BacktraceInfo) -> Result<(), DbErrorWrite> {
+        self.push_backtrace(backtrace);
+        Ok(())
     }
 
     async fn append_non_blocking(
@@ -499,19 +509,18 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 backtraces: backtrace.into_iter().collect(),
             });
         }
-        self.version = Version::new(version.0 + 1);
         Ok(())
     }
 
     async fn append_blocking(
         &mut self,
+        version: Version,
         execution_id: ExecutionId,
         req: AppendRequest,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
-        let version = self.version.clone();
         let next_version = Version::new(version.0 + 1);
         let backtraces = make_backtrace(
             &execution_id,
@@ -526,12 +535,12 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
             req,
             backtraces,
         });
-        self.version = next_version;
         Ok(())
     }
 
     async fn append_join_set_close(
         &mut self,
+        version: Version,
         _cancel_registry: &CancelRegistry,
         execution_id: ExecutionId,
         req: AppendRequest,
@@ -545,7 +554,6 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
             "append_join_set_close must append JoinNext(closing=true)"
         );
         // only CachingDbConnection can assert the flush outcome as here `flush_non_blocking_event_cache` is stateless.
-        let version = self.version.clone();
         let next_version = Version::new(version.0 + 1);
         let backtraces = make_backtrace(
             &execution_id,
@@ -564,12 +572,12 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
             },
             cancellations,
         );
-        self.version = next_version;
         Ok(())
     }
 
     async fn append_batch(
         &mut self,
+        version: Version,
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
@@ -577,7 +585,6 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
-        let version = self.version.clone();
         let next = next_version(&version, batch.len());
         for request in &batch {
             assert!(
@@ -594,12 +601,12 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
             version,
             backtraces,
         });
-        self.version = next;
         Ok(())
     }
 
     async fn append_batch_create_new_execution(
         &mut self,
+        version: Version,
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
@@ -608,7 +615,6 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
-        let version = self.version.clone();
         let next = next_version(&version, batch.len());
         for request in &batch {
             assert!(
@@ -627,7 +633,6 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 child_req,
                 backtraces,
             });
-        self.version = next;
         Ok(())
     }
 
@@ -671,7 +676,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         let backtraces = make_backtrace(
             &self.execution_id,
             component_id,
-            &self.version,
+            &version,
             &next,
             wasm_backtrace,
         );
@@ -801,17 +806,16 @@ mod tests {
                 CachingBuffer::new(JoinNextBlockingStrategy::Await {
                     non_blocking_event_batching: 100,
                 }),
-                parent_version,
             )),
             ConnectionMode::Replay => Box::new(ReplayWorkflowDbConnection::new(
                 parent_execution_id.clone(),
-                parent_version,
                 real_connection,
                 None, // test helper, no parent
             )),
         };
         connection
             .append_batch_create_new_execution(
+                parent_version,
                 created_at,
                 vec![AppendRequest {
                     created_at,

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -470,7 +470,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         &self.execution_id
     }
 
-    fn capture_application_log(&mut self, row: LogInfoAppendRow) -> bool {
+    fn try_defer_application_log(&mut self, row: LogInfoAppendRow) -> bool {
         self.push_log(row);
         true
     }

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_full_replay_1.snap
@@ -19,52 +19,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "join_set_create",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 953,
-                      "col": 21
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 51,
-                      "col": 24
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -120,57 +75,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -191,63 +96,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_1.snap
@@ -19,52 +19,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "join_set_create",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 953,
-                      "col": 21
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 51,
-                      "col": 24
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -120,57 +75,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -191,63 +96,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_2.snap
@@ -57,57 +57,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -128,63 +78,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@advance_paused_workflow_trimmed_to_1_replay_3.snap
@@ -22,63 +22,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_1_replay_1.snap
@@ -19,52 +19,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "join_set_create",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 953,
-                      "col": 21
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 51,
-                      "col": 24
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -120,57 +75,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -191,63 +96,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_1.snap
@@ -19,52 +19,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "join_set_create",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 953,
-                      "col": 21
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 51,
-                      "col": 24
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -120,57 +75,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -226,57 +131,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -332,57 +187,7 @@ expression: redact_replay(&replay)
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 5,
-            "version_max_excluding": 6,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 7>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_submit",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2138,
-                      "col": 11
-                    },
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 53,
-                      "col": 13
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -403,63 +208,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 6,
-            "version_max_excluding": 7,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_2.snap
@@ -22,63 +22,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 7,
-            "version_max_excluding": 8,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/advance_paused_workflow_until_finished@fibo_workflow_each_stage_replay_3_replay_3.snap
@@ -22,63 +22,7 @@ expression: redact_replay(&replay)
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000003",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 8,
-            "version_max_excluding": 9,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "<unknown>",
-                  "func_name": "<wasm function 6>",
-                  "symbols": []
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "test_programs_fibo_workflow::generated::testing::fibo_obelisk_ext::fibo::fibo_await_next::h<REDACTED>",
-                  "symbols": [
-                    {
-                      "func_name": "fibo_await_next",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2167,
-                      "col": 11
-                    }
-                  ]
-                },
-                {
-                  "module": "test_programs_fibo_workflow.wasm",
-                  "func_name": "testing:fibo-workflow/workflow#fiboa-concurrent",
-                  "symbols": [
-                    {
-                      "func_name": "fiboa_concurrent",
-                      "file": "<REDACTED>/lib.rs",
-                      "line": 57,
-                      "col": 20
-                    },
-                    {
-                      "func_name": "_export_fiboa_concurrent_cabi<test_programs_fibo_workflow::Component>",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2486,
-                      "col": 7
-                    },
-                    {
-                      "func_name": "export_fiboa_concurrent",
-                      "file": "<REDACTED>/any.rs",
-                      "line": 2744,
-                      "col": 83
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_1.snap
@@ -19,34 +19,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 3,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -102,34 +75,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 4,
-                      "col": 37
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -168,34 +114,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
           }
         },
         "current_time": "1970-01-01T00:00:00.100Z",
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 2,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 5,
-                      "col": 25
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@full_replay_2.snap
@@ -26,34 +26,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
         ],
         "execution_id": "E_00000000000000000000000000",
         "version": 4,
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 5,
-                      "col": 25
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -74,34 +47,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000000",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 5,
-            "version_max_excluding": 6,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 2,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_full_replay_1.snap
@@ -19,34 +19,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_0000000000000000000000000A",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "submit_and_return",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 3,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -102,34 +75,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_0000000000000000000000000A",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "submit_and_return",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 4,
-                      "col": 22
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_1.snap
@@ -19,34 +19,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_0000000000000000000000000B",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "submit_and_return",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 3,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -102,34 +75,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_0000000000000000000000000B",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "submit_and_return",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 4,
-                      "col": 22
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@submit_cancel_trimmed_to_1_replay_2.snap
@@ -57,34 +57,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_0000000000000000000000000B",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "submit_and_return",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 4,
-                      "col": 22
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_1.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_1.snap
@@ -19,34 +19,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 2,
-            "version_max_excluding": 3,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 3,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -102,34 +75,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 4,
-                      "col": 37
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -168,34 +114,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
           }
         },
         "current_time": "1970-01-01T00:00:00.100Z",
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 2,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 5,
-                      "col": 25
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_2.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_2.snap
@@ -57,34 +57,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             "paused": false
           }
         ],
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 3,
-            "version_max_excluding": 4,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 4,
-                      "col": 37
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -123,34 +96,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
           }
         },
         "current_time": "1970-01-01T00:00:00.300Z",
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 2,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 5,
-                      "col": 25
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_3.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_3.snap
@@ -40,34 +40,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
           }
         },
         "current_time": "1970-01-01T00:00:00.500Z",
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 2,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 5,
-                      "col": 25
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     }
   ]

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_4.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_4.snap
@@ -26,34 +26,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
         ],
         "execution_id": "E_00000000000000000000000001",
         "version": 4,
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 4,
-            "version_max_excluding": 5,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 5,
-                      "col": 25
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {
@@ -74,34 +47,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 5,
-            "version_max_excluding": 6,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 2,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_5.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/workflow_js_step_execution_until_finished@trimmed_to_1_replay_5.snap
@@ -22,34 +22,7 @@ expression: "redact_component_digest(serde_json::to_value(&replay).unwrap())"
             }
           }
         },
-        "backtraces": [
-          {
-            "execution_id": "E_00000000000000000000000001",
-            "component_id": {
-              "component_type": "workflow",
-              "name": "test_js_workflow",
-              "component_digest": "sha256:<REDACTED>"
-            },
-            "version_min_including": 5,
-            "version_max_excluding": 6,
-            "wasm_backtrace": {
-              "frames": [
-                {
-                  "module": "unknown",
-                  "func_name": "call_stub",
-                  "symbols": [
-                    {
-                      "func_name": null,
-                      "file": null,
-                      "line": 2,
-                      "col": 45
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
+        "backtraces": []
       }
     },
     {

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -2960,7 +2960,7 @@ fn emit_application_log_to_tracing_only(ctx: &WorkflowCtx, level: LogLevel, mess
     });
 }
 
-fn capture_replay_application_log(ctx: &mut WorkflowCtx, level: LogLevel, message: &str) -> bool {
+fn try_defer_replay_application_log(ctx: &mut WorkflowCtx, level: LogLevel, message: &str) -> bool {
     if ctx.is_replay != Some(ReplayKind::Unfinished) {
         return false;
     }
@@ -2972,22 +2972,24 @@ fn capture_replay_application_log(ctx: &mut WorkflowCtx, level: LogLevel, messag
         return false;
     }
     if level >= logs_storage_config.min_level {
-        return ctx.db_connection.capture_application_log(LogInfoAppendRow {
-            execution_id: ctx.component_logger.execution_id.clone(),
-            run_id: ctx.component_logger.run_id,
-            log_entry: LogEntry::Log {
-                created_at: ctx.clock_fn.now(),
-                level,
-                message: message.to_owned(),
-            },
-        });
+        return ctx
+            .db_connection
+            .try_defer_application_log(LogInfoAppendRow {
+                execution_id: ctx.component_logger.execution_id.clone(),
+                run_id: ctx.component_logger.run_id,
+                log_entry: LogEntry::Log {
+                    created_at: ctx.clock_fn.now(),
+                    level,
+                    message: message.to_owned(),
+                },
+            });
     }
     false
 }
 
 impl log_activities::obelisk::log::log::Host for WorkflowCtx {
     async fn trace(&mut self, message: String) {
-        if capture_replay_application_log(self, LogLevel::Trace, &message) {
+        if try_defer_replay_application_log(self, LogLevel::Trace, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Trace, &message);
         } else {
             trace_on_replay(self, LogLevel::Trace, message);
@@ -2995,7 +2997,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
     }
 
     async fn debug(&mut self, message: String) {
-        if capture_replay_application_log(self, LogLevel::Debug, &message) {
+        if try_defer_replay_application_log(self, LogLevel::Debug, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Debug, &message);
         } else {
             trace_on_replay(self, LogLevel::Debug, message);
@@ -3003,7 +3005,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
     }
 
     async fn info(&mut self, message: String) {
-        if capture_replay_application_log(self, LogLevel::Info, &message) {
+        if try_defer_replay_application_log(self, LogLevel::Info, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Info, &message);
         } else {
             trace_on_replay(self, LogLevel::Info, message);
@@ -3011,7 +3013,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
     }
 
     async fn warn(&mut self, message: String) {
-        if capture_replay_application_log(self, LogLevel::Warn, &message) {
+        if try_defer_replay_application_log(self, LogLevel::Warn, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Warn, &message);
         } else {
             trace_on_replay(self, LogLevel::Warn, message);
@@ -3019,7 +3021,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
     }
 
     async fn error(&mut self, message: String) {
-        if capture_replay_application_log(self, LogLevel::Error, &message) {
+        if try_defer_replay_application_log(self, LogLevel::Error, &message) {
             emit_application_log_to_tracing_only(self, LogLevel::Error, &message);
         } else {
             trace_on_replay(self, LogLevel::Error, message);

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -1,7 +1,7 @@
 use super::caching_db_connection::WorkflowDbConnection;
 use super::deadline_tracker::DeadlineTracker;
 use super::event_history::{
-    ApplyError, EventHistory, JoinNextRequestingFfqn, OneOffChildExecutionRequest,
+    ApplyError, EventCallCursor, EventHistory, JoinNextRequestingFfqn, OneOffChildExecutionRequest,
     OneOffDelayRequest, Schedule, Stub, SubmitChildExecution,
 };
 use super::host_exports::latest::ScheduleAtTypes;
@@ -143,13 +143,14 @@ impl From<ApplyError> for WorkflowFunctionError {
 
 pub(crate) struct WorkflowCtx {
     pub(crate) execution_id: ExecutionId,
+    event_call_cursor: EventCallCursor,
     event_history: EventHistory,
     rng: StdRng,
     pub(crate) clock_fn: Box<dyn ClockFn>,
     pub(crate) db_connection: Box<dyn WorkflowDbConnection>,
     component_logger: ComponentLogger,
     pub(crate) resource_table: wasmtime::component::ResourceTable,
-    backtrace_persist: bool,
+    backtrace_capture: bool,
     wasi_ctx: WasiCtx,
     is_replay: Option<ReplayKind>,
 }
@@ -190,6 +191,7 @@ impl DirectFnCall<'_> {
             Params::from_wasmtime(Arc::from(params)),
             wasm_backtrace,
             &mut ctx.event_history,
+            &mut ctx.event_call_cursor,
             &mut *ctx.db_connection,
             called_at,
         )
@@ -294,7 +296,12 @@ impl ScheduleFnCall<'_> {
             },
             wasm_backtrace,
         }
-        .apply(&mut ctx.event_history, &mut *ctx.db_connection, called_at)
+        .apply(
+            &mut ctx.event_history,
+            &mut ctx.event_call_cursor,
+            &mut *ctx.db_connection,
+            called_at,
+        )
         .await?
         .map(|()| execution_id_val)
         .expect("Ok intent cannot produce ScheduleRequestError"))
@@ -362,7 +369,12 @@ impl SubmitExecutionFnCall<'_> {
             child_execution_id,
             wasm_backtrace,
         }
-        .apply(&mut ctx.event_history, &mut *ctx.db_connection, called_at)
+        .apply(
+            &mut ctx.event_history,
+            &mut ctx.event_call_cursor,
+            &mut *ctx.db_connection,
+            called_at,
+        )
         .await?
         .map(|()| child_execution_id_val)
         .expect("Ok intent cannot produce ChildExecutionRequestError"))
@@ -427,7 +439,12 @@ impl AwaitNextFnCall {
             wasm_backtrace,
             requested_ffqn: target_ffqn,
         }
-        .apply(&mut ctx.event_history, &mut *ctx.db_connection, called_at)
+        .apply(
+            &mut ctx.event_history,
+            &mut ctx.event_call_cursor,
+            &mut *ctx.db_connection,
+            called_at,
+        )
         .await
     }
 }
@@ -549,7 +566,12 @@ impl StubFnCall<'_> {
             params,
             wasm_backtrace,
         }
-        .apply(&mut ctx.event_history, &mut *ctx.db_connection, called_at)
+        .apply(
+            &mut ctx.event_history,
+            &mut ctx.event_call_cursor,
+            &mut *ctx.db_connection,
+            called_at,
+        )
         .await?;
 
         Ok(stub_result_to_wast_val(stub_result).as_val())
@@ -661,10 +683,9 @@ impl<'a> ImportedFnCall<'a> {
         called_ffqn: FunctionFqn,
         store_ctx: &'ctx mut wasmtime::StoreContextMut<'a, WorkflowCtx>,
         params: &'a [Val],
-        backtrace_persist: bool,
         fn_registry: &dyn FunctionRegistry,
     ) -> Result<ImportedFnCall<'a>, WorkflowFunctionError> {
-        let wasm_backtrace = if backtrace_persist {
+        let wasm_backtrace = if store_ctx.data().backtrace_capture {
             let wasm_backtrace = wasmtime::WasmBacktrace::capture(&store_ctx);
             concepts::storage::WasmBacktrace::maybe_from(&wasm_backtrace)
         } else {
@@ -853,17 +874,22 @@ pub(crate) enum ReplayKind {
 }
 
 impl WorkflowCtx {
+    pub(crate) fn version(&self) -> &Version {
+        self.event_call_cursor.version()
+    }
+
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         deployment_id: DeploymentId,
         db_connection: Box<dyn WorkflowDbConnection>,
+        version: Version,
         event_history: Vec<(HistoryEvent, Version)>,
         responses: Vec<ResponseWithCursor>,
         seed: u64,
         clock_fn: Box<dyn ClockFn>,
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         worker_span: Span,
-        backtrace_persist: bool,
+        backtrace_capture: bool,
         deadline_tracker: Box<dyn DeadlineTracker>,
         fn_registry: Arc<dyn FunctionRegistry>,
         cancel_registry: CancelRegistry,
@@ -879,8 +905,10 @@ impl WorkflowCtx {
         wasi_ctx_builder.insecure_random_seed(0);
         let run_id = locked_event.run_id;
         let execution_id = db_connection.execution_id().clone();
+        let event_call_cursor = EventCallCursor::new(version, &event_history);
         Self {
             execution_id: execution_id.clone(),
+            event_call_cursor,
             db_connection,
             event_history: EventHistory::new(
                 deployment_id,
@@ -905,7 +933,7 @@ impl WorkflowCtx {
                 logs_storage_config,
             },
             resource_table: wasmtime::component::ResourceTable::default(),
-            backtrace_persist,
+            backtrace_capture,
             wasi_ctx: wasi_ctx_builder.build(),
             is_replay,
         }
@@ -945,6 +973,7 @@ impl WorkflowCtx {
             expires_at_if_new,
             wasm_backtrace,
             &mut self.event_history,
+            &mut self.event_call_cursor,
             &mut *self.db_connection,
             self.clock_fn.now(),
         )
@@ -980,6 +1009,7 @@ impl WorkflowCtx {
             }
             .apply(
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -999,16 +1029,16 @@ impl WorkflowCtx {
         caller: &'a mut wasmtime::StoreContextMut<'_, Self>,
         wit_backtrace: Option<typesTypes::backtrace::WasmBacktrace>,
     ) -> (&'a mut WorkflowCtx, Option<storage::WasmBacktrace>) {
-        let backtrace = wit_backtrace
-            .map(Self::wit_wasm_backtrace_to_storage)
-            .or_else(|| {
-                if caller.data().backtrace_persist {
+        let backtrace = if caller.data().backtrace_capture {
+            wit_backtrace
+                .and_then(Self::wit_wasm_backtrace_to_storage)
+                .or_else(|| {
                     let backtrace = wasmtime::WasmBacktrace::capture(&caller);
                     WasmBacktrace::maybe_from(&backtrace)
-                } else {
-                    None
-                }
-            });
+                })
+        } else {
+            None
+        };
         let host = caller.data_mut();
         (host, backtrace)
     }
@@ -1098,8 +1128,11 @@ impl WorkflowCtx {
 
     fn wit_wasm_backtrace_to_storage(
         bt: typesTypes::backtrace::WasmBacktrace,
-    ) -> storage::WasmBacktrace {
-        storage::WasmBacktrace {
+    ) -> Option<storage::WasmBacktrace> {
+        if bt.frames.is_empty() {
+            return None;
+        }
+        Some(storage::WasmBacktrace {
             frames: bt
                 .frames
                 .into_iter()
@@ -1118,12 +1151,12 @@ impl WorkflowCtx {
                         .collect(),
                 })
                 .collect(),
-        }
+        })
     }
 
     /// Register the plain `workflow-support` functions for 6.0.0. Native components
     /// import these; they carry no `backtrace` param. Any host-side backtrace is still
-    /// captured when `backtrace_persist` is enabled (`get_host_maybe_capture_backtrace`
+    /// captured when `backtrace_capture` is enabled (`get_host_maybe_capture_backtrace`
     /// with `None`). The backtrace-carrying variants live on
     /// `workflow-support-backtrace` for interpreted (JS) runtimes.
     fn add_to_linker_workflow_support(
@@ -1946,7 +1979,11 @@ impl WorkflowCtx {
     pub(crate) async fn join_sets_close_on_finish(&mut self) -> Result<(), ApplyError> {
         debug!("Closing opened join sets");
         self.event_history
-            .finalize(&mut *self.db_connection, self.clock_fn.now())
+            .finalize(
+                &mut self.event_call_cursor,
+                &mut *self.db_connection,
+                self.clock_fn.now(),
+            )
             .await?;
         Ok(())
     }
@@ -2056,6 +2093,7 @@ pub(crate) mod workflow_support {
             self.event_history
                 .join_set_close(
                     join_set_id,
+                    &mut self.event_call_cursor,
                     &mut *self.db_connection,
                     self.clock_fn.now(),
                     wasm_backtrace,
@@ -2096,6 +2134,7 @@ pub(crate) mod workflow_support {
                 max_inclusive,
                 wasm_backtrace,
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -2115,6 +2154,7 @@ pub(crate) mod workflow_support {
                 &execution_id,
                 wasm_backtrace,
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -2162,6 +2202,7 @@ pub(crate) mod workflow_support {
                 u64::from(max_length_exclusive),
                 wasm_backtrace,
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -2200,6 +2241,7 @@ pub(crate) mod workflow_support {
             }
             .apply(
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -2324,6 +2366,7 @@ pub(crate) mod workflow_support {
             }
             .apply(
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -2350,6 +2393,7 @@ pub(crate) mod workflow_support {
             }
             .apply(
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 self.clock_fn.now(),
             )
@@ -2448,7 +2492,12 @@ pub(crate) mod workflow_support {
             };
 
             let result = submit
-                .apply(&mut self.event_history, &mut *self.db_connection, called_at)
+                .apply(
+                    &mut self.event_history,
+                    &mut self.event_call_cursor,
+                    &mut *self.db_connection,
+                    called_at,
+                )
                 .await
                 .map_err(wasmtime::Error::new)?; // Wraps `WorkflowFunctionError` with anyhow to be unwrapped by workflow_worker
 
@@ -2554,7 +2603,12 @@ pub(crate) mod workflow_support {
                 intent,
                 wasm_backtrace,
             }
-            .apply(&mut self.event_history, &mut *self.db_connection, called_at)
+            .apply(
+                &mut self.event_history,
+                &mut self.event_call_cursor,
+                &mut *self.db_connection,
+                called_at,
+            )
             .await
             .map_err(wasmtime::Error::new)?; // Wraps `WorkflowFunctionError` with anyhow to be unwrapped by workflow_worker
 
@@ -2771,7 +2825,12 @@ pub(crate) mod workflow_support {
                 params,
                 wasm_backtrace,
             }
-            .apply(&mut self.event_history, &mut *self.db_connection, called_at)
+            .apply(
+                &mut self.event_history,
+                &mut self.event_call_cursor,
+                &mut *self.db_connection,
+                called_at,
+            )
             .await?;
 
             match stub_result {
@@ -2846,6 +2905,7 @@ pub(crate) mod workflow_support {
                 params,
                 wasm_backtrace,
                 &mut self.event_history,
+                &mut self.event_call_cursor,
                 &mut *self.db_connection,
                 called_at,
             )
@@ -3165,13 +3225,13 @@ pub(crate) mod tests {
                 self.db_pool.connection().await.unwrap(),
                 ctx.execution_id.clone(),
                 CachingBuffer::new(join_next_blocking_strategy),
-                ctx.version,
             );
 
             let cancel_registry = CancelRegistry::new();
             let mut workflow_ctx = WorkflowCtx::new(
                 DEPLOYMENT_ID_DUMMY,
                 Box::new(caching_db_connection),
+                ctx.version,
                 ctx.event_history,
                 ctx.responses,
                 seed,
@@ -3315,7 +3375,7 @@ pub(crate) mod tests {
                 if let Err(err) = res {
                     info!("Sending {err:?}");
                     return err
-                        .into_worker_partial_result(workflow_ctx.db_connection.version().clone())
+                        .into_worker_partial_result(workflow_ctx.version().clone())
                         .into();
                 }
             }
@@ -3324,7 +3384,7 @@ pub(crate) mod tests {
                     info!("Finishing");
                     WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
                         retval: SUPPORTED_RETURN_VALUE_OK_EMPTY,
-                        version: workflow_ctx.db_connection.version().clone(),
+                        version: workflow_ctx.version().clone(),
                         http_client_traces: None,
                     }))
                 }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -14,7 +14,7 @@ use crate::workflow::replay_db_proxy::InternalCapturedWrite;
 use async_trait::async_trait;
 use concepts::prefixed_ulid::DeploymentId;
 use concepts::storage::http_client_trace::HttpClientTrace;
-use concepts::storage::{CapturedDbWrite, DbPool, Version};
+use concepts::storage::{BacktraceInfo, CapturedDbWrite, DbPool, Version};
 use concepts::{
     ComponentType, ExecutionFailureKind, ExecutionId, FinishedExecutionFailure, FunctionFqn,
     FunctionMetadata, FunctionRegistry, IfcFqnName, PackageIfcFns, ParameterType, Params,
@@ -166,11 +166,44 @@ pub struct WorkflowJsWorker {
 use crate::js_imports::{NamedFnImport, resolve_js_imports};
 
 impl WorkflowJsWorker {
+    pub async fn capture_backtraces(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Vec<BacktraceInfo>, ReplayError> {
+        assert!(
+            self.inner.deadline_factory.is_for_replay(),
+            "capture_backtraces() requires DeadlineTrackerFactoryForReplay"
+        );
+        let db_conn = self
+            .inner
+            .db_pool
+            .connection()
+            .await
+            .map_err(concepts::storage::DbErrorWrite::from)?;
+        let log = db_conn
+            .get(&execution_id)
+            .await
+            .map_err(concepts::storage::DbErrorWrite::from)?;
+        let (ffqn, params) = Self::boa_invocation(
+            log.params(),
+            self.js_source.clone(),
+            Some(self.js_file_name.clone()),
+            &self.resolved_imports,
+            true,
+        );
+        let (writes, backtraces, _fatal_error, _db_conn) = self
+            .inner
+            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn, true)
+            .await?;
+        Ok(WorkflowWorker::collect_write_backtraces(writes, backtraces))
+    }
+
     fn boa_invocation(
         params: &Params,
         js_source: String,
         js_file_name: Option<String>,
         resolved_imports: &HashMap<IfcFqnName, Vec<NamedFnImport>>,
+        backtrace_enabled: bool,
     ) -> (FunctionFqn, Params) {
         let json_params = params
             .as_json_values()
@@ -210,7 +243,11 @@ impl WorkflowJsWorker {
         let boa_params: Arc<[serde_json::Value]> = Arc::from([
             serde_json::Value::String(js_source),
             serde_json::Value::Array(params_json_list),
-            js_file_name.map_or(serde_json::Value::Null, serde_json::Value::String),
+            if backtrace_enabled {
+                js_file_name.map_or(serde_json::Value::Null, serde_json::Value::String)
+            } else {
+                serde_json::Value::Null
+            },
             serde_json::Value::Array(imports_json),
         ]);
         let named_fn_import_ty = TypeWrapper::Record(IndexMap::from([
@@ -259,6 +296,7 @@ impl Worker for WorkflowJsWorker {
             self.js_source.clone(),
             Some(self.js_file_name.clone()),
             &self.resolved_imports,
+            false, // backtrace is disabled for regular run
         );
 
         let inner_worker_ok = self.inner.run(ctx).await?;
@@ -445,7 +483,11 @@ impl WorkflowJsWorker {
     /// This function recreates the workflow execution from the database log,
     /// transforming the context to call the workflow-js-runtime just like the
     /// regular `run` method does.
-    pub async fn replay(&self, execution_id: ExecutionId) -> Result<ReplayResponse, ReplayError> {
+    pub async fn replay(
+        &self,
+        execution_id: ExecutionId,
+        backtrace_capture: bool,
+    ) -> Result<ReplayResponse, ReplayError> {
         assert!(
             self.inner.deadline_factory.is_for_replay(),
             "replay() requires DeadlineTrackerFactoryForReplay"
@@ -466,13 +508,21 @@ impl WorkflowJsWorker {
             self.js_source.clone(),
             Some(self.js_file_name.clone()),
             &self.resolved_imports,
+            backtrace_capture,
         );
 
-        let (captured_writes, mut fatal_error, _db_conn) = self
+        let (captured_writes, _backtraces, mut fatal_error, _db_conn) = self
             .inner
-            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn)
+            .capture_replay_writes_from_log(
+                execution_id,
+                log,
+                ffqn,
+                params,
+                db_conn,
+                backtrace_capture,
+            )
             .await?;
-        // Remove side effects, unwrapping user retval or fatal error.
+        // Drop replay-only metadata, unwrapping user retval or fatal error.
         let captured_writes: Vec<_> = captured_writes
             .into_iter()
             .map(|internal_write| {
@@ -516,6 +566,7 @@ impl WorkflowJsWorker {
         &self,
         execution_id: ExecutionId,
         requested: ReplayAdvanceable,
+        backtrace_capture: bool,
     ) -> Result<AdvanceResponse, AdvanceError> {
         assert!(
             self.inner.deadline_factory.is_for_replay(),
@@ -549,15 +600,23 @@ impl WorkflowJsWorker {
             self.js_source.clone(),
             Some(self.js_file_name.clone()),
             &self.resolved_imports,
+            backtrace_capture,
         );
         let log_forwarder_sender = self
             .inner
             .logs_storage_config
             .as_ref()
             .map(|config| &config.log_sender);
-        let (mut fresh_replay, _fatal_error, db_conn) = self
+        let (mut fresh_replay, _backtraces, _fatal_error, db_conn) = self
             .inner
-            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn)
+            .capture_replay_writes_from_log(
+                execution_id,
+                log,
+                ffqn,
+                params,
+                db_conn,
+                backtrace_capture,
+            )
             .await
             .map_err(AdvanceError::from)?;
         if let Some(InternalCapturedWrite {
@@ -708,7 +767,6 @@ mod tests {
         let config = WorkflowConfig {
             component_id,
             join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
-            backtrace_persist: true,
             stub_wasi: true,
             fuel: None,
             lock_extension: None,
@@ -769,7 +827,6 @@ mod tests {
         let config = WorkflowConfig {
             component_id: component_id.clone(),
             join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
-            backtrace_persist: false,
             stub_wasi: false,
             fuel: None,
             lock_extension: Some(Duration::from_secs(1)),
@@ -847,7 +904,6 @@ mod tests {
         let config = WorkflowConfig {
             component_id,
             join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
-            backtrace_persist: false,
             stub_wasi: false,
             fuel: None,
             lock_extension: None,
@@ -1154,7 +1210,6 @@ mod tests {
         let config = WorkflowConfig {
             component_id: component_id.clone(),
             join_next_blocking_strategy,
-            backtrace_persist: false,
             stub_wasi: false,
             fuel: None,
             lock_extension: None,
@@ -1636,7 +1691,7 @@ mod tests {
             js_source.to_string(),
             default_return_type(),
         );
-        replay_worker.replay(execution_id).await.unwrap();
+        replay_worker.replay(execution_id, false).await.unwrap();
         // Drop the worker so the log_sender is closed; otherwise `recv_many` blocks indefinitely.
         drop(replay_worker);
         let mut buffer = Vec::new();
@@ -3277,7 +3332,10 @@ mod tests {
             js_source.to_string(),
             default_return_type(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         info!("Stage 1 replay: {replay:?}");
@@ -3311,7 +3369,10 @@ mod tests {
             .await
             .unwrap();
 
-        let replay2 = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay2 = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay2 = assert_matches!(replay2, ReplayResponse::Advanceable(replay2) => replay2);
         info!("Stage 2 replay: {replay2:?}");
@@ -3349,7 +3410,10 @@ mod tests {
             "unexpected result: {result_str}"
         );
 
-        let replay3 = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay3 = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let result = assert_matches!(replay3, ReplayResponse::Finished { result } => result);
         info!("Stage 3 replay result: {result:?}");
@@ -3434,7 +3498,10 @@ mod tests {
             js_source.to_string(),
             default_return_type(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         // With FlushedCache interruption, replay stops after the first cache flush.
@@ -3457,7 +3524,10 @@ mod tests {
                 .len()
         );
         // Replay should return the return value
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         let retval = replay
@@ -3749,14 +3819,20 @@ mod tests {
             js_source.to_string(),
             default_return_type(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         assert_matches!(
             log_recv.try_recv(),
             Err(tokio::sync::mpsc::error::TryRecvError::Empty)
         );
 
-        replay_worker.advance(execution_id, replay).await.unwrap();
+        replay_worker
+            .advance(execution_id, replay, false)
+            .await
+            .unwrap();
 
         assert_matches!(
             log_recv.try_recv(),
@@ -3844,12 +3920,15 @@ mod tests {
         );
         let mut forwarded = Vec::new();
         for expected_len in [3_usize, 2, 1] {
-            let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+            let replay = replay_worker
+                .replay(execution_id.clone(), false)
+                .await
+                .unwrap();
             let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
             assert_eq!(replay.captured_writes.len(), expected_len);
 
             replay_worker
-                .advance(execution_id.clone(), replay.truncate_to(1))
+                .advance(execution_id.clone(), replay.truncate_to(1), false)
                 .await
                 .unwrap();
 
@@ -3860,7 +3939,7 @@ mod tests {
             forwarded,
             vec!["before create", "before delay", "before join"]
         );
-        let replay = replay_worker.replay(execution_id).await.unwrap();
+        let replay = replay_worker.replay(execution_id, false).await.unwrap();
         assert_matches!(replay, ReplayResponse::Blocked);
     }
 
@@ -3900,7 +3979,7 @@ mod tests {
             .await;
             let replay = harness
                 .replay_worker
-                .replay(harness.execution_id.clone())
+                .replay(harness.execution_id.clone(), false)
                 .await
                 .unwrap();
             let replay = match replay {
@@ -3962,7 +4041,7 @@ mod tests {
 
             let advance = harness
                 .replay_worker
-                .advance(harness.execution_id.clone(), requested.clone())
+                .advance(harness.execution_id.clone(), requested.clone(), false)
                 .await
                 .unwrap();
             assert_eq!(advance.finished, requested.get_return_value().cloned());
@@ -4078,7 +4157,10 @@ mod tests {
             js_source.to_string(),
             default_return_type(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         let mut requested = replay.clone();
@@ -4120,7 +4202,7 @@ mod tests {
         sim_clock.move_time_forward(Duration::from_millis(100));
 
         let advance = replay_worker
-            .advance(execution_id, requested)
+            .advance(execution_id, requested, false)
             .await
             .unwrap();
 
@@ -4215,7 +4297,10 @@ mod tests {
             js_source.to_string(),
             default_return_type(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         let mut requested = replay.clone();
@@ -4259,7 +4344,7 @@ mod tests {
         sim_clock.move_time_forward(Duration::from_millis(100));
 
         let advance = replay_worker
-            .advance(execution_id, requested)
+            .advance(execution_id, requested, false)
             .await
             .unwrap();
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -22,8 +22,8 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DeploymentId, ExecutorId, RunId};
 use concepts::storage::{
-    AppendRequest, CapturedDbWrite, ComponentUpgradeOutcome, ComponentUpgradeReason, DbConnection,
-    DbErrorWrite, DbPool, ExecutionLog, ExecutionRequest, Locked, Unlocked, Version,
+    AppendRequest, BacktraceInfo, CapturedDbWrite, ComponentUpgradeOutcome, ComponentUpgradeReason,
+    DbConnection, DbErrorWrite, DbPool, ExecutionLog, ExecutionRequest, Locked, Unlocked, Version,
 };
 use concepts::time::{ClockFn, now_tokio_instant};
 use concepts::{
@@ -61,7 +61,6 @@ pub use deployment_config::config::DEFAULT_NON_BLOCKING_EVENT_BATCHING;
 pub struct WorkflowConfig {
     pub component_id: ComponentId,
     pub join_next_blocking_strategy: JoinNextBlockingStrategy,
-    pub backtrace_persist: bool,
     pub stub_wasi: bool,
     pub fuel: Option<u64>,
     // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
@@ -259,7 +258,6 @@ impl WorkflowWorkerCompiled {
                                     ffqn.clone(),
                                     &mut store_ctx,
                                     params,
-                                    self.config.backtrace_persist,
                                     fn_registry.as_ref(),
                                 ) {
                                     Ok(imported_fn_call) => imported_fn_call,
@@ -411,6 +409,7 @@ enum WorkflowError {
     #[error("fatal error: {err}")]
     FatalError {
         err: FatalError,
+        version: Version,
         #[debug(skip)]
         db_connection: Box<dyn WorkflowDbConnection>,
     },
@@ -426,9 +425,7 @@ impl From<WorkflowError> for WorkerError {
                 WorkerError::LimitReached { reason, version }
             }
             WorkflowError::DbError(db_err) => WorkerError::DbError(db_err),
-            WorkflowError::FatalError { err, db_connection } => {
-                WorkerError::FatalError(err, db_connection.version().clone())
-            }
+            WorkflowError::FatalError { err, version, .. } => WorkerError::FatalError(err, version),
             WorkflowError::LockExpired(version) => WorkerError::TemporaryTimeout {
                 http_client_traces: None,
                 version,
@@ -450,13 +447,16 @@ pub enum JoinSetCloseError {
 impl JoinSetCloseError {
     fn into_workflow_error(
         self,
+        version: Version,
         db_connection: Box<dyn WorkflowDbConnection + 'static>,
     ) -> WorkflowError {
         match self {
             JoinSetCloseError::DbError(db_error_write) => WorkflowError::DbError(db_error_write),
-            JoinSetCloseError::FatalError { err } => {
-                WorkflowError::FatalError { err, db_connection }
-            }
+            JoinSetCloseError::FatalError { err } => WorkflowError::FatalError {
+                err,
+                version,
+                db_connection,
+            },
             JoinSetCloseError::ExecutorClosing(version) => WorkflowError::ExecutorClosing(version),
         }
     }
@@ -485,6 +485,20 @@ struct WorkflowWorkerView<'a> {
 }
 
 impl WorkflowWorker {
+    pub(crate) fn collect_write_backtraces(
+        writes: Vec<InternalCapturedWrite>,
+        mut backtraces: Vec<BacktraceInfo>,
+    ) -> Vec<BacktraceInfo> {
+        backtraces.extend(writes.into_iter().flat_map(|write| match write.write {
+            CapturedDbWrite::Append { backtraces, .. }
+            | CapturedDbWrite::AppendBatch { backtraces, .. }
+            | CapturedDbWrite::AppendBatchCreateNewExecution { backtraces, .. }
+            | CapturedDbWrite::AppendStubResponse { backtraces, .. } => backtraces,
+            CapturedDbWrite::AppendFinished { .. } => Vec::new(),
+        }));
+        backtraces
+    }
+
     pub(crate) async fn capture_replay_writes_from_log(
         &self,
         execution_id: ExecutionId,
@@ -492,9 +506,11 @@ impl WorkflowWorker {
         ffqn: FunctionFqn,
         params: Params,
         db_conn: Box<dyn DbConnection>,
+        backtrace_capture: bool,
     ) -> Result<
         (
             Vec<InternalCapturedWrite>,
+            Vec<BacktraceInfo>,
             Option<FatalError>,
             Box<dyn DbConnection>,
         ),
@@ -537,14 +553,15 @@ impl WorkflowWorker {
             ctx,
             replay_kind,
             execution_id,
-            log.next_version,
             db_conn,
             parent,
+            backtrace_capture,
         )
         .await
-        .map(|(writes, replay_end, db_conn)| {
+        .map(|(writes, backtraces, replay_end, db_conn)| {
             (
                 writes,
+                backtraces,
                 match replay_end {
                     ReplayPendingState::FinishedWithFailure(fatal_error) => Some(fatal_error),
                     _ => None,
@@ -610,6 +627,7 @@ impl WorkflowWorker {
         db_connection: Box<dyn WorkflowDbConnection>,
         is_replay: Option<ReplayKind>,
         view: WorkflowWorkerView<'_>,
+        backtrace_capture: bool,
     ) -> Result<PrepareFuncFinished, WorkflowError> {
         assert_eq!(view.config.component_id, ctx.locked_event.component_id);
         let deadline_tracker = match view
@@ -630,13 +648,14 @@ impl WorkflowWorker {
         let workflow_ctx = WorkflowCtx::new(
             view.deployment_id,
             db_connection,
+            ctx.version,
             ctx.event_history,
             ctx.responses,
             seed,
             view.clock_fn,
             view.config.join_next_blocking_strategy,
             ctx.worker_span,
-            view.config.backtrace_persist,
+            backtrace_capture,
             deadline_tracker,
             view.fn_registry,
             view.cancel_registry,
@@ -690,19 +709,20 @@ impl WorkflowWorker {
                 if let Some(wf_err) = err.downcast_ref::<WorkflowFunctionError>() {
                     match wf_err {
                         WorkflowFunctionError::LockExpired => {
-                            let version = store.into_data().db_connection.version().clone();
+                            let version = store.into_data().version().clone();
                             return Err(WorkflowError::LockExpired(version));
                         }
                         WorkflowFunctionError::ExecutorClosing => {
-                            let version = store.into_data().db_connection.version().clone();
+                            let version = store.into_data().version().clone();
                             return Err(WorkflowError::ExecutorClosing(version));
                         }
                         _ => {}
                     }
                 }
                 let reason = err.to_string();
-                let db_connection = store.into_data().db_connection;
-                let version = db_connection.version().clone();
+                let workflow_ctx = store.into_data();
+                let version = workflow_ctx.version().clone();
+                let db_connection = workflow_ctx.db_connection;
                 if reason.starts_with("maximum concurrent") {
                     return Err(WorkflowError::LimitReached { reason, version });
                 }
@@ -711,6 +731,7 @@ impl WorkflowWorker {
                         reason: format!("cannot instantiate: {err}"),
                         detail: Some(format!("{err:?}")),
                     },
+                    version,
                     db_connection,
                 });
             }
@@ -718,7 +739,9 @@ impl WorkflowWorker {
 
         let func = {
             let Some(fn_export_index) = view.exported_ffqn_to_index.get(&ctx.ffqn) else {
-                let db_connection = store.into_data().db_connection;
+                let workflow_ctx = store.into_data();
+                let version = workflow_ctx.version().clone();
+                let db_connection = workflow_ctx.db_connection;
                 return Err(WorkflowError::FatalError {
                     err: FatalError::CannotInstantiate {
                         reason: format!(
@@ -727,6 +750,7 @@ impl WorkflowWorker {
                         ),
                         detail: None,
                     },
+                    version,
                     db_connection,
                 });
             };
@@ -738,9 +762,12 @@ impl WorkflowWorker {
         let params = match ctx.params.as_vals(component_func.params()) {
             Ok(params) => params,
             Err(err) => {
-                let db_connection = store.into_data().db_connection;
+                let workflow_ctx = store.into_data();
+                let version = workflow_ctx.version().clone();
+                let db_connection = workflow_ctx.db_connection;
                 return Err(WorkflowError::FatalError {
                     err: FatalError::ParamsParsingError(err),
+                    version,
                     db_connection,
                 });
             }
@@ -782,7 +809,7 @@ impl WorkflowWorker {
                 {
                     let worker_partial_result = err
                         .clone()
-                        .into_worker_partial_result(workflow_ctx.db_connection.version().clone());
+                        .into_worker_partial_result(workflow_ctx.version().clone());
                     Err(RunError::WorkerPartialResult(
                         worker_partial_result,
                         workflow_ctx,
@@ -850,7 +877,7 @@ impl WorkflowWorker {
                     Ok(Either::Left(CloseJoinSetOk::Ok)) => Ok((
                         Either::Left(WorkerResultOk::RunFinished(RunFinished {
                             retval,
-                            version: workflow_ctx.db_connection.version().clone(),
+                            version: workflow_ctx.version().clone(),
                             http_client_traces: None,
                         })),
                         workflow_ctx.db_connection,
@@ -864,7 +891,10 @@ impl WorkflowWorker {
                     }
                     Err(closing_err) => {
                         debug!("Error while closing join sets {closing_err:?}");
-                        Err(closing_err.into_workflow_error(workflow_ctx.db_connection))
+                        Err(closing_err.into_workflow_error(
+                            workflow_ctx.version().clone(),
+                            workflow_ctx.db_connection,
+                        ))
                     }
                 }
             }
@@ -882,6 +912,7 @@ impl WorkflowWorker {
                         // Propagate the original error
                         Err(WorkflowError::FatalError {
                             err,
+                            version: workflow_ctx.version().clone(),
                             db_connection: workflow_ctx.db_connection,
                         })
                     }
@@ -891,21 +922,22 @@ impl WorkflowWorker {
                         );
                         // This can be a temporary db or limit reached error, schedule a retry
                         // to properly close join sets.
-                        Err(closing_err.into_workflow_error(workflow_ctx.db_connection))
+                        Err(closing_err.into_workflow_error(
+                            workflow_ctx.version().clone(),
+                            workflow_ctx.db_connection,
+                        ))
                     }
                 }
             }
             WorkerResultRefactored::DbError(err) => Err(WorkflowError::DbError(err)),
             WorkerResultRefactored::LockExpired(mut workflow_ctx) => {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
-                Err(WorkflowError::LockExpired(
-                    workflow_ctx.db_connection.version().clone(),
-                ))
+                Err(WorkflowError::LockExpired(workflow_ctx.version().clone()))
             }
             WorkerResultRefactored::ExecutorClosing(mut workflow_ctx) => {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
                 Err(WorkflowError::ExecutorClosing(
-                    workflow_ctx.db_connection.version().clone(),
+                    workflow_ctx.version().clone(),
                 ))
             }
             WorkerResultRefactored::ReplayInterrupt(workflow_ctx) => {
@@ -1012,7 +1044,7 @@ impl WorkflowWorker {
                 err: FatalError::ConstraintViolation { reason },
             }),
             Err(ApplyError::ExecutorClosing) => Err(JoinSetCloseError::ExecutorClosing(
-                workflow_ctx.db_connection.version().clone(),
+                workflow_ctx.version().clone(),
             )),
             Err(ApplyError::ReplayInterrupt) => Ok(Either::Right(ReplayInterrupt)),
         }
@@ -1028,12 +1060,13 @@ impl WorkflowWorker {
         ctx: WorkerContext,
         replay_kind: ReplayKind,
         execution_id: ExecutionId,
-        version: Version,
         real_connection: Box<dyn DbConnection>,
         parent: Option<(ExecutionId, JoinSetId)>,
+        backtrace_capture: bool,
     ) -> Result<
         (
             Vec<InternalCapturedWrite>,
+            Vec<BacktraceInfo>,
             ReplayPendingState,
             Box<dyn DbConnection>,
         ),
@@ -1054,45 +1087,57 @@ impl WorkflowWorker {
             logs_storage_config: self.logs_storage_config.clone(),
         };
         let replay_db_connection =
-            ReplayWorkflowDbConnection::new(execution_id, version, real_connection, parent);
-        let (retval, replay_db_connection, replay_outcome) =
-            match Self::run_internal(ctx, Box::new(replay_db_connection), Some(replay_kind), view)
-                .await
-            {
-                Ok((Either::Left(WorkerResultOk::RunFinished(RunFinished { retval, .. })), db)) => {
-                    Ok((Some(retval), db, ReplayPendingState::Finished))
-                }
-                Ok((Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher), db)) => {
-                    Ok((None, db, ReplayPendingState::Blocked))
-                }
-                Ok((Either::Right(ReplayInterrupt), db)) => {
-                    // Only first phase of stubbing leaves the execution in `PendingState::Locked`
-                    Ok((None, db, ReplayPendingState::Locked))
-                }
-                Err(WorkflowError::FatalError { err, db_connection }) => {
-                    debug!("Replay finished with fatal error: {err:?}");
-                    let retval = SupportedFunctionReturnValue::ExecutionFailure(
-                        FinishedExecutionFailure::from(&err),
-                    );
-                    Ok((
-                        Some(retval),
-                        db_connection,
-                        ReplayPendingState::FinishedWithFailure(err),
-                    ))
-                }
-                Err(WorkflowError::LimitReached { reason, version }) => {
-                    Err(ReplayInternalError::LimitReached { reason, version })
-                }
-                Err(WorkflowError::DbError(db_error_write)) => {
-                    Err(ReplayInternalError::DbError(db_error_write))
-                }
-                Err(WorkflowError::LockExpired(version)) => {
-                    Err(ReplayInternalError::LockExpired(version))
-                }
-                Err(WorkflowError::ExecutorClosing(version)) => {
-                    Err(ReplayInternalError::ExecutorClosing(version))
-                }
-            }?;
+            ReplayWorkflowDbConnection::new(execution_id, real_connection, parent);
+        let (finished, replay_db_connection, replay_outcome) = match Self::run_internal(
+            ctx,
+            Box::new(replay_db_connection),
+            Some(replay_kind),
+            view,
+            backtrace_capture,
+        )
+        .await
+        {
+            Ok((
+                Either::Left(WorkerResultOk::RunFinished(RunFinished {
+                    retval, version, ..
+                })),
+                db,
+            )) => Ok((Some((retval, version)), db, ReplayPendingState::Finished)),
+            Ok((Either::Left(WorkerResultOk::DbUpdatedByWorkerOrWatcher), db)) => {
+                Ok((None, db, ReplayPendingState::Blocked))
+            }
+            Ok((Either::Right(ReplayInterrupt), db)) => {
+                // Only first phase of stubbing leaves the execution in `PendingState::Locked`
+                Ok((None, db, ReplayPendingState::Locked))
+            }
+            Err(WorkflowError::FatalError {
+                err,
+                version,
+                db_connection,
+            }) => {
+                debug!("Replay finished with fatal error: {err:?}");
+                let retval = SupportedFunctionReturnValue::ExecutionFailure(
+                    FinishedExecutionFailure::from(&err),
+                );
+                Ok((
+                    Some((retval, version)),
+                    db_connection,
+                    ReplayPendingState::FinishedWithFailure(err),
+                ))
+            }
+            Err(WorkflowError::LimitReached { reason, version }) => {
+                Err(ReplayInternalError::LimitReached { reason, version })
+            }
+            Err(WorkflowError::DbError(db_error_write)) => {
+                Err(ReplayInternalError::DbError(db_error_write))
+            }
+            Err(WorkflowError::LockExpired(version)) => {
+                Err(ReplayInternalError::LockExpired(version))
+            }
+            Err(WorkflowError::ExecutorClosing(version)) => {
+                Err(ReplayInternalError::ExecutorClosing(version))
+            }
+        }?;
 
         let Ok(mut replay_db_connection) = replay_db_connection
             .as_any()
@@ -1102,7 +1147,7 @@ impl WorkflowWorker {
         };
 
         if replay_kind == ReplayKind::Unfinished
-            && let Some(retval) = retval
+            && let Some((retval, version)) = finished
         {
             assert_matches!(
                 replay_outcome,
@@ -1110,7 +1155,6 @@ impl WorkflowWorker {
             );
             debug!("Replay finished returning a value: {retval:?}");
             // Capture the Finished event that the executor would write.
-            let version = replay_db_connection.version().clone();
             let execution_id = replay_db_connection.execution_id().clone();
             let parent = replay_db_connection.parent();
             replay_db_connection.push_write(CapturedDbWrite::AppendFinished {
@@ -1121,8 +1165,8 @@ impl WorkflowWorker {
                 parent,
             });
         }
-        let (writes, real_connection) = replay_db_connection.into_parts();
-        Ok((writes, replay_outcome, real_connection))
+        let (writes, backtraces, real_connection) = replay_db_connection.into_parts();
+        Ok((writes, backtraces, replay_outcome, real_connection))
     }
 
     // Returns the same `db_connection` it was supplied.
@@ -1131,6 +1175,7 @@ impl WorkflowWorker {
         db_connection: Box<dyn WorkflowDbConnection>,
         is_replay: Option<ReplayKind>,
         view: WorkflowWorkerView<'_>,
+        backtrace_capture: bool,
     ) -> Result<
         (
             Either<WorkerResultOk, ReplayInterrupt>,
@@ -1146,7 +1191,8 @@ impl WorkflowWorker {
         let worker_span = ctx.worker_span.clone();
         let execution_deadline = ctx.locked_event.lock_expires_at;
         let fuel = view.config.fuel;
-        let prepare_finished = Self::prepare_func(ctx, db_connection, is_replay, view).await?;
+        let prepare_finished =
+            Self::prepare_func(ctx, db_connection, is_replay, view, backtrace_capture).await?;
         Self::call_func_convert_result(
             prepare_finished.store,
             prepare_finished.func,
@@ -1160,7 +1206,37 @@ impl WorkflowWorker {
     }
 
     #[instrument(skip_all, fields(%execution_id))]
-    pub async fn replay(&self, execution_id: ExecutionId) -> Result<ReplayResponse, ReplayError> {
+    pub async fn capture_backtraces(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Vec<BacktraceInfo>, ReplayError> {
+        assert!(
+            self.deadline_factory.is_for_replay(),
+            "capture_backtraces() requires DeadlineTrackerFactoryForReplay"
+        );
+        let db_conn = self
+            .db_pool
+            .connection()
+            .await
+            .map_err(DbErrorWrite::from)?;
+        let log = db_conn
+            .get(&execution_id)
+            .await
+            .map_err(DbErrorWrite::from)?;
+        let ffqn = log.ffqn().clone();
+        let params = log.params().clone();
+        let (writes, backtraces, _fatal_error, _db_conn) = self
+            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn, true)
+            .await?;
+        Ok(Self::collect_write_backtraces(writes, backtraces))
+    }
+
+    #[instrument(skip_all, fields(%execution_id))]
+    pub async fn replay(
+        &self,
+        execution_id: ExecutionId,
+        backtrace_capture: bool,
+    ) -> Result<ReplayResponse, ReplayError> {
         assert!(
             self.deadline_factory.is_for_replay(),
             "replay() requires DeadlineTrackerFactoryForReplay"
@@ -1177,10 +1253,17 @@ impl WorkflowWorker {
         let already_finished_result = log.as_finished_result();
         let ffqn = log.ffqn().clone();
         let params = log.params().clone();
-        let (captured_writes, fatal_error, _db_conn) = self
-            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn)
+        let (captured_writes, _backtraces, fatal_error, _db_conn) = self
+            .capture_replay_writes_from_log(
+                execution_id,
+                log,
+                ffqn,
+                params,
+                db_conn,
+                backtrace_capture,
+            )
             .await?;
-        // Remove side effects
+        // Drop replay-only metadata.
         let captured_writes: Vec<_> = captured_writes
             .into_iter()
             .map(|write| write.write)
@@ -1218,6 +1301,7 @@ impl WorkflowWorker {
         &self,
         execution_id: ExecutionId,
         requested: ReplayAdvanceable,
+        backtrace_capture: bool,
     ) -> Result<AdvanceResponse, AdvanceError> {
         assert!(
             self.deadline_factory.is_for_replay(),
@@ -1254,8 +1338,15 @@ impl WorkflowWorker {
             .logs_storage_config
             .as_ref()
             .map(|config| &config.log_sender);
-        let (fresh_replay, _fatal_error, db_conn) = self
-            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn)
+        let (fresh_replay, _backtraces, _fatal_error, db_conn) = self
+            .capture_replay_writes_from_log(
+                execution_id,
+                log,
+                ffqn,
+                params,
+                db_conn,
+                backtrace_capture,
+            )
             .await?;
 
         Ok(Self::advance_from_log(
@@ -1287,17 +1378,17 @@ impl WorkflowWorker {
             can_be_retried: true, // avoid a warning in log
             ..ctx
         };
-        let (mut fresh_replay, replay_pending_state, db_conn) = self
+        let (mut fresh_replay, _backtraces, replay_pending_state, db_conn) = self
             .replay_internal(
                 replay_ctx,
                 ReplayKind::Unfinished,
                 execution_id.clone(),
-                version.clone(),
                 self.db_pool
                     .connection()
                     .await
                     .map_err(|err| WorkerError::DbError(err.into()))?,
                 parent,
+                false,
             )
             .await
             .map_err(|err| match err {
@@ -1463,7 +1554,6 @@ impl Worker for WorkflowWorker {
             self.db_pool.connection().await.unwrap(),
             ctx.execution_id.clone(),
             CachingBuffer::new(self.config.join_next_blocking_strategy),
-            ctx.version.clone(),
         ));
         let worker_span = ctx.worker_span.clone();
         worker_span.in_scope(|| {
@@ -1486,6 +1576,7 @@ impl Worker for WorkflowWorker {
             db_connection,
             None, // is_replay
             view,
+            false,
         )
         .await;
         worker_span.in_scope(|| match res {
@@ -1715,7 +1806,6 @@ pub(crate) mod tests {
                     WorkflowConfig {
                         component_id,
                         join_next_blocking_strategy,
-                        backtrace_persist: false,
                         stub_wasi: false,
                         fuel: None,
                         lock_extension: None,
@@ -1755,7 +1845,6 @@ pub(crate) mod tests {
         let config = WorkflowConfig {
             component_id,
             join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
-            backtrace_persist: true,
             stub_wasi: true,
             fuel: None,
             lock_extension: None,
@@ -3779,7 +3868,7 @@ pub(crate) mod tests {
             cancellation_driver::tick_test(db_connection, &cancel_registry, sim_clock.now()).await;
             let replay = harness
                 .replay_worker
-                .replay(harness.execution_id.clone())
+                .replay(harness.execution_id.clone(), false)
                 .await
                 .unwrap();
 
@@ -3797,7 +3886,7 @@ pub(crate) mod tests {
             let expected_finished = replay.get_return_value().cloned();
             let advance = harness
                 .replay_worker
-                .advance(harness.execution_id.clone(), replay)
+                .advance(harness.execution_id.clone(), replay, false)
                 .await
                 .unwrap();
             assert_eq!(advance.finished, expected_finished);
@@ -4533,7 +4622,10 @@ pub(crate) mod tests {
         ));
         // Replay just after creating - execution is unfinished with no events,
         // preview should return the first event(s) the workflow would produce.
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         debug!("Preview after creation: {replay:?}");
         assert!(
@@ -4586,7 +4678,7 @@ pub(crate) mod tests {
         assert_eq!(FIBO_10_OUTPUT, fibo);
 
         // Replay after workflow was finished - return_value is present.
-        let replay = replay_worker.replay(execution_id).await.unwrap();
+        let replay = replay_worker.replay(execution_id, false).await.unwrap();
         let result = assert_matches!(replay, ReplayResponse::Finished { result } => result);
         assert_matches!(result, SupportedFunctionReturnValue::Ok(_));
     }
@@ -4645,14 +4737,20 @@ pub(crate) mod tests {
             logs_storage_config,
             sim_clock.clone_box(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         assert_matches!(
             log_recv.try_recv(),
             Err(tokio::sync::mpsc::error::TryRecvError::Empty)
         );
 
-        replay_worker.advance(execution_id, replay).await.unwrap();
+        replay_worker
+            .advance(execution_id, replay, false)
+            .await
+            .unwrap();
 
         assert_matches!(
             log_recv.try_recv(),
@@ -4915,7 +5013,7 @@ pub(crate) mod tests {
             cancellation_driver::tick_test(db_connection, &cancel_registry, sim_clock.now()).await;
             let replay = harness
                 .replay_worker
-                .replay(harness.execution_id.clone())
+                .replay(harness.execution_id.clone(), false)
                 .await
                 .unwrap();
 
@@ -4960,7 +5058,7 @@ pub(crate) mod tests {
 
             let advance = harness
                 .replay_worker
-                .advance(harness.execution_id.clone(), requested.clone())
+                .advance(harness.execution_id.clone(), requested.clone(), false)
                 .await
                 .unwrap();
             assert_eq!(advance.finished, requested.get_return_value().cloned());
@@ -5073,7 +5171,10 @@ pub(crate) mod tests {
         ));
 
         // Step 1: Replay to get expected events and version.
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         assert!(
@@ -5103,7 +5204,7 @@ pub(crate) mod tests {
             }
         };
         let advance_result = replay_worker
-            .advance(execution_id.clone(), wrong_replay)
+            .advance(execution_id.clone(), wrong_replay, false)
             .await
             .unwrap_err();
         assert_matches!(
@@ -5118,6 +5219,7 @@ pub(crate) mod tests {
                 ReplayAdvanceable {
                     captured_writes: vec![], // empty writes
                 },
+                false,
             )
             .await
             .unwrap_err();
@@ -5276,7 +5378,10 @@ pub(crate) mod tests {
             None,
             sim_clock.clone_box(),
         );
-        let replay = replay_worker.replay(execution_id.clone()).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
 
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
         let mut requested = replay.clone();
@@ -5318,7 +5423,7 @@ pub(crate) mod tests {
         sim_clock.move_time_forward(Duration::from_millis(100));
 
         let advance = replay_worker
-            .advance(execution_id, requested)
+            .advance(execution_id, requested, false)
             .await
             .unwrap();
 

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -430,12 +430,11 @@ fn setup_fetch(context: &mut Context) -> JsResult<()> {
     boa_runtime::register(FetchExtension(WasiFetcher), None, context)
 }
 
-/// Capture the current Boa JS stack trace as a `WasmBacktrace`.
-///
-/// The `module` and `file` fields are populated from the `__OBELISK_JS_FILE_NAME__`
-/// environment variable, since JS source is loaded from memory and Boa does not
-/// track a file path for in-memory sources.
+/// Capture the current Boa JS stack trace when enabled by the webhook configuration.
 fn capture_backtrace(ctx: &Context) -> WasmBacktrace {
+    if std::env::var_os("__OBELISK_BACKTRACE_ENABLED__").is_none() {
+        return WasmBacktrace { frames: Vec::new() };
+    }
     use boa_engine::vm::SourcePath;
     let js_file_name = std::env::var("__OBELISK_JS_FILE_NAME__").ok();
     let frames = ctx

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -158,7 +158,7 @@ use boa_engine::{
     object::builtins::{JsDate, JsFunction, JsPromise},
     property::{Attribute, PropertyDescriptor},
 };
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -188,6 +188,7 @@ impl ObeliskLogger for Logger {
 thread_local! {
     static JOIN_SETS: RefCell<Vec<Option<JoinSet>>> = const { RefCell::new(Vec::new()) };
     static JS_FILE_NAME: RefCell<String> = const { RefCell::new(String::new()) };
+    static BACKTRACE_ENABLED: Cell<bool> = const { Cell::new(false) };
 }
 
 fn store_join_set(js: JoinSet) -> usize {
@@ -221,6 +222,9 @@ fn take_join_set(idx: usize) -> Option<JoinSet> {
 /// the `js-file-name` parameter passed to `execute`), since JS source is loaded
 /// from memory and Boa does not track a file path for in-memory sources.
 fn capture_backtrace(ctx: &Context) -> WasmBacktrace {
+    if !BACKTRACE_ENABLED.get() {
+        return WasmBacktrace { frames: Vec::new() };
+    }
     use boa_engine::vm::SourcePath;
     let js_file_name = JS_FILE_NAME.with(|s| s.borrow().clone());
     let js_file_name_opt: Option<&str> = if js_file_name.is_empty() {
@@ -687,6 +691,7 @@ pub fn execute(
     js_file_name: Option<String>,
     resolved_imports: Vec<ResolvedInterfaceImports>,
 ) -> Result<Result<String, String>, JsRuntimeError> {
+    BACKTRACE_ENABLED.set(js_file_name.is_some());
     if let Some(js_file_name) = js_file_name {
         JS_FILE_NAME.with(|s| *s.borrow_mut() = js_file_name);
     }

--- a/obelisk-help-deployment.toml
+++ b/obelisk-help-deployment.toml
@@ -333,6 +333,8 @@
 # env_vars = ["ENV1", {key = "ENV2", value = "somevalue"}, {key = "ENV3", value = "${HOST_VAR}"}, {key = "ENV4", value = "prefix ${HOST_VAR}"}, {key = "ENV5", value = "${OPTIONAL:-fallback}"}]
 ## During manifest preparation, relative paths are rewritten to `{ path = "...", content_digest = "sha256:..." }`.
 # backtrace.sources = {"frame symbol file path" = "path to the source file", ".../src/lib.rs" = "path to source file"}
+## Capture and persist call-site backtraces for this webhook. Default is false.
+# backtrace_persist = false
 ## Outgoing HTTP host allowlist - same syntax as activity_wasm.allowed_host.
 # [[webhook_endpoint_wasm.allowed_host]]
 # pattern = "api.example.com"
@@ -368,6 +370,8 @@
 ## Note: only `${VAR}` triggers interpolation; `$VAR` (no braces) is treated as a literal string.
 ## Forwarded vars ("ENV1") fail startup if missing; value strings with unresolved `${VAR}` also fail.
 # env_vars = ["ENV1", {key = "ENV2", value = "somevalue"}, {key = "ENV3", value = "${HOST_VAR}"}, {key = "ENV4", value = "prefix ${HOST_VAR}"}, {key = "ENV5", value = "${OPTIONAL:-fallback}"}]
+## Capture and persist JavaScript call-site backtraces for this webhook. Default is false.
+# backtrace_persist = false
 ## Outgoing HTTP host allowlist - same syntax as activity_wasm.allowed_host.
 # [[webhook_endpoint_js.allowed_host]]
 # pattern = "api.example.com"

--- a/obelisk-help-server.toml
+++ b/obelisk-help-server.toml
@@ -54,7 +54,6 @@
 ## Path to directory where downloaded or transformed WASM files are stored. Supports path prefixes.
 ## By default "${CACHE_DIR}/wasm" or "./cache/wasm" if no valid home directory path could be retrieved from the operating system.
 # cache_directory = "${CACHE_DIR}/wasm"
-# backtrace.persist = true                       # Persist backtraces on effect calls for all workflows and webhook endpoints.
 # allocator_config = "auto"                      # One of "auto"|"on_demand"|"pooling"
 # global_executor_instance_limiter = "unlimited" # If set to an integer, limits the number of concurrent workflow and activity executions.
 # global_webhook_instance_limiter = "unlimited"  # If set to an integer, limits the number of concurrent webhook requests.

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -30,6 +30,7 @@ service ExecutionRepository {
     rpc ListLogs(ListLogsRequest) returns (ListLogsResponse);
 
     rpc ReplayExecution(ReplayExecutionRequest) returns (ReplayExecutionResponse);
+    rpc PersistExecutionBacktraces(PersistExecutionBacktracesRequest) returns (PersistExecutionBacktracesResponse);
     rpc AdvanceExecution(AdvanceExecutionRequest) returns (AdvanceExecutionResponse);
     rpc UpgradeExecutionComponent(UpgradeExecutionComponentRequest) returns (UpgradeExecutionComponentResponse);
 
@@ -945,9 +946,19 @@ message ReplayExecutionResponse {
   }
 }
 
+message PersistExecutionBacktracesRequest {
+  ExecutionId execution_id = 1;
+}
+
+message PersistExecutionBacktracesResponse {
+  uint32 persisted_backtrace_count = 1;
+}
+
 message AdvanceExecutionRequest {
   ExecutionId execution_id = 1;
   repeated CapturedWrite captured_writes = 2;
+  // Capture and persist call-site backtraces while verifying and applying the writes.
+  bool persist_backtrace = 3;
 }
 
 message AdvanceExecutionResponse {

--- a/src/args.rs
+++ b/src/args.rs
@@ -93,7 +93,7 @@ pub(crate) enum Subcommand {
     /// Run or verify the Obelisk server.
     #[command(subcommand)]
     Server(Server),
-    /// Submit, inspect, stub, cancel, pause, unpause, replay, or upgrade executions against a running server.
+    /// Submit, inspect, stub, cancel, pause, replay, persist backtraces, or upgrade executions.
     #[command(subcommand)]
     Execution(Execution),
     /// Inspect components or add/push them to an OCI registry.
@@ -784,6 +784,14 @@ pub(crate) enum Execution {
         /// Output as JSON instead of human-readable text.
         #[arg(short, long)]
         json: bool,
+    },
+    /// Replay a workflow and persist its call-site backtraces.
+    PersistBacktraces {
+        /// Address of the obelisk server
+        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        api_url: String,
+        /// Execution ID whose backtraces should be persisted.
+        execution_id: ExecutionId,
     },
     /// Advance a paused workflow execution by replaying it and applying the next captured writes.
     Advance {

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -217,6 +217,10 @@ impl args::Execution {
                 execution_id,
                 json,
             } => replay(&api_url, execution_id, json).await,
+            args::Execution::PersistBacktraces {
+                api_url,
+                execution_id,
+            } => persist_backtraces(&api_url, execution_id).await,
             args::Execution::Advance {
                 api_url,
                 execution_id,
@@ -865,6 +869,24 @@ async fn replay(api_url: &str, execution_id: ExecutionId, json: bool) -> anyhow:
     send_and_print(req).await
 }
 
+async fn persist_backtraces(api_url: &str, execution_id: ExecutionId) -> anyhow::Result<()> {
+    let channel = to_channel(api_url).await?;
+    let mut client = get_execution_repository_client(channel).await?;
+    let response = client
+        .persist_execution_backtraces(tonic::Request::new(
+            grpc_gen::PersistExecutionBacktracesRequest {
+                execution_id: Some(grpc_gen::ExecutionId::from(execution_id)),
+            },
+        ))
+        .await?
+        .into_inner();
+    println!(
+        "Persisted {} backtraces",
+        response.persisted_backtrace_count
+    );
+    Ok(())
+}
+
 /// Fetch replay response as JSON. Accepts both 200 (success) and 422 (replay failed with body).
 async fn replay_json(
     api_url: &str,
@@ -945,9 +967,10 @@ fn replay_to_advanceable_request(
     let replay: ReplayResponseSer = serde_json::from_value(replay.clone())
         .context("failed to decode replay response as ReplayResponseSer")?;
     match replay {
-        ReplayResponseSer::Advanceable { captured_writes } => {
-            Ok(AdvanceRequestSer { captured_writes })
-        }
+        ReplayResponseSer::Advanceable { captured_writes } => Ok(AdvanceRequestSer {
+            captured_writes,
+            persist_backtrace: true,
+        }),
         ReplayResponseSer::Finished { .. } => {
             bail!("execution is already finished")
         }
@@ -962,7 +985,10 @@ fn replay_to_advanceable_request(
                 eprintln!(
                     "Replay failed: {error}. Advancing with --force to persist execution failure."
                 );
-                Ok(AdvanceRequestSer { captured_writes })
+                Ok(AdvanceRequestSer {
+                    captured_writes,
+                    persist_backtrace: true,
+                })
             } else {
                 bail!(
                     "replay failed: {error}, {} captured writes available (use --force to advance with execution failure)",
@@ -1160,6 +1186,7 @@ mod tests {
         let delay_id = concepts::prefixed_ulid::DelayId::new(&execution_id, &delay_join_set_id);
         let child_execution_id = execution_id.next_level(&child_join_set_id);
         let mut advance_request = AdvanceRequestSer {
+            persist_backtrace: true,
             captured_writes: vec![
                 CapturedWriteSer::Append {
                     execution_id: execution_id.to_string(),

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -71,9 +71,9 @@ use directories::BaseDirs;
 use grpc::grpc_gen::{
     AdvanceExecutionRequest, CancelExecutionRequest, DeploymentId as GrpcDeploymentId,
     ExecutionId as GrpcExecutionId, GcOrphanFilesRequest, GetDeploymentRequest, GetFileRequest,
-    GetStatusRequest, ListComponentsRequest, ReplayExecutionRequest, RuntimeConfigCheck,
-    SubmitDeploymentRequest, SubmitRequest, SwitchDeploymentRequest,
-    cancel_execution_response::CancelExecutionOutcome,
+    GetStatusRequest, ListComponentsRequest, PersistExecutionBacktracesRequest,
+    ReplayExecutionRequest, RuntimeConfigCheck, SubmitDeploymentRequest, SubmitRequest,
+    SwitchDeploymentRequest, cancel_execution_response::CancelExecutionOutcome,
     deployment_repository_client::DeploymentRepositoryClient,
     execution_repository_client::ExecutionRepositoryClient,
     function_repository_client::FunctionRepositoryClient, switch_deployment_response::Outcome,
@@ -877,6 +877,22 @@ impl TestServer {
             .send()
             .await
             .expect("replay request failed")
+    }
+
+    async fn persist_backtraces(&self, execution_id: &str) -> u32 {
+        let mut client = ExecutionRepositoryClient::connect(format!("http://{}", self.api_addr()))
+            .await
+            .unwrap();
+        client
+            .persist_execution_backtraces(PersistExecutionBacktracesRequest {
+                execution_id: Some(GrpcExecutionId {
+                    id: execution_id.to_string(),
+                }),
+            })
+            .await
+            .unwrap()
+            .into_inner()
+            .persisted_backtrace_count
     }
 
     async fn list_functions(&self) -> Value {
@@ -1817,6 +1833,7 @@ impl TestServer {
                         id: exec_id.clone(),
                     }),
                     captured_writes,
+                    persist_backtrace: true,
                 })
                 .await
                 .unwrap()
@@ -1898,7 +1915,10 @@ impl TestServer {
                 .client
                 .put(format!("{}/v1/executions/{exec_id}/advance", self.base_url))
                 .header("Accept", "application/json")
-                .json(&json!({ "captured_writes": captured_writes }))
+                .json(&json!({
+                    "captured_writes": captured_writes,
+                    "persist_backtrace": true,
+                }))
                 .send()
                 .await
                 .expect("advance request failed");
@@ -3180,6 +3200,12 @@ async fn replaying_paused_workflow_should_return_preview_events(
         replay.captured_writes_len > 0,
         "captured_writes must not be empty for a paused workflow: {client:?}"
     );
+    assert_eq!(
+        server.persist_backtraces(&exec_id).await,
+        0,
+        "backtraces for replay-produced future events must be omitted"
+    );
+    assert_eq!(server.get_backtrace(&exec_id, None).await.status(), 404);
 
     server.shutdown().await;
 }
@@ -3963,16 +3989,40 @@ async fn backtrace_workflow_calling_activity() {
     let server = TestServer::start(test_addr!(35)).await;
     let exec_id = server.generate_execution_id().await;
 
-    // Run a workflow that calls a child activity — backtrace is captured at the join-set call site.
+    // Run a workflow that calls a child activity.
     let resp = server
         .submit_follow_with_id(
             &exec_id,
-            "testing:integration/workflow-add-via-activity.add-via-activity",
+            "testing:integration/workflow-call-activity.call-activity",
             vec![json!(3), json!(4)],
         )
         .await;
     assert_eq!(resp.status().as_u16(), 201);
     let _: Value = resp.json().await.unwrap(); // consume body
+
+    let resp = server.get_backtrace(&exec_id, None).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "regular execution must not persist backtraces"
+    );
+
+    let replay = server.replay(&exec_id).await;
+    assert_eq!(replay.status().as_u16(), 200);
+    let _: Value = replay.json().await.unwrap();
+    let resp = server.get_backtrace(&exec_id, None).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        404,
+        "replay must not persist backtraces"
+    );
+
+    assert!(server.persist_backtraces(&exec_id).await > 0);
+    assert_eq!(
+        server.persist_backtraces(&exec_id).await,
+        0,
+        "persisting the same backtraces again must be idempotent"
+    );
 
     // Default (last) filter.
     let resp = server.get_backtrace(&exec_id, None).await;
@@ -3990,6 +4040,12 @@ async fn backtrace_workflow_calling_activity() {
     assert!(
         body["version_max_excluding"].is_number(),
         "version_max_excluding must be a number"
+    );
+    assert_eq!(
+        body["version_max_excluding"].as_u64().unwrap()
+            - body["version_min_including"].as_u64().unwrap(),
+        3,
+        "a direct call backtrace must cover its three history events"
     );
     assert!(
         body["wasm_backtrace"]["frames"].is_array(),
@@ -4043,7 +4099,7 @@ async fn backtrace_source_workflow_calling_activity() {
     let server = TestServer::start(test_addr!(36)).await;
     let exec_id = server.generate_execution_id().await;
 
-    // Run the workflow to ensure it has an associated component digest in the backtrace table.
+    // Run and replay the workflow to populate lazy backtraces.
     let resp = server
         .submit_follow_with_id(
             &exec_id,
@@ -4053,6 +4109,7 @@ async fn backtrace_source_workflow_calling_activity() {
         .await;
     assert_eq!(resp.status().as_u16(), 201);
     let _: Value = resp.json().await.unwrap();
+    assert!(server.persist_backtraces(&exec_id).await > 0);
 
     // The deployment config registers "add_via_activity.js" as an exact-key source for this
     // workflow component.  The endpoint resolves source by component digest (from the backtrace)

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1019,7 +1019,6 @@ pub(crate) async fn deployment_verify_config(
         prepared_dirs.wasm_cache_dir.clone(),
         prepared_dirs.metadata_dir.clone(),
         params.runtime_config_availability,
-        server_verified.global_backtrace_persist,
         server_verified.global_executor_instance_limiter.clone(),
         server_verified.fuel,
         termination_watcher,
@@ -1760,7 +1759,7 @@ pub(crate) async fn run_internal(
         // Normally Axum blocks before this point until all clients are disconnected.
         debug!("Server {api_listening_addr} has been closed");
     } else {
-        info!("Obeliskg is ready");
+        info!("Obelisk is ready");
         let _: Result<_, _> = termination_watcher.changed().await;
         server_init.close().await;
     }
@@ -1785,7 +1784,6 @@ pub(crate) struct ServerVerified {
     allow_exec_activities: AllowExecActivities,
     http_servers: Vec<HttpServer>,
     fuel: Option<u64>,
-    global_backtrace_persist: bool,
     global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     database_subscription_interruption: Option<Duration>,
     api_addr_if_webui_enabled: Option<String>,
@@ -1829,7 +1827,6 @@ impl ServerVerified {
         let fuel: Option<u64> = config.wasm_global_config.fuel.into();
         let workflows_lock_extension_leeway =
             config.workflows_global_config.lock_extension_leeway.into();
-        let global_backtrace_persist = config.wasm_global_config.backtrace.persist;
         let build_semaphore = config.wasm_global_config.build_semaphore.into();
         let global_executor_instance_limiter = config
             .wasm_global_config
@@ -1852,7 +1849,6 @@ impl ServerVerified {
             allow_exec_activities: config.allow_exec_activities,
             http_servers,
             fuel,
-            global_backtrace_persist,
             global_executor_instance_limiter,
             database_subscription_interruption,
             api_addr_if_webui_enabled: if config.webui.enabled {
@@ -1907,7 +1903,6 @@ impl ServerCompiledLinked {
             webhooks_js_by_names,
             crons,
             http_servers_to_webhook_names,
-            global_backtrace_persist,
             fuel,
         } = deployment_verified;
         let linked = compile_and_link(
@@ -1922,7 +1917,6 @@ impl ServerCompiledLinked {
             webhooks_wasm_by_names,
             webhooks_js_by_names,
             crons,
-            global_backtrace_persist,
             fuel,
             server_verified.build_semaphore,
             server_verified.workflows_lock_extension_leeway,
@@ -3156,7 +3150,6 @@ pub(crate) struct DeploymentVerified {
     webhooks_js_by_names: IndexMap<ConfigName, WebhookJsConfigVerified>,
     crons: Vec<CronConfigVerified>,
     http_servers_to_webhook_names: Vec<(webhook::HttpServer, Vec<ConfigName>)>,
-    global_backtrace_persist: bool,
     fuel: Option<u64>,
 }
 
@@ -3280,7 +3273,6 @@ impl DeploymentVerified {
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
         runtime_config_availability: RuntimeConfigAvailability,
-        global_backtrace_persist: bool,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         termination_watcher: &mut watch::Receiver<()>,
@@ -3323,6 +3315,7 @@ impl DeploymentVerified {
                         value: target_url.clone(),
                     }],
                     backtrace: crate::config::toml::ComponentBacktraceConfigResolved::default(),
+                    backtrace_persist: false,
                     logs_store_min_level: LogLevelToml::Off,
                     allowed_hosts: vec![AllowedHostToml {
                         pattern: target_url,
@@ -3428,7 +3421,6 @@ impl DeploymentVerified {
                         .fetch_and_verify(
                             wasm_cache_dir.clone(),
                             metadata_dir.clone(),
-                            global_backtrace_persist,
                             global_executor_instance_limiter.clone(),
                             fuel,
                             subscription_interruption,
@@ -3621,7 +3613,6 @@ impl DeploymentVerified {
                     webhooks_js_by_names,
                     crons,
                     http_servers_to_webhook_names,
-                    global_backtrace_persist,
                     fuel
                 };
                 deployment_verified.validate_component_digests()?;
@@ -3675,7 +3666,6 @@ async fn compile_and_link(
     webhooks_wasm_by_names: IndexMap<ConfigName, WebhookWasmComponentConfigVerified>,
     webhooks_js_by_names: IndexMap<ConfigName, WebhookJsConfigVerified>,
     crons: Vec<CronConfigVerified>,
-    global_backtrace_persist: bool,
     fuel: Option<u64>,
     build_semaphore: Option<u64>,
     workflows_lock_extension_leeway: Duration,
@@ -3905,7 +3895,7 @@ async fn compile_and_link(
                                 forward_stderr: webhook.forward_stderr,
                                 env_vars: webhook.env_vars,
                                 fuel,
-                                backtrace_persist: global_backtrace_persist,
+                                backtrace_persist: webhook.backtrace_persist,
                                 subscription_interruption: webhook.subscription_interruption,
                                 logs_store_min_level: webhook.logs_store_min_level,
                                 allowed_hosts: webhook.allowed_hosts,
@@ -3946,7 +3936,7 @@ async fn compile_and_link(
                                 forward_stderr: webhook_js.forward_stderr,
                                 env_vars: webhook_js.env_vars,
                                 fuel,
-                                backtrace_persist: false,
+                                backtrace_persist: webhook_js.backtrace_persist,
                                 subscription_interruption: None,
                                 logs_store_min_level: webhook_js.logs_store_min_level,
                                 allowed_hosts: webhook_js.allowed_hosts,
@@ -4499,13 +4489,12 @@ fn prespawn_workflow_js(
     ))
 }
 
-/// Replay-purposed [`WorkflowConfig`]: Interrupt strategy, persisted backtraces, stubbed WASI,
-/// no lock extension, no subscription interruption, no fuel limit.
+/// Replay-purposed [`WorkflowConfig`]: Interrupt strategy, stubbed WASI, no lock
+/// extension, no subscription interruption, no fuel limit.
 fn replay_workflow_config(component_id: &ComponentId) -> WorkflowConfig {
     WorkflowConfig {
         component_id: component_id.clone(),
         join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
-        backtrace_persist: true,
         stub_wasi: true,
         fuel: None,
         lock_extension: None, // does not matter for the `Interrupt` strategy.
@@ -4516,7 +4505,7 @@ fn replay_workflow_config(component_id: &ComponentId) -> WorkflowConfig {
 struct WorkflowWorkerCompiledWithConfig {
     worker: WorkflowWorkerCompiled,
     workflows_lock_extension_leeway: Duration,
-    /// Replay-purposed compiled worker (Interrupt strategy, stubbed WASI, persisted backtraces).
+    /// Replay-purposed compiled worker (Interrupt strategy and stubbed WASI).
     /// Linked alongside the production worker; spawned into a long-lived [`ReplayWorker`].
     replay_compiled: WorkflowWorkerCompiled,
 }
@@ -5027,7 +5016,6 @@ mod tests {
             prepared_dirs.wasm_cache_dir.clone(),
             prepared_dirs.metadata_dir.clone(),
             params.runtime_config_availability,
-            server_verified.global_backtrace_persist,
             server_verified.global_executor_instance_limiter,
             server_verified.fuel,
             &mut termination_watcher,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -704,8 +704,6 @@ pub(crate) struct WasmGlobalConfigToml {
     #[serde(default)]
     pub(crate) codegen_cache: CodegenCache,
     #[serde(default)]
-    pub(crate) backtrace: WasmGlobalBacktrace,
-    #[serde(default)]
     cache_directory: Option<String>,
     #[serde(default)]
     pub(crate) allocator_config: WasmtimeAllocatorConfig,
@@ -728,7 +726,6 @@ impl Default for WasmGlobalConfigToml {
     fn default() -> Self {
         WasmGlobalConfigToml {
             codegen_cache: CodegenCache::default(),
-            backtrace: WasmGlobalBacktrace::default(),
             cache_directory: Option::default(),
             allocator_config: WasmtimeAllocatorConfig::default(),
             global_executor_instance_limiter: InflightSemaphore::default(),
@@ -757,21 +754,6 @@ impl WasmGlobalConfigToml {
         path_prefixes
             .server_config_replace_path_prefix_mkdir(wasm_directory)
             .await
-    }
-}
-
-#[derive(Debug, Deserialize, JsonSchema, Clone)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct WasmGlobalBacktrace {
-    #[serde(default = "default_global_backtrace_persist")]
-    pub(crate) persist: bool,
-}
-
-impl Default for WasmGlobalBacktrace {
-    fn default() -> Self {
-        Self {
-            persist: default_global_backtrace_persist(),
-        }
     }
 }
 
@@ -2202,7 +2184,6 @@ pub(crate) trait WorkflowWasmComponentConfigResolvedExt {
         self,
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
-        global_backtrace_persist: bool,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
@@ -2215,7 +2196,6 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
         self,
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
-        global_backtrace_persist: bool,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
@@ -2253,7 +2233,6 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
         let workflow_config = WorkflowConfig {
             component_id: component_id.clone(),
             join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
-            backtrace_persist: global_backtrace_persist,
             stub_wasi: self.stub_wasi,
             fuel,
             lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
@@ -2350,7 +2329,6 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
         let workflow_config = WorkflowConfig {
             component_id: component_id.clone(),
             join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
-            backtrace_persist: false,
             stub_wasi: false,
             fuel: None,
             lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
@@ -2469,6 +2447,7 @@ async fn resolve_local_refs_to_canonical(
             env_vars: w.env_vars,
             backtrace: resolve_backtrace_to_canonical(&w.backtrace, &deployment_dir, provider)
                 .await?,
+            backtrace_persist: w.backtrace_persist,
             logs_store_min_level: w.logs_store_min_level,
             allowed_hosts: w.allowed_hosts,
         });
@@ -2494,6 +2473,7 @@ async fn resolve_local_refs_to_canonical(
             forward_stderr: w.forward_stderr,
             logs_store_min_level: w.logs_store_min_level,
             env_vars: w.env_vars,
+            backtrace_persist: w.backtrace_persist,
             allowed_hosts: w.allowed_hosts,
         });
     }
@@ -3091,6 +3071,9 @@ pub(crate) mod webhook {
         pub(crate) env_vars: Vec<EnvVarConfig>,
         #[serde(default)]
         pub(crate) backtrace: ComponentBacktraceConfig,
+        /// Capture and persist backtraces for requests handled by this webhook.
+        #[serde(default)]
+        pub(crate) backtrace_persist: bool,
         #[serde(default)]
         pub(crate) logs_store_min_level: LogLevelToml,
         /// Allowed outgoing HTTP hosts with optional method restrictions and secrets.
@@ -3107,6 +3090,7 @@ pub(crate) mod webhook {
         pub(crate) forward_stderr: Option<StdOutputConfig>,
         pub(crate) env_vars: Arc<[EnvVar]>,
         pub(crate) frame_files_to_sources: FrameFilesToSourceContent,
+        pub(crate) backtrace_persist: bool,
         pub(crate) subscription_interruption: Option<Duration>,
         pub(crate) logs_store_min_level: Option<LogLevel>,
         pub(crate) allowed_hosts: Arc<[AllowedHostConfig]>,
@@ -3172,6 +3156,9 @@ pub(crate) mod webhook {
         pub(crate) logs_store_min_level: LogLevelToml,
         #[serde(default)]
         pub(crate) env_vars: Vec<EnvVarConfig>,
+        /// Capture and persist backtraces for requests handled by this webhook.
+        #[serde(default)]
+        pub(crate) backtrace_persist: bool,
         /// Allowed outgoing HTTP hosts with optional method restrictions and secrets.
         #[serde(default, rename = "allowed_host")]
         pub(crate) allowed_hosts: Vec<AllowedHostToml>,
@@ -3187,6 +3174,7 @@ pub(crate) mod webhook {
         pub(crate) forward_stdout: Option<StdOutputConfig>,
         pub(crate) forward_stderr: Option<StdOutputConfig>,
         pub(crate) env_vars: Arc<[EnvVar]>,
+        pub(crate) backtrace_persist: bool,
         pub(crate) logs_store_min_level: Option<LogLevel>,
         pub(crate) allowed_hosts: Arc<[AllowedHostConfig]>,
         /// The TOML config section type for error messages
@@ -3249,6 +3237,7 @@ pub(crate) mod webhook {
                     forward_stderr: self.forward_stderr.into_std_output_config(),
                     env_vars,
                     frame_files_to_sources,
+                    backtrace_persist: self.backtrace_persist,
                     subscription_interruption,
                     logs_store_min_level: self.logs_store_min_level.into_log_level(),
                     allowed_hosts,
@@ -3309,6 +3298,7 @@ pub(crate) mod webhook {
                     forward_stdout: self.forward_stdout.into_std_output_config(),
                     forward_stderr: self.forward_stderr.into_std_output_config(),
                     env_vars,
+                    backtrace_persist: self.backtrace_persist,
                     logs_store_min_level: self.logs_store_min_level.into_log_level(),
                     allowed_hosts,
                     config_section_hint: ConfigSectionHint::WebhookEndpointJs,
@@ -3594,10 +3584,6 @@ const fn default_parallel_compilation() -> bool {
 const fn default_debug() -> bool {
     false
 }
-const fn default_global_backtrace_persist() -> bool {
-    true
-}
-
 const fn default_codegen_enabled() -> bool {
     true
 }

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -79,7 +79,6 @@ use tracing::info_span;
 use tracing::instrument;
 use val_json::wast_val_ser::deserialize_slice;
 use wasm_workers::activity::cancel_registry::CancelRegistry;
-use wasm_workers::registry::ReplayWorker;
 use wasm_workers::workflow::workflow_worker::{AdvanceError, ReplayAdvanceable, ReplayResponse};
 
 pub(crate) struct GrpcServer {
@@ -899,10 +898,8 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 ))
             })?;
 
-        let replay_res = match replay_worker {
-            ReplayWorker::Js(worker) => worker.replay(execution_id.clone()).await,
-            ReplayWorker::Wasm(worker) => worker.replay(execution_id.clone()).await,
-        };
+        // Always capture backtrace so that advance can persist it
+        let replay_res = replay_worker.replay(execution_id.clone(), true).await;
         let outcome = match replay_res {
             Ok(ReplayResponse::Advanceable(replay)) => {
                 grpc_gen::replay_execution_response::Outcome::Advanceable(
@@ -948,6 +945,70 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
         Ok(tonic::Response::new(grpc_gen::ReplayExecutionResponse {
             outcome: Some(outcome),
         }))
+    }
+
+    #[instrument(skip_all, fields(execution_id))]
+    async fn persist_execution_backtraces(
+        &self,
+        request: tonic::Request<grpc_gen::PersistExecutionBacktracesRequest>,
+    ) -> Result<tonic::Response<grpc_gen::PersistExecutionBacktracesResponse>, tonic::Status> {
+        let execution_id: ExecutionId = request
+            .into_inner()
+            .execution_id
+            .argument_must_exist("execution_id")?
+            .try_into()?;
+        tracing::Span::current().record("execution_id", tracing::field::display(&execution_id));
+        let (component_registry_ro, replay_workers) = {
+            let ctx = self.deployment_ctx.read().await;
+            (
+                ctx.component_registry_ro.clone(),
+                ctx.replay_workers.clone(),
+            )
+        };
+        let conn = self.db_pool.connection().await.map_err(map_to_status)?;
+        let create_req = conn.get_create_request(&execution_id).await.to_status()?;
+        let (component_id, _fn_metadata) = component_registry_ro
+            .find_by_exported_ffqn_submittable(&create_req.ffqn)
+            .ok_or_else(|| {
+                tonic::Status::not_found(format!(
+                    "component for function '{}' not found",
+                    create_req.ffqn
+                ))
+            })?;
+        let (_component_id, replay_worker) = replay_workers
+            .get(&component_id.component_digest)
+            .ok_or_else(|| {
+                tonic::Status::not_found(format!(
+                    "replay worker for component '{component_id}' not found"
+                ))
+            })?;
+
+        let captured_backtraces = match replay_worker.capture_backtraces(execution_id.clone()).await
+        {
+            Ok(backtraces) => backtraces,
+            Err(err) => {
+                return Err(tonic::Status::internal(format!("replay error: {err}")));
+            }
+        };
+
+        let persisted_next_version = conn.get(&execution_id).await.to_status()?.next_version;
+        let backtraces: Vec<_> = captured_backtraces
+            .into_iter()
+            .filter(|backtrace| {
+                backtrace.execution_id == execution_id
+                    && backtrace.version_max_excluding <= persisted_next_version
+            })
+            .collect();
+        let persisted_backtrace_count =
+            conn.append_backtrace_batch(backtraces).await.to_status()?;
+        let persisted_backtrace_count = u32::try_from(persisted_backtrace_count)
+            .map_err(|_| tonic::Status::resource_exhausted("too many backtraces persisted"))?;
+
+        Ok(tonic::Response::new(
+            grpc_gen::PersistExecutionBacktracesResponse {
+                persisted_backtrace_count,
+            },
+        ))
     }
 
     #[instrument(skip_all, fields(execution_id))]
@@ -1001,10 +1062,9 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 .collect::<Result<Vec<_>, _>>()?,
         };
 
-        let advance_res = match replay_worker {
-            ReplayWorker::Js(worker) => worker.advance(execution_id.clone(), expected).await,
-            ReplayWorker::Wasm(worker) => worker.advance(execution_id.clone(), expected).await,
-        };
+        let advance_res = replay_worker
+            .advance(execution_id.clone(), expected, request.persist_backtrace)
+            .await;
 
         let result = match advance_res {
             Ok(advance_response) => grpc_gen::advance_execution_response::Result::Success(
@@ -1079,10 +1139,8 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             let (_component_id, replay_worker) = replay_workers.get(&new).ok_or_else(|| {
                 tonic::Status::not_found(format!("new component '{new}' not found in registry"))
             })?;
-            let replay_res = match replay_worker {
-                ReplayWorker::Js(worker) => worker.replay(execution_id.clone()).await,
-                ReplayWorker::Wasm(worker) => worker.replay(execution_id.clone()).await,
-            };
+            // no backtrace capture on upgrade
+            let replay_res = replay_worker.replay(execution_id.clone(), false).await;
             if let Err(err) = replay_res {
                 info!("Replay failed: {err:?}");
                 return Err(tonic::Status::internal(format!("replay failed: {err}")));

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1933,6 +1933,9 @@ impl From<wasm_workers::workflow::workflow_worker::ReplayResponse> for ReplayRes
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub(crate) struct AdvanceRequestSer {
     pub(crate) captured_writes: Vec<CapturedWriteSer>,
+    /// Capture and persist call-site backtraces while advancing.
+    #[serde(default)]
+    pub(crate) persist_backtrace: bool,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -2313,10 +2316,13 @@ async fn execution_advance(
         ));
     }
 
-    let advance_res = match &replay_worker {
-        ReplayWorker::Js(worker) => worker.advance(execution_id.clone(), captured_writes).await,
-        ReplayWorker::Wasm(worker) => worker.advance(execution_id.clone(), captured_writes).await,
-    };
+    let advance_res = replay_worker
+        .advance(
+            execution_id.clone(),
+            captured_writes,
+            payload.persist_backtrace,
+        )
+        .await;
 
     let advance_response = match advance_res {
         Ok(ok) => ok,
@@ -2463,10 +2469,8 @@ async fn replay_execution_internal(
             }
         };
 
-    let replay_res = match &replay_worker {
-        ReplayWorker::Js(worker) => worker.replay(execution_id.clone()).await,
-        ReplayWorker::Wasm(worker) => worker.replay(execution_id.clone()).await,
-    };
+    // Always capture backtrace so that advance can persist it
+    let replay_res = replay_worker.replay(execution_id.clone(), true).await;
     match replay_res {
         Ok(response) => Ok(ReplayResponseSer::from(response)),
         Err(err) => map_replay_err(err),
@@ -2517,10 +2521,8 @@ async fn execution_upgrade(
         let (_component_id, replay_worker) = replay_workers
             .get(&payload.new)
             .ok_or_else(|| HttpResponse::not_found(accept, Some("new component")))?;
-        let replay_res = match replay_worker {
-            ReplayWorker::Js(worker) => worker.replay(execution_id.clone()).await,
-            ReplayWorker::Wasm(worker) => worker.replay(execution_id.clone()).await,
-        };
+        // no backtrace capture on upgrade
+        let replay_res = replay_worker.replay(execution_id.clone(), false).await;
         if let Err(err) = replay_res {
             info!("Replay failed: {err:?}");
             return Err(HttpResponse {


### PR DESCRIPTION
Add the PersistExecutionBacktraces RPC and the execution persist-backtraces CLI command for idempotently persisting captured call-site backtraces.
