### PR TITLE
js transparent rethrow plaform errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it searched and replaced across the entire raw request URI.
 - *(deployment)* `--allow-unavailable-runtime-config` now tolerates missing environment variable
   interpolations in plain key/value `env_vars` entries, including entries that rename a variable.
+- *(js)* A child execution's platform failure (timeout, cancellation, out-of-fuel, uncategorized)
+  awaited via `joinNext`/`getResult` now surfaces on the thrown `obelisk.ChildError` as
+  `.value = "execution-failed"` (matching the host projection onto the child's `err` type), instead
+  of `undefined`. An uncaught such error therefore encodes as a correctly-typed `err` for a
+  workflow returning `result<_, string>` or a variant `err`, rather than failing to type check as
+  `null`.
 
 ### Deprecated
 

--- a/assets/activity-js-runtime-version.txt
+++ b/assets/activity-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/activity-js-runtime:2026-07-26@sha256:5493fbdb7ea24877331991ea54fa54c2d1f89c285bec98aa4ab38a074269da70
+oci://docker.io/getobelisk/activity-js-runtime:2026-08-03@sha256:448cdd52fcb03f4b155ca431ebfd14cbb50b5a5710c9e6a04dae135321c989a8

--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-07-28@sha256:4d4fcba2854fc96eff9009ec12ec1935fa68f0abf3f0b5fb7faeb02bbf557b79
+oci://docker.io/getobelisk/webhook-js-runtime:2026-08-03@sha256:fd3391f497605d3375186ac6cc7d372d32e2ab5eb24bd7e532f8a2a4e63a8ebe

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-07-28@sha256:31e8c57f970981b72e77de88a0c29cc61d26256a16184901e2b970f6793c895f
+oci://docker.io/getobelisk/workflow-js-runtime:2026-08-03@sha256:6cd649786bd24e298d91bd39ca5077ecdbe7846a34c41f5d9532c3b79f1dbe25

--- a/crates/boa-common/src/child_error.rs
+++ b/crates/boa-common/src/child_error.rs
@@ -87,8 +87,9 @@ pub struct ChildErrorParts<'a> {
     pub child_id: Option<&'a str>,
     /// Cancelled delay id; `Some` only for a cancelled delay.
     pub delay_id: Option<&'a str>,
-    /// Business `err` payload as a JSON string; `None` for a unit err or a
-    /// platform failure.
+    /// Payload as a JSON string: the business `err`, or the host-projected
+    /// value for a platform failure (e.g. `"execution-failed"`); `None` for a
+    /// unit err or a cancelled delay/sleep.
     pub value_json: Option<&'a str>,
     /// Execution-failure kind as a kebab string (mirrors the WIT
     /// `execution-failure-kind` enum) for a platform failure or a cancelled
@@ -103,11 +104,12 @@ pub struct ChildErrorParts<'a> {
 
 /// Build a `ChildError` and wrap it as a throwable [`JsError`].
 pub fn make_child_error(parts: &ChildErrorParts, context: &mut Context) -> JsResult<JsError> {
-    // `.value` is the parsed business payload, and `undefined` for a platform
-    // failure (kind set, synthesized sentinel dropped) or a unit err.
-    let value = match (parts.failure_kind, parts.value_json) {
-        (Some(_), _) | (None, None) => JsValue::undefined(),
-        (None, Some(json)) => context.eval(Source::from_bytes(&format!("({json})")))?,
+    // `.value` is the parsed payload (business `err`, or the host-projected
+    // value for a platform failure such as "execution-failed"), and `undefined`
+    // when there is none (unit err, cancelled delay/sleep).
+    let value = match parts.value_json {
+        Some(json) => context.eval(Source::from_bytes(&format!("({json})")))?,
+        None => JsValue::undefined(),
     };
 
     let message = match parts.message {

--- a/crates/testing/test-programs/js/workflow/cancel_child_error.js
+++ b/crates/testing/test-programs/js/workflow/cancel_child_error.js
@@ -1,7 +1,7 @@
 // Await a child execution that is cancelled out-of-band. The child's cancellation
 // is a platform failure (not a business err), so `joinNext` throws a
 // `ChildError` whose `.cancelled` is true, `.failureKind` is `cancelled`
-// and `.value` is undefined (no err payload to carry).
+// and `.value` is projected onto the child's string err type.
 export default function cancel_child_error() {
     // Deprecated alias must stay the very same constructor.
     if (obelisk.ChildExecutionError !== obelisk.ChildError) {
@@ -25,8 +25,8 @@ export default function cancel_child_error() {
         if (e.childId !== childId) {
             throw `expected childId=${childId}, got: ${e.childId}`;
         }
-        if (e.value !== undefined) {
-            throw `expected value=undefined, got: ${JSON.stringify(e.value)}`;
+        if (e.value !== 'execution-failed') {
+            throw `expected value=execution-failed, got: ${JSON.stringify(e.value)}`;
         }
         return 'cancelled-child-observed';
     }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -180,23 +180,15 @@ fn finished_status_to_wit(
 /// Err(None) for error result with no value.
 fn supported_return_value_to_json_result(
     retval: &SupportedFunctionReturnValue,
+    ret_type: concepts::TypeWrapperTopLevel,
 ) -> Result<Option<String>, Option<String>> {
-    match retval {
-        SupportedFunctionReturnValue::Ok(Some(val_with_type)) => {
-            let json =
-                serde_json::to_string(&val_with_type.value).unwrap_or_else(|_| "null".to_string());
-            Ok(Some(json))
-        }
-        SupportedFunctionReturnValue::Ok(None) => Ok(None),
-        SupportedFunctionReturnValue::Err(Some(val_with_type)) => {
-            let json =
-                serde_json::to_string(&val_with_type.value).unwrap_or_else(|_| "null".to_string());
-            Err(Some(json))
-        }
-        SupportedFunctionReturnValue::Err(None) => Err(None),
-        SupportedFunctionReturnValue::ExecutionFailure(err) => {
-            Err(Some(format!("execution error: {err}")))
-        }
+    match retval.clone().into_wast_val_res(|| ret_type) {
+        Ok(value) => Ok(value.map(|value| {
+            serde_json::to_string(&*value).expect("WastVal must be JSON serializable")
+        })),
+        Err(value) => Err(value.map(|value| {
+            serde_json::to_string(&*value).expect("WastVal must be JSON serializable")
+        })),
     }
 }
 
@@ -1085,6 +1077,10 @@ impl WebhookEndpointCtx {
                 .await;
             return Err(ScheduleJsonError::FunctionNotFound.into());
         };
+        let ret_type = self
+            .fn_registry
+            .get_ret_type(&ffqn)
+            .expect("exported webhook-call target must have a supported return type");
 
         // Parse params JSON array
         let params_json: Vec<serde_json::Value> = match serde_json::from_str(&params) {
@@ -1238,7 +1234,7 @@ impl WebhookEndpointCtx {
         .await;
 
         match result {
-            Ok(retval) => Ok(supported_return_value_to_json_result(&retval)),
+            Ok(retval) => Ok(supported_return_value_to_json_result(&retval, ret_type)),
             Err(err) => Err(wasmtime::Error::msg(format!("execution error: {err:?}")).into()),
         }
     }
@@ -1269,6 +1265,17 @@ impl WebhookEndpointCtx {
                 );
             }
         };
+        let execution = match db_connection.get_pending_state(&parsed_execution_id).await {
+            Ok(execution) => execution,
+            Err(DbErrorRead::NotFound) => return Err(GetError::NotFound.into()),
+            Err(err) => {
+                return Err(wasmtime::Error::msg(format!("database read error: {err:?}")).into());
+            }
+        };
+        let ret_type = self
+            .fn_registry
+            .get_ret_type(&execution.ffqn)
+            .expect("webhook get target must have a supported return type");
 
         // Extract needed values before the async call to avoid borrowing issues
         let subscription_interruption = self.subscription_interruption;
@@ -1288,7 +1295,7 @@ impl WebhookEndpointCtx {
         .await;
 
         match result {
-            Ok(retval) => Ok(supported_return_value_to_json_result(&retval)),
+            Ok(retval) => Ok(supported_return_value_to_json_result(&retval, ret_type)),
             Err(err) => Err(wasmtime::Error::msg(format!("execution error: {err:?}")).into()),
         }
     }
@@ -1333,6 +1340,10 @@ impl WebhookEndpointCtx {
                 return Err(wasmtime::Error::msg(format!("database read error: {err:?}")).into());
             }
         };
+        let ret_type = self
+            .fn_registry
+            .get_ret_type(&execution_with_state.ffqn)
+            .expect("webhook try-get target must have a supported return type");
 
         // Check if finished
         match execution_with_state.pending_state {
@@ -1342,7 +1353,7 @@ impl WebhookEndpointCtx {
                     .wait_for_finished_result(&parsed_execution_id, None)
                     .await
                 {
-                    Ok(retval) => Ok(supported_return_value_to_json_result(&retval)),
+                    Ok(retval) => Ok(supported_return_value_to_json_result(&retval, ret_type)),
                     Err(err) => {
                         Err(wasmtime::Error::msg(format!("database read error: {err:?}")).into())
                     }
@@ -3490,6 +3501,14 @@ pub(crate) mod tests {
                         test_programs_fibo_activity_builder::TEST_PROGRAMS_FIBO_ACTIVITY,
                     )
                     .await,
+                    compile_activity(
+                        test_programs_http_get_activity_builder::TEST_PROGRAMS_HTTP_GET_ACTIVITY,
+                    )
+                    .await,
+                    compile_activity(
+                        test_programs_serde_activity_builder::TEST_PROGRAMS_SERDE_ACTIVITY,
+                    )
+                    .await,
                 ]);
 
                 let engine =
@@ -3811,6 +3830,140 @@ pub(crate) mod tests {
             assert_eq!(body["valueIsUndefined"], serde_json::json!(true));
             assert_eq!(body["cancelled"], serde_json::json!(false));
             assert_eq!(body["hasChildId"], serde_json::json!(true));
+        }
+
+        #[tokio::test]
+        async fn webhook_js_child_platform_failure_keeps_projected_value() {
+            use crate::workflow::workflow_worker::tests::write_stub_response;
+            use concepts::storage::{
+                ExecutionListPagination, FunctionNameFilter, ListExecutionsFilter,
+            };
+            use concepts::{
+                ExecutionFailureKind, ExecutionId, FinishedExecutionFailure,
+                SupportedFunctionReturnValue,
+            };
+
+            test_utils::set_up();
+            let cases = [
+                (
+                    "import { fibo } from 'testing:fibo/fibo';",
+                    "fibo(1);",
+                    "testing:fibo/fibo.fibo",
+                    true,
+                    serde_json::Value::Null,
+                ),
+                (
+                    "import { get } from 'testing:http/http-get';",
+                    "get('http://unused');",
+                    "testing:http/http-get.get",
+                    false,
+                    serde_json::json!("execution-failed"),
+                ),
+                (
+                    "import { trap } from 'testing:serde/serde';",
+                    "trap();",
+                    "testing:serde/serde.trap",
+                    false,
+                    serde_json::json!("execution_failed"),
+                ),
+            ];
+
+            for (import, call, target_ffqn, value_is_undefined, expected_value) in cases {
+                let js_source = format!(
+                    r"
+                    {import}
+                    export default function handle(_request) {{
+                        try {{
+                            {call}
+                            return Response.json({{ threw: false }});
+                        }} catch (e) {{
+                            return Response.json({{
+                                threw: true,
+                                isChildError: e instanceof obelisk.ChildError,
+                                valueIsUndefined: e.value === undefined,
+                                value: e.value ?? null,
+                                failureKind: e.failureKind,
+                                cancelled: e.cancelled,
+                                hasChildId: typeof e.childId === 'string',
+                            }});
+                        }}
+                    }}
+                    "
+                );
+                let harness = JsWebhookWithActivitiesHarness::new(&js_source).await;
+                let server_addr = harness.server_addr;
+                let fetch_task = tokio::spawn(async move {
+                    reqwest::get(format!("http://{server_addr}/"))
+                        .await
+                        .unwrap()
+                });
+
+                let child_execution_id =
+                    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                        loop {
+                            let conn = harness.db_pool.external_api_conn().await.unwrap();
+                            let executions = conn
+                                .list_executions(
+                                    ListExecutionsFilter {
+                                        function_name_filter: Some(
+                                            FunctionNameFilter::FunctionName(
+                                                target_ffqn.to_string(),
+                                            ),
+                                        ),
+                                        show_derived: true,
+                                        ..Default::default()
+                                    },
+                                    ExecutionListPagination::default(),
+                                )
+                                .await
+                                .unwrap();
+                            if let Some(execution) = executions
+                                .into_iter()
+                                .find(|execution| execution.ffqn.to_string() == target_ffqn)
+                            {
+                                break match execution.execution_id {
+                                    ExecutionId::Derived(id) => id,
+                                    ExecutionId::TopLevel(_) => {
+                                        panic!("activity execution must be derived")
+                                    }
+                                };
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                        }
+                    })
+                    .await
+                    .expect("webhook should submit the child activity");
+                let conn = harness.db_pool.connection_test().await.unwrap();
+                write_stub_response(
+                    conn.as_ref(),
+                    harness.sim_clock.now(),
+                    child_execution_id,
+                    SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
+                        kind: ExecutionFailureKind::Uncategorized,
+                        reason: Some("injected platform failure".to_string()),
+                        detail: None,
+                    }),
+                )
+                .await;
+
+                let resp = fetch_task.await.unwrap();
+                assert_eq!(resp.status().as_u16(), 200);
+                let body: serde_json::Value = resp.json().await.unwrap();
+                assert_eq!(body["threw"], serde_json::json!(true));
+                assert_eq!(
+                    body["isChildError"],
+                    serde_json::json!(true),
+                    "unexpected webhook response: {body}"
+                );
+                assert_eq!(
+                    body["valueIsUndefined"],
+                    serde_json::json!(value_is_undefined)
+                );
+                assert_eq!(body["value"], expected_value);
+                assert_eq!(body["failureKind"], serde_json::json!("uncategorized"));
+                assert_eq!(body["cancelled"], serde_json::json!(false));
+                assert_eq!(body["hasChildId"], serde_json::json!(true));
+            }
         }
     }
 

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -681,6 +681,7 @@ mod tests {
     use crate::workflow::deadline_tracker::{
         DeadlineTrackerFactory, DeadlineTrackerFactoryTokio, deadline_tracker_factory_test,
     };
+    use crate::workflow::workflow_worker::tests::write_stub_response;
     use crate::workflow::workflow_worker::{JoinNextBlockingStrategy, WorkflowConfig};
     use assert_matches::assert_matches;
     use chrono::DateTime;
@@ -713,7 +714,7 @@ mod tests {
     use test_utils::{ExecutionLogSanitized, redact_component_digest};
     use tokio::sync::mpsc;
     use tracing::{info, info_span};
-    use val_json::wast_val::WastVal;
+    use val_json::wast_val::{ValKey, WastVal};
     use wasmtime::Engine;
 
     type ExecTaskAndClose = (ExecTask, tokio::sync::watch::Sender<bool>);
@@ -1219,9 +1220,35 @@ mod tests {
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         deadline_factory: Arc<dyn DeadlineTrackerFactory>,
     ) -> (WorkflowJsWorker, concepts::ComponentId, RunnableComponent) {
+        compile_js_workflow_worker_with_deployment_id_and_return_type(
+            js_source,
+            user_ffqn,
+            db_pool,
+            clock_fn,
+            fn_registry,
+            workflow_engine,
+            deployment_id,
+            join_next_blocking_strategy,
+            deadline_factory,
+            default_return_type(),
+        )
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn compile_js_workflow_worker_with_deployment_id_and_return_type(
+        js_source: &str,
+        user_ffqn: &FunctionFqn,
+        db_pool: Arc<dyn DbPool>,
+        clock_fn: &dyn ClockFn,
+        fn_registry: Arc<dyn FunctionRegistry>,
+        workflow_engine: Arc<Engine>,
+        deployment_id: DeploymentId,
+        join_next_blocking_strategy: JoinNextBlockingStrategy,
+        deadline_factory: Arc<dyn DeadlineTrackerFactory>,
+        return_type: ReturnTypeExtendable,
+    ) -> (WorkflowJsWorker, concepts::ComponentId, RunnableComponent) {
         let wasm_path = workflow_js_runtime_builder::WORKFLOW_JS_RUNTIME;
         let params = default_js_params();
-        let return_type = default_return_type();
         let component_id = concepts::ComponentId::new(
             ComponentType::Workflow,
             StrVariant::Static("test_js_workflow"),
@@ -1731,6 +1758,7 @@ mod tests {
     enum TestActivities {
         None,
         Stub,
+        ChildErrorProjections,
     }
 
     /// Helper for running JS workflow tests with reduced boilerplate.
@@ -1801,6 +1829,25 @@ mod tests {
             activities: TestActivities,
             join_next_blocking_strategy: JoinNextBlockingStrategy,
         ) -> Self {
+            Self::new_with_return_type(
+                db_pool,
+                js_source,
+                fn_name,
+                activities,
+                join_next_blocking_strategy,
+                default_return_type(),
+            )
+            .await
+        }
+
+        async fn new_with_return_type(
+            db_pool: Arc<dyn DbPool>,
+            js_source: &str,
+            fn_name: &'static str,
+            activities: TestActivities,
+            join_next_blocking_strategy: JoinNextBlockingStrategy,
+            return_type: ReturnTypeExtendable,
+        ) -> Self {
             use crate::activity::activity_worker::test::compile_activity_stub;
 
             let sim_clock = SimClock::epoch();
@@ -1811,6 +1858,20 @@ mod tests {
                 TestActivities::Stub => vec![
                     compile_activity_stub(
                         test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY,
+                    )
+                    .await,
+                ],
+                TestActivities::ChildErrorProjections => vec![
+                    compile_activity(
+                        test_programs_fibo_activity_builder::TEST_PROGRAMS_FIBO_ACTIVITY,
+                    )
+                    .await,
+                    compile_activity(
+                        test_programs_http_get_activity_builder::TEST_PROGRAMS_HTTP_GET_ACTIVITY,
+                    )
+                    .await,
+                    compile_activity(
+                        test_programs_serde_activity_builder::TEST_PROGRAMS_SERDE_ACTIVITY,
                     )
                     .await,
                 ],
@@ -1832,7 +1893,7 @@ mod tests {
             let workflow_engine =
                 Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
             let (worker, component_id, _runnable_component) =
-                compile_js_workflow_worker_with_deployment_id(
+                compile_js_workflow_worker_with_deployment_id_and_return_type(
                     js_source,
                     &user_ffqn,
                     db_pool.clone(),
@@ -1842,6 +1903,7 @@ mod tests {
                     DEPLOYMENT_ID_DUMMY,
                     join_next_blocking_strategy,
                     deadline_factory,
+                    return_type,
                 );
 
             let (workflow_exec, workflow_close_tx) =
@@ -1912,6 +1974,242 @@ mod tests {
     }
 
     // ==================== Workflow tests ====================
+
+    #[derive(Clone, Copy, Debug)]
+    enum ChildErrorAwaitStyle {
+        DirectImport,
+        JoinNext,
+        JoinNextTry,
+    }
+
+    impl ChildErrorAwaitStyle {
+        fn js_source(self, projection: ChildErrProjection) -> String {
+            let (direct_import, direct_call) = projection.direct_import();
+            let (import, setup, await_child) = match self {
+                Self::DirectImport => (direct_import, String::new(), direct_call.to_string()),
+                Self::JoinNext => (
+                    "",
+                    format!(
+                        "const js = obelisk.createJoinSet();\njs.submit('{}', {});",
+                        projection.target_ffqn(),
+                        projection.params_json()
+                    ),
+                    "js.joinNext();".to_string(),
+                ),
+                Self::JoinNextTry => (
+                    "",
+                    format!(
+                        "const js = obelisk.createJoinSet();\njs.submit('{}', {});\nobelisk.sleep({{ milliseconds: 1 }});",
+                        projection.target_ffqn(),
+                        projection.params_json()
+                    ),
+                    "js.joinNextTry();\nthrow 'expected ChildError';".to_string(),
+                ),
+            };
+            let value_assertion = projection.value_assertion();
+            format!(
+                r"
+                {import}
+                export default function test_child_error(_params) {{
+                    {setup}
+                    try {{
+                        {await_child}
+                    }} catch (e) {{
+                        if (!(e instanceof obelisk.ChildError)) {{
+                            throw `expected ChildError, got: ${{e}}`;
+                        }}
+                        {value_assertion}
+                        if (e.failureKind !== 'uncategorized') {{
+                            throw `unexpected failure kind: ${{e.failureKind}}`;
+                        }}
+                        throw e;
+                    }}
+                }}
+                "
+            )
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ChildErrProjection {
+        Unit,
+        String,
+        ExecutionFailedVariant,
+    }
+
+    impl ChildErrProjection {
+        fn direct_import(self) -> (&'static str, &'static str) {
+            match self {
+                Self::Unit => ("import { fibo } from 'testing:fibo/fibo';", "fibo(1);"),
+                Self::String => (
+                    "import { get } from 'testing:http/http-get';",
+                    "get('http://unused');",
+                ),
+                Self::ExecutionFailedVariant => {
+                    ("import { trap } from 'testing:serde/serde';", "trap();")
+                }
+            }
+        }
+
+        fn target_ffqn(self) -> &'static str {
+            match self {
+                Self::Unit => "testing:fibo/fibo.fibo",
+                Self::String => "testing:http/http-get.get",
+                Self::ExecutionFailedVariant => "testing:serde/serde.trap",
+            }
+        }
+
+        fn params_json(self) -> &'static str {
+            match self {
+                Self::Unit => "[1]",
+                Self::String => "['http://unused']",
+                Self::ExecutionFailedVariant => "[]",
+            }
+        }
+
+        fn value_assertion(self) -> &'static str {
+            match self {
+                Self::Unit => {
+                    "if (e.value !== undefined) { throw `unexpected child err value: ${e.value}`; }"
+                }
+                Self::String => {
+                    "if (e.value !== 'execution-failed') { throw `unexpected child err value: ${e.value}`; }"
+                }
+                Self::ExecutionFailedVariant => {
+                    "if (e.value !== 'execution_failed') { throw `unexpected child err value: ${e.value}`; }"
+                }
+            }
+        }
+
+        fn parent_return_type(self) -> ReturnTypeExtendable {
+            let err = match self {
+                Self::Unit => None,
+                Self::String => Some(Box::new(TypeWrapper::String)),
+                Self::ExecutionFailedVariant => {
+                    Some(Box::new(TypeWrapper::Variant(IndexMap::from([
+                        (TypeKey::new_kebab("foo"), None),
+                        (TypeKey::new_kebab("execution-failed"), None),
+                    ]))))
+                }
+            };
+            let wit_type = match self {
+                Self::Unit => StrVariant::Static("result<string>"),
+                Self::String => StrVariant::Static("result<string, string>"),
+                Self::ExecutionFailedVariant => {
+                    StrVariant::Static("result<string, variant { foo, execution-failed }>")
+                }
+            };
+            ReturnTypeExtendable {
+                type_wrapper_tl: TypeWrapperTopLevel {
+                    ok: Some(Box::new(TypeWrapper::String)),
+                    err,
+                },
+                wit_type,
+            }
+        }
+    }
+
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_rethrows_child_platform_failure(
+        database: Database,
+        #[values(
+            ChildErrorAwaitStyle::DirectImport,
+            ChildErrorAwaitStyle::JoinNext,
+            ChildErrorAwaitStyle::JoinNextTry
+        )]
+        await_style: ChildErrorAwaitStyle,
+        #[values(
+            ChildErrProjection::Unit,
+            ChildErrProjection::String,
+            ChildErrProjection::ExecutionFailedVariant
+        )]
+        projection: ChildErrProjection,
+    ) {
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+        let js_source = await_style.js_source(projection);
+        let harness = JsWorkflowTestHarness::new_with_return_type(
+            db_pool,
+            &js_source,
+            "test-child-error",
+            TestActivities::ChildErrorProjections,
+            JoinNextBlockingStrategy::Interrupt,
+            projection.parent_return_type(),
+        )
+        .await;
+
+        harness.tick().await;
+        let log = harness
+            .db_connection
+            .get(&harness.execution_id)
+            .await
+            .unwrap();
+        let child_ffqn = projection.target_ffqn().parse::<FunctionFqn>().unwrap();
+        let child_execution_id = log
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                ExecutionRequest::HistoryEvent {
+                    event:
+                        HistoryEvent::JoinSetRequest {
+                            request:
+                                JoinSetRequest::ChildExecutionRequest {
+                                    child_execution_id,
+                                    target_ffqn,
+                                    ..
+                                },
+                            ..
+                        },
+                } if target_ffqn == &child_ffqn => Some(child_execution_id.clone()),
+                _ => None,
+            })
+            .expect("workflow should submit the child activity");
+        write_stub_response(
+            harness.db_connection.as_ref(),
+            harness.sim_clock.now(),
+            child_execution_id,
+            SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
+                kind: ExecutionFailureKind::Uncategorized,
+                reason: Some("injected platform failure".to_string()),
+                detail: None,
+            }),
+        )
+        .await;
+
+        if matches!(await_style, ChildErrorAwaitStyle::JoinNextTry) {
+            harness.advance_time(Duration::from_millis(1)).await;
+        }
+        harness.tick().await;
+
+        let result = harness
+            .db_connection
+            .get_finished_result(&harness.execution_id)
+            .await
+            .unwrap();
+        match projection {
+            ChildErrProjection::Unit => {
+                assert_matches!(result, SupportedFunctionReturnValue::Err(None));
+            }
+            ChildErrProjection::String => {
+                let err =
+                    assert_matches!(result, SupportedFunctionReturnValue::Err(Some(err)) => err);
+                assert_eq!(WastVal::String("execution-failed".into()), err.value);
+            }
+            ChildErrProjection::ExecutionFailedVariant => {
+                let err =
+                    assert_matches!(result, SupportedFunctionReturnValue::Err(Some(err)) => err);
+                assert_eq!(
+                    WastVal::Variant(ValKey::from_kebab("execution-failed"), None),
+                    err.value
+                );
+            }
+        }
+
+        drop(harness);
+        db_close.close().await;
+    }
 
     /// Test: JS workflow uses `obelisk.stub()` to stub an `activity_stub` execution.
     #[expand_enum_database]

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -4317,7 +4317,7 @@ pub(crate) mod tests {
         db_close.close().await;
     }
 
-    async fn write_stub_response(
+    pub(crate) async fn write_stub_response(
         db_connection: &dyn DbConnection,
         created_at: DateTime<Utc>,
         stub_execution_id: ExecutionIdDerived,

--- a/crates/webhook-js-runtime/src/webhook_js_runtime.rs
+++ b/crates/webhook-js-runtime/src/webhook_js_runtime.rs
@@ -507,7 +507,7 @@ fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsR
                 &ChildErrorParts {
                     child_id: Some(exec_id),
                     delay_id: None,
-                    value_json: None,
+                    value_json: payload.as_deref(),
                     failure_kind: Some(exec_failure_kind_str(kind)),
                     cancelled,
                     message: None,

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -510,13 +510,16 @@ fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsR
         id: exec_id.to_string(),
     };
     match get_execution_failure_kind(&exec) {
+        // Platform failure: keep the host-projected `err` payload (e.g.
+        // "execution-failed" for a string/variant err type) so transparent
+        // rethrow re-serializes a correctly-typed value, not `null`.
         Ok(Some(kind)) => {
             let cancelled = matches!(kind, ExecutionFailureKind::Cancelled);
             make_child_error(
                 &ChildErrorParts {
                     child_id: Some(exec_id),
                     delay_id: None,
-                    value_json: None,
+                    value_json: payload.as_deref(),
                     failure_kind: Some(exec_failure_kind_str(kind)),
                     cancelled,
                     message: None,

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -3385,7 +3385,7 @@ async fn submit_workflow_rethrows_child_execution_error() {
 
 /// A child execution cancelled out-of-band surfaces to an awaiting JS parent as a
 /// `ChildError` with `.cancelled === true` and `.failureKind === "cancelled"`
-/// (a platform failure with no err payload), not as a business err value.
+/// whose `.value` is projected onto the child's string err type.
 #[tokio::test]
 async fn submit_workflow_child_cancelled_surfaces_child_execution_error() {
     use concepts::{ExecutionId, JoinSetId, JoinSetKind, StrVariant};


### PR DESCRIPTION
- **fix(js): keep projected err value on platform-failure ChildError**
- **test(js): cover all child error projections**
- **fix(webhook-js): project child platform failures**
- **build: Push webhook and workflow JS runtimes**
