### PR TITLE
fix(exec): materialize inline exec scripts to cache, drop per-execution temp file

### DIFF
--- a/.envrc-example
+++ b/.envrc-example
@@ -12,3 +12,5 @@ export TEST_POSTGRES_HOST="localhost"
 export TEST_POSTGRES_USER="postgres"
 export TEST_POSTGRES_PASSWORD="postgres"
 export TEST_POSTGRES_DATABASE_PREFIX="obelisk_test"
+#
+export MY_SECRET="foo"

--- a/crates/wasm-workers/Cargo.toml
+++ b/crates/wasm-workers/Cargo.toml
@@ -41,7 +41,6 @@ serde_json.workspace = true
 serde.workspace = true
 strum.workspace = true
 thiserror.workspace = true
-tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-error.workspace = true

--- a/crates/wasm-workers/src/activity/activity_exec_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_exec_worker.rs
@@ -34,18 +34,10 @@ pub struct ExecSecrets {
     pub resolver: Arc<dyn crate::http_request_policy::SecretResolver>,
 }
 
-/// How the exec activity program is provided to the worker.
-#[derive(Debug)]
-pub enum ExecProgram {
-    /// Inline script content. Written to a temp file at each execution.
-    Inline(String),
-    /// Path to an immutable cached script file (from OCI). Executed directly.
-    CachedFile(PathBuf), // TODO: Use for CAS as well
-}
-
 /// Compiled exec activity. No WASM engine needed.
 pub struct ActivityExecWorkerCompiled {
-    program: ExecProgram,
+    /// Immutable cached script file, executed directly (see issue #821).
+    program: PathBuf,
     user_ffqn: FunctionFqn,
     user_params: Vec<ParameterType>,
     user_return_type: ReturnTypeExtendable,
@@ -65,7 +57,7 @@ pub struct ActivityExecWorkerCompiled {
 impl ActivityExecWorkerCompiled {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
-        program: ExecProgram,
+        program: PathBuf,
         user_ffqn: FunctionFqn,
         user_params: Vec<ParameterType>,
         user_return_type: ReturnTypeExtendable,
@@ -148,7 +140,7 @@ impl ActivityExecWorkerCompiled {
 }
 
 pub struct ActivityExecWorker {
-    program: ExecProgram,
+    program: PathBuf,
     #[allow(dead_code)]
     user_ffqn: FunctionFqn,
     user_params: Vec<ParameterType>,
@@ -215,48 +207,7 @@ impl Worker for ActivityExecWorker {
 
         let mut param_args: Vec<String> = Vec::new();
 
-        // Build the command depending on program source.
-        // For inline scripts, write to a temp file each execution.
-        // For cached files (from OCI), execute the immutable file directly.
-        let _temp_file_guard;
-        let mut cmd = match &self.program {
-            ExecProgram::Inline(content) => {
-                let mut builder = tempfile::Builder::new();
-                builder.prefix("obelisk-exec-");
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    builder.permissions(std::fs::Permissions::from_mode(0o755));
-                }
-                let mut tmp = builder.tempfile().map_err(|e| {
-                    WorkerError::FatalError(
-                        FatalError::CannotInstantiate {
-                            reason: "failed to create temp file for inline script".to_string(),
-                            detail: Some(e.to_string()),
-                        },
-                        version.clone(),
-                    )
-                })?;
-                use std::io::Write;
-                tmp.write_all(content.as_bytes()).map_err(|e| {
-                    WorkerError::FatalError(
-                        FatalError::CannotInstantiate {
-                            reason: "failed to write inline script".to_string(),
-                            detail: Some(e.to_string()),
-                        },
-                        version.clone(),
-                    )
-                })?;
-                let temp_path = tmp.into_temp_path();
-                let cmd = tokio::process::Command::new(&temp_path);
-                _temp_file_guard = Some(temp_path);
-                cmd
-            }
-            ExecProgram::CachedFile(path) => {
-                _temp_file_guard = None;
-                tokio::process::Command::new(path)
-            }
-        };
+        let mut cmd = tokio::process::Command::new(&self.program);
 
         let json_params = ctx
             .params

--- a/obelisk-testing-exec.toml
+++ b/obelisk-testing-exec.toml
@@ -33,6 +33,28 @@ return_type = "result<string, string>"
 env_vars = ["PATH"] # for jq
 
 
+# Fan-out workflow to reproduce https://github.com/obeli-sk/obelisk/issues/821:
+# submitting many inline exec activities at once makes their spawns race.
+[[workflow_js]]
+ffqn = "testing:integration/workflow-exec-fanout.exec-fanout"
+content = '''
+export default function exec_fanout(count) {
+    const js = obelisk.createJoinSet();
+    for (let i = 0; i < count; i++) {
+        js.submit('testing:integration/exec-greet.greet-inline', [`name-${i}`]);
+    }
+    const results = [];
+    for (let i = 0; i < count; i++) {
+        results.push(js.joinNext());
+    }
+    return JSON.stringify(results);
+}
+'''
+params = [
+  { name = "count", type = "u32" },
+]
+return_type = "result<string, string>"
+
 [[activity_exec]]
 ffqn = "testing:integration/exec-busy.busy"
 content = '''

--- a/server-postgres.toml
+++ b/server-postgres.toml
@@ -22,4 +22,5 @@ target = true
 directory = "."
 prefix = "obelisk.log" # File name prefix
 
-
+[secrets]
+MY_SECRET = { env = "MY_SECRET" }

--- a/server-postgres.toml
+++ b/server-postgres.toml
@@ -4,6 +4,8 @@ database.postgres.password = "${POSTGRES_PASSWORD}"
 database.postgres.db_name =  "${POSTGRES_DATABASE}"
 database.postgres.provision_policy = "auto"
 
+allow_exec_activities = true
+
 [[outbound_http.allowed_host]]
 pattern = "*"
 methods = "*"
@@ -19,3 +21,5 @@ enabled = true
 target = true
 directory = "."
 prefix = "obelisk.log" # File name prefix
+
+

--- a/server-sqlite.toml
+++ b/server-sqlite.toml
@@ -19,5 +19,3 @@ replace_in = ["headers", "params", "body"]
 
 [secrets]
 MY_SECRET = { env = "MY_SECRET" }
-
-

--- a/server-sqlite.toml
+++ b/server-sqlite.toml
@@ -1,3 +1,5 @@
+allow_exec_activities = true
+
 [log.file]
 level = "info,obeli_sk_wasm_workers=debug"
 enabled = true
@@ -14,3 +16,8 @@ pattern = "httpbin.org"
 methods = "*"
 secrets = ["MY_SECRET"]
 replace_in = ["headers", "params", "body"]
+
+[secrets]
+MY_SECRET = { env = "MY_SECRET" }
+
+

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -189,9 +189,9 @@ replace_in = ["headers", "params", "body"]
         codegen_cache = workspace.join("test-codegen-cache").display(),
         db_dir = db_dir.path().display(),
     );
-    let server_path = db_dir.path().join("obelisk-test-server.toml");
-    std::fs::write(&server_path, server_contents).unwrap();
+    let server_path = db_dir.path().join("server.toml");
 
+    std::fs::write(&server_path, server_contents).unwrap();
     let ws = ".";
     let deployment_contents = format!(
         r#"
@@ -655,7 +655,7 @@ routes = [{{ methods = ["POST"], route = "/body-form-data" }}]
 "#,
     );
     debug!("Deployment TOML:{deployment_contents}");
-    let deployment_path = db_dir.path().join("obelisk-test-deployment.toml");
+    let deployment_path = db_dir.path().join("deployment.toml");
     std::fs::write(&deployment_path, deployment_contents).unwrap();
     (db_dir, server_path, deployment_path)
 }
@@ -1227,10 +1227,7 @@ impl TestServer {
     }
 }
 
-/// v1 API token auth (`meta/designs/server-security-guard.md`): with auth active
-/// (tests otherwise run with `allow_unauthenticated_api`), the API port denies requests without a
-/// valid bearer token and accepts both the plaintext `api.token` and an
-/// `api.token_hashes` entry, on the web API and at gRPC stream open.
+/// api.token is not tested as it interferes with `OBELISK__API__TOKEN` that might be set.
 #[tokio::test]
 async fn api_auth_should_deny_unauthenticated_requests() {
     fn list_components_request() -> ListComponentsRequest {
@@ -1242,12 +1239,11 @@ async fn api_auth_should_deny_unauthenticated_requests() {
         }
     }
 
-    let plain_token = "plain-secret-token";
     let hashed_token = "hashed-secret-token";
     let server = TestServer::start_empty_with_auth(
         test_addr!(89),
         &format!(
-            "api.token = \"{plain_token}\"\napi.token_hashes = [\"{hash}\"]",
+            "api.token_hashes = [\"{hash}\"]",
             hash = crate::api::token_hash(hashed_token)
         ),
     )
@@ -1263,16 +1259,15 @@ async fn api_auth_should_deny_unauthenticated_requests() {
             reqwest::StatusCode::UNAUTHORIZED
         );
     }
-    for accepted in [plain_token, hashed_token] {
-        let resp = server
-            .client
-            .get(&url)
-            .bearer_auth(accepted)
-            .send()
-            .await
-            .unwrap();
-        assert!(resp.status().is_success(), "status: {}", resp.status());
-    }
+
+    let resp = server
+        .client
+        .get(&url)
+        .bearer_auth(hashed_token)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "status: {}", resp.status());
 
     let mut fn_client = FunctionRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
@@ -1285,7 +1280,7 @@ async fn api_auth_should_deny_unauthenticated_requests() {
     let mut authenticated = tonic::Request::new(list_components_request());
     authenticated.metadata_mut().insert(
         "authorization",
-        format!("Bearer {plain_token}").parse().unwrap(),
+        format!("Bearer {hashed_token}").parse().unwrap(),
     );
     fn_client.list_components(authenticated).await.unwrap();
 

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -5631,15 +5631,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deployment_verify_rejects_exec_activities_unless_allowed_or_deferred()
+    async fn deployment_verify_rejects_exec_activities_on_any_runtime_config_availability()
     -> Result<(), anyhow::Error> {
         test_utils::set_up();
+
+        let server_toml_empty = tempfile::NamedTempFile::new().unwrap();
+        let server_toml_empty_path = server_toml_empty.path();
 
         let workspace = get_workspace_dir();
         let config_holder = ConfigHolder::new(
             crate::project_dirs(),
             BaseDirs::new(),
-            Some(workspace.join("server-sqlite.toml")),
+            Some(server_toml_empty_path.to_path_buf()),
         )?;
         let config = config_holder.load_config()?;
         assert_eq!(config.allow_exec_activities, AllowExecActivities::Deny);

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1131,7 +1131,7 @@ async fn exec_content_digest_lines(
     let mut digests_with_lines = Vec::with_capacity(activities_exec.len());
     for activity in activities_exec {
         let resolved = activity.resolve(wasm_cache_dir).await?;
-        let digest = compute_content_digest(&resolved.source_bytes);
+        let digest = resolved.content_digest;
         let line = format!(
             "\"{name}\" = \"{digest}\" # {ffqn}",
             name = activity.name,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1681,7 +1681,8 @@ pub(crate) struct ActivityExecComponentConfigToml {
 pub(crate) struct ResolvedExecProgram {
     /// Path to the immutable cached script file the worker executes directly.
     pub(crate) program: PathBuf,
-    pub(crate) source_bytes: Vec<u8>, // FIXME: Store content digest instead
+    /// Content digest of the script text (component identity and allowlist line).
+    pub(crate) content_digest: ContentDigest,
 }
 
 async fn write_inline_exec_file_to_cache_dir(
@@ -1746,7 +1747,7 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
                 .await?;
                 Ok(ResolvedExecProgram {
                     program: exec_path,
-                    source_bytes: content.as_bytes().to_vec(),
+                    content_digest,
                 })
             }
             ScriptLocationResolved::Oci { image } => {
@@ -1764,12 +1765,9 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
                         "content digest mismatch for OCI exec `{image}`: expected {expected}, got {actual}"
                     );
                 }
-                let source_bytes = tokio::fs::read(&result.exec_path).await.with_context(|| {
-                    format!("cannot read cached exec file {:?}", result.exec_path)
-                })?;
                 Ok(ResolvedExecProgram {
                     program: result.exec_path,
-                    source_bytes,
+                    content_digest: result.content_digest,
                 })
             }
         }
@@ -1814,7 +1812,7 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
         let component_digest = self.component_digest.unwrap_or_else(|| {
             let mut hasher = Sha256::new();
             hasher.update(b"activity_exec:");
-            hasher.update(&resolved_program.source_bytes);
+            hasher.update(resolved_program.content_digest.0.0);
             hasher.update(self.ffqn.to_string().as_bytes());
             for p in &parsed_params {
                 hasher.update(p.wit_type.as_ref().as_bytes());
@@ -4331,10 +4329,14 @@ name = "my_stub"
             }
         }
 
+        fn content_digest_of(bytes: &[u8]) -> ContentDigest {
+            ContentDigest(Digest(Sha256::digest(bytes).into()))
+        }
+
         fn inline_program() -> ResolvedExecProgram {
             ResolvedExecProgram {
                 program: PathBuf::from("/tmp/fake-exec-script.sh"),
-                source_bytes: b"#!/usr/bin/env bash\necho null\n".to_vec(),
+                content_digest: content_digest_of(b"#!/usr/bin/env bash\necho null\n"),
             }
         }
 
@@ -4402,7 +4404,7 @@ name = "my_stub"
                 .fetch_and_verify(
                     ResolvedExecProgram {
                         program: PathBuf::from("/tmp/fake-exec-script.sh"),
-                        source_bytes: source.clone(),
+                        content_digest: content_digest_of(&source),
                     },
                     true,
                     &std::sync::Arc::new(SecretRegistry::empty()),
@@ -4413,7 +4415,7 @@ name = "my_stub"
                 .fetch_and_verify(
                     ResolvedExecProgram {
                         program: PathBuf::from("/tmp/fake-exec-script.sh"),
-                        source_bytes: source,
+                        content_digest: content_digest_of(&source),
                     },
                     true,
                     &std::sync::Arc::new(SecretRegistry::empty()),

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -10,7 +10,7 @@ use crate::config::secret_registry::{
     RestrictedSecretRegistry, SecretRegistry, SecretViolation, SecretsToml,
 };
 use crate::config::toml::cron::CronComponentConfigToml;
-use crate::config::wasm_cache_metadata_dir;
+use crate::config::{content_digest_to_exec_file, wasm_cache_metadata_dir};
 use crate::oci;
 use anyhow::{Context, ensure};
 use anyhow::{anyhow, bail};
@@ -42,7 +42,7 @@ use std::{
 };
 use tracing::{debug, instrument, warn};
 use utils::wasm_tools::WasmComponent;
-use wasm_workers::activity::activity_exec_worker::{ExecProgram, ExecSecrets};
+use wasm_workers::activity::activity_exec_worker::ExecSecrets;
 use wasm_workers::cron::cron_worker::CronOrOnce;
 use wasm_workers::http_hooks::ConfigSectionHint;
 use wasm_workers::http_request_policy::HostPatternError;
@@ -1679,8 +1679,30 @@ pub(crate) struct ActivityExecComponentConfigToml {
 
 #[derive(Debug)]
 pub(crate) struct ResolvedExecProgram {
-    pub(crate) program: ExecProgram,
-    pub(crate) source_bytes: Vec<u8>,
+    /// Path to the immutable cached script file the worker executes directly.
+    pub(crate) program: PathBuf,
+    pub(crate) source_bytes: Vec<u8>, // FIXME: Store content digest instead
+}
+
+async fn write_inline_exec_file_to_cache_dir(
+    exec_path: &Path,
+    exec_cache_dir: &Path,
+    content: &[u8],
+) -> anyhow::Result<()> {
+    if let Ok(existing) = tokio::fs::read(exec_path).await
+        && existing == content
+    {
+        return Ok(());
+    }
+    let tmp = tempfile::NamedTempFile::new_in(exec_cache_dir)?;
+    tokio::fs::write(tmp.path(), content).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o755)).await?;
+    }
+    tmp.persist(exec_path)?;
+    Ok(())
 }
 
 pub(crate) trait ActivityExecComponentConfigResolvedExt {
@@ -1703,25 +1725,33 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
         &self,
         wasm_cache_dir: &std::path::Path,
     ) -> anyhow::Result<ResolvedExecProgram> {
+        let exec_cache_dir = wasm_cache_dir.join("exec");
         match &self.location {
             ScriptLocationResolved::Content { content, .. } => {
+                let hash: [u8; 32] = Sha256::digest(content.as_bytes()).into();
+                let content_digest = ContentDigest(Digest(hash));
                 if let Some(expected) = self.content_digest.as_ref() {
-                    let hash: [u8; 32] = Sha256::digest(content.as_bytes()).into();
-                    let actual = ContentDigest(Digest(hash));
                     ensure!(
-                        *expected == actual,
-                        "content digest mismatch for inline exec content: expected {expected}, got {actual}"
+                        *expected == content_digest,
+                        "content digest mismatch for inline exec content: expected {expected}, got {content_digest}"
                     );
                 }
+                tokio::fs::create_dir_all(&exec_cache_dir).await?;
+                let exec_path = content_digest_to_exec_file(&exec_cache_dir, &content_digest);
+                write_inline_exec_file_to_cache_dir(
+                    &exec_path,
+                    &exec_cache_dir,
+                    content.as_bytes(),
+                )
+                .await?;
                 Ok(ResolvedExecProgram {
-                    program: ExecProgram::Inline(content.clone()),
+                    program: exec_path,
                     source_bytes: content.as_bytes().to_vec(),
                 })
             }
             ScriptLocationResolved::Oci { image } => {
                 let oci_ref = oci_client::Reference::from_str(image)
                     .map_err(|e| anyhow!("invalid OCI reference `{image}`: {e}"))?;
-                let exec_cache_dir = wasm_cache_dir.join("exec");
                 tokio::fs::create_dir_all(&exec_cache_dir).await?;
                 let metadata_dir = wasm_cache_metadata_dir(wasm_cache_dir);
                 let result =
@@ -1738,7 +1768,7 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
                     format!("cannot read cached exec file {:?}", result.exec_path)
                 })?;
                 Ok(ResolvedExecProgram {
-                    program: ExecProgram::CachedFile(result.exec_path),
+                    program: result.exec_path,
                     source_bytes,
                 })
             }
@@ -1840,7 +1870,7 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
 
 #[derive(Debug)]
 pub(crate) struct ActivityExecConfigVerified {
-    pub(crate) program: wasm_workers::activity::activity_exec_worker::ExecProgram,
+    pub(crate) program: PathBuf,
     pub(crate) ffqn: FunctionFqn,
     pub(crate) params: Vec<concepts::ParameterType>,
     pub(crate) return_type: concepts::ReturnTypeExtendable,
@@ -4247,7 +4277,6 @@ name = "my_stub"
 
     mod activity_exec {
         use secrecy::{ExposeSecret as _, SecretString};
-        use wasm_workers::activity::activity_exec_worker::ExecProgram;
 
         use super::super::*;
 
@@ -4304,7 +4333,7 @@ name = "my_stub"
 
         fn inline_program() -> ResolvedExecProgram {
             ResolvedExecProgram {
-                program: ExecProgram::Inline("#!/usr/bin/env bash\necho null\n".into()),
+                program: PathBuf::from("/tmp/fake-exec-script.sh"),
                 source_bytes: b"#!/usr/bin/env bash\necho null\n".to_vec(),
             }
         }
@@ -4372,7 +4401,7 @@ name = "my_stub"
             let inline_verified = inline
                 .fetch_and_verify(
                     ResolvedExecProgram {
-                        program: ExecProgram::Inline(String::from_utf8(source.clone()).unwrap()),
+                        program: PathBuf::from("/tmp/fake-exec-script.sh"),
                         source_bytes: source.clone(),
                     },
                     true,
@@ -4383,9 +4412,7 @@ name = "my_stub"
             let oci_verified = oci
                 .fetch_and_verify(
                     ResolvedExecProgram {
-                        program: ExecProgram::CachedFile(std::path::PathBuf::from(
-                            "/tmp/fake-exec-script.sh",
-                        )),
+                        program: PathBuf::from("/tmp/fake-exec-script.sh"),
                         source_bytes: source,
                     },
                     true,


### PR DESCRIPTION
Fixes #821
