### PR TITLE
Correct the version for CapturedWrite::AppendStubResponse's backtrace

### DIFF
--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -751,7 +751,7 @@
         "tags": [
           "executions"
         ],
-        "summary": "Advance a paused execution using replay-captured writes.",
+        "summary": "Advance a paused execution by applying captured writes from a prior replay; set `persist_backtrace` to persist fresh backtraces.",
         "operationId": "execution_advance",
         "parameters": [
           {
@@ -1222,7 +1222,7 @@
         "tags": [
           "executions"
         ],
-        "summary": "Replay an execution (re-run from execution log)",
+        "summary": "Replay an execution. An advanceable (unfinished and unblocked) execution produces captured writes for the advance endpoint; backtraces on captured writes are display-only.",
         "operationId": "execution_replay",
         "parameters": [
           {
@@ -1649,7 +1649,7 @@
           },
           "persist_backtrace": {
             "type": "boolean",
-            "description": "Capture and persist call-site backtraces while advancing."
+            "description": "Capture and persist fresh call-site backtraces while advancing."
           }
         }
       },
@@ -1921,7 +1921,7 @@
             }
           }
         ],
-        "description": "A serializable captured database write operation."
+        "description": "A write captured during replay, produced by the replay endpoint and applied by the advance endpoint."
       },
       "ComponentConfig": {
         "type": "object",

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -82,7 +82,7 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite>;
 
-    #[expect(clippy::too_many_arguments)]
+    // `stub_backtrace` is display-only, keyed to the parent's future stub-event version so persist skips it.
     async fn upsert_stub_response(
         &mut self,
         execution_id: ExecutionIdDerived,
@@ -90,8 +90,7 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
         req: AppendRequest,
         response: AppendResponseToExecution,
         current_time: DateTime<Utc>,
-        wasm_backtrace: Option<storage::WasmBacktrace>,
-        component_id: &ComponentId,
+        stub_backtrace: Option<BacktraceInfo>,
     ) -> Result<(), UpsertStubOrReplayInterrupt>;
 
     // Part of writing stub response: start with this read, then attempt to write the response in `EventHistory::append_to_db_non_blocking`.
@@ -442,8 +441,7 @@ impl WorkflowDbConnection for CachingDbConnection {
         req: AppendRequest,
         response: AppendResponseToExecution,
         current_time: DateTime<Utc>,
-        _wasm_backtrace: Option<storage::WasmBacktrace>,
-        _component_id: &ComponentId,
+        _stub_backtrace: Option<BacktraceInfo>,
     ) -> Result<(), UpsertStubOrReplayInterrupt> {
         // This write bypasses the cache (it must return the conflict result
         // immediately), so flush first to keep it ordered after any buffered write.

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -1636,6 +1636,15 @@ impl EventHistory {
                                 http_client_traces: None,
                             },
                         };
+                        // Display-only backtrace keyed to the parent's stub-event version (`version`), where the HistoryEvent::Stub below lands.
+                        let stub_backtrace =
+                            wasm_backtrace.clone().map(|wasm_backtrace| BacktraceInfo {
+                                execution_id: db_connection.execution_id().clone(),
+                                component_id: self.locked_event.component_id.clone(),
+                                version_min_including: version.clone(),
+                                version_max_excluding: Version::new(version.0 + 1),
+                                wasm_backtrace,
+                            });
                         let result = match db_connection
                             .upsert_stub_response(
                                 params.target_execution_id.clone(),
@@ -1650,8 +1659,7 @@ impl EventHistory {
                                     result: retval_intent.clone(),
                                 },
                                 called_at,
-                                wasm_backtrace.clone(),
-                                &self.locked_event.component_id,
+                                stub_backtrace,
                             )
                             .await
                         {

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -643,8 +643,7 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         req: AppendRequest,
         response: AppendResponseToExecution,
         current_time: DateTime<Utc>,
-        wasm_backtrace: Option<storage::WasmBacktrace>,
-        component_id: &ComponentId,
+        stub_backtrace: Option<BacktraceInfo>,
     ) -> Result<(), UpsertStubOrReplayInterrupt> {
         let execution_id = ExecutionId::Derived(execution_id);
         // Query the database first.
@@ -672,14 +671,6 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
             }
         }
 
-        let next = next_version(&version, 1);
-        let backtraces = make_backtrace(
-            &self.execution_id,
-            component_id,
-            &version,
-            &next,
-            wasm_backtrace,
-        );
         self.collector
             .push_write(CapturedDbWrite::AppendStubResponse {
                 events: AppendEventsToExecution {
@@ -689,7 +680,8 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
                 },
                 response,
                 current_time,
-                backtraces,
+                // Display-only; the caller keys it to the parent's stub-event version, not `version` (the child's).
+                backtraces: stub_backtrace.into_iter().collect(),
             });
         // no idea about the response
         Err(UpsertStubOrReplayInterrupt::ReplayInterrupt)

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -3673,6 +3673,112 @@ mod tests {
         db_close.close().await;
     }
 
