### PR TITLE
 fix!: Normalize execution failure JSON spelling, fix!(webapi): rename execution failure result field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   other payload-less `ChildError`, instead of propagating the message string.
 - *(js)* A delay cancelled inside a join set now also sets `failureKind: "cancelled"` on the
   `ChildError` thrown by `joinNext`/`joinNextTry` (previously only `cancelled: true` was set).
+- **Breaking:** *(wit, js)* Platform failures projected onto a `result<_, string>` error now use
+  `"execution_failed"`, matching the JSON encoding of the `execution-failed` WIT variant case.
 
 ### Fixed
 
@@ -73,11 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interpolations in plain key/value `env_vars` entries, including entries that rename a variable.
 - *(js)* A child execution's platform failure (timeout, cancellation, out-of-fuel, uncategorized)
   awaited via `joinNext`/`getResult` now surfaces on the thrown `obelisk.ChildError` as
-  `.value = "execution-failed"` (matching the host projection onto the child's `err` type), instead
+  `.value = "execution_failed"` (matching the host projection onto the child's `err` type), instead
   of `undefined`. An uncaught such error therefore encodes as a correctly-typed `err` for a
   workflow returning `result<_, string>` or a variant `err`, rather than failing to type check as
   `null`.
-
 ### Deprecated
 
 - *(js)* Renamed `obelisk.ChildExecutionError` to `obelisk.ChildError`, which now also covers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `undefined`. An uncaught such error therefore encodes as a correctly-typed `err` for a
   workflow returning `result<_, string>` or a variant `err`, rather than failing to type check as
   `null`.
+- **Breaking:** *(webapi)* Execution failure results now use the canonical `execution_failed`
+  field instead of `execution_failure`.
+
 ### Deprecated
 
 - *(js)* Renamed `obelisk.ChildExecutionError` to `obelisk.ChildError`, which now also covers

--- a/assets/activity-js-runtime-version.txt
+++ b/assets/activity-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/activity-js-runtime:2026-08-03@sha256:448cdd52fcb03f4b155ca431ebfd14cbb50b5a5710c9e6a04dae135321c989a8
+oci://docker.io/getobelisk/activity-js-runtime:2026-08-03-1@sha256:5bc802eef07805c84b555acd6472aa4f77f361989bf1a63f0d69dc0163349ea1

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -2883,10 +2883,10 @@
             "type": "object",
             "description": "Execution failed",
             "required": [
-              "execution_failure"
+              "execution_failed"
             ],
             "properties": {
-              "execution_failure": {
+              "execution_failed": {
                 "type": "object",
                 "description": "Execution failed"
               }

--- a/assets/webhook-js-runtime-version.txt
+++ b/assets/webhook-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/webhook-js-runtime:2026-08-03@sha256:fd3391f497605d3375186ac6cc7d372d32e2ab5eb24bd7e532f8a2a4e63a8ebe
+oci://docker.io/getobelisk/webhook-js-runtime:2026-08-03-1@sha256:0628dbd78fb90d22aca76fbef1b23557aa9aa47823aaaeebffe9d0c06b27f27b

--- a/assets/workflow-js-runtime-version.txt
+++ b/assets/workflow-js-runtime-version.txt
@@ -1,1 +1,1 @@
-oci://docker.io/getobelisk/workflow-js-runtime:2026-08-03@sha256:6cd649786bd24e298d91bd39ca5077ecdbe7846a34c41f5d9532c3b79f1dbe25
+oci://docker.io/getobelisk/workflow-js-runtime:2026-08-03-1@sha256:045fe7349a5f84718df75e399dddf7e00782c62c0281fbd9ea6d0006e61450b1

--- a/crates/boa-common/src/child_error.rs
+++ b/crates/boa-common/src/child_error.rs
@@ -88,7 +88,7 @@ pub struct ChildErrorParts<'a> {
     /// Cancelled delay id; `Some` only for a cancelled delay.
     pub delay_id: Option<&'a str>,
     /// Payload as a JSON string: the business `err`, or the host-projected
-    /// value for a platform failure (e.g. `"execution-failed"`); `None` for a
+    /// value for a platform failure (e.g. `"execution_failed"`); `None` for a
     /// unit err or a cancelled delay/sleep.
     pub value_json: Option<&'a str>,
     /// Execution-failure kind as a kebab string (mirrors the WIT
@@ -105,7 +105,7 @@ pub struct ChildErrorParts<'a> {
 /// Build a `ChildError` and wrap it as a throwable [`JsError`].
 pub fn make_child_error(parts: &ChildErrorParts, context: &mut Context) -> JsResult<JsError> {
     // `.value` is the parsed payload (business `err`, or the host-projected
-    // value for a platform failure such as "execution-failed"), and `undefined`
+    // value for a platform failure such as "execution_failed"), and `undefined`
     // when there is none (unit err, cancelled delay/sleep).
     let value = match parts.value_json {
         Some(json) => context.eval(Source::from_bytes(&format!("({json})")))?,

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -330,14 +330,14 @@ impl SupportedFunctionReturnValue {
                 err: Some(inner),
             } => match inner.as_ref() {
                 TypeWrapper::String => Some(Box::new(WastVal::String(
-                    EXECUTION_FAILED_STRING_OR_VARIANT.to_string(),
+                    EXECUTION_FAILED_JSON_STRING.to_string(),
                 ))),
                 TypeWrapper::Variant(variants)
-                    if variants.get(&TypeKey::new_kebab(EXECUTION_FAILED_STRING_OR_VARIANT))
+                    if variants.get(&TypeKey::new_kebab(EXECUTION_FAILED_WIT_CASE))
                         == Some(&None) =>
                 {
                     Some(Box::new(WastVal::Variant(
-                        ValKey::from_kebab(EXECUTION_FAILED_STRING_OR_VARIANT),
+                        ValKey::from_kebab(EXECUTION_FAILED_WIT_CASE),
                         None,
                     )))
                 }
@@ -1636,7 +1636,8 @@ impl<'a> arbitrary::Arbitrary<'a> for JoinSetId {
     }
 }
 
-const EXECUTION_FAILED_STRING_OR_VARIANT: &str = "execution-failed";
+const EXECUTION_FAILED_WIT_CASE: &str = "execution-failed";
+const EXECUTION_FAILED_JSON_STRING: &str = "execution_failed";
 #[derive(
     Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, derive_more::Display,
 )]
@@ -1671,8 +1672,7 @@ impl ReturnType {
                     wit_type,
                 });
             } else if let TypeWrapper::Variant(fields) = err.as_ref()
-                && let Some(None) =
-                    fields.get(&TypeKey::new_kebab(EXECUTION_FAILED_STRING_OR_VARIANT))
+                && let Some(None) = fields.get(&TypeKey::new_kebab(EXECUTION_FAILED_WIT_CASE))
             {
                 return ReturnType::Extendable(ReturnTypeExtendable {
                     type_wrapper_tl: TypeWrapperTopLevel { ok, err: Some(err) },
@@ -1962,13 +1962,35 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        ExecutionId, FunctionFqn, JoinSetId, JoinSetKind, StrVariant, prefixed_ulid::ExecutorId,
+        ExecutionFailureKind, ExecutionId, FinishedExecutionFailure, FunctionFqn, JoinSetId,
+        JoinSetKind, StrVariant, SupportedFunctionReturnValue, TypeWrapperTopLevel,
+        prefixed_ulid::ExecutorId,
     };
     use std::{
         hash::{DefaultHasher, Hash, Hasher},
         str::FromStr,
         sync::Arc,
     };
+    use val_json::{type_wrapper::TypeWrapper, wast_val::WastVal};
+
+    #[test]
+    fn execution_failure_projects_to_snake_case_string() {
+        let failure = SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
+            kind: ExecutionFailureKind::TimedOut,
+            reason: None,
+            detail: None,
+        });
+
+        assert_eq!(
+            failure.into_wast_val_res(|| TypeWrapperTopLevel {
+                ok: None,
+                err: Some(Box::new(TypeWrapper::String)),
+            }),
+            Err(Some(Box::new(WastVal::String(
+                "execution_failed".to_string()
+            ))))
+        );
+    }
 
     #[test]
     fn ulid_parsing() {

--- a/crates/testing/test-programs/js/workflow/cancel_child_error.js
+++ b/crates/testing/test-programs/js/workflow/cancel_child_error.js
@@ -25,8 +25,8 @@ export default function cancel_child_error() {
         if (e.childId !== childId) {
             throw `expected childId=${childId}, got: ${e.childId}`;
         }
-        if (e.value !== 'execution-failed') {
-            throw `expected value=execution-failed, got: ${JSON.stringify(e.value)}`;
+        if (e.value !== 'execution_failed') {
+            throw `expected value=execution_failed, got: ${JSON.stringify(e.value)}`;
         }
         return 'cancelled-child-observed';
     }

--- a/crates/wasm-workers/src/webhook/webhook_trigger.rs
+++ b/crates/wasm-workers/src/webhook/webhook_trigger.rs
@@ -3857,7 +3857,7 @@ pub(crate) mod tests {
                     "get('http://unused');",
                     "testing:http/http-get.get",
                     false,
-                    serde_json::json!("execution-failed"),
+                    serde_json::json!("execution_failed"),
                 ),
                 (
                     "import { trap } from 'testing:serde/serde';",

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2072,10 +2072,7 @@ mod tests {
                 Self::Unit => {
                     "if (e.value !== undefined) { throw `unexpected child err value: ${e.value}`; }"
                 }
-                Self::String => {
-                    "if (e.value !== 'execution-failed') { throw `unexpected child err value: ${e.value}`; }"
-                }
-                Self::ExecutionFailedVariant => {
+                Self::String | Self::ExecutionFailedVariant => {
                     "if (e.value !== 'execution_failed') { throw `unexpected child err value: ${e.value}`; }"
                 }
             }
@@ -2195,7 +2192,7 @@ mod tests {
             ChildErrProjection::String => {
                 let err =
                     assert_matches!(result, SupportedFunctionReturnValue::Err(Some(err)) => err);
-                assert_eq!(WastVal::String("execution-failed".into()), err.value);
+                assert_eq!(WastVal::String("execution_failed".into()), err.value);
             }
             ChildErrProjection::ExecutionFailedVariant => {
                 let err =

--- a/crates/workflow-js-runtime/src/workflow_js_runtime.rs
+++ b/crates/workflow-js-runtime/src/workflow_js_runtime.rs
@@ -511,7 +511,7 @@ fn child_error(exec_id: &str, payload: Option<String>, ctx: &mut Context) -> JsR
     };
     match get_execution_failure_kind(&exec) {
         // Platform failure: keep the host-projected `err` payload (e.g.
-        // "execution-failed" for a string/variant err type) so transparent
+        // "execution_failed" for a string/variant err type) so transparent
         // rethrow re-serializes a correctly-typed value, not `null`.
         Ok(Some(kind)) => {
             let cancelled = matches!(kind, ExecutionFailureKind::Cancelled);

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -3275,15 +3275,18 @@ async fn replay_failed_js_workflow_then_advance(client: TestExecutionClient, add
         .step_execution_until_finished(&server, REPLAY_FAILED_FFQN, vec![])
         .await;
     assert_eq!(stepped.steps, 1);
+    let failure_key = match client {
+        TestExecutionClient::Grpc => "execution_failure",
+        TestExecutionClient::WebApi => "execution_failed",
+    };
     assert_eq!(
-        json!(
-            {
-                "execution_failure":{
-                    "kind":"uncategorized",
-                    "reason":"value does not type check - failed to type check the ok variant value `\"not-a-number\"` as type u32 - invalid type: string \"not-a-number\", expected value matching \"u32\" at line 1 column 14"
-                }
-            }
-        ),
+        serde_json::Value::Object(serde_json::Map::from_iter([(
+            failure_key.to_string(),
+            json!({
+                "kind":"uncategorized",
+                "reason":"value does not type check - failed to type check the ok variant value `\"not-a-number\"` as type u32 - invalid type: string \"not-a-number\", expected value matching \"u32\" at line 1 column 14"
+            }),
+        )])),
         stepped.retval
     );
     server.shutdown().await;

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1475,7 +1475,7 @@ enum RetVal {
     Err(Option<WastVal>),
     /// Execution failed
     #[schema(value_type = Object)]
-    ExecutionFailure(FinishedExecutionFailure),
+    ExecutionFailed(FinishedExecutionFailure),
 }
 impl From<SupportedFunctionReturnValue> for RetVal {
     fn from(value: SupportedFunctionReturnValue) -> RetVal {
@@ -1486,7 +1486,7 @@ impl From<SupportedFunctionReturnValue> for RetVal {
             SupportedFunctionReturnValue::Err(val_with_type) => {
                 RetVal::Err(val_with_type.map(|it| it.value))
             }
-            SupportedFunctionReturnValue::ExecutionFailure(err) => RetVal::ExecutionFailure(err),
+            SupportedFunctionReturnValue::ExecutionFailure(err) => RetVal::ExecutionFailed(err),
         }
     }
 }
@@ -4327,7 +4327,7 @@ impl From<ErrorWrapper<SubmitError>> for HttpResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::format_execution_status_text;
+    use super::{RetVal, format_execution_status_text};
     use chrono::{DateTime, Utc};
     use concepts::{
         ExecutionFailureKind, SupportedFunctionReturnValue,
@@ -4370,6 +4370,25 @@ mod tests {
                 ),
             })),
             "Finished: Execution failure (Uncategorized)"
+        );
+    }
+
+    #[test]
+    fn execution_failure_retval_has_canonical_field() {
+        let failure = concepts::FinishedExecutionFailure {
+            kind: ExecutionFailureKind::TimedOut,
+            reason: Some("timed out".to_string()),
+            detail: None,
+        };
+
+        assert_eq!(
+            serde_json::to_value(RetVal::from(
+                SupportedFunctionReturnValue::ExecutionFailure(failure.clone())
+            ))
+            .unwrap(),
+            serde_json::json!({
+                "execution_failed": failure,
+            })
         );
     }
 


### PR DESCRIPTION
- **fix!: Normalize execution failure JSON spelling**
- **fix!(webapi): rename execution failure result field**
