### PR TITLE
persist backtrace web api

### DIFF
--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -848,6 +848,44 @@
         }
       }
     },
+    "/v1/executions/{execution_id}/backtrace/persist": {
+      "put": {
+        "tags": [
+          "executions"
+        ],
+        "summary": "Replay an execution and persist its call-site backtraces (idempotent).",
+        "operationId": "execution_persist_backtraces",
+        "parameters": [
+          {
+            "name": "execution_id",
+            "in": "path",
+            "description": "Execution ID whose backtraces to persist",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Backtraces persisted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersistBacktracesResponseSer"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Replay failed"
+          }
+        }
+      }
+    },
     "/v1/executions/{execution_id}/backtrace/source": {
       "get": {
         "tags": [
@@ -2677,6 +2715,20 @@
           "wit_type": {
             "type": "string",
             "description": "WIT type representation"
+          }
+        }
+      },
+      "PersistBacktracesResponseSer": {
+        "type": "object",
+        "required": [
+          "persisted_backtrace_count"
+        ],
+        "properties": {
+          "persisted_backtrace_count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of newly persisted backtraces (already-persisted ones are skipped).",
+            "minimum": 0
           }
         }
       },

--- a/crates/wasm-workers/src/registry.rs
+++ b/crates/wasm-workers/src/registry.rs
@@ -15,7 +15,6 @@ use concepts::IfcFqnName;
 use concepts::PackageIfcFns;
 use concepts::StrVariant;
 use concepts::component_id::ComponentDigest;
-use concepts::storage::BacktraceInfo;
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use std::fmt::Debug;
@@ -72,13 +71,13 @@ impl ReplayWorker {
         }
     }
 
