### PR TITLE
 Reload fixed SecretRegistry, Add preflight, Resolve secrets lazily

### DIFF
--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -77,7 +77,7 @@
   "additionalProperties": false,
   "$defs": {
     "SecretSourceToml": {
-      "description": "Source of a secret in the `[secrets]` table. Untagged so `{ env = \"VAR\" }`\nparses directly; more variants (`{ file = \"...\" }`, Vault, ...) are added later.",
+      "description": "Source of a secret in the `[secrets]` table.",
       "anyOf": [
         {
           "description": "Read the secret from a process environment variable at startup.",

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -58,6 +58,7 @@ mod bench {
             fuel: None,
             allowed_hosts: Arc::from([]),
             global_http_config: wasm_workers::http_request_policy::GlobalHttpConfig::default(),
+            secrets: Arc::new(wasm_workers::http_request_policy::NoSecrets),
             config_section_hint: wasm_workers::http_hooks::ConfigSectionHint::ActivityWasm,
         }
     }

--- a/crates/wasm-workers/src/activity/activity_ctx.rs
+++ b/crates/wasm-workers/src/activity/activity_ctx.rs
@@ -91,6 +91,7 @@ pub(crate) fn store(
     let http_policy = build_http_policy(
         &config.allowed_hosts,
         &config.global_http_config,
+        config.secrets.as_ref(),
         &mut wasi_ctx,
     );
 

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -17,7 +17,6 @@ use concepts::{
 use executor::worker::{
     FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
 };
-use indexmap::IndexMap;
 use secrecy::{ExposeSecret, SecretString};
 use std::sync::Arc;
 use std::{io::ErrorKind, path::PathBuf};
@@ -25,6 +24,15 @@ use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tracing::{debug, trace, warn};
 use utils::wasm_tools::WasmComponent;
+
+/// Exec-activity secrets: the declared names plus the component-scoped resolver
+/// that supplies their values at spawn time. Values are never baked into the
+/// verified config; they are fetched by name when the child's stdin is assembled.
+#[derive(Debug, Clone)]
+pub struct ExecSecrets {
+    pub names: Vec<String>,
+    pub resolver: Arc<dyn crate::http_request_policy::SecretResolver>,
+}
 
 /// How the exec activity program is provided to the worker.
 #[derive(Debug)]
@@ -45,9 +53,9 @@ pub struct ActivityExecWorkerCompiled {
     max_output_bytes: u64,
     forward_stdout: Option<StdOutputConfig>,
     forward_stderr: Option<StdOutputConfig>,
-    /// Resolved secrets, nested under the `secrets` key of the stdin JSON.
-    /// `None` when no secrets are configured.
-    secrets: Option<IndexMap<String, SecretString>>,
+    /// Declared secrets resolved by name at spawn time and nested under the
+    /// `secrets` key of the stdin JSON. `None` when no secrets are configured.
+    secrets: Option<ExecSecrets>,
     /// When `true`, parameters are passed via the stdin JSON `params` array
     /// instead of argv, sidestepping the `execve` argument-size limit.
     params_via_stdin: bool,
@@ -65,7 +73,7 @@ impl ActivityExecWorkerCompiled {
         max_output_bytes: u64,
         forward_stdout: Option<StdOutputConfig>,
         forward_stderr: Option<StdOutputConfig>,
-        secrets: Option<IndexMap<String, SecretString>>,
+        secrets: Option<ExecSecrets>,
         params_via_stdin: bool,
     ) -> Result<Self, utils::wasm_tools::DecodeError> {
         let user_wasm_component = WasmComponent::new_from_fn_signature(
@@ -149,7 +157,7 @@ pub struct ActivityExecWorker {
     max_output_bytes: u64,
     forward_stdout: Option<StdOutputConfigWithSender>,
     forward_stderr: Option<StdOutputConfigWithSender>,
-    secrets: Option<IndexMap<String, SecretString>>,
+    secrets: Option<ExecSecrets>,
     params_via_stdin: bool,
     cancel_registry: CancelRegistry,
     user_exports_noext: Vec<FunctionMetadata>,
@@ -267,13 +275,19 @@ impl Worker for ActivityExecWorker {
         {
             let mut obj = serde_json::Map::new();
             if let Some(secrets) = &self.secrets {
+                // Resolve each declared name on demand; a name the (restricted)
+                // resolver cannot supply is dropped, so the child simply does not
+                // receive it.
                 let secrets_obj = secrets
+                    .names
                     .iter()
-                    .map(|(name, value)| {
-                        (
-                            name.clone(),
-                            serde_json::Value::String(value.expose_secret().to_string()),
-                        )
+                    .filter_map(|name| {
+                        secrets.resolver.secret_lookup(name).map(|value| {
+                            (
+                                name.clone(),
+                                serde_json::Value::String(value.expose_secret().to_string()),
+                            )
+                        })
                     })
                     .collect();
                 obj.insert(

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -363,7 +363,7 @@ mod tests {
             self.allowed_hosts.push(AllowedHostConfig {
                 pattern,
                 request_url_regex: None,
-                secret_env_mappings: Vec::new(),
+                secret_names: Vec::new(),
                 replace_in: hashbrown::HashSet::new(),
             });
             self
@@ -409,6 +409,7 @@ mod tests {
                 fuel: None,
                 allowed_hosts: allowed_hosts.clone(),
                 global_http_config: allowed_hosts.into(),
+                secrets: Arc::new(crate::http_request_policy::NoSecrets),
                 config_section_hint: ConfigSectionHint::ActivityJs,
             };
 

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -35,6 +35,9 @@ pub struct ActivityConfig {
     pub fuel: Option<u64>,
     pub allowed_hosts: Arc<[crate::http_request_policy::AllowedHostConfig]>,
     pub global_http_config: crate::http_request_policy::GlobalHttpConfig,
+    /// Resolves the component's declared secret names to values at execution-run
+    /// policy-build time (scoped `RestrictedSecretRegistry` in production).
+    pub secrets: Arc<dyn crate::http_request_policy::SecretResolver>,
     /// The TOML config section type for error messages
     pub config_section_hint: ConfigSectionHint,
 }
@@ -599,6 +602,7 @@ pub(crate) mod tests {
             fuel: None,
             allowed_hosts: Arc::from([]),
             global_http_config: crate::http_request_policy::GlobalHttpConfig::default(),
+            secrets: Arc::new(crate::http_request_policy::NoSecrets),
             config_section_hint: ConfigSectionHint::ActivityWasm,
         }
     }
@@ -611,7 +615,7 @@ pub(crate) mod tests {
             pattern: HostPattern::parse_with_methods(allowed_host, MethodsPattern::AllMethods)
                 .unwrap(),
             request_url_regex: None,
-            secret_env_mappings: Vec::new(),
+            secret_names: Vec::new(),
             replace_in: hashbrown::HashSet::new(),
         }]);
         ActivityConfig {
@@ -623,6 +627,7 @@ pub(crate) mod tests {
             fuel: None,
             allowed_hosts: allowed_hosts.clone(),
             global_http_config: allowed_hosts.into(),
+            secrets: Arc::new(crate::http_request_policy::NoSecrets),
             config_section_hint: ConfigSectionHint::ActivityWasm,
         }
     }
@@ -1766,16 +1771,19 @@ pub(crate) mod tests {
                         Arc::from(vec![AllowedHostConfig {
                             pattern: host_pattern,
                             request_url_regex: None,
-                            secret_env_mappings: vec![(
-                                SECRET_ENV_VAR.to_string(),
-                                SecretString::from(SECRET_VALUE.to_string()),
-                            )],
+                            secret_names: vec![SECRET_ENV_VAR.to_string()],
                             replace_in: HashSet::from_iter([
                                 ReplacementLocation::Headers,
                                 ReplacementLocation::Params,
                                 ReplacementLocation::Body,
                             ]),
                         }]);
+                    let secrets = Arc::new(crate::http_request_policy::TestSecretResolver(
+                        hashbrown::HashMap::from_iter([(
+                            SECRET_ENV_VAR.to_string(),
+                            SecretString::from(SECRET_VALUE.to_string()),
+                        )]),
+                    ));
                     ActivityConfig {
                         component_id,
                         forward_stdout: None,
@@ -1784,6 +1792,7 @@ pub(crate) mod tests {
                         fuel: None,
                         allowed_hosts: allowed_hosts.clone(),
                         global_http_config: allowed_hosts.into(),
+                        secrets,
                         config_section_hint: ConfigSectionHint::ActivityWasm,
                     }
                 }
@@ -1905,6 +1914,7 @@ pub(crate) mod tests {
                 fuel: None,
                 allowed_hosts: Arc::from([]),
                 global_http_config: crate::http_request_policy::GlobalHttpConfig::default(),
+                secrets: Arc::new(crate::http_request_policy::NoSecrets),
                 config_section_hint: ConfigSectionHint::ActivityWasm,
             },
             ComponentRetryConfig::ZERO,
@@ -1980,6 +1990,7 @@ pub(crate) mod tests {
                 fuel: None,
                 allowed_hosts: Arc::from([]),
                 global_http_config: crate::http_request_policy::GlobalHttpConfig::default(),
+                secrets: Arc::new(crate::http_request_policy::NoSecrets),
                 config_section_hint: ConfigSectionHint::ActivityWasm,
             },
             ComponentRetryConfig::ZERO,
@@ -2061,6 +2072,7 @@ pub(crate) mod tests {
                 fuel: None,
                 allowed_hosts: Arc::from([]),
                 global_http_config: crate::http_request_policy::GlobalHttpConfig::default(),
+                secrets: Arc::new(crate::http_request_policy::NoSecrets),
                 config_section_hint: ConfigSectionHint::ActivityWasm,
             },
             retry_config,

--- a/crates/wasm-workers/src/http_request_policy.rs
+++ b/crates/wasm-workers/src/http_request_policy.rs
@@ -674,13 +674,50 @@ pub fn generate_placeholder() -> String {
     format!("OBELISK_SECRET_{hex}")
 }
 
-/// Resolved per-host configuration: host pattern + optional secrets.
+/// Resolves a secret's value by logical name at the point of use.
+///
+/// Verified configs ([`AllowedHostConfig`]) carry only secret *names* (the
+/// authorization identity); the actual value is fetched through this resolver
+/// when a policy is built for an execution run, never baked into the long-lived
+/// verified config. The main crate supplies a `RestrictedSecretRegistry` scoped
+/// to the subset of names a component declared. Env-backed today, Vault-backed
+/// later, hence resolution stays out of the verify/startup path.
+pub trait SecretResolver: Send + Sync + fmt::Debug {
+    /// Return the secret value for `name`, or `None` when the name is unknown or
+    /// not visible to this (restricted) resolver.
+    fn secret_lookup(&self, name: &str) -> Option<SecretString>;
+}
+
+/// A resolver that knows no secrets. Used where a component declares none and in
+/// tests that never inject secret values.
+#[derive(Clone, Copy, Debug)]
+pub struct NoSecrets;
+impl SecretResolver for NoSecrets {
+    fn secret_lookup(&self, _name: &str) -> Option<SecretString> {
+        None
+    }
+}
+
+/// Test-only resolver backed by a fixed name -> value map.
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(crate) struct TestSecretResolver(pub(crate) hashbrown::HashMap<String, SecretString>);
+#[cfg(test)]
+impl SecretResolver for TestSecretResolver {
+    fn secret_lookup(&self, name: &str) -> Option<SecretString> {
+        self.0.get(name).cloned()
+    }
+}
+
+/// Resolved per-host configuration: host pattern + declared secret names.
 #[derive(Clone, Debug)]
 pub struct AllowedHostConfig {
     pub pattern: HostPattern,
     pub request_url_regex: Option<Regex>,
-    /// `(env_key_for_wasm, real_value)` pairs.
-    pub secret_env_mappings: Vec<(String, SecretString)>,
+    /// Logical secret names the component declared for this host. Values are
+    /// resolved lazily per execution run via a [`SecretResolver`]; the name also
+    /// doubles as the env key exposed to WASM.
+    pub secret_names: Vec<String>,
     /// Where in the request to perform replacement.
     pub replace_in: hashbrown::HashSet<ReplacementLocation>,
 }
@@ -736,7 +773,7 @@ mod tests {
         AllowedHostConfig {
             pattern: HostPattern::parse_with_methods(spec, methods).unwrap(),
             request_url_regex: regex.map(|r| Regex::new(r).unwrap()),
-            secret_env_mappings: Vec::new(),
+            secret_names: Vec::new(),
             replace_in: hashbrown::HashSet::new(),
         }
     }

--- a/crates/wasm-workers/src/policy_builder.rs
+++ b/crates/wasm-workers/src/policy_builder.rs
@@ -1,24 +1,30 @@
 use crate::http_request_policy::{
     AllowedHostConfig, AllowedHostPolicy, GlobalHttpConfig, HttpRequestPolicy, PlaceholderSecret,
-    generate_placeholder,
+    SecretResolver, generate_placeholder,
 };
 use secrecy::SecretString;
 use wasmtime_wasi::WasiCtxBuilder;
 
 /// Build an [`HttpRequestPolicy`] from resolved allowed-host configs, generating
-/// one random placeholder per unique secret env var name and binding each env
-/// var into `wasi_ctx` exactly once.
+/// one random placeholder per unique secret name and binding each into `wasi_ctx`
+/// exactly once.
+///
+/// Secret values are fetched from `resolver` here, at execution-run policy build
+/// time, rather than baked into the verified [`AllowedHostConfig`]. A name the
+/// resolver cannot resolve (unknown, or outside the component's restricted view)
+/// mints no placeholder and injects nothing, so the request fails closed.
 ///
 /// `global_allowlist` is the operator-owned allowlist from `server.toml`. Egress
 /// must additionally match it and secret injection is intersected against it
 /// (see [`HttpRequestPolicy`]). The global allowlist contributes authorization only:
-/// it mints no placeholders and binds nothing into the guest env.
+/// it mints no placeholders, resolves no values, and binds nothing into the guest env.
 pub(crate) fn build_http_policy(
     allowed_hosts: &[AllowedHostConfig],
     global_http_config: &GlobalHttpConfig,
+    resolver: &dyn SecretResolver,
     wasi_ctx: &mut WasiCtxBuilder,
 ) -> HttpRequestPolicy {
-    let (mut policy, placeholders) = build_http_policy_inner(allowed_hosts);
+    let (mut policy, placeholders) = build_http_policy_inner(allowed_hosts, resolver);
     for (env_key, placeholder) in &placeholders {
         wasi_ctx.env(env_key, placeholder);
     }
@@ -36,10 +42,10 @@ fn build_authorization_hosts(allowed_hosts: &[AllowedHostConfig]) -> Vec<Allowed
             pattern: host_config.pattern.clone(),
             request_url_regex: host_config.request_url_regex.clone(),
             secrets: host_config
-                .secret_env_mappings
+                .secret_names
                 .iter()
-                .map(|(env_key, _real_value)| PlaceholderSecret {
-                    name: env_key.clone(),
+                .map(|name| PlaceholderSecret {
+                    name: name.clone(),
                     placeholder: String::new(),
                     real_value: SecretString::from(String::new()),
                     replace_in: host_config.replace_in.clone(),
@@ -49,35 +55,45 @@ fn build_authorization_hosts(allowed_hosts: &[AllowedHostConfig]) -> Vec<Allowed
         .collect()
 }
 
-/// Pure core of [`build_http_policy`]: returns the policy plus the
-/// `env_key -> placeholder` map that must be set on the guest env.
+/// Pure core of [`build_http_policy`]: resolves declared secret names to values
+/// via `resolver` and returns the policy plus the `env_key -> placeholder` map
+/// that must be set on the guest env.
 ///
-/// The same secret env var may be declared on multiple `allowed_host` entries
-/// (e.g. one per method/path regex). Since the real value is identical across
-/// entries, a single shared placeholder is generated per env var name and bound
-/// once.
+/// The same secret name may be declared on multiple `allowed_host` entries (e.g.
+/// one per method/path regex). Since the value is identical across entries, it is
+/// resolved once and a single shared placeholder is generated per name and bound
+/// once. A name the resolver cannot resolve is skipped (no placeholder, no
+/// binding), so a request referencing it fails closed.
 fn build_http_policy_inner(
     allowed_hosts: &[AllowedHostConfig],
+    resolver: &dyn SecretResolver,
 ) -> (
     HttpRequestPolicy,
     hashbrown::HashMap<
-        &str,   // env key
+        String, // env key (== secret name)
         String, // placeholder
     >,
 ) {
-    let mut placeholders: hashbrown::HashMap<&str, String> = hashbrown::HashMap::new();
+    // Resolve each distinct name once; `None` (unknown / restricted) drops it, so
+    // any host referencing that name mints no placeholder and fails closed.
+    let mut by_name: hashbrown::HashMap<String, (String, SecretString)> = hashbrown::HashMap::new();
+    let mut placeholders: hashbrown::HashMap<String, String> = hashbrown::HashMap::new();
     let mut hosts = Vec::with_capacity(allowed_hosts.len());
     for host_config in allowed_hosts {
-        let mut secrets = Vec::with_capacity(host_config.secret_env_mappings.len());
-        for (env_key, real_value) in &host_config.secret_env_mappings {
-            let placeholder = placeholders
-                .entry(env_key.as_str())
-                .or_insert_with(generate_placeholder)
-                .clone();
+        let mut secrets = Vec::with_capacity(host_config.secret_names.len());
+        for name in &host_config.secret_names {
+            if !by_name.contains_key(name) {
+                let Some(value) = resolver.secret_lookup(name) else {
+                    continue;
+                };
+                by_name.insert(name.clone(), (generate_placeholder(), value));
+            }
+            let (placeholder, value) = &by_name[name];
+            placeholders.insert(name.clone(), placeholder.clone());
             secrets.push(PlaceholderSecret {
-                name: env_key.clone(),
-                placeholder,
-                real_value: real_value.clone(),
+                name: name.clone(),
+                placeholder: placeholder.clone(),
+                real_value: value.clone(),
                 replace_in: host_config.replace_in.clone(),
             });
         }
@@ -100,11 +116,20 @@ fn build_http_policy_inner(
 mod tests {
     use super::build_http_policy_inner;
     use crate::http_request_policy::{
-        AllowedHostConfig, HostPattern, MethodsPattern, ReplacementLocation,
+        AllowedHostConfig, HostPattern, MethodsPattern, ReplacementLocation, SecretResolver,
     };
     use hyper::http::Method;
     use secrecy::SecretString;
     use wasmtime_wasi_http::p2::body::HyperOutgoingBody;
+
+    /// Test resolver backed by a fixed name -> value map.
+    #[derive(Debug)]
+    struct MapResolver(hashbrown::HashMap<String, SecretString>);
+    impl SecretResolver for MapResolver {
+        fn secret_lookup(&self, name: &str) -> Option<SecretString> {
+            self.0.get(name).cloned()
+        }
+    }
 
     fn empty_body() -> HyperOutgoingBody {
         http_body_util::combinators::UnsyncBoxBody::new(http_body_util::BodyExt::map_err(
@@ -113,7 +138,7 @@ mod tests {
         ))
     }
 
-    fn host_config(env_key: &str, real_value: &str, methods: Vec<Method>) -> AllowedHostConfig {
+    fn host_config(name: &str, methods: Vec<Method>) -> AllowedHostConfig {
         AllowedHostConfig {
             pattern: HostPattern::parse_with_methods(
                 "api.example.com",
@@ -121,7 +146,7 @@ mod tests {
             )
             .unwrap(),
             request_url_regex: None,
-            secret_env_mappings: vec![(env_key.to_string(), SecretString::from(real_value))],
+            secret_names: vec![name.to_string()],
             replace_in: hashbrown::HashSet::from([ReplacementLocation::Headers]),
         }
     }
@@ -135,11 +160,15 @@ mod tests {
         const REAL_VALUE: &str = "real-token-value";
 
         let allowed_hosts = vec![
-            host_config(ENV_KEY, REAL_VALUE, vec![Method::GET]),
-            host_config(ENV_KEY, REAL_VALUE, vec![Method::PUT]),
+            host_config(ENV_KEY, vec![Method::GET]),
+            host_config(ENV_KEY, vec![Method::PUT]),
         ];
+        let resolver = MapResolver(hashbrown::HashMap::from([(
+            ENV_KEY.to_string(),
+            SecretString::from(REAL_VALUE),
+        )]));
 
-        let (policy, placeholders) = build_http_policy_inner(&allowed_hosts);
+        let (policy, placeholders) = build_http_policy_inner(&allowed_hosts, &resolver);
 
         // Exactly one placeholder bound into the guest env for this env var.
         assert_eq!(

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -610,6 +610,9 @@ pub struct WebhookEndpointConfig {
     pub logs_store_min_level: Option<LogLevel>,
     pub allowed_hosts: Arc<[crate::http_request_policy::AllowedHostConfig]>,
     pub global_http_config: crate::http_request_policy::GlobalHttpConfig,
+    /// Resolves the endpoint's declared secret names to values at request-time
+    /// policy-build (scoped `RestrictedSecretRegistry` in production).
+    pub secrets: Arc<dyn crate::http_request_policy::SecretResolver>,
     pub js_config: Option<WebhookEndpointJsConfig>,
     /// The TOML config section type for error messages
     pub config_section_hint: crate::http_hooks::ConfigSectionHint,
@@ -1821,6 +1824,7 @@ impl WebhookEndpointCtx {
         let http_policy = crate::policy_builder::build_http_policy(
             &config.allowed_hosts,
             &config.global_http_config,
+            config.secrets.as_ref(),
             &mut wasi_ctx,
         );
 
@@ -2372,6 +2376,7 @@ pub(crate) mod tests {
                             allowed_hosts: Arc::from([]),
                             global_http_config:
                                 crate::http_request_policy::GlobalHttpConfig::default(),
+                            secrets: Arc::new(crate::http_request_policy::NoSecrets),
                             js_config: None,
                             config_section_hint: ConfigSectionHint::WebhookEndpointWasm,
                         },
@@ -2660,7 +2665,7 @@ pub(crate) mod tests {
                             )
                             .unwrap(),
                             request_url_regex: None,
-                            secret_env_mappings: Vec::new(),
+                            secret_names: Vec::new(),
                             replace_in: hashbrown::HashSet::new(),
                         }]),
                         global_http_config: vec![AllowedHostConfig {
@@ -2670,10 +2675,11 @@ pub(crate) mod tests {
                             )
                             .unwrap(),
                             request_url_regex: None,
-                            secret_env_mappings: Vec::new(),
+                            secret_names: Vec::new(),
                             replace_in: hashbrown::HashSet::new(),
                         }]
                         .into(),
+                        secrets: Arc::new(crate::http_request_policy::NoSecrets),
                         js_config: None,
                         config_section_hint: ConfigSectionHint::WebhookEndpointWasm,
                     },
@@ -2850,6 +2856,7 @@ pub(crate) mod tests {
                         logs_store_min_level: None,
                         allowed_hosts: Arc::from([]), // NO allowed hosts - request should be denied
                         global_http_config: crate::http_request_policy::GlobalHttpConfig::default(),
+                        secrets: Arc::new(crate::http_request_policy::NoSecrets),
                         js_config: None,
                         config_section_hint: ConfigSectionHint::WebhookEndpointWasm,
                     },
@@ -2969,6 +2976,7 @@ pub(crate) mod tests {
                         logs_store_min_level: None,
                         allowed_hosts: Arc::from([]),
                         global_http_config: crate::http_request_policy::GlobalHttpConfig::default(),
+                        secrets: Arc::new(crate::http_request_policy::NoSecrets),
                         js_config: Some(WebhookEndpointJsConfig {
                             source: source.to_string(),
                             file_name: String::new(),
@@ -3117,16 +3125,17 @@ pub(crate) mod tests {
                         allowed_hosts: Arc::from(vec![AllowedHostConfig {
                             pattern: host_pattern.clone(),
                             request_url_regex: None,
-                            secret_env_mappings: Vec::new(),
+                            secret_names: Vec::new(),
                             replace_in: hashbrown::HashSet::new(),
                         }]),
                         global_http_config: vec![AllowedHostConfig {
                             pattern: host_pattern,
                             request_url_regex: None,
-                            secret_env_mappings: Vec::new(),
+                            secret_names: Vec::new(),
                             replace_in: hashbrown::HashSet::new(),
                         }]
                         .into(),
+                        secrets: Arc::new(crate::http_request_policy::NoSecrets),
                         js_config: Some(WebhookEndpointJsConfig {
                             source: source.to_string(),
                             file_name: String::new(),
@@ -3510,6 +3519,7 @@ pub(crate) mod tests {
                             allowed_hosts: Arc::from([]),
                             global_http_config:
                                 crate::http_request_policy::GlobalHttpConfig::default(),
+                            secrets: Arc::new(crate::http_request_policy::NoSecrets),
                             js_config: Some(WebhookEndpointJsConfig {
                                 source: js_source.to_string(),
                                 file_name: String::new(),

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -3,8 +3,8 @@
 set -exuo pipefail
 cd "$(dirname "$0")/.."
 
-cargo fmt
-
+cargo fmt # format first to allow cache hits of clippy on re-runs
 cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged  "$@" -- -D warnings
+cargo fmt # format fixes
 
 git status -s

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -35,7 +35,6 @@ use crate::config::toml::ComponentLocationFetchExt as _;
 use crate::config::toml::ComponentLocationToml;
 use crate::config::toml::ComponentStdOutputToml;
 use crate::config::toml::ConfigName;
-use crate::config::toml::ConfigWarnings;
 use crate::config::toml::DatabaseConfigToml;
 use crate::config::toml::DeploymentResolved;
 use crate::config::toml::InflightSemaphoreExt as _;
@@ -59,7 +58,7 @@ use crate::config::toml::webhook::WebhookRoute;
 use crate::config::toml::webhook::WebhookRouteVerified;
 use crate::config::toml::webhook::WebhookWasmComponentConfigResolvedExt as _;
 use crate::config::toml::webhook::WebhookWasmComponentConfigVerified;
-use crate::config::toml::{AllowedHostToml, MethodsInput, MethodsInputStar, ReplaceIn};
+use crate::config::toml::{AllowedHostToml, MethodsInput, MethodsInputStar};
 use crate::config::wasm_cache_metadata_dir;
 use crate::init;
 use crate::init::Guard;
@@ -162,7 +161,7 @@ use wasm_workers::engines::EngineConfig;
 use wasm_workers::engines::Engines;
 use wasm_workers::engines::PoolingConfig;
 use wasm_workers::epoch_ticker::EpochTicker;
-use wasm_workers::http_request_policy::{AllowedHostConfig, GlobalHttpConfig, ReplacementLocation};
+use wasm_workers::http_request_policy::{AllowedHostConfig, GlobalHttpConfig};
 use wasm_workers::log_db_forwarder;
 use wasm_workers::registry::ComponentConfig;
 use wasm_workers::registry::ComponentConfigImportable;
@@ -635,184 +634,6 @@ impl RuntimeConfigAvailability {
     }
 }
 
-fn replacement_target(replace_in: ReplaceIn) -> ReplacementLocation {
-    match replace_in {
-        ReplaceIn::Headers => ReplacementLocation::Headers,
-        ReplaceIn::Body => ReplacementLocation::Body,
-        ReplaceIn::Params => ReplacementLocation::Params,
-    }
-}
-
-fn replacement_target_name(replace_in: ReplaceIn) -> &'static str {
-    match replace_in {
-        ReplaceIn::Headers => "headers",
-        ReplaceIn::Body => "body",
-        ReplaceIn::Params => "params",
-    }
-}
-
-fn allowed_host_snippet(
-    section: &str,
-    entry: &AllowedHostToml,
-    secret: &str,
-    replace_in: ReplaceIn,
-) -> String {
-    let mut entry = entry.clone();
-    entry.secrets = vec![secret.to_string()];
-    entry.replace_in = vec![replace_in];
-    let body = toml::to_string(&entry).expect("AllowedHostToml must serialize to TOML");
-    format!("[[{section}.allowed_host]]\n{body}")
-}
-
-/// A secret replacement a component requests that the operator global allowlist
-/// does not authorize. Collected across the whole deployment so every missing
-/// allowance is reported at once, letting the operator add them all in one pass.
-struct MissingSecretReplacement {
-    component_section: &'static str,
-    component_name: ConfigName,
-    entry: AllowedHostToml,
-    secret: String,
-    replace_in: ReplaceIn,
-}
-
-/// Every component's outbound HTTP `allowed_hosts`, over the same component kinds the
-/// deployment pre-pass checks. Used by `--fix` to gather referenced secret names.
-fn deployment_allowed_host_lists(deployment: &DeploymentResolved) -> Vec<&[AllowedHostToml]> {
-    let mut lists: Vec<&[AllowedHostToml]> = Vec::new();
-    lists.extend(deployment.activities_wasm.iter().map(|c| &*c.allowed_hosts));
-    lists.extend(deployment.activities_js.iter().map(|c| &*c.allowed_hosts));
-    lists.extend(deployment.webhooks_wasm.iter().map(|c| &*c.allowed_hosts));
-    lists.extend(deployment.webhooks_js.iter().map(|c| &*c.allowed_hosts));
-    lists
-}
-
-/// The `(secret name, replacement target)` pairs the operator global allowlist authorizes.
-fn global_secret_replacements(
-    global_http_config: &GlobalHttpConfig,
-) -> hashbrown::HashSet<(&str, ReplacementLocation)> {
-    global_http_config
-        .entries()
-        .iter()
-        .flat_map(|entry| {
-            entry.secret_env_mappings.iter().flat_map(|(name, _)| {
-                entry
-                    .replace_in
-                    .iter()
-                    .copied()
-                    .map(move |target| (name.as_str(), target))
-            })
-        })
-        .collect()
-}
-
-/// Append every secret replacement `entries` requests that `server_replacements`
-/// does not authorize onto `missing`. Registered-only secrets are checked (an
-/// unregistered secret name cannot be injected, so it is skipped here).
-fn collect_outbound_http_secret_replacements(
-    component_section: &'static str,
-    component_name: &ConfigName,
-    entries: &[AllowedHostToml],
-    server_replacements: &hashbrown::HashSet<(&str, ReplacementLocation)>,
-    secret_registry: &SecretRegistry,
-    missing: &mut Vec<MissingSecretReplacement>,
-) {
-    for entry in entries {
-        if entry.methods.is_none()
-            || matches!(&entry.methods, Some(MethodsInput::List(methods)) if methods.is_empty())
-        {
-            continue;
-        }
-        for secret in &entry.secrets {
-            if secret_registry.secret_lookup(secret).is_none() {
-                continue;
-            }
-            for replace_in in &entry.replace_in {
-                let requested_replacement = (secret.as_str(), replacement_target(*replace_in));
-                if server_replacements.contains(&requested_replacement) {
-                    continue;
-                }
-                missing.push(MissingSecretReplacement {
-                    component_section,
-                    component_name: component_name.clone(),
-                    entry: entry.clone(),
-                    secret: secret.clone(),
-                    replace_in: *replace_in,
-                });
-            }
-        }
-    }
-}
-
-/// Emit a single report covering every collected missing secret replacement, so
-/// the operator can add all the required allowlist entries to server.toml in one edit.
-/// Bails under strict availability; downgrades to a warning when unavailable
-/// runtime config is allowed (activation re-checks strictly).
-fn report_missing_outbound_http_secret_replacements(
-    missing: &[MissingSecretReplacement],
-    availability: RuntimeConfigAvailability,
-    warnings: &ConfigWarnings,
-) -> Result<(), anyhow::Error> {
-    if missing.is_empty() {
-        return Ok(());
-    }
-    use std::fmt::Write as _;
-    let mut details = String::new();
-    let mut server_snippets: Vec<String> = Vec::new();
-    let mut deployment_snippets: Vec<String> = Vec::new();
-    for m in missing {
-        let _ = writeln!(
-            details,
-            "  - component `{name}` (`[[{section}.allowed_host]]`) requests replacing secret \
-             `{secret}` in `{target}`",
-            name = m.component_name,
-            section = m.component_section,
-            secret = m.secret,
-            target = replacement_target_name(m.replace_in),
-        );
-        // Multiple components may request the same allowlist entry; list each unique
-        // snippet once so the operator does not paste duplicates.
-        let server_snippet =
-            allowed_host_snippet("outbound_http", &m.entry, &m.secret, m.replace_in);
-        if !server_snippets.contains(&server_snippet) {
-            server_snippets.push(server_snippet);
-        }
-        let deployment_snippet =
-            allowed_host_snippet(m.component_section, &m.entry, &m.secret, m.replace_in);
-        if !deployment_snippets.contains(&deployment_snippet) {
-            deployment_snippets.push(deployment_snippet);
-        }
-    }
-    let message = format!(
-        "the deployment requests {count} outbound HTTP secret replacement(s) that no server.toml \
-         `[[outbound_http.allowed_host]]` entry authorizes:\n\
-         {details}\n\
-         After review, add these allowlist entries to server.toml:\n\n\
-         {server}\n\
-         The corresponding deployment.toml entries are:\n\n\
-         {deployment}",
-        count = missing.len(),
-        server = server_snippets.join("\n"),
-        deployment = deployment_snippets.join("\n"),
-    );
-    if availability.allows_unavailable() {
-        warnings.insert(format!(
-            "{message}\nSkipping these load-time secret replacement checks because unavailable \
-             runtime configuration is allowed; activation will enforce them strictly."
-        ));
-        Ok(())
-    } else {
-        bail!("{message}");
-    }
-}
-
-/// A component destination that no operator global allowlist entry covers, collected
-/// across the deployment so every gap is reported at load time rather than one-by-one.
-struct UncoveredOutboundHost {
-    component_section: &'static str,
-    component_name: ConfigName,
-    entry: AllowedHostToml,
-}
-
 /// The global allowlist to enforce for a webhook. A `self_authorize` webhook (only
 /// the framework-injected, operator-owned web UI) is bounded by its own component
 /// allowlist rather than requiring an explicit server.toml entry; every other
@@ -827,108 +648,6 @@ fn webhook_global_http_allowlist(
     } else {
         operator_global.clone()
     }
-}
-
-/// Render a destination-only `[[<section>.allowed_host]]` snippet, dropping secret fields.
-fn host_allowlist_snippet(section: &str, entry: &AllowedHostToml) -> String {
-    #[derive(serde::Serialize)]
-    struct DestinationEntry {
-        pattern: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        methods: Option<MethodsInput>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        request_url_regex: Option<String>,
-    }
-    let body = toml::to_string(&DestinationEntry {
-        pattern: entry.pattern.clone(),
-        methods: entry.methods.clone(),
-        request_url_regex: entry.request_url_regex.clone(),
-    })
-    .expect("destination allowlist entry must serialize to TOML");
-    format!("[[{section}.allowed_host]]\n{body}")
-}
-
-/// Append every destination in `entries` that no global allowlist entry covers onto
-/// `uncovered`. Allow-nothing entries need no allowlist entry; resolution failures are
-/// left for component preparation to report authoritatively.
-#[expect(clippy::too_many_arguments)]
-fn collect_uncovered_outbound_http_hosts(
-    component_section: &'static str,
-    component_name: &ConfigName,
-    entries: &[AllowedHostToml],
-    global_http_config: &GlobalHttpConfig,
-    secret_registry: &SecretRegistry,
-    ignore_missing_env_vars: bool,
-    warnings: &ConfigWarnings,
-    uncovered: &mut Vec<UncoveredOutboundHost>,
-) {
-    for entry in entries {
-        if entry.methods.is_none()
-            || matches!(&entry.methods, Some(MethodsInput::List(methods)) if methods.is_empty())
-        {
-            continue;
-        }
-        // Resolve one entry at a time to keep the original TOML for the snippet.
-        let Ok(resolved) = resolve_allowed_hosts(
-            vec![entry.clone()],
-            ignore_missing_env_vars,
-            secret_registry,
-            warnings,
-        ) else {
-            continue;
-        };
-        let Some(resolved) = resolved.first() else {
-            continue;
-        };
-        if !global_http_config
-            .entries()
-            .iter()
-            .any(|allowed| allowed.covers(resolved))
-        {
-            uncovered.push(UncoveredOutboundHost {
-                component_section,
-                component_name: component_name.clone(),
-                entry: entry.clone(),
-            });
-        }
-    }
-}
-
-/// Warn once, listing the allowlist entries to add. A warning, not an error: coverage
-/// is conservative and a component may declare destinations it never calls.
-fn report_uncovered_outbound_http_hosts(
-    uncovered: &[UncoveredOutboundHost],
-    warnings: &ConfigWarnings,
-) {
-    if uncovered.is_empty() {
-        return;
-    }
-    use std::fmt::Write as _;
-    let mut details = String::new();
-    let mut snippets: Vec<String> = Vec::new();
-    for host in uncovered {
-        let _ = writeln!(
-            details,
-            "  - component `{name}` (`[[{section}.allowed_host]]`) allows `{pattern}`",
-            name = host.component_name,
-            section = host.component_section,
-            pattern = host.entry.pattern,
-        );
-        let snippet = host_allowlist_snippet("outbound_http", &host.entry);
-        if !snippets.contains(&snippet) {
-            snippets.push(snippet);
-        }
-    }
-    warnings.insert(format!(
-        "{count} outbound HTTP destination(s) the deployment allows are not covered by any \
-         server.toml `[[outbound_http.allowed_host]]` allowlist entry; requests to them will be \
-         denied at runtime:\n\
-         {details}\n\
-         After review, add these allowlist entries to server.toml:\n\n\
-         {snippets}",
-        count = uncovered.len(),
-        snippets = snippets.join("\n"),
-    ));
 }
 
 #[derive(Debug, Clone)]
@@ -999,7 +718,7 @@ pub(crate) async fn verify(
             &mut unregistered,
         );
         if let Some(deployment) = deployment_opt.as_ref() {
-            for hosts in deployment_allowed_host_lists(deployment) {
+            for hosts in config_prepass::deployment_allowed_host_lists(deployment) {
                 config_prepass::collect_unregistered_secrets(
                     hosts,
                     &secret_registry,
@@ -1081,6 +800,11 @@ pub(crate) async fn verify(
         .await?
     };
     let server_verified = Box::pin(server_verify(config, engines, secret_registry)).await?;
+    config_prepass::preflight(
+        &server_verified,
+        Some(&deployment),
+        verify_params.runtime_config_availability,
+    )?;
     let cas: Option<Arc<dyn concepts::cas::Cas>> = if let Some((pool, _)) = db_pool.as_ref() {
         Some(pool.cas_conn().await?.into())
     } else {
@@ -1268,11 +992,7 @@ pub(crate) async fn deployment_verify_config_compile_link(
         params.clone(),
         termination_watcher,
     )
-    .await;
-    if deployment_verified.is_err() {
-        server_verified.config_warnings.report();
-    }
-    let deployment_verified = deployment_verified?;
+    .await?;
     deployment_compile_link(
         server_verified,
         deployment_verified,
@@ -1291,7 +1011,6 @@ pub(crate) async fn deployment_compile_link(
     params: VerifyParams,
     termination_watcher: &mut watch::Receiver<()>,
 ) -> Result<ServerCompiledLinked, anyhow::Error> {
-    let config_warnings = server_verified.config_warnings.clone();
     let compiled_and_linked = ServerCompiledLinked::new(
         deployment_id,
         deployment_verified,
@@ -1300,9 +1019,7 @@ pub(crate) async fn deployment_compile_link(
         params.suppress_type_checking_errors,
         params.suppress_linking_errors,
     )
-    .await;
-    config_warnings.report();
-    let compiled_and_linked = compiled_and_linked?;
+    .await?;
     if compiled_and_linked.supressed_errors.is_none() {
         info!("Obelisk configuration was verified");
     } else {
@@ -1401,7 +1118,6 @@ pub(crate) async fn deployment_verify_config(
         server_verified.api_addr_if_webui_enabled.clone(),
         server_verified.secret_registry.clone(),
         server_verified.global_http_config.clone(),
-        server_verified.config_warnings.clone(),
     ))
     .await?;
     trace!("Verified deployment: {deployment_verified:#?}");
@@ -2015,6 +1731,11 @@ pub(crate) async fn run_internal(
         };
     let engines = create_engines(&config, &prepared_dirs)?;
     let server_verified = server_verify(config, engines, secret_registry).await?;
+    config_prepass::preflight(
+        &server_verified,
+        Some(&deployment_resolved),
+        RuntimeConfigAvailability::Strict,
+    )?;
     let cas: Arc<dyn concepts::cas::Cas> = db_pool.cas_conn().await?.into();
     let compiled_and_linked = Box::pin(deployment_verify_config_compile_link(
         server_verified.clone(),
@@ -2236,7 +1957,10 @@ pub(crate) struct ServerVerified {
     api_addr_if_webui_enabled: Option<String>,
     max_deployment_file_bytes: u32,
     global_http_config: GlobalHttpConfig,
-    config_warnings: ConfigWarnings,
+    /// The server's own `[[outbound_http.allowed_host]]` entries, verbatim. Kept so the
+    /// `config_prepass::preflight` can report unregistered secret names before they are
+    /// dropped by resolution.
+    server_outbound_allowed_hosts: Vec<AllowedHostToml>,
     /// Operator-owned secret registry, resolved before the runtime started. Carried
     /// here so runtime redeploys/submits resolve deployment secret references without
     /// re-reading the (already wiped) process environment.
@@ -2258,10 +1982,6 @@ impl ServerVerified {
         secret_registry: Arc<SecretRegistry>,
     ) -> Result<ServerVerified, anyhow::Error> {
         trace!("Using server toml: {config:#?}");
-        let config_warnings = ConfigWarnings::default();
-        if let Some(source_path) = &config.source_path {
-            config_warnings.index_allowed_hosts(source_path);
-        }
         let mut http_servers = config.http_servers;
         if config.webui.enabled {
             let webui_listening_addr = config.webui.listening_addr;
@@ -2293,35 +2013,18 @@ impl ServerVerified {
             .as_semaphore();
         let database_subscription_interruption = config.database.get_subscription_interruption();
         if config.allow_exec_activities == AllowExecActivities::AllowAny {
-            config_warnings.insert(
+            warn!(
                 "`allow_exec_activities = true` permits deployments to run arbitrary host \
                  programs; consider allowlisting reviewed scripts by content digest instead"
-                    .to_string(),
             );
         }
-        // Fail fast on the server's own config: unregistered `[[outbound_http.allowed_host]]`
-        // secrets are always fatal (the server cannot run with an invalid allowlist), but
-        // collect every missing name first so the operator can register them in one edit.
-        let mut unregistered_secrets = BTreeSet::new();
-        config_prepass::collect_unregistered_secrets(
-            &config.outbound_http.allowed_hosts,
-            &secret_registry,
-            &mut unregistered_secrets,
-        );
-        config_prepass::report_unregistered_secrets(
-            &unregistered_secrets,
-            "server.toml `[[outbound_http.allowed_host]]` entries",
-            RuntimeConfigAvailability::Strict,
-            &config_warnings,
-        )?;
+        // Unregistered secret names in these entries are reported by `config_prepass::preflight`
+        // (which runs before this) using `server_outbound_allowed_hosts`; here they resolve to
+        // nothing and are dropped.
+        let server_outbound_allowed_hosts = config.outbound_http.allowed_hosts.clone();
         let global_http_config = GlobalHttpConfig::from(
-            resolve_allowed_hosts(
-                config.outbound_http.allowed_hosts,
-                false,
-                &secret_registry,
-                &config_warnings,
-            )
-            .context("invalid server.toml `[[outbound_http.allowed_host]]` entry")?,
+            resolve_allowed_hosts(config.outbound_http.allowed_hosts, false, &secret_registry)
+                .context("invalid server.toml `[[outbound_http.allowed_host]]` entry")?,
         );
 
         Ok(Self {
@@ -2342,7 +2045,7 @@ impl ServerVerified {
             },
             max_deployment_file_bytes: config.max_deployment_file_bytes.0,
             global_http_config,
-            config_warnings,
+            server_outbound_allowed_hosts,
             secret_registry,
         })
     }
@@ -2887,6 +2590,12 @@ pub(crate) async fn submit_deployment(
         .map_err(anyhow::Error::from)?
         .into();
     let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
+    config_prepass::preflight(
+        &server_verified,
+        Some(&deployment_resolved),
+        runtime_config_check.availability(),
+    )
+    .map_err(SubmitDeploymentError::Other)?;
     let compiled_linked = deployment_verify_config_compile_link(
         server_verified,
         prepared_dirs,
@@ -3188,6 +2897,12 @@ async fn prepare_switch_deployment(
 
     // Cold switch: validation (compile + link) always runs before enqueuing, so a
     // deployment queued for the next restart is known-good against the current host.
+    config_prepass::preflight(
+        &deployment_switch_manager.inner.server_verified,
+        Some(&target_deployment),
+        verify_params.runtime_config_availability,
+    )
+    .map_err(SwitchError::Other)?;
     let compiled_linked = deployment_verify_config_compile_link(
         deployment_switch_manager.inner.server_verified.clone(),
         &deployment_switch_manager.inner.prepared_dirs,
@@ -3769,83 +3484,13 @@ impl DeploymentVerified {
         api_addr_if_webui_enabled: Option<String>,
         secret_registry: Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
-        config_warnings: ConfigWarnings,
     ) -> Result<DeploymentVerified, anyhow::Error> {
         let ignore_missing_env_vars = runtime_config_availability.allows_unavailable();
         let mut deployment = deployment.into_resolved();
-        if let Some(source_path) = &deployment.source_path {
-            config_warnings.index_allowed_hosts(source_path);
-        }
         trace!("Using deployment toml: {deployment:#?}");
-        // Scoped so the `server_replacements` borrow of `global_http_config` ends
-        // before the config is moved into the deployment below. Each component's
-        // outbound HTTP entries are checked against the operator global allowlist for
-        // both unauthorized secret replacements and uncovered destinations.
-        let (missing_replacements, uncovered_hosts, unregistered_secrets) = {
-            let server_replacements = global_secret_replacements(&global_http_config);
-            let mut missing_replacements = Vec::new();
-            let mut uncovered_hosts = Vec::new();
-            let mut unregistered_secrets = BTreeSet::new();
-            let mut check =
-                |section: &'static str, name: &ConfigName, hosts: &[AllowedHostToml]| {
-                    collect_outbound_http_secret_replacements(
-                        section,
-                        name,
-                        hosts,
-                        &server_replacements,
-                        &secret_registry,
-                        &mut missing_replacements,
-                    );
-                    collect_uncovered_outbound_http_hosts(
-                        section,
-                        name,
-                        hosts,
-                        &global_http_config,
-                        &secret_registry,
-                        ignore_missing_env_vars,
-                        &config_warnings,
-                        &mut uncovered_hosts,
-                    );
-                    config_prepass::collect_unregistered_secrets(
-                        hosts,
-                        &secret_registry,
-                        &mut unregistered_secrets,
-                    );
-                };
-            for activity in &deployment.activities_wasm {
-                check(
-                    "activity_wasm",
-                    &activity.common.name,
-                    &activity.allowed_hosts,
-                );
-            }
-            for activity in &deployment.activities_js {
-                check("activity_js", &activity.name, &activity.allowed_hosts);
-            }
-            for webhook in &deployment.webhooks_wasm {
-                check(
-                    "webhook_endpoint_wasm",
-                    &webhook.common.name,
-                    &webhook.allowed_hosts,
-                );
-            }
-            for webhook in &deployment.webhooks_js {
-                check("webhook_endpoint_js", &webhook.name, &webhook.allowed_hosts);
-            }
-            (missing_replacements, uncovered_hosts, unregistered_secrets)
-        };
-        config_prepass::report_unregistered_secrets(
-            &unregistered_secrets,
-            "the deployment's outbound HTTP entries",
-            runtime_config_availability,
-            &config_warnings,
-        )?;
-        report_missing_outbound_http_secret_replacements(
-            &missing_replacements,
-            runtime_config_availability,
-            &config_warnings,
-        )?;
-        report_uncovered_outbound_http_hosts(&uncovered_hosts, &config_warnings);
+        // The outbound-HTTP allowlist pre-pass (unregistered secrets, uncovered hosts,
+        // unauthorized secret replacements) runs in `config_prepass::preflight` before this
+        // point; the authoritative per-request enforcement lives in `http_request_policy`.
         // Check uniqueness of http_server names.
         if http_servers.len()
             > http_servers
@@ -3946,7 +3591,6 @@ impl DeploymentVerified {
                 let global_executor_instance_limiter = global_executor_instance_limiter.clone();
                 let secret_registry = secret_registry.clone();
                 let global_http_config = global_http_config.clone();
-                let config_warnings = config_warnings.clone();
                 tokio::spawn(
                     async move {
                         activity_wasm
@@ -3955,7 +3599,6 @@ impl DeploymentVerified {
                                 metadata_dir,
                                 ignore_missing_env_vars,
                                 &secret_registry,
-                                config_warnings,
                                 global_http_config,
                                 global_executor_instance_limiter,
                                 fuel,
@@ -4014,7 +3657,6 @@ impl DeploymentVerified {
                 let wasm_cache_dir = wasm_cache_dir.clone();
                 let metadata_dir = metadata_dir.clone();
                 let secret_registry = secret_registry.clone();
-                let config_warnings = config_warnings.clone();
                 tokio::spawn(
                     async move {
                         webhook
@@ -4023,7 +3665,6 @@ impl DeploymentVerified {
                                 metadata_dir,
                                 ignore_missing_env_vars,
                                 &secret_registry,
-                                config_warnings,
                                 subscription_interruption,
                             )
                             .await
@@ -4122,7 +3763,6 @@ impl DeploymentVerified {
                                 wasm_cache_dir.clone(),
                                 ignore_missing_env_vars,
                                 &secret_registry,
-                                config_warnings.clone(),
                                 global_http_config.clone(),
                                 global_executor_instance_limiter.clone(),
                                 fuel,
@@ -4164,7 +3804,6 @@ impl DeploymentVerified {
                             wasm_cache_dir.clone(),
                             ignore_missing_env_vars,
                             &secret_registry,
-                            config_warnings.clone(),
                         ).await?;
                         webhooks_js_by_names.insert(k, v);
                     }
@@ -4178,7 +3817,6 @@ impl DeploymentVerified {
                             resolved_program,
                             ignore_missing_env_vars,
                             &secret_registry,
-                            &config_warnings,
                             global_executor_instance_limiter.clone(),
                         )?
                     );
@@ -5500,11 +5138,14 @@ mod tests {
     use crate::{
         command::server::{
             DeploymentRunnable, DeploymentVerified, PrepareDirsParams, RuntimeConfigAvailability,
-            ServerCompiledLinked, ServerVerified, VerifyParams,
-            collect_outbound_http_secret_replacements, collect_uncovered_outbound_http_hosts,
-            compile_activity_inline, compute_content_digest, create_engines,
-            deployment_verify_config, fix_server_exec_digests, global_secret_replacements,
-            host_allowlist_snippet, prepare_dirs, report_missing_outbound_http_secret_replacements,
+            ServerCompiledLinked, ServerVerified, VerifyParams, compile_activity_inline,
+            compute_content_digest,
+            config_prepass::{
+                collect_outbound_http_secret_replacements, collect_uncovered_outbound_http_hosts,
+                global_secret_replacements, host_allowlist_snippet,
+                report_missing_outbound_http_secret_replacements,
+            },
+            create_engines, deployment_verify_config, fix_server_exec_digests, prepare_dirs,
             webhook_global_http_allowlist,
         },
         config::{
@@ -5571,7 +5212,6 @@ mod tests {
         let err = report_missing_outbound_http_secret_replacements(
             &missing,
             RuntimeConfigAvailability::Strict,
-            &crate::config::toml::ConfigWarnings::default(),
         )
         .unwrap_err()
         .to_string();
@@ -5610,7 +5250,6 @@ mod tests {
             &unregistered,
             "the deployment's outbound HTTP entries",
             RuntimeConfigAvailability::Strict,
-            &crate::config::toml::ConfigWarnings::default(),
         )
         .unwrap_err()
         .to_string();
@@ -5633,7 +5272,6 @@ mod tests {
             &unregistered,
             "the deployment's outbound HTTP entries",
             RuntimeConfigAvailability::AllowUnavailable,
-            &crate::config::toml::ConfigWarnings::default(),
         )
         .expect("unavailable runtime config downgrades unregistered secrets to a warning");
     }
@@ -5707,7 +5345,6 @@ mod tests {
         let err = report_missing_outbound_http_secret_replacements(
             &missing,
             RuntimeConfigAvailability::Strict,
-            &crate::config::toml::ConfigWarnings::default(),
         )
         .unwrap_err()
         .to_string();
@@ -5735,15 +5372,9 @@ mod tests {
         };
         let registry =
             SecretRegistry::from_test_values(Vec::<(String, secrecy::SecretString)>::new());
-        let warnings = crate::config::toml::ConfigWarnings::default();
         let global = GlobalHttpConfig::from(
-            crate::config::toml::resolve_allowed_hosts(
-                vec![host("obeli.sk")],
-                false,
-                &registry,
-                &warnings,
-            )
-            .unwrap(),
+            crate::config::toml::resolve_allowed_hosts(vec![host("obeli.sk")], false, &registry)
+                .unwrap(),
         );
         let name = crate::config::toml::ConfigName::new("caller".into()).unwrap();
 
@@ -5755,7 +5386,6 @@ mod tests {
             &global,
             &registry,
             false,
-            &warnings,
             &mut uncovered,
         );
 
@@ -5912,7 +5542,6 @@ mod tests {
             webui_enabled,
             server_verified.secret_registry,
             server_verified.global_http_config,
-            server_verified.config_warnings,
         ))
         .await?;
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1095,7 +1095,11 @@ pub(crate) async fn verify(
                 config_holder,
                 config,
                 secret_registry,
-            } = prepare_server_startup(config_holder.config_source, EnvVarCleanupStrategy::Noop)?;
+            } = prepare_server_startup(
+                config_holder.config_source,
+                EnvVarCleanupStrategy::Noop,
+                verify_params.runtime_config_availability,
+            )?;
             (config_holder, config, secret_registry)
         } else {
             (config_holder, config, secret_registry)

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1959,8 +1959,11 @@ pub(crate) struct ServerVerified {
     global_http_config: GlobalHttpConfig,
     /// The server's own `[[outbound_http.allowed_host]]` entries, verbatim. Kept so the
     /// `config_prepass::preflight` can report unregistered secret names before they are
-    /// dropped by resolution.
+    /// dropped by resolution, and locate its per-entry advisories in `source_path`.
     server_outbound_allowed_hosts: Vec<AllowedHostToml>,
+    /// Path to the server.toml the config was loaded from, if any. Used by the pre-pass to
+    /// annotate `[[outbound_http.allowed_host]]` advisories with their source line.
+    source_path: Option<PathBuf>,
     /// Operator-owned secret registry, resolved before the runtime started. Carried
     /// here so runtime redeploys/submits resolve deployment secret references without
     /// re-reading the (already wiped) process environment.
@@ -2022,10 +2025,11 @@ impl ServerVerified {
         // (which runs before this) using `server_outbound_allowed_hosts`; here they resolve to
         // nothing and are dropped.
         let server_outbound_allowed_hosts = config.outbound_http.allowed_hosts.clone();
-        let global_http_config = GlobalHttpConfig::from(
+        let source_path = config.source_path.clone();
+        let (server_hosts, _advisories) =
             resolve_allowed_hosts(config.outbound_http.allowed_hosts, false, &secret_registry)
-                .context("invalid server.toml `[[outbound_http.allowed_host]]` entry")?,
-        );
+                .context("invalid server.toml `[[outbound_http.allowed_host]]` entry")?;
+        let global_http_config = GlobalHttpConfig::from(server_hosts);
 
         Ok(Self {
             launch: ServerVerifiedLaunch {
@@ -2046,6 +2050,7 @@ impl ServerVerified {
             max_deployment_file_bytes: config.max_deployment_file_bytes.0,
             global_http_config,
             server_outbound_allowed_hosts,
+            source_path,
             secret_registry,
         })
     }
@@ -5374,7 +5379,8 @@ mod tests {
             SecretRegistry::from_test_values(Vec::<(String, secrecy::SecretString)>::new());
         let global = GlobalHttpConfig::from(
             crate::config::toml::resolve_allowed_hosts(vec![host("obeli.sk")], false, &registry)
-                .unwrap(),
+                .unwrap()
+                .0,
         );
         let name = crate::config::toml::ConfigName::new("caller".into()).unwrap();
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1,5 +1,6 @@
 mod config_prepass;
 
+use crate::ServerStartup;
 use crate::args::Server;
 use crate::args::shadow::PKG_VERSION;
 use crate::command::termination_notifier::termination_notifier;
@@ -12,6 +13,7 @@ use crate::config::file_provider::CasFileProvider;
 use crate::config::manifest::DeploymentManifest;
 use crate::config::manifest::DeploymentManifestFile;
 use crate::config::manifest::reconcile_deployment_digests;
+use crate::config::secret_registry::EnvVarCleanupStrategy;
 use crate::config::secret_registry::SecretRegistry;
 use crate::config::toml::ActivityExecComponentConfigResolvedExt as _;
 use crate::config::toml::ActivityExecConfigVerified;
@@ -62,6 +64,7 @@ use crate::config::toml::{AllowedHostToml, MethodsInput, MethodsInputStar, Repla
 use crate::config::wasm_cache_metadata_dir;
 use crate::init;
 use crate::init::Guard;
+use crate::prepare_server_startup;
 use crate::server::grpc_server::GrpcServer;
 use crate::server::web_api_server::WebApiState;
 use crate::server::web_api_server::app_router;
@@ -1014,7 +1017,7 @@ pub(crate) struct VerifyParams {
 
 pub(crate) async fn verify(
     config_holder: ConfigHolder,
-    mut config: ServerConfigToml,
+    config: ServerConfigToml,
     deployment: Option<PathBuf>,
     verify_params: VerifyParams,
     skip_db: bool,
@@ -1061,42 +1064,45 @@ pub(crate) async fn verify(
         None
     };
 
-    // Bucket 2 auto-fix: scaffold `[secrets]` stubs for every unregistered secret the
-    // server and deployment reference. The stub has no value, so the operator must point
-    // each `env` at a set variable and re-run; stop here rather than bail confusingly on
-    // the secrets we just scaffolded.
-    if fix {
-        if let Some(server_config_path) = config_holder.config_source() {
-            let mut unregistered = BTreeSet::new();
-            config_prepass::collect_unregistered_secrets(
-                &config.outbound_http.allowed_hosts,
-                &secret_registry,
-                &mut unregistered,
-            );
-            if let Some(deployment) = deployment_opt.as_ref() {
-                for hosts in deployment_allowed_host_lists(deployment) {
-                    config_prepass::collect_unregistered_secrets(
-                        hosts,
-                        &secret_registry,
-                        &mut unregistered,
-                    );
-                }
-            }
-            let written =
-                config_prepass::fix_server_secret_scaffolds(server_config_path, &unregistered)
-                    .await?;
-            if written > 0 {
-                info!(
-                    "Scaffolded {written} `[secrets]` entry(ies) in {}; point each `env` at a set \
-                     variable and re-run verify.",
-                    server_config_path.display()
+    let (config_holder, config, secret_registry) = if fix
+        && let Some(server_config_path) = config_holder.config_source.as_deref()
+    {
+        // Add unregistered secrets
+        let mut unregistered = BTreeSet::new();
+        config_prepass::collect_unregistered_secrets(
+            &config.outbound_http.allowed_hosts,
+            &secret_registry,
+            &mut unregistered,
+        );
+        if let Some(deployment) = deployment_opt.as_ref() {
+            for hosts in deployment_allowed_host_lists(deployment) {
+                config_prepass::collect_unregistered_secrets(
+                    hosts,
+                    &secret_registry,
+                    &mut unregistered,
                 );
-                return Ok(());
             }
-        } else {
-            warn!("Cannot scaffold `[secrets]`: the server config was not loaded from a file");
         }
-    }
+        if !unregistered.is_empty() {
+            config_prepass::fix_server_secret_scaffolds(server_config_path, &unregistered).await?;
+
+            warn!(
+                "Scaffolded `[secrets]` entries in {}: {unregistered:?}",
+                server_config_path.display()
+            );
+            // Reload server config
+            let ServerStartup {
+                config_holder,
+                config,
+                secret_registry,
+            } = prepare_server_startup(config_holder.config_source, EnvVarCleanupStrategy::Noop)?;
+            (config_holder, config, secret_registry)
+        } else {
+            (config_holder, config, secret_registry)
+        }
+    } else {
+        (config_holder, config, secret_registry)
+    };
 
     let (termination_sender, mut termination_watcher) = watch::channel(());
     let prepared_dirs = prepare_dirs(
@@ -1106,18 +1112,23 @@ pub(crate) async fn verify(
         &secret_registry,
     )
     .await?;
-    if fix
-        && let (Some(server_config_path), Some(deployment)) =
-            (config_holder.config_source(), deployment_opt.as_ref())
-    {
+    let config = if fix
+        && let (Some(server_config_path), Some(deployment)) = (
+            config_holder.config_source.as_deref(),
+            deployment_opt.as_ref(),
+        ) {
         let allowlist = fix_server_exec_digests(
             server_config_path,
             &deployment.activities_exec,
             &prepared_dirs.wasm_cache_dir,
         )
         .await?;
+        let mut config = config;
         config.allow_exec_activities = AllowExecActivities::Allowlist(allowlist);
-    }
+        config
+    } else {
+        config
+    };
     let engines = create_engines(&config, &prepared_dirs)?;
     tokio::spawn(async move { termination_notifier(termination_sender).await });
     let mut db_pool = if !skip_db {
@@ -5699,10 +5710,9 @@ mod tests {
         .expect("unavailable runtime config downgrades unregistered secrets to a warning");
     }
 
-    /// `--fix` appends a `[secrets]` scaffold only for names not already present,
-    /// preserving existing entries, and is a no-op on re-run.
+    /// `--fix` appends a `[secrets]` scaffold for all specified names
     #[tokio::test]
-    async fn fix_server_secret_scaffolds_appends_missing_and_is_idempotent() {
+    async fn fix_server_secret_scaffolds_appends_missing() {
         use crate::command::server::config_prepass::fix_server_secret_scaffolds;
         use std::io::Write as _;
         let mut file = tempfile::NamedTempFile::new().unwrap();
@@ -5710,10 +5720,8 @@ mod tests {
         let path = file.path();
 
         let mut names = std::collections::BTreeSet::new();
-        names.insert("EXISTING".to_string()); // already present, must not be duplicated
         names.insert("NEW_ONE".to_string());
-        let written = fix_server_secret_scaffolds(path, &names).await.unwrap();
-        assert_eq!(written, 1, "only NEW_ONE is scaffolded");
+        fix_server_secret_scaffolds(path, &names).await.unwrap();
 
         let after = std::fs::read_to_string(path).unwrap();
         assert!(
@@ -5721,9 +5729,6 @@ mod tests {
             "{after}"
         );
         assert!(after.contains("NEW_ONE = { env = \"NEW_ONE\" }"), "{after}");
-
-        let written_again = fix_server_secret_scaffolds(path, &names).await.unwrap();
-        assert_eq!(written_again, 0, "re-running scaffolds nothing new");
     }
 
     /// Missing replacements from several components are gathered into one report,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1,7 +1,6 @@
 mod config_prepass;
 
 use crate::ServerStartup;
-use crate::args::Server;
 use crate::args::shadow::PKG_VERSION;
 use crate::command::termination_notifier::termination_notifier;
 use crate::config::config_holder::ConfigHolder;
@@ -408,81 +407,6 @@ const HTTP_SERVER_NAME_WEBUI: &str = "webui";
 const HTTP_SERVER_NAME_EXTERNAL: &str = "external";
 /// Component name of the operator-owned web UI webhook injected when the web UI is enabled.
 const COMPONENT_NAME_WEBUI: &str = "obelisk_webui";
-
-impl Server {
-    pub(crate) async fn run(
-        self,
-        config_holder: ConfigHolder,
-        config: ServerConfigToml,
-        secret_registry: Arc<SecretRegistry>,
-    ) -> Result<(), anyhow::Error> {
-        match self {
-            Server::Run {
-                clean_sqlite_directory,
-                clean_cache,
-                clean_codegen_cache,
-                server_config: _,
-                deployment,
-                empty: deployment_empty,
-                description,
-                suppress_type_checking_errors,
-                allow_unauthenticated_api,
-            } => {
-                Box::pin(run(
-                    config_holder,
-                    config,
-                    deployment,
-                    deployment_empty,
-                    description,
-                    RunParams {
-                        dir_params: PrepareDirsParams {
-                            clean_cache,
-                            clean_codegen_cache,
-                        },
-                        clean_sqlite_directory,
-                        suppress_type_checking_errors,
-                        allow_unauthenticated_api,
-                    },
-                    secret_registry,
-                ))
-                .await
-            }
-            Server::Verify(crate::args::VerifyArgs {
-                clean_cache,
-                clean_codegen_cache,
-                server_config: _,
-                deployment,
-                allow_unavailable_runtime_config,
-                suppress_type_checking_errors,
-                skip_db,
-                fix,
-            }) => {
-                Box::pin(verify(
-                    config_holder,
-                    config,
-                    deployment,
-                    VerifyParams {
-                        dir_params: PrepareDirsParams {
-                            clean_cache,
-                            clean_codegen_cache,
-                        },
-                        runtime_config_availability: if allow_unavailable_runtime_config {
-                            RuntimeConfigAvailability::AllowUnavailable
-                        } else {
-                            RuntimeConfigAvailability::Strict
-                        },
-                        suppress_type_checking_errors,
-                        suppress_linking_errors: false,
-                    },
-                    skip_db,
-                    fix,
-                    secret_registry,
-                ))
-                .await
-            }
-        }
-    }
-}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SubmitError {

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -4144,6 +4144,7 @@ async fn compile_and_link(
                                 logs_store_min_level: webhook.logs_store_min_level,
                                 allowed_hosts,
                                 global_http_config,
+                                secrets: webhook.secrets,
                                 js_config: None,
                                 config_section_hint: webhook.config_section_hint,
                             };
@@ -4187,6 +4188,7 @@ async fn compile_and_link(
                                 logs_store_min_level: webhook_js.logs_store_min_level,
                                 allowed_hosts: webhook_js.allowed_hosts,
                                 global_http_config: global_http_config.clone(),
+                                secrets: webhook_js.secrets,
                                 js_config: Some(WebhookEndpointJsConfig {
                                     source: webhook_js.js_source,
                                     file_name: webhook_js.js_file_name.clone(),
@@ -4536,9 +4538,9 @@ fn prespawn_activity_exec(
 
     let program = activity_exec.program;
 
-    // The worker nests these secrets under the `secrets` key of the stdin JSON document
-    // at execution time.
-    let secrets = activity_exec.secrets.map(|secrets| secrets.env_vars);
+    // The worker resolves these declared secrets by name and nests them under the
+    // `secrets` key of the stdin JSON document at execution time.
+    let secrets = activity_exec.secrets;
 
     let worker = ActivityExecWorkerCompiled::new(
         program,
@@ -5420,7 +5422,7 @@ mod tests {
             )
             .unwrap(),
             request_url_regex: None,
-            secret_env_mappings: Vec::new(),
+            secret_names: Vec::new(),
             replace_in: hashbrown::HashSet::new(),
         };
         let allowed: Arc<[AllowedHostConfig]> = Arc::from(vec![target]);

--- a/src/command/server/config_prepass.rs
+++ b/src/command/server/config_prepass.rs
@@ -79,16 +79,13 @@ pub(super) fn report_unregistered_secrets(
     }
 }
 
-/// Append a `[secrets]` scaffold entry `X = { env = "X" }` for each name not already
-/// present to the server config file, preserving existing formatting. Returns how many
-/// were written. Bucket 2 (semi-fixable): the stub has no value, so a later verify still
-/// fails until the operator points `env` at a set variable.
+/// Append a `[secrets]` scaffold entry `X = { env = "X" }` for each name.
 pub(super) async fn fix_server_secret_scaffolds(
     server_config_path: &Path,
     names: &BTreeSet<String>,
-) -> Result<usize, anyhow::Error> {
+) -> Result<(), anyhow::Error> {
     if names.is_empty() {
-        return Ok(0);
+        return Ok(());
     }
     let source = tokio::fs::read_to_string(server_config_path)
         .await
@@ -102,20 +99,17 @@ pub(super) async fn fix_server_secret_scaffolds(
         .or_insert_with(|| Item::Table(Table::new()))
         .as_table_mut()
         .context("`secrets` in server config is not a table")?;
-    let mut written = 0;
     for name in names {
         if table.contains_key(name) {
-            continue;
+            bail!("secret {name} must not be present");
         }
         let mut inline = toml_edit::InlineTable::new();
         inline.insert("env", name.as_str().into());
         table.insert(name, value(inline));
-        written += 1;
     }
-    if written > 0 {
-        tokio::fs::write(server_config_path, doc.to_string())
-            .await
-            .with_context(|| format!("cannot write fixed server config {server_config_path:?}"))?;
-    }
-    Ok(written)
+    tokio::fs::write(server_config_path, doc.to_string())
+        .await
+        .with_context(|| format!("cannot write fixed server config {server_config_path:?}"))?;
+
+    Ok(())
 }

--- a/src/command/server/config_prepass.rs
+++ b/src/command/server/config_prepass.rs
@@ -4,9 +4,10 @@
 //!
 //! The pre-pass owns the continue/bail/fix decision for the outbound-HTTP allowlist:
 //! unregistered secret names, secret replacements the operator allowlist does not authorize,
-//! and destinations no allowlist entry covers. The resolvers (`resolve_allowed_hosts`,
-//! `resolve_named_secrets`) no longer make that decision; they drop what they cannot resolve,
-//! and `http_request_policy` enforces the same rules per request (failing closed). Running the
+//! and destinations no allowlist entry covers. The verified config carries only secret
+//! *names*; `resolve_allowed_hosts` no longer makes that decision, and values are fetched
+//! lazily per execution run through a component-scoped `RestrictedSecretRegistry`, which
+//! (like `http_request_policy`) fails closed when a name cannot be resolved. Running the
 //! pre-pass here lets the operator fix every finding in one edit.
 
 use super::RuntimeConfigAvailability;
@@ -329,7 +330,7 @@ pub(super) fn global_secret_replacements(
         .entries()
         .iter()
         .flat_map(|entry| {
-            entry.secret_env_mappings.iter().flat_map(|(name, _)| {
+            entry.secret_names.iter().flat_map(|name| {
                 entry
                     .replace_in
                     .iter()

--- a/src/command/server/config_prepass.rs
+++ b/src/command/server/config_prepass.rs
@@ -12,14 +12,123 @@
 use super::RuntimeConfigAvailability;
 use crate::config::secret_registry::SecretRegistry;
 use crate::config::toml::{
-    AllowedHostToml, ConfigName, DeploymentResolved, MethodsInput, ReplaceIn, resolve_allowed_hosts,
+    AllowedHostToml, ConfigName, DeploymentResolved, MethodsInput, ReplaceIn,
+    allowed_host_fingerprint, resolve_allowed_hosts,
 };
 use anyhow::{Context, bail};
-use std::collections::BTreeSet;
-use std::path::Path;
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, Item, Table, value};
 use tracing::warn;
 use wasm_workers::http_request_policy::{GlobalHttpConfig, ReplacementLocation};
+
+/// Collects the per-entry `allowed_host` advisories the resolver emits and pairs each with the
+/// source `path:line` of the `[[*.allowed_host]]` block it came from, deduplicating identical
+/// findings that appear in several entries. Single-threaded (owned by the pre-pass), so it
+/// needs no lock; the resolvers no longer carry a warning sink.
+#[derive(Default)]
+struct LocatedWarnings {
+    /// advisory message -> set of `path:line` locations
+    by_message: BTreeMap<String, BTreeSet<String>>,
+    /// `allowed_host` TOML fingerprint -> source locations parsed out of the indexed files
+    locations: BTreeMap<String, BTreeSet<(PathBuf, usize)>>,
+}
+
+impl LocatedWarnings {
+    /// Parse `path` and record the line of every `[[*.allowed_host]]` block, keyed by the
+    /// fingerprint of the entry it deserializes to. Best-effort: unreadable or unparsable
+    /// files leave the index empty and advisories are reported without a location.
+    fn index_file(&mut self, path: &Path) {
+        #[derive(Deserialize)]
+        struct AllowedHostBlock {
+            allowed_host: Vec<AllowedHostToml>,
+        }
+        let Ok(source) = std::fs::read_to_string(path) else {
+            return;
+        };
+        let lines = source.lines().collect::<Vec<_>>();
+        for (start, line) in lines.iter().enumerate() {
+            let header = line.split('#').next().unwrap_or_default().trim();
+            if !(header.starts_with("[[") && header.ends_with(".allowed_host]]")) {
+                continue;
+            }
+            let end = lines[start + 1..]
+                .iter()
+                .position(|line| {
+                    line.split('#')
+                        .next()
+                        .unwrap_or_default()
+                        .trim_start()
+                        .starts_with('[')
+                })
+                .map_or(lines.len(), |offset| start + 1 + offset);
+            let mut block = String::from("[[allowed_host]]\n");
+            for line in &lines[start + 1..end] {
+                block.push_str(line);
+                block.push('\n');
+            }
+            let Ok(block) = toml::from_str::<AllowedHostBlock>(&block) else {
+                continue;
+            };
+            let Some(entry) = block.allowed_host.first() else {
+                continue;
+            };
+            self.locations
+                .entry(allowed_host_fingerprint(entry))
+                .or_default()
+                .insert((path.to_path_buf(), start + 1));
+        }
+    }
+
+    /// Resolve `entries` for their advisories and record each against its source locations.
+    fn lint(
+        &mut self,
+        entries: &[AllowedHostToml],
+        ignore_missing_env_vars: bool,
+        secret_registry: &SecretRegistry,
+    ) {
+        let Ok((_hosts, advisories)) =
+            resolve_allowed_hosts(entries.to_vec(), ignore_missing_env_vars, secret_registry)
+        else {
+            return;
+        };
+        for advisory in advisories {
+            let located = self
+                .locations
+                .get(&advisory.fingerprint)
+                .into_iter()
+                .flatten()
+                .map(|(path, line)| format!("{}:{line}", path.display()))
+                .collect::<Vec<_>>();
+            self.by_message
+                .entry(advisory.message)
+                .or_default()
+                .extend(located);
+        }
+    }
+
+    fn emit(self) {
+        if self.by_message.is_empty() {
+            return;
+        }
+        let lines = self
+            .by_message
+            .into_iter()
+            .map(|(message, locations)| {
+                if locations.is_empty() {
+                    message
+                } else {
+                    format!(
+                        "{message} ({})",
+                        locations.into_iter().collect::<Vec<_>>().join(", ")
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        warn!("Configuration warnings:\n- {}", lines.join("\n- "));
+    }
+}
 
 /// Run the outbound-HTTP allowlist pre-pass over the server's own config and, when present,
 /// the deployment being started/verified. Bails on the first fatal category collected so far
@@ -32,86 +141,107 @@ pub(super) fn preflight(
 ) -> Result<(), anyhow::Error> {
     let secret_registry = &*server_verified.secret_registry;
     let global_http_config = &server_verified.global_http_config;
+    let ignore_missing_env_vars = availability.allows_unavailable();
 
-    // Unregistered secrets: the server's own `[[outbound_http.allowed_host]]` entries are always
-    // fatal (the server cannot run with an invalid allowlist); the deployment's follow availability.
+    // Index the source files up front so per-entry advisories can be located, then lint the
+    // server's own outbound allowlist. Resolution (in `ServerVerified::new` and component
+    // preparation) drops these advisories; the pre-pass is their sole, located emitter.
+    let mut warnings = LocatedWarnings::default();
+    if let Some(path) = &server_verified.source_path {
+        warnings.index_file(path);
+    }
+    if let Some(deployment) = deployment
+        && let Some(path) = &deployment.source_path
+    {
+        warnings.index_file(path);
+    }
+    warnings.lint(
+        &server_verified.server_outbound_allowed_hosts,
+        false,
+        secret_registry,
+    );
+
+    // The server's own `[[outbound_http.allowed_host]]` unregistered secrets are always fatal
+    // (the server cannot run with an invalid allowlist); the deployment's follow availability.
     let mut server_unregistered = BTreeSet::new();
     collect_unregistered_secrets(
         &server_verified.server_outbound_allowed_hosts,
         secret_registry,
         &mut server_unregistered,
     );
+
+    let server_replacements = global_secret_replacements(global_http_config);
+    let mut missing_replacements = Vec::new();
+    let mut uncovered_hosts = Vec::new();
+    let mut unregistered = BTreeSet::new();
+    if let Some(deployment) = deployment {
+        let mut check = |section: &'static str, name: &ConfigName, hosts: &[AllowedHostToml]| {
+            warnings.lint(hosts, ignore_missing_env_vars, secret_registry);
+            collect_outbound_http_secret_replacements(
+                section,
+                name,
+                hosts,
+                &server_replacements,
+                secret_registry,
+                &mut missing_replacements,
+            );
+            collect_uncovered_outbound_http_hosts(
+                section,
+                name,
+                hosts,
+                global_http_config,
+                secret_registry,
+                ignore_missing_env_vars,
+                &mut uncovered_hosts,
+            );
+            collect_unregistered_secrets(hosts, secret_registry, &mut unregistered);
+        };
+        for activity in &deployment.activities_wasm {
+            check(
+                "activity_wasm",
+                &activity.common.name,
+                &activity.allowed_hosts,
+            );
+        }
+        for activity in &deployment.activities_js {
+            check("activity_js", &activity.name, &activity.allowed_hosts);
+        }
+        for webhook in &deployment.webhooks_wasm {
+            check(
+                "webhook_endpoint_wasm",
+                &webhook.common.name,
+                &webhook.allowed_hosts,
+            );
+        }
+        for webhook in &deployment.webhooks_js {
+            check("webhook_endpoint_js", &webhook.name, &webhook.allowed_hosts);
+        }
+        // Exec activities reference secrets directly (exposed on stdin), not via `allowed_host`.
+        for exec in &deployment.activities_exec {
+            for name in &exec.secrets {
+                if secret_registry.secret_lookup(name).is_none() {
+                    unregistered.insert(name.clone());
+                }
+            }
+        }
+    }
+
+    // Emit the informational warnings (located advisories, uncovered hosts) before any fatal
+    // report, so the operator sees every finding even when a fatal one aborts the run.
+    warnings.emit();
+    report_uncovered_outbound_http_hosts(&uncovered_hosts);
+
     report_unregistered_secrets(
         &server_unregistered,
         "server.toml `[[outbound_http.allowed_host]]` entries",
         RuntimeConfigAvailability::Strict,
     )?;
-
-    let Some(deployment) = deployment else {
-        return Ok(());
-    };
-
-    let ignore_missing_env_vars = availability.allows_unavailable();
-    let server_replacements = global_secret_replacements(global_http_config);
-    let mut missing_replacements = Vec::new();
-    let mut uncovered_hosts = Vec::new();
-    let mut unregistered = BTreeSet::new();
-    let mut check = |section: &'static str, name: &ConfigName, hosts: &[AllowedHostToml]| {
-        collect_outbound_http_secret_replacements(
-            section,
-            name,
-            hosts,
-            &server_replacements,
-            secret_registry,
-            &mut missing_replacements,
-        );
-        collect_uncovered_outbound_http_hosts(
-            section,
-            name,
-            hosts,
-            global_http_config,
-            secret_registry,
-            ignore_missing_env_vars,
-            &mut uncovered_hosts,
-        );
-        collect_unregistered_secrets(hosts, secret_registry, &mut unregistered);
-    };
-    for activity in &deployment.activities_wasm {
-        check(
-            "activity_wasm",
-            &activity.common.name,
-            &activity.allowed_hosts,
-        );
-    }
-    for activity in &deployment.activities_js {
-        check("activity_js", &activity.name, &activity.allowed_hosts);
-    }
-    for webhook in &deployment.webhooks_wasm {
-        check(
-            "webhook_endpoint_wasm",
-            &webhook.common.name,
-            &webhook.allowed_hosts,
-        );
-    }
-    for webhook in &deployment.webhooks_js {
-        check("webhook_endpoint_js", &webhook.name, &webhook.allowed_hosts);
-    }
-    // Exec activities reference secrets directly (exposed on stdin), not via `allowed_host`.
-    for exec in &deployment.activities_exec {
-        for name in &exec.secrets {
-            if secret_registry.secret_lookup(name).is_none() {
-                unregistered.insert(name.clone());
-            }
-        }
-    }
-
     report_unregistered_secrets(
         &unregistered,
         "the deployment's secret references",
         availability,
     )?;
     report_missing_outbound_http_secret_replacements(&missing_replacements, availability)?;
-    report_uncovered_outbound_http_hosts(&uncovered_hosts);
     Ok(())
 }
 
@@ -395,7 +525,7 @@ pub(super) fn collect_uncovered_outbound_http_hosts(
             continue;
         }
         // Resolve one entry at a time to keep the original TOML for the snippet.
-        let Ok(resolved) = resolve_allowed_hosts(
+        let Ok((resolved, _advisories)) = resolve_allowed_hosts(
             vec![entry.clone()],
             ignore_missing_env_vars,
             secret_registry,
@@ -486,4 +616,43 @@ pub(super) async fn fix_server_secret_scaffolds(
         .with_context(|| format!("cannot write fixed server config {server_config_path:?}"))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A resolver advisory is joined to the `[[*.allowed_host]]` block it came from and
+    /// annotated with the source `path:line`, deduplicating identical findings.
+    #[test]
+    fn advisory_is_located_to_source_line() {
+        // `methods` omitted triggers the "no methods" advisory; the entry still resolves.
+        let entry = AllowedHostToml {
+            pattern: "http://localhost:5005".to_string(),
+            methods: None,
+            request_url_regex: None,
+            secrets: Vec::new(),
+            replace_in: Vec::new(),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("server.toml");
+        // Write the block from the same entry so its fingerprint matches on both sides.
+        std::fs::write(
+            &path,
+            format!(
+                "# policy\n[[outbound_http.allowed_host]]\n{}",
+                toml::to_string(&entry).unwrap()
+            ),
+        )
+        .unwrap();
+
+        let mut warnings = LocatedWarnings::default();
+        warnings.index_file(&path);
+        warnings.lint(&[entry], false, &SecretRegistry::empty());
+
+        let (message, locations) = warnings.by_message.iter().next().expect("one advisory");
+        assert!(message.contains("has no `methods`"), "{message}");
+        let location = locations.iter().next().expect("one location");
+        assert!(location.ends_with("server.toml:2"), "{location}");
+    }
 }

--- a/src/command/server/config_prepass.rs
+++ b/src/command/server/config_prepass.rs
@@ -1,19 +1,132 @@
-//! Config verify pre-pass: aggregate config findings across a whole `server verify`
-//! run instead of bailing on the first, and apply the auto-fixable subset under `--fix`.
+//! Config verify pre-pass: aggregate config findings across a whole server startup or
+//! `server verify` run instead of bailing on the first, and apply the auto-fixable subset
+//! under `--fix`.
 //!
-//! The pre-pass drives the existing `resolve_*` validators and collects their findings;
-//! it never re-implements validation, so the resolvers stay the single source of truth.
-//! This module owns the "unregistered secret" category and the server-config `--fix`
-//! applier; the outbound-HTTP coverage/replacement collectors live next to the pre-pass
-//! in `server.rs`. See `meta/designs/config-verify-prepass.md`.
+//! The pre-pass owns the continue/bail/fix decision for the outbound-HTTP allowlist:
+//! unregistered secret names, secret replacements the operator allowlist does not authorize,
+//! and destinations no allowlist entry covers. The resolvers (`resolve_allowed_hosts`,
+//! `resolve_named_secrets`) no longer make that decision; they drop what they cannot resolve,
+//! and `http_request_policy` enforces the same rules per request (failing closed). Running the
+//! pre-pass here lets the operator fix every finding in one edit.
 
 use super::RuntimeConfigAvailability;
 use crate::config::secret_registry::SecretRegistry;
-use crate::config::toml::{AllowedHostToml, ConfigWarnings};
+use crate::config::toml::{
+    AllowedHostToml, ConfigName, DeploymentResolved, MethodsInput, ReplaceIn, resolve_allowed_hosts,
+};
 use anyhow::{Context, bail};
 use std::collections::BTreeSet;
 use std::path::Path;
 use toml_edit::{DocumentMut, Item, Table, value};
+use tracing::warn;
+use wasm_workers::http_request_policy::{GlobalHttpConfig, ReplacementLocation};
+
+/// Run the outbound-HTTP allowlist pre-pass over the server's own config and, when present,
+/// the deployment being started/verified. Bails on the first fatal category collected so far
+/// under strict availability; downgrades the fatal categories to warnings when unavailable
+/// runtime configuration is allowed (activation re-checks strictly).
+pub(super) fn preflight(
+    server_verified: &super::ServerVerified,
+    deployment: Option<&DeploymentResolved>,
+    availability: RuntimeConfigAvailability,
+) -> Result<(), anyhow::Error> {
+    let secret_registry = &*server_verified.secret_registry;
+    let global_http_config = &server_verified.global_http_config;
+
+    // Unregistered secrets: the server's own `[[outbound_http.allowed_host]]` entries are always
+    // fatal (the server cannot run with an invalid allowlist); the deployment's follow availability.
+    let mut server_unregistered = BTreeSet::new();
+    collect_unregistered_secrets(
+        &server_verified.server_outbound_allowed_hosts,
+        secret_registry,
+        &mut server_unregistered,
+    );
+    report_unregistered_secrets(
+        &server_unregistered,
+        "server.toml `[[outbound_http.allowed_host]]` entries",
+        RuntimeConfigAvailability::Strict,
+    )?;
+
+    let Some(deployment) = deployment else {
+        return Ok(());
+    };
+
+    let ignore_missing_env_vars = availability.allows_unavailable();
+    let server_replacements = global_secret_replacements(global_http_config);
+    let mut missing_replacements = Vec::new();
+    let mut uncovered_hosts = Vec::new();
+    let mut unregistered = BTreeSet::new();
+    let mut check = |section: &'static str, name: &ConfigName, hosts: &[AllowedHostToml]| {
+        collect_outbound_http_secret_replacements(
+            section,
+            name,
+            hosts,
+            &server_replacements,
+            secret_registry,
+            &mut missing_replacements,
+        );
+        collect_uncovered_outbound_http_hosts(
+            section,
+            name,
+            hosts,
+            global_http_config,
+            secret_registry,
+            ignore_missing_env_vars,
+            &mut uncovered_hosts,
+        );
+        collect_unregistered_secrets(hosts, secret_registry, &mut unregistered);
+    };
+    for activity in &deployment.activities_wasm {
+        check(
+            "activity_wasm",
+            &activity.common.name,
+            &activity.allowed_hosts,
+        );
+    }
+    for activity in &deployment.activities_js {
+        check("activity_js", &activity.name, &activity.allowed_hosts);
+    }
+    for webhook in &deployment.webhooks_wasm {
+        check(
+            "webhook_endpoint_wasm",
+            &webhook.common.name,
+            &webhook.allowed_hosts,
+        );
+    }
+    for webhook in &deployment.webhooks_js {
+        check("webhook_endpoint_js", &webhook.name, &webhook.allowed_hosts);
+    }
+    // Exec activities reference secrets directly (exposed on stdin), not via `allowed_host`.
+    for exec in &deployment.activities_exec {
+        for name in &exec.secrets {
+            if secret_registry.secret_lookup(name).is_none() {
+                unregistered.insert(name.clone());
+            }
+        }
+    }
+
+    report_unregistered_secrets(
+        &unregistered,
+        "the deployment's secret references",
+        availability,
+    )?;
+    report_missing_outbound_http_secret_replacements(&missing_replacements, availability)?;
+    report_uncovered_outbound_http_hosts(&uncovered_hosts);
+    Ok(())
+}
+
+/// Every component's outbound HTTP `allowed_hosts`, over the same component kinds the
+/// deployment pre-pass checks. Used by `--fix` to gather referenced secret names.
+pub(super) fn deployment_allowed_host_lists(
+    deployment: &DeploymentResolved,
+) -> Vec<&[AllowedHostToml]> {
+    let mut lists: Vec<&[AllowedHostToml]> = Vec::new();
+    lists.extend(deployment.activities_wasm.iter().map(|c| &*c.allowed_hosts));
+    lists.extend(deployment.activities_js.iter().map(|c| &*c.allowed_hosts));
+    lists.extend(deployment.webhooks_wasm.iter().map(|c| &*c.allowed_hosts));
+    lists.extend(deployment.webhooks_js.iter().map(|c| &*c.allowed_hosts));
+    lists
+}
 
 /// Append every secret name referenced by `entries` that the operator registry does not
 /// know onto `unregistered` (deduplicated). An unregistered name can never be injected,
@@ -50,7 +163,6 @@ pub(super) fn report_unregistered_secrets(
     unregistered: &BTreeSet<String>,
     source_desc: &str,
     availability: RuntimeConfigAvailability,
-    warnings: &ConfigWarnings,
 ) -> Result<(), anyhow::Error> {
     if unregistered.is_empty() {
         return Ok(());
@@ -69,14 +181,276 @@ pub(super) fn report_unregistered_secrets(
          {snippet}"
     );
     if availability.allows_unavailable() {
-        warnings.insert(format!(
+        warn!(
             "{message}\nSkipping these load-time secret checks because unavailable runtime \
              configuration is allowed; activation will enforce them strictly."
-        ));
+        );
         Ok(())
     } else {
         bail!("{message}");
     }
+}
+
+/// The `(secret name, replacement target)` pairs the operator global allowlist authorizes.
+pub(super) fn global_secret_replacements(
+    global_http_config: &GlobalHttpConfig,
+) -> hashbrown::HashSet<(&str, ReplacementLocation)> {
+    global_http_config
+        .entries()
+        .iter()
+        .flat_map(|entry| {
+            entry.secret_env_mappings.iter().flat_map(|(name, _)| {
+                entry
+                    .replace_in
+                    .iter()
+                    .copied()
+                    .map(move |target| (name.as_str(), target))
+            })
+        })
+        .collect()
+}
+
+fn replacement_target(replace_in: ReplaceIn) -> ReplacementLocation {
+    match replace_in {
+        ReplaceIn::Headers => ReplacementLocation::Headers,
+        ReplaceIn::Body => ReplacementLocation::Body,
+        ReplaceIn::Params => ReplacementLocation::Params,
+    }
+}
+
+fn replacement_target_name(replace_in: ReplaceIn) -> &'static str {
+    match replace_in {
+        ReplaceIn::Headers => "headers",
+        ReplaceIn::Body => "body",
+        ReplaceIn::Params => "params",
+    }
+}
+
+fn allowed_host_snippet(
+    section: &str,
+    entry: &AllowedHostToml,
+    secret: &str,
+    replace_in: ReplaceIn,
+) -> String {
+    let mut entry = entry.clone();
+    entry.secrets = vec![secret.to_string()];
+    entry.replace_in = vec![replace_in];
+    let body = toml::to_string(&entry).expect("AllowedHostToml must serialize to TOML");
+    format!("[[{section}.allowed_host]]\n{body}")
+}
+
+/// A secret replacement a component requests that the operator global allowlist
+/// does not authorize. Collected across the whole deployment so every missing
+/// allowance is reported at once, letting the operator add them all in one pass.
+pub(super) struct MissingSecretReplacement {
+    component_section: &'static str,
+    component_name: ConfigName,
+    entry: AllowedHostToml,
+    secret: String,
+    replace_in: ReplaceIn,
+}
+
+/// Append every secret replacement `entries` requests that `server_replacements`
+/// does not authorize onto `missing`. Registered-only secrets are checked (an
+/// unregistered secret name cannot be injected, so it is skipped here).
+pub(super) fn collect_outbound_http_secret_replacements(
+    component_section: &'static str,
+    component_name: &ConfigName,
+    entries: &[AllowedHostToml],
+    server_replacements: &hashbrown::HashSet<(&str, ReplacementLocation)>,
+    secret_registry: &SecretRegistry,
+    missing: &mut Vec<MissingSecretReplacement>,
+) {
+    for entry in entries {
+        if entry.methods.is_none()
+            || matches!(&entry.methods, Some(MethodsInput::List(methods)) if methods.is_empty())
+        {
+            continue;
+        }
+        for secret in &entry.secrets {
+            if secret_registry.secret_lookup(secret).is_none() {
+                continue;
+            }
+            for replace_in in &entry.replace_in {
+                let requested_replacement = (secret.as_str(), replacement_target(*replace_in));
+                if server_replacements.contains(&requested_replacement) {
+                    continue;
+                }
+                missing.push(MissingSecretReplacement {
+                    component_section,
+                    component_name: component_name.clone(),
+                    entry: entry.clone(),
+                    secret: secret.clone(),
+                    replace_in: *replace_in,
+                });
+            }
+        }
+    }
+}
+
+/// Emit a single report covering every collected missing secret replacement, so
+/// the operator can add all the required allowlist entries to server.toml in one edit.
+/// Bails under strict availability; downgrades to a warning when unavailable
+/// runtime config is allowed (activation re-checks strictly).
+pub(super) fn report_missing_outbound_http_secret_replacements(
+    missing: &[MissingSecretReplacement],
+    availability: RuntimeConfigAvailability,
+) -> Result<(), anyhow::Error> {
+    if missing.is_empty() {
+        return Ok(());
+    }
+    use std::fmt::Write as _;
+    let mut details = String::new();
+    let mut server_snippets: Vec<String> = Vec::new();
+    let mut deployment_snippets: Vec<String> = Vec::new();
+    for m in missing {
+        let _ = writeln!(
+            details,
+            "  - component `{name}` (`[[{section}.allowed_host]]`) requests replacing secret \
+             `{secret}` in `{target}`",
+            name = m.component_name,
+            section = m.component_section,
+            secret = m.secret,
+            target = replacement_target_name(m.replace_in),
+        );
+        // Multiple components may request the same allowlist entry; list each unique
+        // snippet once so the operator does not paste duplicates.
+        let server_snippet =
+            allowed_host_snippet("outbound_http", &m.entry, &m.secret, m.replace_in);
+        if !server_snippets.contains(&server_snippet) {
+            server_snippets.push(server_snippet);
+        }
+        let deployment_snippet =
+            allowed_host_snippet(m.component_section, &m.entry, &m.secret, m.replace_in);
+        if !deployment_snippets.contains(&deployment_snippet) {
+            deployment_snippets.push(deployment_snippet);
+        }
+    }
+    let message = format!(
+        "the deployment requests {count} outbound HTTP secret replacement(s) that no server.toml \
+         `[[outbound_http.allowed_host]]` entry authorizes:\n\
+         {details}\n\
+         After review, add these allowlist entries to server.toml:\n\n\
+         {server}\n\
+         The corresponding deployment.toml entries are:\n\n\
+         {deployment}",
+        count = missing.len(),
+        server = server_snippets.join("\n"),
+        deployment = deployment_snippets.join("\n"),
+    );
+    if availability.allows_unavailable() {
+        warn!(
+            "{message}\nSkipping these load-time secret replacement checks because unavailable \
+             runtime configuration is allowed; activation will enforce them strictly."
+        );
+        Ok(())
+    } else {
+        bail!("{message}");
+    }
+}
+
+/// A component destination that no operator global allowlist entry covers, collected
+/// across the deployment so every gap is reported at load time rather than one-by-one.
+pub(super) struct UncoveredOutboundHost {
+    component_section: &'static str,
+    component_name: ConfigName,
+    pub(super) entry: AllowedHostToml,
+}
+
+/// Render a destination-only `[[<section>.allowed_host]]` snippet, dropping secret fields.
+pub(super) fn host_allowlist_snippet(section: &str, entry: &AllowedHostToml) -> String {
+    #[derive(serde::Serialize)]
+    struct DestinationEntry {
+        pattern: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        methods: Option<MethodsInput>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        request_url_regex: Option<String>,
+    }
+    let body = toml::to_string(&DestinationEntry {
+        pattern: entry.pattern.clone(),
+        methods: entry.methods.clone(),
+        request_url_regex: entry.request_url_regex.clone(),
+    })
+    .expect("destination allowlist entry must serialize to TOML");
+    format!("[[{section}.allowed_host]]\n{body}")
+}
+
+/// Append every destination in `entries` that no global allowlist entry covers onto
+/// `uncovered`. Allow-nothing entries need no allowlist entry; resolution failures are
+/// left for component preparation to report authoritatively.
+pub(super) fn collect_uncovered_outbound_http_hosts(
+    component_section: &'static str,
+    component_name: &ConfigName,
+    entries: &[AllowedHostToml],
+    global_http_config: &GlobalHttpConfig,
+    secret_registry: &SecretRegistry,
+    ignore_missing_env_vars: bool,
+    uncovered: &mut Vec<UncoveredOutboundHost>,
+) {
+    for entry in entries {
+        if entry.methods.is_none()
+            || matches!(&entry.methods, Some(MethodsInput::List(methods)) if methods.is_empty())
+        {
+            continue;
+        }
+        // Resolve one entry at a time to keep the original TOML for the snippet.
+        let Ok(resolved) = resolve_allowed_hosts(
+            vec![entry.clone()],
+            ignore_missing_env_vars,
+            secret_registry,
+        ) else {
+            continue;
+        };
+        let Some(resolved) = resolved.first() else {
+            continue;
+        };
+        if !global_http_config
+            .entries()
+            .iter()
+            .any(|allowed| allowed.covers(resolved))
+        {
+            uncovered.push(UncoveredOutboundHost {
+                component_section,
+                component_name: component_name.clone(),
+                entry: entry.clone(),
+            });
+        }
+    }
+}
+
+/// Warn once, listing the allowlist entries to add. A warning, not an error: coverage
+/// is conservative and a component may declare destinations it never calls.
+pub(super) fn report_uncovered_outbound_http_hosts(uncovered: &[UncoveredOutboundHost]) {
+    if uncovered.is_empty() {
+        return;
+    }
+    use std::fmt::Write as _;
+    let mut details = String::new();
+    let mut snippets: Vec<String> = Vec::new();
+    for host in uncovered {
+        let _ = writeln!(
+            details,
+            "  - component `{name}` (`[[{section}.allowed_host]]`) allows `{pattern}`",
+            name = host.component_name,
+            section = host.component_section,
+            pattern = host.entry.pattern,
+        );
+        let snippet = host_allowlist_snippet("outbound_http", &host.entry);
+        if !snippets.contains(&snippet) {
+            snippets.push(snippet);
+        }
+    }
+    warn!(
+        "{count} outbound HTTP destination(s) the deployment allows are not covered by any \
+         server.toml `[[outbound_http.allowed_host]]` allowlist entry; requests to them will be \
+         denied at runtime:\n\
+         {details}\n\
+         After review, add these allowlist entries to server.toml:\n\n\
+         {snippets}",
+        count = uncovered.len(),
+        snippets = snippets.join("\n"),
+    );
 }
 
 /// Append a `[secrets]` scaffold entry `X = { env = "X" }` for each name.

--- a/src/config/config_holder.rs
+++ b/src/config/config_holder.rs
@@ -85,15 +85,11 @@ impl PathPrefixes {
 
 #[derive(Clone)]
 pub(crate) struct ConfigHolder {
-    config_source: Option<PathBuf>,
+    pub(crate) config_source: Option<PathBuf>,
     pub(crate) path_prefixes: PathPrefixes,
 }
 
 impl ConfigHolder {
-    pub(crate) fn config_source(&self) -> Option<&Path> {
-        self.config_source.as_deref()
-    }
-
     pub(crate) async fn generate_default_server_config(
         dst: Option<PathBuf>,
         overwrite: bool,
@@ -146,17 +142,13 @@ impl ConfigHolder {
         })
     }
 
-    pub(crate) fn load_config(&self) -> Result<ServerConfigToml, anyhow::Error> {
-        self.load_config_sync()
-    }
-
     /// Load the complete server configuration before the async runtime starts.
     ///
     /// This uses the same file and `OBELISK__...` environment sources as
     /// [`Self::load_config`]. Server startup uses this synchronous variant so the
     /// exact config value that defines `[secrets]` is passed into the runtime after
     /// its env-backed sources have been wiped.
-    pub(crate) fn load_config_sync(&self) -> Result<ServerConfigToml, anyhow::Error> {
+    pub(crate) fn load_config(&self) -> Result<ServerConfigToml, anyhow::Error> {
         let mut builder = Config::builder();
         if let Some(path) = &self.config_source {
             builder = builder.add_source(

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -107,7 +107,9 @@ impl SecretRegistry {
                 }
             }
         }
-        if runtime_config_availability == RuntimeConfigAvailability::Strict {
+        if runtime_config_availability == RuntimeConfigAvailability::Strict
+            && !missing_env_vars.is_empty()
+        {
             bail!("secrets sourced from environment variables are not set: {missing_env_vars:?}");
         }
         if env_var_cleanup == EnvVarCleanupStrategy::Wipe {
@@ -186,6 +188,10 @@ mod tests {
         )
         .unwrap_err()
         .to_string();
-        assert!(err.contains("is not set"), "unexpected error: {err}");
+        assert!(err.contains("not set"), "unexpected error: {err}");
+        assert!(
+            err.contains("OBELISK_TEST_DEFINITELY_UNSET_2B9C"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -1,20 +1,4 @@
-//! Operator-owned secret registry.
-//!
-//! The `[secrets]` table in `server.toml` maps a logical secret name to a source
-//! (currently only an environment variable). At startup, before the tokio runtime
-//! is constructed and while the process is still single-threaded, env-backed
-//! secrets are resolved into `SecretString` and their source variables are removed
-//! from the process environment (see [`SecretRegistry::resolve_and_wipe`]).
-//!
-//! The resulting [`SecretRegistry`] is a plain value (not a global) that is passed
-//! by ownership into the server code. It exposes:
-//! - the set of sensitive names (logical names plus env source names), used to
-//!   reject `${VAR}` interpolation of a registered secret, and
-//! - a name -> `SecretString` getter ([`SecretRegistry::secret_lookup`]), the only
-//!   way a deployment-referenced secret becomes a plaintext value (exec stdin or
-//!   HTTP placeholder injection).
-//!
-//! See `meta/designs/secret-registry.md`.
+//! Operator-owned secret registry built from `server.toml`.
 
 use anyhow::Context as _;
 use hashbrown::{HashMap, HashSet};
@@ -26,8 +10,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) const API_TOKEN_CLIENT: &str = "OBELISK_API_TOKEN";
 pub(crate) const API_TOKEN_SERVER: &str = "OBELISK__API__TOKEN";
 
-/// Source of a secret in the `[secrets]` table. Untagged so `{ env = "VAR" }`
-/// parses directly; more variants (`{ file = "..." }`, Vault, ...) are added later.
+/// Source of a secret in the `[secrets]` table.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(untagged, deny_unknown_fields)]
 pub(crate) enum SecretSourceToml {
@@ -35,24 +18,25 @@ pub(crate) enum SecretSourceToml {
     Env { env: String },
 }
 
-/// The `[secrets]` table: logical name -> source. `IndexMap` preserves author order.
+/// The `[secrets]` table: logical name -> source.
 pub(crate) type SecretsToml = IndexMap<String, SecretSourceToml>;
 
-/// A deployment or config value referenced a name that is a registered secret.
-/// Registered secrets are inject-only and must never be interpolated as plaintext.
 #[derive(Debug, thiserror::Error)]
-#[error(
-    "cannot interpolate secret `{0}`: registered secrets are inject-only and cannot be \
-     interpolated into configuration"
-)]
+#[error("attempted to load secret `{0}` as an environment variable")]
 pub(crate) struct SecretViolation(pub(crate) String);
 
 #[derive(Debug, Clone)]
 pub(crate) struct SecretRegistry {
     /// Logical secret name -> resolved value.
     values: HashMap<String, SecretString>,
-    /// Used to reject `public_env_lookup`.
+    /// Used to reject `public_env_lookup`, contains both logical and `env` names.
     sensitive: HashSet<String>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum EnvVarCleanupStrategy {
+    Wipe,
+    Noop,
 }
 
 impl SecretRegistry {
@@ -65,7 +49,7 @@ impl SecretRegistry {
     }
 
     /// Public (non-secret) environment lookup. Rejects the name when it is sensitive
-    /// (a secret's logical name or a secret's source env var); otherwise reads it
+    /// (a secret's logical name or a secret's source env var name); otherwise reads it
     /// from the process environment, returning `None` when unset.
     pub(crate) fn public_env_lookup(&self, name: &str) -> Result<Option<String>, SecretViolation> {
         if self.sensitive.contains(name) {
@@ -75,7 +59,6 @@ impl SecretRegistry {
         }
     }
 
-    /// Resolve a registered secret by its logical name into its value.
     pub(crate) fn secret_lookup(&self, name: &str) -> Option<SecretString> {
         self.values.get(name).cloned()
     }
@@ -91,13 +74,14 @@ impl SecretRegistry {
         Self { values, sensitive }
     }
 
-    /// Build the registry from the resolved server configuration and wipe env-backed
-    /// source variables.
+    /// Build the registry from the resolved server configuration
     ///
-    /// MUST run during early, single-threaded startup, before the tokio runtime is
-    /// constructed: it calls `std::env::remove_var`, which is only sound without
-    /// concurrent readers.
-    pub(crate) fn resolve_and_wipe(secrets: SecretsToml) -> anyhow::Result<Self> {
+    /// If [`EnvVarCleanupStrategy::Wipe`] is set, MUST run during early, single-threaded startup, before the tokio runtime is
+    /// constructed: it calls `std::env::remove_var`, which is only sound without concurrent readers.
+    pub(crate) fn resolve(
+        secrets: SecretsToml,
+        env_var_cleanup: EnvVarCleanupStrategy,
+    ) -> anyhow::Result<Self> {
         let mut values = HashMap::new();
 
         // Always sensitive, even when the operator did not register them as secrets.
@@ -116,10 +100,12 @@ impl SecretRegistry {
                 }
             }
         }
-        for src in &sensitive {
-            // SAFETY: `resolve_and_wipe` runs during single-threaded startup, before the
-            // tokio runtime is constructed, so there are no concurrent environment readers.
-            unsafe { std::env::remove_var(src) };
+        if env_var_cleanup == EnvVarCleanupStrategy::Wipe {
+            for src in &sensitive {
+                // SAFETY: `resolve_and_wipe` runs during single-threaded startup, before the
+                // tokio runtime is constructed, so there are no concurrent environment readers.
+                unsafe { std::env::remove_var(src) };
+            }
         }
 
         Ok(Self { values, sensitive })
@@ -132,7 +118,7 @@ mod tests {
     use secrecy::ExposeSecret as _;
 
     #[test]
-    fn resolve_and_wipe_reads_value_wipes_source_and_rejects_lookup() {
+    fn resolve_reads_value_wipes_source_and_rejects_lookup() {
         // A source name distinct from the logical name exercises the rename mapping.
         const SRC: &str = "OBELISK_TEST_SECRET_SRC_7A3F";
         // SAFETY: test-only, unique var name, no concurrent access.
@@ -145,7 +131,7 @@ mod tests {
                 env: SRC.to_string(),
             },
         );
-        let registry = SecretRegistry::resolve_and_wipe(secrets).unwrap();
+        let registry = SecretRegistry::resolve(secrets, EnvVarCleanupStrategy::Wipe).unwrap();
 
         // Value is available under the logical name only.
         assert_eq!(
@@ -178,7 +164,7 @@ mod tests {
                 env: "OBELISK_TEST_DEFINITELY_UNSET_2B9C".to_string(),
             },
         );
-        let err = SecretRegistry::resolve_and_wipe(secrets)
+        let err = SecretRegistry::resolve(secrets, EnvVarCleanupStrategy::Noop)
             .unwrap_err()
             .to_string();
         assert!(err.contains("is not set"), "unexpected error: {err}");

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -95,7 +95,9 @@ impl SecretRegistry {
         for (logical_name, source) in secrets {
             match source {
                 SecretSourceToml::Env { env } => {
-                    let value = if let Ok(value) = std::env::var(&env) { value } else {
+                    let value = if let Ok(value) = std::env::var(&env) {
+                        value
+                    } else {
                         missing_env_vars.insert(env.clone());
                         String::new()
                     };

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -1,11 +1,13 @@
 //! Operator-owned secret registry built from `server.toml`.
 
-use anyhow::Context as _;
+use crate::command::server::RuntimeConfigAvailability;
+use anyhow::bail;
 use hashbrown::{HashMap, HashSet};
 use indexmap::IndexMap;
 use schemars::JsonSchema;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 pub(crate) const API_TOKEN_CLIENT: &str = "OBELISK_API_TOKEN";
 pub(crate) const API_TOKEN_SERVER: &str = "OBELISK__API__TOKEN";
@@ -81,6 +83,7 @@ impl SecretRegistry {
     pub(crate) fn resolve(
         secrets: SecretsToml,
         env_var_cleanup: EnvVarCleanupStrategy,
+        runtime_config_availability: RuntimeConfigAvailability,
     ) -> anyhow::Result<Self> {
         let mut values = HashMap::new();
 
@@ -88,17 +91,22 @@ impl SecretRegistry {
         let mut sensitive =
             HashSet::from([API_TOKEN_SERVER.to_string(), API_TOKEN_CLIENT.to_string()]);
 
-        for (name, source) in secrets {
+        let mut missing_env_vars = BTreeSet::new();
+        for (logical_name, source) in secrets {
             match source {
                 SecretSourceToml::Env { env } => {
-                    let value = std::env::var(&env).with_context(|| {
-                        format!("secret `{name}` source environment variable `{env}` is not set")
-                    })?;
-                    values.insert(name.clone(), SecretString::from(value));
+                    let value = if let Ok(value) = std::env::var(&env) { value } else {
+                        missing_env_vars.insert(env.clone());
+                        String::new()
+                    };
+                    values.insert(logical_name.clone(), SecretString::from(value));
                     sensitive.insert(env);
-                    sensitive.insert(name);
+                    sensitive.insert(logical_name);
                 }
             }
+        }
+        if runtime_config_availability == RuntimeConfigAvailability::Strict {
+            bail!("secrets sourced from environment variables are not set: {missing_env_vars:?}");
         }
         if env_var_cleanup == EnvVarCleanupStrategy::Wipe {
             for src in &sensitive {
@@ -131,7 +139,12 @@ mod tests {
                 env: SRC.to_string(),
             },
         );
-        let registry = SecretRegistry::resolve(secrets, EnvVarCleanupStrategy::Wipe).unwrap();
+        let registry = SecretRegistry::resolve(
+            secrets,
+            EnvVarCleanupStrategy::Wipe,
+            RuntimeConfigAvailability::Strict,
+        )
+        .unwrap();
 
         // Value is available under the logical name only.
         assert_eq!(
@@ -164,9 +177,13 @@ mod tests {
                 env: "OBELISK_TEST_DEFINITELY_UNSET_2B9C".to_string(),
             },
         );
-        let err = SecretRegistry::resolve(secrets, EnvVarCleanupStrategy::Noop)
-            .unwrap_err()
-            .to_string();
+        let err = SecretRegistry::resolve(
+            secrets,
+            EnvVarCleanupStrategy::Noop,
+            RuntimeConfigAvailability::Strict,
+        )
+        .unwrap_err()
+        .to_string();
         assert!(err.contains("is not set"), "unexpected error: {err}");
     }
 }

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -8,6 +8,8 @@ use schemars::JsonSchema;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+use std::sync::Arc;
+use wasm_workers::http_request_policy::SecretResolver;
 
 pub(crate) const API_TOKEN_CLIENT: &str = "OBELISK_API_TOKEN";
 pub(crate) const API_TOKEN_SERVER: &str = "OBELISK__API__TOKEN";
@@ -121,6 +123,43 @@ impl SecretRegistry {
         }
 
         Ok(Self { values, sensitive })
+    }
+}
+
+/// A component-scoped view over the operator [`SecretRegistry`].
+///
+/// Handed to activities and webhooks so they resolve secret values *by name, on
+/// demand* (at execution-run policy build / process spawn), never baking values
+/// into long-lived verified configs. Lookups are restricted to the subset of
+/// names the component declared: an undeclared name resolves to `None` even if
+/// the operator registered it, so a component can only reach the secrets it
+/// asked for. Env-backed today via the shared registry, Vault-backed later
+/// without changing this boundary.
+#[derive(Debug, Clone)]
+pub(crate) struct RestrictedSecretRegistry {
+    registry: Arc<SecretRegistry>,
+    allowed: Arc<HashSet<String>>,
+}
+
+impl RestrictedSecretRegistry {
+    pub(crate) fn new(
+        registry: Arc<SecretRegistry>,
+        allowed: impl IntoIterator<Item = String>,
+    ) -> Self {
+        Self {
+            registry,
+            allowed: Arc::new(allowed.into_iter().collect()),
+        }
+    }
+}
+
+impl SecretResolver for RestrictedSecretRegistry {
+    fn secret_lookup(&self, name: &str) -> Option<SecretString> {
+        if self.allowed.contains(name) {
+            self.registry.secret_lookup(name)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -6,7 +6,9 @@ use crate::config::env_var::{
     EnvVarError, EnvVarsMissing, interpolate_env_vars_plaintext, interpolate_env_vars_secret,
 };
 use crate::config::file_provider::{DiskProvider, FileProvider, verify_content_digest};
-use crate::config::secret_registry::{SecretRegistry, SecretViolation, SecretsToml};
+use crate::config::secret_registry::{
+    RestrictedSecretRegistry, SecretRegistry, SecretViolation, SecretsToml,
+};
 use crate::config::toml::cron::CronComponentConfigToml;
 use crate::config::wasm_cache_metadata_dir;
 use crate::oci;
@@ -40,7 +42,7 @@ use std::{
 };
 use tracing::{debug, instrument, warn};
 use utils::wasm_tools::WasmComponent;
-use wasm_workers::activity::activity_exec_worker::ExecProgram;
+use wasm_workers::activity::activity_exec_worker::{ExecProgram, ExecSecrets};
 use wasm_workers::cron::cron_worker::CronOrOnce;
 use wasm_workers::http_hooks::ConfigSectionHint;
 use wasm_workers::http_request_policy::HostPatternError;
@@ -49,6 +51,7 @@ use wasm_workers::{
     envvar::EnvVar,
     http_request_policy::{
         AllowedHostConfig, GlobalHttpConfig, HostPattern, MethodsPattern, ReplacementLocation,
+        SecretResolver,
     },
     std_output_stream::StdOutputConfig,
     workflow::workflow_worker::{
@@ -1463,7 +1466,7 @@ pub(crate) trait ActivityWasmComponentConfigTomlExt {
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
-        secret_registry: &SecretRegistry,
+        secret_registry: &Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -1477,7 +1480,7 @@ impl ActivityWasmComponentConfigTomlExt for ActivityWasmComponentConfigToml {
         wasm_cache_dir: Arc<Path>,
         metadata_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
-        secret_registry: &SecretRegistry,
+        secret_registry: &Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -1507,6 +1510,7 @@ impl ActivityWasmComponentConfigTomlExt for ActivityWasmComponentConfigToml {
             StrVariant::from(common.name),
             component_digest,
         )?;
+        let secrets = restricted_secret_registry(secret_registry, &allowed_hosts, None);
         let activity_config = ActivityConfig {
             component_id: component_id.clone(),
             forward_stdout: self.forward_stdout.into_std_output_config(),
@@ -1515,6 +1519,7 @@ impl ActivityWasmComponentConfigTomlExt for ActivityWasmComponentConfigToml {
             fuel,
             allowed_hosts,
             global_http_config,
+            secrets,
             config_section_hint: ConfigSectionHint::ActivityWasm,
         };
         let retry_config = ComponentRetryConfig {
@@ -1687,7 +1692,7 @@ pub(crate) trait ActivityExecComponentConfigResolvedExt {
         self,
         resolved_program: ResolvedExecProgram,
         ignore_missing_env_vars: bool,
-        secret_registry: &SecretRegistry,
+        secret_registry: &Arc<SecretRegistry>,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     ) -> Result<ActivityExecConfigVerified, anyhow::Error>;
 }
@@ -1745,7 +1750,7 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
         self,
         resolved_program: ResolvedExecProgram,
         ignore_missing_env_vars: bool,
-        secret_registry: &SecretRegistry,
+        secret_registry: &Arc<SecretRegistry>,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     ) -> Result<ActivityExecConfigVerified, anyhow::Error> {
         let parsed_params = self
@@ -1795,15 +1800,17 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
         )?;
         let env_vars =
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars, secret_registry)?;
-        let resolved_secrets = {
-            let resolved = resolve_named_secrets(&self.secrets, secret_registry)
-                .into_iter()
-                .collect::<indexmap::IndexMap<_, _>>();
-            if resolved.is_empty() {
-                None
-            } else {
-                Some(ResolvedExecSecrets { env_vars: resolved })
-            }
+        // Carry only the declared names plus a component-scoped resolver; values are
+        // fetched by name when the child's stdin is assembled, never baked here.
+        let resolved_secrets = if self.secrets.is_empty() {
+            None
+        } else {
+            let resolver =
+                restricted_secret_registry(secret_registry, &[], self.secrets.iter().cloned());
+            Some(ExecSecrets {
+                names: self.secrets,
+                resolver,
+            })
         };
         let retry_config = ComponentRetryConfig {
             max_retries: Some(self.max_retries),
@@ -1831,13 +1838,6 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
     }
 }
 
-/// Resolved secrets for exec activities. Secret values are stored in `SecretString`.
-#[derive(derive_more::Debug)]
-pub(crate) struct ResolvedExecSecrets {
-    /// Resolved secret env vars: name → secret value.
-    pub(crate) env_vars: indexmap::IndexMap<String, secrecy::SecretString>,
-}
-
 #[derive(Debug)]
 pub(crate) struct ActivityExecConfigVerified {
     pub(crate) program: wasm_workers::activity::activity_exec_worker::ExecProgram,
@@ -1848,7 +1848,7 @@ pub(crate) struct ActivityExecConfigVerified {
     pub(crate) max_output_bytes: u64,
     pub(crate) forward_stdout: Option<StdOutputConfig>,
     pub(crate) forward_stderr: Option<StdOutputConfig>,
-    pub(crate) secrets: Option<ResolvedExecSecrets>,
+    pub(crate) secrets: Option<wasm_workers::activity::activity_exec_worker::ExecSecrets>,
     pub(crate) params_via_stdin: bool,
     pub(crate) component_id: ComponentId,
     pub(crate) exec_config: executor::executor::ExecConfig,
@@ -2146,7 +2146,7 @@ pub(crate) trait ActivityJsComponentConfigResolvedExt {
         wasm_path: Arc<Path>,
         wasm_cache_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
-        secret_registry: &SecretRegistry,
+        secret_registry: &Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -2160,7 +2160,7 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
         wasm_path: Arc<Path>,
         wasm_cache_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
-        secret_registry: &SecretRegistry,
+        secret_registry: &Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -2222,6 +2222,7 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
         let (allowed_hosts, _advisories) =
             resolve_allowed_hosts(self.allowed_hosts, ignore_missing_env_vars, secret_registry)?;
         validate_no_env_collision(&env_vars, &allowed_hosts)?;
+        let secrets = restricted_secret_registry(secret_registry, &allowed_hosts, None);
         let activity_config = ActivityConfig {
             component_id: component_id.clone(),
             forward_stdout: self.forward_stdout.into_std_output_config(),
@@ -2230,6 +2231,7 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
             fuel,
             allowed_hosts,
             global_http_config,
+            secrets,
             config_section_hint: ConfigSectionHint::ActivityJs,
         };
         let retry_config = ComponentRetryConfig {
@@ -3089,8 +3091,9 @@ pub(crate) mod webhook {
     use super::{
         AllowedHostToml, ComponentBacktraceConfig, ComponentCommon, ComponentCommonFetchExt,
         ComponentStdOutputToml, ComponentStdOutputTomlExt, ConfigName, JsContent,
-        JsLocationResolvedExt, JsLocationToml, LogLevelTomlExt, resolve_allowed_hosts,
-        resolve_env_vars_plaintext, validate_no_env_collision,
+        JsLocationResolvedExt, JsLocationToml, LogLevelTomlExt, SecretResolver,
+        resolve_allowed_hosts, resolve_env_vars_plaintext, restricted_secret_registry,
+        validate_no_env_collision,
     };
     use crate::command::server::FrameFilesToSourceContent;
     use crate::config::secret_registry::SecretRegistry;
@@ -3170,6 +3173,8 @@ pub(crate) mod webhook {
         pub(crate) subscription_interruption: Option<Duration>,
         pub(crate) logs_store_min_level: Option<LogLevel>,
         pub(crate) allowed_hosts: Arc<[AllowedHostConfig]>,
+        /// Component-scoped resolver for the endpoint's declared secret names.
+        pub(crate) secrets: Arc<dyn SecretResolver>,
         pub(crate) is_webui: bool,
         /// The TOML config section type for error messages
         pub(crate) config_section_hint: ConfigSectionHint,
@@ -3254,6 +3259,8 @@ pub(crate) mod webhook {
         pub(crate) backtrace_persist: bool,
         pub(crate) logs_store_min_level: Option<LogLevel>,
         pub(crate) allowed_hosts: Arc<[AllowedHostConfig]>,
+        /// Component-scoped resolver for the endpoint's declared secret names.
+        pub(crate) secrets: Arc<dyn SecretResolver>,
         /// The TOML config section type for error messages
         pub(crate) config_section_hint: ConfigSectionHint,
     }
@@ -3270,7 +3277,7 @@ pub(crate) mod webhook {
             wasm_cache_dir: Arc<Path>,
             metadata_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
-            secret_registry: &SecretRegistry,
+            secret_registry: &Arc<SecretRegistry>,
             subscription_interruption: Option<Duration>,
         ) -> Result<(ConfigName, WebhookWasmComponentConfigVerified), anyhow::Error>;
     }
@@ -3282,7 +3289,7 @@ pub(crate) mod webhook {
             wasm_cache_dir: Arc<Path>,
             metadata_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
-            secret_registry: &SecretRegistry,
+            secret_registry: &Arc<SecretRegistry>,
             subscription_interruption: Option<Duration>,
         ) -> Result<(ConfigName, WebhookWasmComponentConfigVerified), anyhow::Error> {
             let expected_content_digest = self.content_digest;
@@ -3310,6 +3317,7 @@ pub(crate) mod webhook {
                 secret_registry,
             )?;
             validate_no_env_collision(&env_vars, &allowed_hosts)?;
+            let secrets = restricted_secret_registry(secret_registry, &allowed_hosts, None);
             Ok((
                 common.name,
                 WebhookWasmComponentConfigVerified {
@@ -3328,6 +3336,7 @@ pub(crate) mod webhook {
                     subscription_interruption,
                     logs_store_min_level: self.logs_store_min_level.into_log_level(),
                     allowed_hosts,
+                    secrets,
                     is_webui: self.is_webui,
                     config_section_hint: ConfigSectionHint::WebhookEndpointWasm,
                 },
@@ -3341,7 +3350,7 @@ pub(crate) mod webhook {
             wasm_path: Arc<Path>,
             wasm_cache_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
-            secret_registry: &SecretRegistry,
+            secret_registry: &Arc<SecretRegistry>,
         ) -> Result<(ConfigName, WebhookJsConfigVerified), anyhow::Error>;
     }
 
@@ -3352,7 +3361,7 @@ pub(crate) mod webhook {
             wasm_path: Arc<Path>,
             wasm_cache_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
-            secret_registry: &SecretRegistry,
+            secret_registry: &Arc<SecretRegistry>,
         ) -> Result<(ConfigName, WebhookJsConfigVerified), anyhow::Error> {
             let JsContent {
                 source: js_source,
@@ -3381,6 +3390,7 @@ pub(crate) mod webhook {
                 secret_registry,
             )?;
             validate_no_env_collision(&env_vars, &allowed_hosts)?;
+            let secrets = restricted_secret_registry(secret_registry, &allowed_hosts, None);
             Ok((
                 self.name,
                 WebhookJsConfigVerified {
@@ -3399,6 +3409,7 @@ pub(crate) mod webhook {
                     backtrace_persist: self.backtrace_persist,
                     logs_store_min_level: self.logs_store_min_level.into_log_level(),
                     allowed_hosts,
+                    secrets,
                     config_section_hint: ConfigSectionHint::WebhookEndpointJs,
                 },
             ))
@@ -3471,27 +3482,6 @@ fn resolve_env_vars_plaintext(
             },
         })
         .collect::<Result<_, _>>()
-}
-
-/// Resolve deployment-referenced secret names against the operator-owned registry.
-/// An unknown name is fatal unless `ignore_missing` (used when verifying a deployment on
-/// a server that lacks the runtime config), matching the env-var missing behavior.
-/// Resolve the values of the named secrets that the registry knows, dropping any it does
-/// not. Unregistered names are intentionally silent here: `config_prepass::preflight` owns
-/// the continue/bail/fix decision and its aggregated message, and the per-request policy in
-/// `http_request_policy` fails closed when a value is absent.
-fn resolve_named_secrets(
-    names: &[String],
-    secret_registry: &SecretRegistry,
-) -> Vec<(String, SecretString)> {
-    names
-        .iter()
-        .filter_map(|name| {
-            secret_registry
-                .secret_lookup(name)
-                .map(|value| (name.clone(), value))
-        })
-        .collect()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -3638,7 +3628,7 @@ pub(crate) fn resolve_allowed_hosts(
                 Err(e) => return Some(Err(e.into())),
             };
 
-            let (secret_env_mappings, replace_in) = if entry.secrets.is_empty() {
+            let (secret_names, replace_in) = if entry.secrets.is_empty() {
                 if !entry.replace_in.is_empty() {
                     advise(format!(
                         "allowed_host `{}` has `replace_in` but no `secrets` - nothing to inject",
@@ -3659,7 +3649,6 @@ pub(crate) fn resolve_allowed_hosts(
                     ));
                 }
 
-                let env_mappings = resolve_named_secrets(&entry.secrets, secret_registry);
                 let replace_in = entry
                     .replace_in
                     .into_iter()
@@ -3669,18 +3658,42 @@ pub(crate) fn resolve_allowed_hosts(
                         ReplaceIn::Params => ReplacementLocation::Params,
                     })
                     .collect();
-                (env_mappings, replace_in)
+                // Carry only the declared names: values are resolved lazily per
+                // execution run via the component's `RestrictedSecretRegistry`, never
+                // baked into this verified config. An unregistered name is handled by
+                // `config_prepass::preflight` (continue/bail/fix) and fails closed at
+                // runtime when the resolver cannot supply it.
+                (entry.secrets, replace_in)
             };
 
             Some(Ok(AllowedHostConfig {
                 pattern,
                 request_url_regex,
-                secret_env_mappings,
+                secret_names,
                 replace_in,
             }))
         })
         .collect::<Result<Arc<[AllowedHostConfig]>, _>>()?;
     Ok((hosts, advisories))
+}
+
+/// Build a component-scoped [`SecretResolver`] over the operator registry, limited
+/// to the union of secret names the component declared across its `allowed_host`
+/// entries plus `extra_names` (exec-activity `secrets`). Values are fetched through
+/// this at execution time, never baked into the verified config.
+fn restricted_secret_registry(
+    secret_registry: &Arc<SecretRegistry>,
+    allowed_hosts: &[AllowedHostConfig],
+    extra_names: impl IntoIterator<Item = String>,
+) -> Arc<dyn SecretResolver> {
+    let names = allowed_hosts
+        .iter()
+        .flat_map(|h| h.secret_names.iter().cloned())
+        .chain(extra_names);
+    Arc::new(RestrictedSecretRegistry::new(
+        secret_registry.clone(),
+        names,
+    ))
 }
 
 fn validate_no_env_collision(
@@ -3689,7 +3702,7 @@ fn validate_no_env_collision(
 ) -> Result<(), anyhow::Error> {
     let env_var_keys: hashbrown::HashSet<_> = env_vars.iter().map(|e| e.key.as_str()).collect();
     for host in allowed_hosts {
-        for (key, _) in &host.secret_env_mappings {
+        for key in &host.secret_names {
             ensure!(
                 !env_var_keys.contains(key.as_str()),
                 "secret env var `{key}` collides with an `env_vars` entry"
@@ -4076,7 +4089,7 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
                     r"^GET https://${OBELISK_TEST_REQUEST_URL_REGEX_DOMAIN:-api\.example\.com}/v1/",
                 )],
                 false,
-                &SecretRegistry::empty(),
+                &std::sync::Arc::new(SecretRegistry::empty()),
             )
             .unwrap();
 
@@ -4093,7 +4106,7 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
                     "^GET https://${{{VAR}}}/"
                 ))],
                 false,
-                &SecretRegistry::empty(),
+                &std::sync::Arc::new(SecretRegistry::empty()),
             )
             .unwrap_err()
             .to_string();
@@ -4108,7 +4121,7 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
                     "^GET https://${{{VAR}}}/"
                 ))],
                 true,
-                &SecretRegistry::empty(),
+                &std::sync::Arc::new(SecretRegistry::empty()),
             )
             .unwrap();
             assert!(hosts.is_empty());
@@ -4233,7 +4246,7 @@ name = "my_stub"
     }
 
     mod activity_exec {
-        use secrecy::SecretString;
+        use secrecy::{ExposeSecret as _, SecretString};
         use wasm_workers::activity::activity_exec_worker::ExecProgram;
 
         use super::super::*;
@@ -4296,29 +4309,47 @@ name = "my_stub"
             }
         }
 
-        /// An unregistered secret is dropped by resolution (whether or not unavailable runtime
-        /// config is allowed); `config_prepass::preflight` owns the fatal/continue/fix decision.
+        /// A declared secret name is always carried; an unregistered one simply
+        /// resolves to nothing at use (the child never receives it).
+        /// `config_prepass::preflight` owns the fatal/continue/fix decision.
         #[test]
         fn fetch_and_verify_activity_exec_secret_dropped_when_unregistered() {
             let config = exec_config_with_secret();
             let verified = config
-                .fetch_and_verify(inline_program(), false, &SecretRegistry::empty(), None)
+                .fetch_and_verify(
+                    inline_program(),
+                    false,
+                    &std::sync::Arc::new(SecretRegistry::empty()),
+                    None,
+                )
                 .unwrap();
-            assert!(verified.secrets.is_none());
+            let secrets = verified.secrets.expect("declared secret name is carried");
+            assert!(secrets.names.contains(&"MY_SECRET".to_string()));
+            // Unregistered: the resolver supplies no value, so it is dropped at use.
+            assert!(secrets.resolver.secret_lookup("MY_SECRET").is_none());
         }
 
         #[test]
         fn fetch_and_verify_activity_exec_secret_resolves_from_registry() {
             let config = exec_config_with_secret();
-            let registry = SecretRegistry::from_test_values([(
+            let registry = std::sync::Arc::new(SecretRegistry::from_test_values([(
                 "MY_SECRET".to_string(),
                 SecretString::from("s3cret_value"),
-            )]);
+            )]));
             let verified = config
                 .fetch_and_verify(inline_program(), false, &registry, None)
                 .unwrap();
-            let secrets = verified.secrets.expect("secret must be resolved");
-            assert!(secrets.env_vars.contains_key("MY_SECRET"));
+            let secrets = verified.secrets.expect("secret must be declared");
+            // Only the name is carried; the value is fetched on demand via the resolver.
+            assert!(secrets.names.contains(&"MY_SECRET".to_string()));
+            assert_eq!(
+                secrets
+                    .resolver
+                    .secret_lookup("MY_SECRET")
+                    .expect("resolver supplies the declared secret")
+                    .expose_secret(),
+                "s3cret_value"
+            );
         }
 
         #[test]
@@ -4345,7 +4376,7 @@ name = "my_stub"
                         source_bytes: source.clone(),
                     },
                     true,
-                    &SecretRegistry::empty(),
+                    &std::sync::Arc::new(SecretRegistry::empty()),
                     None,
                 )
                 .unwrap();
@@ -4358,7 +4389,7 @@ name = "my_stub"
                         source_bytes: source,
                     },
                     true,
-                    &SecretRegistry::empty(),
+                    &std::sync::Arc::new(SecretRegistry::empty()),
                     None,
                 )
                 .unwrap();

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1493,7 +1493,7 @@ impl ActivityWasmComponentConfigTomlExt for ActivityWasmComponentConfigToml {
 
         let env_vars =
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars, secret_registry)?;
-        let allowed_hosts =
+        let (allowed_hosts, _advisories) =
             resolve_allowed_hosts(self.allowed_hosts, ignore_missing_env_vars, secret_registry)?;
 
         // Validate no collision between env_vars and secret env names
@@ -2219,7 +2219,7 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
         )?;
         let env_vars =
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars, secret_registry)?;
-        let allowed_hosts =
+        let (allowed_hosts, _advisories) =
             resolve_allowed_hosts(self.allowed_hosts, ignore_missing_env_vars, secret_registry)?;
         validate_no_env_collision(&env_vars, &allowed_hosts)?;
         let activity_config = ActivityConfig {
@@ -3304,7 +3304,7 @@ pub(crate) mod webhook {
                 ignore_missing_env_vars,
                 secret_registry,
             )?;
-            let allowed_hosts = resolve_allowed_hosts(
+            let (allowed_hosts, _advisories) = resolve_allowed_hosts(
                 self.allowed_hosts,
                 ignore_missing_env_vars,
                 secret_registry,
@@ -3375,7 +3375,7 @@ pub(crate) mod webhook {
                 ignore_missing_env_vars,
                 secret_registry,
             )?;
-            let allowed_hosts = resolve_allowed_hosts(
+            let (allowed_hosts, _advisories) = resolve_allowed_hosts(
                 self.allowed_hosts,
                 ignore_missing_env_vars,
                 secret_registry,
@@ -3502,8 +3502,6 @@ pub(crate) enum ResolveAllowedHostsError {
     EnvVarsMissing(#[from] EnvVarsMissing),
     #[error(transparent)]
     SecretViolation(#[from] SecretViolation),
-    #[error(transparent)]
-    NamedSecret(#[from] anyhow::Error),
     #[error("cannot parse HTTP method `{0}`")]
     InvalidMethod(String),
     #[error("use `methods = \"*\"` to allow all methods, not `methods = [\"*\"]`")]
@@ -3512,23 +3510,47 @@ pub(crate) enum ResolveAllowedHostsError {
     InvalidRequestUrlRegex { pattern: String, err: regex::Error },
 }
 
+/// An `allowed_host` entry that is valid but likely misconfigured. Carries the entry's TOML
+/// fingerprint so a located reporter (`config_prepass`) can map it back to a source line.
+/// Resolution collects these instead of logging them, so a single deduplicated, source-located
+/// report is emitted once by the pre-pass rather than scattered across the resolvers.
+#[derive(Debug)]
+pub(crate) struct AllowedHostAdvisory {
+    pub(crate) fingerprint: String,
+    pub(crate) message: String,
+}
+
+/// The TOML serialization of an entry, used as a stable key to join a resolver advisory to the
+/// `[[*.allowed_host]]` block it came from in the source file.
+pub(crate) fn allowed_host_fingerprint(entry: &AllowedHostToml) -> String {
+    toml::to_string(entry).expect("allowed host must serialize")
+}
+
 pub(crate) fn resolve_allowed_hosts(
     entries: Vec<AllowedHostToml>,
     ignore_missing_env_vars: bool,
     secret_registry: &SecretRegistry,
-) -> Result<Arc<[AllowedHostConfig]>, ResolveAllowedHostsError> {
-    entries
+) -> Result<(Arc<[AllowedHostConfig]>, Vec<AllowedHostAdvisory>), ResolveAllowedHostsError> {
+    let mut advisories = Vec::new();
+    let hosts = entries
         .into_iter()
         .filter_map(|entry| {
+            let fingerprint = allowed_host_fingerprint(&entry);
+            let mut advise = |message: String| {
+                advisories.push(AllowedHostAdvisory {
+                    fingerprint: fingerprint.clone(),
+                    message,
+                });
+            };
             // Convert MethodsInput to MethodsPattern
             let methods = match entry.methods {
                 None => {
                     // Omitted methods: nothing allowed, warn and skip
-                    warn!(
+                    advise(format!(
                         "allowed_host `{}` has no `methods` field - no requests will be allowed; \
                          use `methods = \"*\"` to allow all methods",
                         entry.pattern
-                    );
+                    ));
                     return None;
                 }
                 Some(MethodsInput::Star(_)) => {
@@ -3538,10 +3560,10 @@ pub(crate) fn resolve_allowed_hosts(
                 Some(MethodsInput::List(list)) => {
                     if list.is_empty() {
                         // Empty list: nothing allowed, warn and skip
-                        warn!(
+                        advise(format!(
                             "allowed_host `{}` has empty `methods = []` - no requests will be allowed",
                             entry.pattern
-                        );
+                        ));
                         return None;
                     }
                     // Parse specific methods
@@ -3568,10 +3590,10 @@ pub(crate) fn resolve_allowed_hosts(
                 Ok(s) => s,
                 Err(EnvVarError::Missing(var)) => {
                     if ignore_missing_env_vars {
-                        warn!(
+                        advise(format!(
                             "allowed_host pattern `{}` references missing env var `{var}`, skipping",
                             entry.pattern
-                        );
+                        ));
                         return None;
                     }
                     return Some(Err(ResolveAllowedHostsError::EnvVarsMissing(
@@ -3586,9 +3608,9 @@ pub(crate) fn resolve_allowed_hosts(
                         Ok(s) => s,
                         Err(EnvVarError::Missing(var)) => {
                             if ignore_missing_env_vars {
-                                warn!(
+                                advise(format!(
                                     "allowed_host request_url_regex `{pattern}` references missing env var `{var}`, skipping"
-                                );
+                                ));
                                 return None;
                             }
                             return Some(Err(ResolveAllowedHostsError::EnvVarsMissing(
@@ -3618,21 +3640,23 @@ pub(crate) fn resolve_allowed_hosts(
 
             let (secret_env_mappings, replace_in) = if entry.secrets.is_empty() {
                 if !entry.replace_in.is_empty() {
-                    warn!(
+                    advise(format!(
                         "allowed_host `{}` has `replace_in` but no `secrets` - nothing to inject",
                         entry.pattern
-                    );
+                    ));
                 }
                 (Vec::new(), hashbrown::HashSet::new())
             } else {
                 if entry.replace_in.is_empty() {
-                    warn!(
+                    advise(format!(
                         "allowed_host `{}` has empty `replace_in` - secrets will never be injected",
                         entry.pattern
-                    );
+                    ));
                 }
                 if pattern.scheme.allows_unencrypted() {
-                    warn!("secrets allowed for potentially unencrypted host `{pattern}`");
+                    advise(format!(
+                        "secrets allowed for potentially unencrypted host `{pattern}`"
+                    ));
                 }
 
                 let env_mappings = resolve_named_secrets(&entry.secrets, secret_registry);
@@ -3655,7 +3679,8 @@ pub(crate) fn resolve_allowed_hosts(
                 replace_in,
             }))
         })
-        .collect::<Result<_, _>>()
+        .collect::<Result<Arc<[AllowedHostConfig]>, _>>()?;
+    Ok((hosts, advisories))
 }
 
 fn validate_no_env_collision(
@@ -4046,7 +4071,7 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
 
         #[test]
         fn request_url_regex_interpolates_env_vars() {
-            let hosts = resolve_allowed_hosts(
+            let (hosts, _advisories) = resolve_allowed_hosts(
                 vec![allowed_host_with_regex(
                     r"^GET https://${OBELISK_TEST_REQUEST_URL_REGEX_DOMAIN:-api\.example\.com}/v1/",
                 )],
@@ -4078,7 +4103,7 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
         #[test]
         fn request_url_regex_missing_env_var_skips_when_ignored() {
             const VAR: &str = "OBELISK_TEST_MISSING_REQUEST_URL_REGEX_DOMAIN_IGNORED_9E5F58E0";
-            let hosts = resolve_allowed_hosts(
+            let (hosts, _advisories) = resolve_allowed_hosts(
                 vec![allowed_host_with_regex(&format!(
                     "^GET https://${{{VAR}}}/"
                 ))],

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -32,10 +32,10 @@ use sha2::{Digest as _, Sha256};
 use std::fmt::Display;
 use std::str::FromStr;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     net::SocketAddr,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 use tracing::{debug, instrument, warn};
@@ -1464,7 +1464,6 @@ pub(crate) trait ActivityWasmComponentConfigTomlExt {
         metadata_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
         secret_registry: &SecretRegistry,
-        warnings: ConfigWarnings,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -1479,7 +1478,6 @@ impl ActivityWasmComponentConfigTomlExt for ActivityWasmComponentConfigToml {
         metadata_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
         secret_registry: &SecretRegistry,
-        warnings: ConfigWarnings,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -1495,12 +1493,8 @@ impl ActivityWasmComponentConfigTomlExt for ActivityWasmComponentConfigToml {
 
         let env_vars =
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars, secret_registry)?;
-        let allowed_hosts = resolve_allowed_hosts(
-            self.allowed_hosts,
-            ignore_missing_env_vars,
-            secret_registry,
-            &warnings,
-        )?;
+        let allowed_hosts =
+            resolve_allowed_hosts(self.allowed_hosts, ignore_missing_env_vars, secret_registry)?;
 
         // Validate no collision between env_vars and secret env names
         validate_no_env_collision(&env_vars, &allowed_hosts)?;
@@ -1694,7 +1688,6 @@ pub(crate) trait ActivityExecComponentConfigResolvedExt {
         resolved_program: ResolvedExecProgram,
         ignore_missing_env_vars: bool,
         secret_registry: &SecretRegistry,
-        warnings: &ConfigWarnings,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     ) -> Result<ActivityExecConfigVerified, anyhow::Error>;
 }
@@ -1753,7 +1746,6 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
         resolved_program: ResolvedExecProgram,
         ignore_missing_env_vars: bool,
         secret_registry: &SecretRegistry,
-        warnings: &ConfigWarnings,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     ) -> Result<ActivityExecConfigVerified, anyhow::Error> {
         let parsed_params = self
@@ -1804,15 +1796,9 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
         let env_vars =
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars, secret_registry)?;
         let resolved_secrets = {
-            let resolved = resolve_named_secrets(
-                &self.secrets,
-                secret_registry,
-                ignore_missing_env_vars,
-                warnings,
-            )
-            .map_err(|e| anyhow!("failed to resolve exec secrets: {e}"))?
-            .into_iter()
-            .collect::<indexmap::IndexMap<_, _>>();
+            let resolved = resolve_named_secrets(&self.secrets, secret_registry)
+                .into_iter()
+                .collect::<indexmap::IndexMap<_, _>>();
             if resolved.is_empty() {
                 None
             } else {
@@ -2161,7 +2147,6 @@ pub(crate) trait ActivityJsComponentConfigResolvedExt {
         wasm_cache_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
         secret_registry: &SecretRegistry,
-        warnings: ConfigWarnings,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -2176,7 +2161,6 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
         wasm_cache_dir: Arc<Path>,
         ignore_missing_env_vars: bool,
         secret_registry: &SecretRegistry,
-        warnings: ConfigWarnings,
         global_http_config: GlobalHttpConfig,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
@@ -2235,12 +2219,8 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
         )?;
         let env_vars =
             resolve_env_vars_plaintext(self.env_vars, ignore_missing_env_vars, secret_registry)?;
-        let allowed_hosts = resolve_allowed_hosts(
-            self.allowed_hosts,
-            ignore_missing_env_vars,
-            secret_registry,
-            &warnings,
-        )?;
+        let allowed_hosts =
+            resolve_allowed_hosts(self.allowed_hosts, ignore_missing_env_vars, secret_registry)?;
         validate_no_env_collision(&env_vars, &allowed_hosts)?;
         let activity_config = ActivityConfig {
             component_id: component_id.clone(),
@@ -3108,7 +3088,7 @@ impl ComponentStdOutputTomlExt for ComponentStdOutputToml {
 pub(crate) mod webhook {
     use super::{
         AllowedHostToml, ComponentBacktraceConfig, ComponentCommon, ComponentCommonFetchExt,
-        ComponentStdOutputToml, ComponentStdOutputTomlExt, ConfigName, ConfigWarnings, JsContent,
+        ComponentStdOutputToml, ComponentStdOutputTomlExt, ConfigName, JsContent,
         JsLocationResolvedExt, JsLocationToml, LogLevelTomlExt, resolve_allowed_hosts,
         resolve_env_vars_plaintext, validate_no_env_collision,
     };
@@ -3291,7 +3271,6 @@ pub(crate) mod webhook {
             metadata_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
             secret_registry: &SecretRegistry,
-            warnings: ConfigWarnings,
             subscription_interruption: Option<Duration>,
         ) -> Result<(ConfigName, WebhookWasmComponentConfigVerified), anyhow::Error>;
     }
@@ -3304,7 +3283,6 @@ pub(crate) mod webhook {
             metadata_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
             secret_registry: &SecretRegistry,
-            warnings: ConfigWarnings,
             subscription_interruption: Option<Duration>,
         ) -> Result<(ConfigName, WebhookWasmComponentConfigVerified), anyhow::Error> {
             let expected_content_digest = self.content_digest;
@@ -3330,7 +3308,6 @@ pub(crate) mod webhook {
                 self.allowed_hosts,
                 ignore_missing_env_vars,
                 secret_registry,
-                &warnings,
             )?;
             validate_no_env_collision(&env_vars, &allowed_hosts)?;
             Ok((
@@ -3365,7 +3342,6 @@ pub(crate) mod webhook {
             wasm_cache_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
             secret_registry: &SecretRegistry,
-            warnings: ConfigWarnings,
         ) -> Result<(ConfigName, WebhookJsConfigVerified), anyhow::Error>;
     }
 
@@ -3377,7 +3353,6 @@ pub(crate) mod webhook {
             wasm_cache_dir: Arc<Path>,
             ignore_missing_env_vars: bool,
             secret_registry: &SecretRegistry,
-            warnings: ConfigWarnings,
         ) -> Result<(ConfigName, WebhookJsConfigVerified), anyhow::Error> {
             let JsContent {
                 source: js_source,
@@ -3404,7 +3379,6 @@ pub(crate) mod webhook {
                 self.allowed_hosts,
                 ignore_missing_env_vars,
                 secret_registry,
-                &warnings,
             )?;
             validate_no_env_collision(&env_vars, &allowed_hosts)?;
             Ok((
@@ -3502,143 +3476,22 @@ fn resolve_env_vars_plaintext(
 /// Resolve deployment-referenced secret names against the operator-owned registry.
 /// An unknown name is fatal unless `ignore_missing` (used when verifying a deployment on
 /// a server that lacks the runtime config), matching the env-var missing behavior.
+/// Resolve the values of the named secrets that the registry knows, dropping any it does
+/// not. Unregistered names are intentionally silent here: `config_prepass::preflight` owns
+/// the continue/bail/fix decision and its aggregated message, and the per-request policy in
+/// `http_request_policy` fails closed when a value is absent.
 fn resolve_named_secrets(
     names: &[String],
     secret_registry: &SecretRegistry,
-    ignore_missing: bool,
-    warnings: &ConfigWarnings,
-) -> Result<Vec<(String, SecretString)>, anyhow::Error> {
-    let mut resolved = Vec::with_capacity(names.len());
-    for name in names {
-        match secret_registry.secret_lookup(name) {
-            Some(value) => resolved.push((name.clone(), value)),
-            None if ignore_missing => {
-                warnings.insert(format!(
-                    "secret `{name}` is not registered on this server; skipping"
-                ));
-            }
-            None => bail!("secret `{name}` is not registered in the server `[secrets]` table"),
-        }
-    }
-    Ok(resolved)
-}
-
-#[derive(Default)]
-struct ConfigWarningState {
-    warnings: BTreeMap<String, BTreeSet<ConfigWarningSource>>,
-    allowed_host_sources: BTreeMap<String, BTreeSet<ConfigWarningSource>>,
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct ConfigWarningSource {
-    path: PathBuf,
-    line: usize,
-}
-
-#[derive(Clone, Default)]
-pub(crate) struct ConfigWarnings(Arc<Mutex<ConfigWarningState>>);
-
-impl ConfigWarnings {
-    pub(crate) fn insert(&self, warning: String) {
-        self.0
-            .lock()
-            .expect("config warnings lock poisoned")
-            .warnings
-            .entry(warning)
-            .or_default();
-    }
-
-    fn allowed_host_fingerprint(entry: &AllowedHostToml) -> String {
-        toml::to_string(entry).expect("allowed host must serialize")
-    }
-
-    fn insert_allowed_host(&self, warning: String, fingerprint: &str) {
-        let mut state = self.0.lock().expect("config warnings lock poisoned");
-        let sources = state
-            .allowed_host_sources
-            .get(fingerprint)
-            .cloned()
-            .unwrap_or_default();
-        state.warnings.entry(warning).or_default().extend(sources);
-    }
-
-    pub(crate) fn index_allowed_hosts(&self, path: &Path) {
-        #[derive(Deserialize)]
-        struct AllowedHostBlock {
-            allowed_host: Vec<AllowedHostToml>,
-        }
-
-        let Ok(source) = std::fs::read_to_string(path) else {
-            return;
-        };
-        let lines = source.lines().collect::<Vec<_>>();
-        let mut state = self.0.lock().expect("config warnings lock poisoned");
-        for (start, line) in lines.iter().enumerate() {
-            let header = line.split('#').next().unwrap_or_default().trim();
-            if !(header.starts_with("[[") && header.ends_with(".allowed_host]]")) {
-                continue;
-            }
-            let end = lines[start + 1..]
-                .iter()
-                .position(|line| {
-                    line.split('#')
-                        .next()
-                        .unwrap_or_default()
-                        .trim_start()
-                        .starts_with('[')
-                })
-                .map_or(lines.len(), |offset| start + 1 + offset);
-            let mut block = String::from("[[allowed_host]]\n");
-            for line in &lines[start + 1..end] {
-                block.push_str(line);
-                block.push('\n');
-            }
-            let Ok(block) = toml::from_str::<AllowedHostBlock>(&block) else {
-                continue;
-            };
-            let Some(entry) = block.allowed_host.first() else {
-                continue;
-            };
-            state
-                .allowed_host_sources
-                .entry(Self::allowed_host_fingerprint(entry))
-                .or_default()
-                .insert(ConfigWarningSource {
-                    path: path.to_path_buf(),
-                    line: start + 1,
-                });
-        }
-    }
-
-    pub(crate) fn report(&self) {
-        let warnings = std::mem::take(
-            &mut self
-                .0
-                .lock()
-                .expect("config warnings lock poisoned")
-                .warnings,
-        );
-        if !warnings.is_empty() {
-            let warnings = warnings
-                .into_iter()
-                .map(|(warning, sources)| {
-                    if sources.is_empty() {
-                        warning
-                    } else {
-                        format!(
-                            "{warning} ({})",
-                            sources
-                                .into_iter()
-                                .map(|source| format!("{}:{}", source.path.display(), source.line))
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        )
-                    }
-                })
-                .collect::<Vec<_>>();
-            warn!("Configuration warnings:\n- {}", warnings.join("\n- "));
-        }
-    }
+) -> Vec<(String, SecretString)> {
+    names
+        .iter()
+        .filter_map(|name| {
+            secret_registry
+                .secret_lookup(name)
+                .map(|value| (name.clone(), value))
+        })
+        .collect()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -3663,23 +3516,18 @@ pub(crate) fn resolve_allowed_hosts(
     entries: Vec<AllowedHostToml>,
     ignore_missing_env_vars: bool,
     secret_registry: &SecretRegistry,
-    warnings: &ConfigWarnings,
 ) -> Result<Arc<[AllowedHostConfig]>, ResolveAllowedHostsError> {
     entries
         .into_iter()
         .filter_map(|entry| {
-            let fingerprint = ConfigWarnings::allowed_host_fingerprint(&entry);
             // Convert MethodsInput to MethodsPattern
             let methods = match entry.methods {
                 None => {
                     // Omitted methods: nothing allowed, warn and skip
-                    warnings.insert_allowed_host(
-                        format!(
-                            "allowed_host `{}` has no `methods` field - no requests will be allowed; \
-                             use `methods = \"*\"` to allow all methods",
-                            entry.pattern
-                        ),
-                        &fingerprint,
+                    warn!(
+                        "allowed_host `{}` has no `methods` field - no requests will be allowed; \
+                         use `methods = \"*\"` to allow all methods",
+                        entry.pattern
                     );
                     return None;
                 }
@@ -3690,12 +3538,9 @@ pub(crate) fn resolve_allowed_hosts(
                 Some(MethodsInput::List(list)) => {
                     if list.is_empty() {
                         // Empty list: nothing allowed, warn and skip
-                        warnings.insert_allowed_host(
-                            format!(
-                                "allowed_host `{}` has empty `methods = []` - no requests will be allowed",
-                                entry.pattern
-                            ),
-                            &fingerprint,
+                        warn!(
+                            "allowed_host `{}` has empty `methods = []` - no requests will be allowed",
+                            entry.pattern
                         );
                         return None;
                     }
@@ -3723,12 +3568,9 @@ pub(crate) fn resolve_allowed_hosts(
                 Ok(s) => s,
                 Err(EnvVarError::Missing(var)) => {
                     if ignore_missing_env_vars {
-                        warnings.insert_allowed_host(
-                            format!(
-                                "allowed_host pattern `{}` references missing env var `{var}`, skipping",
-                                entry.pattern
-                            ),
-                            &fingerprint,
+                        warn!(
+                            "allowed_host pattern `{}` references missing env var `{var}`, skipping",
+                            entry.pattern
                         );
                         return None;
                     }
@@ -3744,11 +3586,8 @@ pub(crate) fn resolve_allowed_hosts(
                         Ok(s) => s,
                         Err(EnvVarError::Missing(var)) => {
                             if ignore_missing_env_vars {
-                                warnings.insert_allowed_host(
-                                    format!(
-                                        "allowed_host request_url_regex `{pattern}` references missing env var `{var}`, skipping"
-                                    ),
-                                    &fingerprint,
+                                warn!(
+                                    "allowed_host request_url_regex `{pattern}` references missing env var `{var}`, skipping"
                                 );
                                 return None;
                             }
@@ -3779,41 +3618,24 @@ pub(crate) fn resolve_allowed_hosts(
 
             let (secret_env_mappings, replace_in) = if entry.secrets.is_empty() {
                 if !entry.replace_in.is_empty() {
-                    warnings.insert_allowed_host(
-                        format!(
-                            "allowed_host `{}` has `replace_in` but no `secrets` - nothing to inject",
-                            entry.pattern
-                        ),
-                        &fingerprint,
+                    warn!(
+                        "allowed_host `{}` has `replace_in` but no `secrets` - nothing to inject",
+                        entry.pattern
                     );
                 }
                 (Vec::new(), hashbrown::HashSet::new())
             } else {
                 if entry.replace_in.is_empty() {
-                    warnings.insert_allowed_host(
-                        format!(
-                            "allowed_host `{}` has empty `replace_in` - secrets will never be injected",
-                            entry.pattern
-                        ),
-                        &fingerprint,
+                    warn!(
+                        "allowed_host `{}` has empty `replace_in` - secrets will never be injected",
+                        entry.pattern
                     );
                 }
                 if pattern.scheme.allows_unencrypted() {
-                    warnings.insert_allowed_host(
-                        format!("secrets allowed for potentially unencrypted host `{pattern}`"),
-                        &fingerprint,
-                    );
+                    warn!("secrets allowed for potentially unencrypted host `{pattern}`");
                 }
 
-                let env_mappings = match resolve_named_secrets(
-                    &entry.secrets,
-                    secret_registry,
-                    ignore_missing_env_vars,
-                    warnings,
-                ) {
-                    Ok(m) => m,
-                    Err(e) => return Some(Err(e.into())),
-                };
+                let env_mappings = resolve_named_secrets(&entry.secrets, secret_registry);
                 let replace_in = entry
                     .replace_in
                     .into_iter()
@@ -4230,7 +4052,6 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
                 )],
                 false,
                 &SecretRegistry::empty(),
-                &ConfigWarnings::default(),
             )
             .unwrap();
 
@@ -4248,7 +4069,6 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
                 ))],
                 false,
                 &SecretRegistry::empty(),
-                &ConfigWarnings::default(),
             )
             .unwrap_err()
             .to_string();
@@ -4264,65 +4084,9 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
                 ))],
                 true,
                 &SecretRegistry::empty(),
-                &ConfigWarnings::default(),
             )
             .unwrap();
             assert!(hosts.is_empty());
-        }
-
-        #[test]
-        fn warnings_are_deduplicated_across_resolutions() {
-            let entry = AllowedHostToml {
-                pattern: "http://localhost:5005".to_string(),
-                methods: Some(MethodsInput::List(vec!["GET".to_string()])),
-                request_url_regex: None,
-                secrets: vec!["TOKEN".to_string()],
-                replace_in: vec![ReplaceIn::Headers],
-            };
-            let registry = SecretRegistry::from_test_values([(
-                "TOKEN".to_string(),
-                SecretString::from("value"),
-            )]);
-            let warnings = ConfigWarnings::default();
-
-            resolve_allowed_hosts(vec![entry.clone()], false, &registry, &warnings).unwrap();
-            resolve_allowed_hosts(vec![entry], false, &registry, &warnings).unwrap();
-
-            let state = warnings.0.lock().unwrap();
-            assert_eq!(state.warnings.len(), 1);
-            assert_eq!(
-                state.warnings.first_key_value().unwrap().0,
-                "secrets allowed for potentially unencrypted host `http://localhost:5005 [GET]`"
-            );
-        }
-
-        #[test]
-        fn warnings_include_toml_file_and_line() {
-            let dir = tempfile::tempdir().unwrap();
-            let path = dir.path().join("server.toml");
-            std::fs::write(
-                &path,
-                "# policy\n[[outbound_http.allowed_host]]\npattern = \"http://localhost:5005\"\n",
-            )
-            .unwrap();
-            let entry = AllowedHostToml {
-                pattern: "http://localhost:5005".to_string(),
-                methods: None,
-                request_url_regex: None,
-                secrets: Vec::new(),
-                replace_in: Vec::new(),
-            };
-            let warnings = ConfigWarnings::default();
-            warnings.index_allowed_hosts(&path);
-
-            resolve_allowed_hosts(vec![entry], false, &SecretRegistry::empty(), &warnings).unwrap();
-
-            let state = warnings.0.lock().unwrap();
-            let sources = state.warnings.first_key_value().unwrap().1;
-            assert_eq!(
-                sources.first().unwrap(),
-                &ConfigWarningSource { path, line: 2 }
-            );
         }
     }
 
@@ -4507,37 +4271,13 @@ name = "my_stub"
             }
         }
 
+        /// An unregistered secret is dropped by resolution (whether or not unavailable runtime
+        /// config is allowed); `config_prepass::preflight` owns the fatal/continue/fix decision.
         #[test]
-        fn fetch_and_verify_activity_exec_secret_fails_when_unregistered_and_not_ignored() {
-            let config = exec_config_with_secret();
-            let error = config
-                .fetch_and_verify(
-                    inline_program(),
-                    false,
-                    &SecretRegistry::empty(),
-                    &ConfigWarnings::default(),
-                    None,
-                )
-                .unwrap_err()
-                .to_string();
-            assert!(
-                error.contains("failed to resolve exec secrets"),
-                "unexpected error: {error}"
-            );
-            assert!(error.contains("MY_SECRET"), "unexpected error: {error}");
-        }
-
-        #[test]
-        fn fetch_and_verify_activity_exec_secret_is_skipped_when_unregistered_and_ignored() {
+        fn fetch_and_verify_activity_exec_secret_dropped_when_unregistered() {
             let config = exec_config_with_secret();
             let verified = config
-                .fetch_and_verify(
-                    inline_program(),
-                    true,
-                    &SecretRegistry::empty(),
-                    &ConfigWarnings::default(),
-                    None,
-                )
+                .fetch_and_verify(inline_program(), false, &SecretRegistry::empty(), None)
                 .unwrap();
             assert!(verified.secrets.is_none());
         }
@@ -4550,13 +4290,7 @@ name = "my_stub"
                 SecretString::from("s3cret_value"),
             )]);
             let verified = config
-                .fetch_and_verify(
-                    inline_program(),
-                    false,
-                    &registry,
-                    &ConfigWarnings::default(),
-                    None,
-                )
+                .fetch_and_verify(inline_program(), false, &registry, None)
                 .unwrap();
             let secrets = verified.secrets.expect("secret must be resolved");
             assert!(secrets.env_vars.contains_key("MY_SECRET"));
@@ -4587,7 +4321,6 @@ name = "my_stub"
                     },
                     true,
                     &SecretRegistry::empty(),
-                    &ConfigWarnings::default(),
                     None,
                 )
                 .unwrap();
@@ -4601,7 +4334,6 @@ name = "my_stub"
                     },
                     true,
                     &SecretRegistry::empty(),
-                    &ConfigWarnings::default(),
                     None,
                 )
                 .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,9 @@ mod oci;
 mod server;
 mod wit_printer;
 
-use crate::command::server::{PrepareDirsParams, RuntimeConfigAvailability, VerifyParams, verify};
+use crate::command::server::{
+    PrepareDirsParams, RunParams, RuntimeConfigAvailability, VerifyParams, run, verify,
+};
 use crate::config::secret_registry::EnvVarCleanupStrategy;
 use args::{
     Args, ComponentArgs, Deployment, DeploymentArgs, DeploymentVerifyArgs, ExecutionArgs, Server,
@@ -40,29 +42,59 @@ fn main() -> Result<(), anyhow::Error> {
 
     type CommandFuture = Pin<Box<dyn Future<Output = Result<(), anyhow::Error>>>>;
     let future: CommandFuture = match command {
-        Subcommand::Server(server) => {
-            let (server_config, env_var_cleanup, runtime_config_availability) = match &server {
-                Server::Run { server_config, .. } => (
-                    server_config,
-                    EnvVarCleanupStrategy::Wipe, // only wipe on `server run`, as `* verify --fix` reloads the secret registry.
-                    RuntimeConfigAvailability::Strict,
-                ),
-                Server::Verify(VerifyArgs {
-                    server_config,
-                    allow_unavailable_runtime_config,
-                    ..
-                }) => {
-                    let runtime_config_availability = if *allow_unavailable_runtime_config {
-                        RuntimeConfigAvailability::AllowUnavailable
-                    } else {
-                        RuntimeConfigAvailability::Strict
-                    };
-                    (
-                        server_config,
-                        EnvVarCleanupStrategy::Noop,
-                        runtime_config_availability,
-                    )
-                }
+        Subcommand::Server(Server::Run {
+            server_config,
+            clean_sqlite_directory,
+            clean_cache,
+            clean_codegen_cache,
+            deployment,
+            empty: deployment_empty,
+            description,
+            suppress_type_checking_errors,
+            allow_unauthenticated_api,
+        }) => {
+            let ServerStartup {
+                config_holder,
+                config,
+                secret_registry,
+            } = prepare_server_startup(
+                server_config.clone(),
+                EnvVarCleanupStrategy::Wipe,
+                RuntimeConfigAvailability::Strict,
+            )?;
+            Box::pin(run(
+                config_holder,
+                config,
+                deployment,
+                deployment_empty,
+                description,
+                RunParams {
+                    dir_params: PrepareDirsParams {
+                        clean_cache,
+                        clean_codegen_cache,
+                    },
+                    clean_sqlite_directory,
+                    suppress_type_checking_errors,
+                    allow_unauthenticated_api,
+                },
+                secret_registry,
+            ))
+        }
+
+        Subcommand::Server(Server::Verify(VerifyArgs {
+            server_config,
+            allow_unavailable_runtime_config,
+            clean_cache,
+            clean_codegen_cache,
+            deployment,
+            suppress_type_checking_errors,
+            skip_db,
+            fix,
+        })) => {
+            let runtime_config_availability = if allow_unavailable_runtime_config {
+                RuntimeConfigAvailability::AllowUnavailable
+            } else {
+                RuntimeConfigAvailability::Strict
             };
             let ServerStartup {
                 config_holder,
@@ -70,24 +102,28 @@ fn main() -> Result<(), anyhow::Error> {
                 secret_registry,
             } = prepare_server_startup(
                 server_config.clone(),
-                env_var_cleanup,
+                EnvVarCleanupStrategy::Noop,
                 runtime_config_availability,
             )?;
-            Box::pin(server.run(config_holder, config, secret_registry))
+            Box::pin(verify(
+                config_holder,
+                config,
+                deployment,
+                VerifyParams {
+                    dir_params: PrepareDirsParams {
+                        clean_cache,
+                        clean_codegen_cache,
+                    },
+                    runtime_config_availability,
+                    suppress_type_checking_errors,
+                    suppress_linking_errors: false,
+                },
+                skip_db,
+                fix,
+                secret_registry,
+            ))
         }
-        Subcommand::Component(ComponentArgs { command, token }) => {
-            // Resolve the client token before the wipe in `resolve_and_wipe`.
-            let client_startup = ClientStartup::new(token.api_token);
-            let secret_registry = Arc::new(SecretRegistry::resolve(
-                SecretsToml::new(),
-                EnvVarCleanupStrategy::Noop,
-                RuntimeConfigAvailability::AllowUnavailable,
-            )?);
-            Box::pin(command.run(client_startup, secret_registry))
-        }
-        Subcommand::Execution(ExecutionArgs { command, token }) => {
-            Box::pin(command.run(ClientStartup::new(token.api_token)))
-        }
+
         // `deployment verify` uses server configuration and compilation machinery locally, but
         // never opens the database or uses its content-addressed store.
         Subcommand::Deployment(DeploymentArgs {
@@ -117,7 +153,6 @@ fn main() -> Result<(), anyhow::Error> {
                 EnvVarCleanupStrategy::Noop,
                 runtime_config_availability,
             )?;
-
             Box::pin(verify(
                 config_holder,
                 config,
@@ -136,9 +171,11 @@ fn main() -> Result<(), anyhow::Error> {
                 secret_registry,
             ))
         }
+
         Subcommand::Deployment(DeploymentArgs { command, token }) => {
             Box::pin(command.run(ClientStartup::new(token.api_token)))
         }
+
         Subcommand::Generate(generate) => {
             let secret_registry = Arc::new(SecretRegistry::resolve(
                 SecretsToml::new(),
@@ -146,6 +183,20 @@ fn main() -> Result<(), anyhow::Error> {
                 RuntimeConfigAvailability::AllowUnavailable,
             )?);
             Box::pin(generate.run(secret_registry))
+        }
+
+        Subcommand::Component(ComponentArgs { command, token }) => {
+            let client_startup = ClientStartup::new(token.api_token);
+            let secret_registry = Arc::new(SecretRegistry::resolve(
+                SecretsToml::new(),
+                EnvVarCleanupStrategy::Noop,
+                RuntimeConfigAvailability::AllowUnavailable,
+            )?);
+            Box::pin(command.run(client_startup, secret_registry))
+        }
+
+        Subcommand::Execution(ExecutionArgs { command, token }) => {
+            Box::pin(command.run(ClientStartup::new(token.api_token)))
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod oci;
 mod server;
 mod wit_printer;
 
+use crate::config::secret_registry::EnvVarCleanupStrategy;
 use args::{
     Args, ComponentArgs, Deployment, DeploymentArgs, DeploymentVerifyArgs, ExecutionArgs, Server,
     Subcommand, VerifyArgs,
@@ -39,19 +40,26 @@ fn main() -> Result<(), anyhow::Error> {
     type CommandFuture = Pin<Box<dyn Future<Output = Result<(), anyhow::Error>>>>;
     let future: CommandFuture = match command {
         Subcommand::Server(server) => {
-            let (Server::Run { server_config, .. }
-            | Server::Verify(VerifyArgs { server_config, .. })) = &server;
+            let (server_config, env_var_cleanup) = match &server {
+                Server::Run { server_config, .. } => (server_config, EnvVarCleanupStrategy::Wipe), // only wipe on `server run`, as `* verify --fix` reloads the secret registry.
+                Server::Verify(VerifyArgs { server_config, .. }) => {
+                    (server_config, EnvVarCleanupStrategy::Noop)
+                }
+            };
             let ServerStartup {
                 config_holder,
                 config,
                 secret_registry,
-            } = prepare_server_startup(server_config.clone())?;
+            } = prepare_server_startup(server_config.clone(), env_var_cleanup)?;
             Box::pin(server.run(config_holder, config, secret_registry))
         }
         Subcommand::Component(ComponentArgs { command, token }) => {
             // Resolve the client token before the wipe in `resolve_and_wipe`.
             let client_startup = ClientStartup::new(token.api_token);
-            let secret_registry = Arc::new(SecretRegistry::resolve_and_wipe(SecretsToml::new())?);
+            let secret_registry = Arc::new(SecretRegistry::resolve(
+                SecretsToml::new(),
+                EnvVarCleanupStrategy::Noop,
+            )?);
             Box::pin(command.run(client_startup, secret_registry))
         }
         Subcommand::Execution(ExecutionArgs { command, token }) => {
@@ -76,7 +84,7 @@ fn main() -> Result<(), anyhow::Error> {
                 config_holder,
                 config,
                 secret_registry,
-            } = prepare_server_startup(server_config.clone())?;
+            } = prepare_server_startup(server_config.clone(), EnvVarCleanupStrategy::Noop)?;
             let server = Server::Verify(VerifyArgs {
                 clean_cache,
                 clean_codegen_cache,
@@ -93,7 +101,10 @@ fn main() -> Result<(), anyhow::Error> {
             Box::pin(command.run(ClientStartup::new(token.api_token)))
         }
         Subcommand::Generate(generate) => {
-            let secret_registry = Arc::new(SecretRegistry::resolve_and_wipe(SecretsToml::new())?);
+            let secret_registry = Arc::new(SecretRegistry::resolve(
+                SecretsToml::new(),
+                EnvVarCleanupStrategy::Noop,
+            )?);
             Box::pin(generate.run(secret_registry))
         }
     };
@@ -113,10 +124,16 @@ struct ServerStartup {
 
 /// Parse the complete server config once, then resolve and wipe its secret sources
 /// before the runtime starts.
-fn prepare_server_startup(server_config: Option<PathBuf>) -> anyhow::Result<ServerStartup> {
+fn prepare_server_startup(
+    server_config: Option<PathBuf>,
+    env_var_cleanup: EnvVarCleanupStrategy,
+) -> anyhow::Result<ServerStartup> {
     let config_holder = ConfigHolder::new(project_dirs(), BaseDirs::new(), server_config)?;
-    let config = config_holder.load_config_sync()?;
-    let secret_registry = Arc::new(SecretRegistry::resolve_and_wipe(config.secrets.clone())?);
+    let config = config_holder.load_config()?;
+    let secret_registry = Arc::new(SecretRegistry::resolve(
+        config.secrets.clone(),
+        env_var_cleanup,
+    )?);
     Ok(ServerStartup {
         config_holder,
         config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod oci;
 mod server;
 mod wit_printer;
 
+use crate::command::server::{PrepareDirsParams, RuntimeConfigAvailability, VerifyParams, verify};
 use crate::config::secret_registry::EnvVarCleanupStrategy;
 use args::{
     Args, ComponentArgs, Deployment, DeploymentArgs, DeploymentVerifyArgs, ExecutionArgs, Server,
@@ -40,17 +41,38 @@ fn main() -> Result<(), anyhow::Error> {
     type CommandFuture = Pin<Box<dyn Future<Output = Result<(), anyhow::Error>>>>;
     let future: CommandFuture = match command {
         Subcommand::Server(server) => {
-            let (server_config, env_var_cleanup) = match &server {
-                Server::Run { server_config, .. } => (server_config, EnvVarCleanupStrategy::Wipe), // only wipe on `server run`, as `* verify --fix` reloads the secret registry.
-                Server::Verify(VerifyArgs { server_config, .. }) => {
-                    (server_config, EnvVarCleanupStrategy::Noop)
+            let (server_config, env_var_cleanup, runtime_config_availability) = match &server {
+                Server::Run { server_config, .. } => (
+                    server_config,
+                    EnvVarCleanupStrategy::Wipe, // only wipe on `server run`, as `* verify --fix` reloads the secret registry.
+                    RuntimeConfigAvailability::Strict,
+                ),
+                Server::Verify(VerifyArgs {
+                    server_config,
+                    allow_unavailable_runtime_config,
+                    ..
+                }) => {
+                    let runtime_config_availability = if *allow_unavailable_runtime_config {
+                        RuntimeConfigAvailability::AllowUnavailable
+                    } else {
+                        RuntimeConfigAvailability::Strict
+                    };
+                    (
+                        server_config,
+                        EnvVarCleanupStrategy::Noop,
+                        runtime_config_availability,
+                    )
                 }
             };
             let ServerStartup {
                 config_holder,
                 config,
                 secret_registry,
-            } = prepare_server_startup(server_config.clone(), env_var_cleanup)?;
+            } = prepare_server_startup(
+                server_config.clone(),
+                env_var_cleanup,
+                runtime_config_availability,
+            )?;
             Box::pin(server.run(config_holder, config, secret_registry))
         }
         Subcommand::Component(ComponentArgs { command, token }) => {
@@ -59,6 +81,7 @@ fn main() -> Result<(), anyhow::Error> {
             let secret_registry = Arc::new(SecretRegistry::resolve(
                 SecretsToml::new(),
                 EnvVarCleanupStrategy::Noop,
+                RuntimeConfigAvailability::AllowUnavailable,
             )?);
             Box::pin(command.run(client_startup, secret_registry))
         }
@@ -80,22 +103,38 @@ fn main() -> Result<(), anyhow::Error> {
                 suppress_type_checking_errors,
                 fix,
             } = args;
+            let runtime_config_availability = if allow_unavailable_runtime_config {
+                RuntimeConfigAvailability::AllowUnavailable
+            } else {
+                RuntimeConfigAvailability::Strict
+            };
             let ServerStartup {
                 config_holder,
                 config,
                 secret_registry,
-            } = prepare_server_startup(server_config.clone(), EnvVarCleanupStrategy::Noop)?;
-            let server = Server::Verify(VerifyArgs {
-                clean_cache,
-                clean_codegen_cache,
-                server_config,
-                deployment: Some(deployment),
-                allow_unavailable_runtime_config,
-                suppress_type_checking_errors,
-                skip_db: true,
+            } = prepare_server_startup(
+                server_config.clone(),
+                EnvVarCleanupStrategy::Noop,
+                runtime_config_availability,
+            )?;
+
+            Box::pin(verify(
+                config_holder,
+                config,
+                Some(deployment),
+                VerifyParams {
+                    dir_params: PrepareDirsParams {
+                        clean_cache,
+                        clean_codegen_cache,
+                    },
+                    runtime_config_availability,
+                    suppress_type_checking_errors,
+                    suppress_linking_errors: false,
+                },
+                true, // `deployment verify` does not verify db.
                 fix,
-            });
-            Box::pin(server.run(config_holder, config, secret_registry))
+                secret_registry,
+            ))
         }
         Subcommand::Deployment(DeploymentArgs { command, token }) => {
             Box::pin(command.run(ClientStartup::new(token.api_token)))
@@ -104,6 +143,7 @@ fn main() -> Result<(), anyhow::Error> {
             let secret_registry = Arc::new(SecretRegistry::resolve(
                 SecretsToml::new(),
                 EnvVarCleanupStrategy::Noop,
+                RuntimeConfigAvailability::AllowUnavailable,
             )?);
             Box::pin(generate.run(secret_registry))
         }
@@ -127,12 +167,20 @@ struct ServerStartup {
 fn prepare_server_startup(
     server_config: Option<PathBuf>,
     env_var_cleanup: EnvVarCleanupStrategy,
+    runtime_config_availability: RuntimeConfigAvailability,
 ) -> anyhow::Result<ServerStartup> {
+    if env_var_cleanup == EnvVarCleanupStrategy::Wipe {
+        assert_eq!(
+            RuntimeConfigAvailability::Strict,
+            runtime_config_availability,
+        );
+    }
     let config_holder = ConfigHolder::new(project_dirs(), BaseDirs::new(), server_config)?;
     let config = config_holder.load_config()?;
     let secret_registry = Arc::new(SecretRegistry::resolve(
         config.secrets.clone(),
         env_var_cleanup,
+        runtime_config_availability,
     )?);
     Ok(ServerStartup {
         config_holder,


### PR DESCRIPTION
- **refactor(cli): Reload `server.toml` on fixing secrets in `server.toml`**
- **refactor(cli): Pass strict/allow to secret reg to advance `--fix`**
- **refactor: Move server run / verify to `main`**
- **style: Clippy**
- **refactor(server): move config allowlist checks into a verify/startup pre-pass**
- **refactor(config): only fail strict secret load when a source env var is missing**
- **refactor(server): restore source-located allowlist advisories in the pre-pass**
- **refactor(secrets): resolve component secrets lazily via RestrictedSecretRegistry**