+    /// The stub call site backtrace must be keyed to the parent's future `HistoryEvent::Stub`
+    /// version, not the stub child's `1..2` domain, so `persist_execution_backtraces` skips it while
+    /// the event is unpersisted instead of storing it against the parent.
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn capture_backtraces_keys_stub_to_future_history_event(database: Database) {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+
+        let js_source = r"
+        export default function call_stub() {
+            const js = obelisk.createJoinSet();
+            const execId = js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            obelisk.stub(execId, { 'ok': 'hello' });
+            return js.joinNext();
+        }";
+
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "call-stub");
+        let sim_clock = SimClock::epoch();
+
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+
+        let (_worker, component_id, runnable_component) = compile_js_workflow_worker(
+            js_source,
+            &user_ffqn,
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            fn_registry.clone(),
+            workflow_engine.clone(),
+        );
+
+        let db_connection = db_pool.connection_test().await.unwrap();
+        let execution_id = ExecutionId::from_parts(0, 0);
+        db_connection
+            .create(CreateRequest {
+                created_at: sim_clock.now(),
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn.clone(),
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: sim_clock.now(),
+                component_id: component_id.clone(),
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: true,
+            })
+            .await
+            .unwrap();
+
+        let (log_sender, _log_recv) = mpsc::channel(100);
+        let replay_worker = build_js_replay_worker(
+            DeploymentId::from_parts(0, 0),
+            component_id,
+            &runnable_component,
+            workflow_engine,
+            fn_registry,
+            db_pool.clone(),
+            Some(LogStrageConfig {
+                min_level: concepts::storage::LogLevel::Debug,
+                log_sender,
+            }),
+            sim_clock.clone_box(),
+            js_source.to_string(),
+            default_return_type(),
+        );
+
+        // The paused workflow has not executed, so every backtrace the replay captures belongs to a
+        // future log entry (at or after `next_version`), including the stub's display backtrace.
+        let next_version = db_connection.get(&execution_id).await.unwrap().next_version;
+        let captured = replay_worker
+            .capture_backtraces(execution_id.clone())
+            .await
+            .unwrap();
+        assert!(!captured.is_empty(), "replay must capture backtraces");
+        assert!(
+            captured
+                .iter()
+                .all(|bt| bt.version_min_including >= next_version),
+            "paused workflow: every captured backtrace targets a future log entry",
+        );
+
+        // Persisting must trim those future backtraces. The stub used to key its backtrace to the
+        // child's `1..2` range, which persist would treat as already-written and store against the
+        // parent; the fix keys it to the future `HistoryEvent::Stub`, so nothing is persisted here.
+        let persisted = replay_worker
+            .persist_backtraces(execution_id.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            persisted, 0,
+            "future backtraces must be trimmed, not persisted"
+        );
+
+        drop(db_connection);
+        db_close.close().await;
+    }
+
     #[expand_enum_database]
     #[rstest]
     #[case::full(None, "submit_cancel_full", 10)]

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -29,6 +29,8 @@ service ExecutionRepository {
     rpc CancelDelay(CancelDelayRequest) returns (CancelDelayResponse);
     rpc ListLogs(ListLogsRequest) returns (ListLogsResponse);
 
+    // Replays the execution. An advancable (unfinished and unblocked) execution produces captured writes that can be passed to the AdvanceExecution RPC.
+    // Backtraces on captured writes are display-only.
     rpc ReplayExecution(ReplayExecutionRequest) returns (ReplayExecutionResponse);
     rpc PersistExecutionBacktraces(PersistExecutionBacktracesRequest) returns (PersistExecutionBacktracesResponse);
     rpc AdvanceExecution(AdvanceExecutionRequest) returns (AdvanceExecutionResponse);
@@ -777,6 +779,7 @@ message WasmBacktrace {
     uint32 version_max_excluding = 3;
 }
 
+// Display-only call-site backtrace attached to a captured write.
 message CapturedBacktrace {
     ExecutionId execution_id = 1;
     ComponentId component_id = 2;
@@ -854,7 +857,7 @@ message ReplayExecutionRequest {
   ExecutionId execution_id = 1;
 }
 
-// A database write operation captured during replay.
+// A write captured during replay, produced by ReplayExecution and applied by AdvanceExecution.
 message CapturedWrite {
   message Append {
     ExecutionId execution_id = 1;
@@ -957,7 +960,7 @@ message PersistExecutionBacktracesResponse {
 message AdvanceExecutionRequest {
   ExecutionId execution_id = 1;
   repeated CapturedWrite captured_writes = 2;
-  // Capture and persist call-site backtraces while verifying and applying the writes.
+  // Capture and persist fresh call-site backtraces while verifying and applying the writes.
   bool persist_backtrace = 3;
 }
 

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1647,7 +1647,7 @@ impl TryFrom<StubResponseSer> for concepts::storage::AppendResponseToExecution {
     }
 }
 
-/// A serializable captured database write operation.
+/// A write captured during replay, produced by the replay endpoint and applied by the advance endpoint.
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum CapturedWriteSer {
@@ -1939,7 +1939,7 @@ impl From<wasm_workers::workflow::workflow_worker::ReplayResponse> for ReplayRes
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub(crate) struct AdvanceRequestSer {
     pub(crate) captured_writes: Vec<CapturedWriteSer>,
-    /// Capture and persist call-site backtraces while advancing.
+    /// Capture and persist fresh call-site backtraces while advancing.
     #[serde(default)]
     pub(crate) persist_backtrace: bool,
 }
@@ -2232,7 +2232,7 @@ async fn stream_execution_response_task(
     }
 }
 
-/// Replay an execution (re-run from execution log)
+/// Replay an execution. An advanceable (unfinished and unblocked) execution produces captured writes for the advance endpoint; backtraces on captured writes are display-only.
 #[utoipa::path(
     put,
     path = "/v1/executions/{execution_id}/replay",
@@ -2284,7 +2284,7 @@ async fn execution_replay(
     })
 }
 
-/// Advance a paused execution using replay-captured writes.
+/// Advance a paused execution by applying captured writes from a prior replay; set `persist_backtrace` to persist fresh backtraces.
 #[utoipa::path(
     put,
     path = "/v1/executions/{execution_id}/advance",


### PR DESCRIPTION
- **refactor: Correct the version for CapturedWrite::AppendStubResponse's backtrace**
- **docs: Document display-only backtrace contract on replay/advance API**