-    pub async fn capture_backtraces(
+    pub async fn persist_backtraces(
         &self,
         execution_id: ExecutionId,
-    ) -> Result<Vec<BacktraceInfo>, ReplayError> {
+    ) -> Result<usize, ReplayError> {
         match self {
-            Self::Wasm(worker) => worker.capture_backtraces(execution_id).await,
-            Self::Js(worker) => worker.capture_backtraces(execution_id).await,
+            Self::Wasm(worker) => worker.persist_backtraces(execution_id).await,
+            Self::Js(worker) => worker.persist_backtraces(execution_id).await,
         }
     }
 

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -198,6 +198,34 @@ impl WorkflowJsWorker {
         Ok(WorkflowWorker::collect_write_backtraces(writes, backtraces))
     }
 
+    /// See [`WorkflowWorker::persist_backtraces`].
+    pub async fn persist_backtraces(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<usize, ReplayError> {
+        let captured = self.capture_backtraces(execution_id.clone()).await?;
+        let db_conn = self
+            .inner
+            .db_pool
+            .connection()
+            .await
+            .map_err(concepts::storage::DbErrorWrite::from)?;
+        let next_version = db_conn
+            .get(&execution_id)
+            .await
+            .map_err(concepts::storage::DbErrorWrite::from)?
+            .next_version;
+        Ok(
+            WorkflowWorker::trim_and_persist_backtraces(
+                db_conn.as_ref(),
+                &execution_id,
+                &next_version,
+                captured,
+            )
+            .await?,
+        )
+    }
+
     fn boa_invocation(
         params: &Params,
         js_source: String,

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -215,15 +215,13 @@ impl WorkflowJsWorker {
             .await
             .map_err(concepts::storage::DbErrorWrite::from)?
             .next_version;
-        Ok(
-            WorkflowWorker::trim_and_persist_backtraces(
-                db_conn.as_ref(),
-                &execution_id,
-                &next_version,
-                captured,
-            )
-            .await?,
+        Ok(WorkflowWorker::trim_and_persist_backtraces(
+            db_conn.as_ref(),
+            &execution_id,
+            &next_version,
+            captured,
         )
+        .await?)
     }
 
     fn boa_invocation(

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1231,6 +1231,41 @@ impl WorkflowWorker {
         Ok(Self::collect_write_backtraces(writes, backtraces))
     }
 
+    /// Replay the execution and persist the captured backtraces, returning how many were stored.
+    /// Backtraces keyed to a future (not-yet-written) log entry are trimmed, so a stub's
+    /// display-only backtrace (keyed to its future `HistoryEvent::Stub`) is never persisted.
+    #[instrument(skip_all, fields(%execution_id))]
+    pub async fn persist_backtraces(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<usize, ReplayError> {
+        let captured = self.capture_backtraces(execution_id.clone()).await?;
+        let db_conn = self.db_pool.connection().await.map_err(DbErrorWrite::from)?;
+        let next_version = db_conn
+            .get(&execution_id)
+            .await
+            .map_err(DbErrorWrite::from)?
+            .next_version;
+        Ok(Self::trim_and_persist_backtraces(db_conn.as_ref(), &execution_id, &next_version, captured).await?)
+    }
+
+    /// Keep only backtraces whose range lies fully within the already-written log
+    /// (`version_max_excluding <= next_version`) for this execution, then persist them.
+    pub(crate) async fn trim_and_persist_backtraces(
+        db_conn: &dyn DbConnection,
+        execution_id: &ExecutionId,
+        next_version: &Version,
+        captured: Vec<BacktraceInfo>,
+    ) -> Result<usize, DbErrorWrite> {
+        let persistable = captured
+            .into_iter()
+            .filter(|bt| {
+                bt.execution_id == *execution_id && bt.version_max_excluding <= *next_version
+            })
+            .collect();
+        db_conn.append_backtrace_batch(persistable).await
+    }
+
     #[instrument(skip_all, fields(%execution_id))]
     pub async fn replay(
         &self,

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1240,13 +1240,23 @@ impl WorkflowWorker {
         execution_id: ExecutionId,
     ) -> Result<usize, ReplayError> {
         let captured = self.capture_backtraces(execution_id.clone()).await?;
-        let db_conn = self.db_pool.connection().await.map_err(DbErrorWrite::from)?;
+        let db_conn = self
+            .db_pool
+            .connection()
+            .await
+            .map_err(DbErrorWrite::from)?;
         let next_version = db_conn
             .get(&execution_id)
             .await
             .map_err(DbErrorWrite::from)?
             .next_version;
-        Ok(Self::trim_and_persist_backtraces(db_conn.as_ref(), &execution_id, &next_version, captured).await?)
+        Ok(Self::trim_and_persist_backtraces(
+            db_conn.as_ref(),
+            &execution_id,
+            &next_version,
+            captured,
+        )
+        .await?)
     }
 
     /// Keep only backtraces whose range lies fully within the already-written log

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -71,7 +71,7 @@ use directories::BaseDirs;
 use grpc::grpc_gen::{
     AdvanceExecutionRequest, CancelExecutionRequest, DeploymentId as GrpcDeploymentId,
     ExecutionId as GrpcExecutionId, GcOrphanFilesRequest, GetDeploymentRequest, GetFileRequest,
-    GetStatusRequest, ListComponentsRequest, PersistExecutionBacktracesRequest,
+    GetStatusRequest, ListComponentsRequest,
     ReplayExecutionRequest, RuntimeConfigCheck, SubmitDeploymentRequest, SubmitRequest,
     SwitchDeploymentRequest, cancel_execution_response::CancelExecutionOutcome,
     deployment_repository_client::DeploymentRepositoryClient,
@@ -880,19 +880,24 @@ impl TestServer {
     }
 
     async fn persist_backtraces(&self, execution_id: &str) -> u32 {
-        let mut client = ExecutionRepositoryClient::connect(format!("http://{}", self.api_addr()))
+        let body: Value = self
+            .client
+            .put(format!(
+                "{}/v1/executions/{execution_id}/backtrace/persist",
+                self.base_url
+            ))
+            .header("Accept", "application/json")
+            .send()
             .await
-            .unwrap();
-        client
-            .persist_execution_backtraces(PersistExecutionBacktracesRequest {
-                execution_id: Some(GrpcExecutionId {
-                    id: execution_id.to_string(),
-                }),
-            })
+            .expect("persist-backtraces request failed")
+            .json()
             .await
-            .unwrap()
-            .into_inner()
-            .persisted_backtrace_count
+            .expect("persist-backtraces parse failed");
+        body["persisted_backtrace_count"]
+            .as_u64()
+            .expect("persisted_backtrace_count must be a number")
+            .try_into()
+            .expect("persisted_backtrace_count must fit u32")
     }
 
     async fn list_functions(&self) -> Value {

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -71,9 +71,9 @@ use directories::BaseDirs;
 use grpc::grpc_gen::{
     AdvanceExecutionRequest, CancelExecutionRequest, DeploymentId as GrpcDeploymentId,
     ExecutionId as GrpcExecutionId, GcOrphanFilesRequest, GetDeploymentRequest, GetFileRequest,
-    GetStatusRequest, ListComponentsRequest,
-    ReplayExecutionRequest, RuntimeConfigCheck, SubmitDeploymentRequest, SubmitRequest,
-    SwitchDeploymentRequest, cancel_execution_response::CancelExecutionOutcome,
+    GetStatusRequest, ListComponentsRequest, ReplayExecutionRequest, RuntimeConfigCheck,
+    SubmitDeploymentRequest, SubmitRequest, SwitchDeploymentRequest,
+    cancel_execution_response::CancelExecutionOutcome,
     deployment_repository_client::DeploymentRepositoryClient,
     execution_repository_client::ExecutionRepositoryClient,
     function_repository_client::FunctionRepositoryClient, switch_deployment_response::Outcome,

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -983,24 +983,13 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 ))
             })?;
 
-        let captured_backtraces = match replay_worker.capture_backtraces(execution_id.clone()).await
-        {
-            Ok(backtraces) => backtraces,
-            Err(err) => {
-                return Err(tonic::Status::internal(format!("replay error: {err}")));
-            }
-        };
-
-        let persisted_next_version = conn.get(&execution_id).await.to_status()?.next_version;
-        let backtraces: Vec<_> = captured_backtraces
-            .into_iter()
-            .filter(|backtrace| {
-                backtrace.execution_id == execution_id
-                    && backtrace.version_max_excluding <= persisted_next_version
-            })
-            .collect();
         let persisted_backtrace_count =
-            conn.append_backtrace_batch(backtraces).await.to_status()?;
+            match replay_worker.persist_backtraces(execution_id.clone()).await {
+                Ok(count) => count,
+                Err(err) => {
+                    return Err(tonic::Status::internal(format!("replay error: {err}")));
+                }
+            };
         let persisted_backtrace_count = u32::try_from(persisted_backtrace_count)
             .map_err(|_| tonic::Status::resource_exhausted("too many backtraces persisted"))?;
 

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -98,6 +98,7 @@ pub(crate) struct WebApiState {
         execution_submit_post,
         execution_replay,
         execution_advance,
+        execution_persist_backtraces,
         execution_upgrade,
         backtrace::execution_backtrace,
         backtrace::execution_backtrace_source,
@@ -123,6 +124,7 @@ pub(crate) struct WebApiState {
         ReplayResponseSer,
         AdvanceRequestSer,
         AdvanceResponseSer,
+        PersistBacktracesResponseSer,
         ExecutionSubmitPayload,
         ExecutionUpgradePayload,
         logs::LogEntryRowSer,
@@ -213,6 +215,10 @@ fn v1_router() -> Router<Arc<WebApiState>> {
         .route(
             "/executions/{execution-id}/advance",
             routing::put(execution_advance),
+        )
+        .route(
+            "/executions/{execution-id}/backtrace/persist",
+            routing::put(execution_persist_backtraces),
         )
         .route(
             "/executions/{execution-id}/responses",
@@ -1958,6 +1964,12 @@ enum AdvanceErrorSer {
     Transient(String),
 }
 
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct PersistBacktracesResponseSer {
+    /// Number of newly persisted backtraces (already-persisted ones are skipped).
+    pub(crate) persisted_backtrace_count: u32,
+}
+
 /// Get execution return value
 #[utoipa::path(
     get,
@@ -2396,6 +2408,53 @@ async fn execution_advance(
             }
         }),
     }
+}
+
+/// Replay an execution and persist its call-site backtraces (idempotent).
+#[utoipa::path(
+    put,
+    path = "/v1/executions/{execution_id}/backtrace/persist",
+    tag = "executions",
+    params(
+        ("execution_id" = String, Path, description = "Execution ID whose backtraces to persist")
+    ),
+    responses(
+        (status = 200, description = "Backtraces persisted", body = PersistBacktracesResponseSer),
+        (status = 404, description = "Not found"),
+        (status = 422, description = "Replay failed")
+    )
+)]
+#[instrument(skip_all, fields(execution_id))]
+async fn execution_persist_backtraces(
+    Path(execution_id): Path<ExecutionId>,
+    state: State<Arc<WebApiState>>,
+    accept: AcceptHeader,
+) -> Result<Response, HttpResponse> {
+    let replay_worker = get_replay_target(&state, &execution_id, accept).await?;
+    let persisted_backtrace_count = replay_worker
+        .persist_backtraces(execution_id.clone())
+        .await
+        .map_err(|err| HttpResponse {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            message: format!("Replay error: {err}"),
+            accept,
+        })?;
+    let persisted_backtrace_count = u32::try_from(persisted_backtrace_count).map_err(|_| {
+        HttpResponse {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: "too many backtraces persisted".to_string(),
+            accept,
+        }
+    })?;
+    let ser = PersistBacktracesResponseSer {
+        persisted_backtrace_count,
+    };
+    Ok(match accept {
+        AcceptHeader::Json => pretty_json_response(StatusCode::OK, &ser),
+        AcceptHeader::Text => {
+            format!("persisted {persisted_backtrace_count} backtraces").into_response()
+        }
+    })
 }
 
 async fn get_replay_target(

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -2439,13 +2439,12 @@ async fn execution_persist_backtraces(
             message: format!("Replay error: {err}"),
             accept,
         })?;
-    let persisted_backtrace_count = u32::try_from(persisted_backtrace_count).map_err(|_| {
-        HttpResponse {
+    let persisted_backtrace_count =
+        u32::try_from(persisted_backtrace_count).map_err(|_| HttpResponse {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             message: "too many backtraces persisted".to_string(),
             accept,
-        }
-    })?;
+        })?;
     let ser = PersistBacktracesResponseSer {
         persisted_backtrace_count,
     };


### PR DESCRIPTION
- **refactor(workflow): persist backtraces in the worker, trimming future entries**
- **feat(web-api): add persist-backtraces endpoint**
- **style: Formatting**
