### PR TITLE
feat(api): Expose component file references

### DIFF
--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -1927,7 +1927,8 @@
         "type": "object",
         "description": "Component configuration with optional imports/exports",
         "required": [
-          "component_id"
+          "component_id",
+          "files"
         ],
         "properties": {
           "component_id": {
@@ -1944,6 +1945,13 @@
             },
             "description": "Exported functions"
           },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ComponentFileRef"
+            },
+            "description": "Deployment-owned files used by this component."
+          },
           "imports": {
             "type": [
               "array",
@@ -1953,6 +1961,42 @@
               "$ref": "#/components/schemas/FunctionMetadataLite"
             },
             "description": "Imported functions"
+          }
+        }
+      },
+      "ComponentFile": {
+        "type": "object",
+        "required": [
+          "path",
+          "digest",
+          "size"
+        ],
+        "properties": {
+          "digest": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "ComponentFileRef": {
+        "type": "object",
+        "required": [
+          "file",
+          "role"
+        ],
+        "properties": {
+          "file": {
+            "$ref": "#/components/schemas/ComponentFile"
+          },
+          "role": {
+            "type": "string"
           }
         }
       },

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1716,6 +1716,7 @@ pub struct DeploymentRecord {
     pub obelisk_version: String,
     pub created_by: Option<String>,
     pub files: Vec<DeploymentFileRecord>,
+    pub component_files: Vec<DeploymentComponentFileRecord>,
 }
 
 impl DeploymentRecord {
@@ -1733,6 +1734,40 @@ pub struct DeploymentFileRecord {
     pub path: String,
     pub digest: ContentDigest,
     pub size: u64,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::Display,
+    strum::EnumString,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ComponentFileRole {
+    WasmComponent,
+    ExecProgram,
+    JsEntrypoint,
+    JsModule,
+    BacktraceSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentComponentFileRecord {
+    pub component_name: StrVariant,
+    pub path: String,
+    pub role: ComponentFileRole,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentComponentFileDetail {
+    pub file: DeploymentFileRecord,
+    pub role: ComponentFileRole,
 }
 
 #[derive(Debug, Clone)]
@@ -1759,6 +1794,7 @@ pub struct DeploymentComponentDetail {
     pub imports: Vec<PersistedFunctionMetadata>,
     pub exports: Vec<PersistedFunctionMetadata>,
     pub wit: String,
+    pub files: Vec<DeploymentComponentFileDetail>,
 }
 
 #[derive(

--- a/crates/db-postgres/migrations/V15__component_file_references.sql
+++ b/crates/db-postgres/migrations/V15__component_file_references.sql
@@ -1,0 +1,19 @@
+ALTER TABLE t_deployment_file DROP CONSTRAINT t_deployment_file_pkey;
+ALTER TABLE t_deployment_file ADD PRIMARY KEY (deployment_id, path);
+
+CREATE TABLE t_deployment_component_file (
+    deployment_id  VARCHAR(30) NOT NULL,
+    component_name TEXT NOT NULL,
+    path           TEXT NOT NULL,
+    role           VARCHAR(16) NOT NULL CHECK (role IN (
+        'wasm_component', 'exec_program', 'js_entrypoint', 'js_module', 'backtrace_source'
+    )),
+    PRIMARY KEY (deployment_id, component_name, path),
+    FOREIGN KEY (deployment_id, component_name)
+        REFERENCES t_deployment_component(deployment_id, component_name),
+    FOREIGN KEY (deployment_id, path)
+        REFERENCES t_deployment_file(deployment_id, path)
+);
+
+CREATE INDEX idx_t_deployment_component_file_path
+ON t_deployment_component_file (deployment_id, path);

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -10,10 +10,11 @@ use concepts::{
     storage::{
         AppendBatchResponse, AppendDelayResponseOutcome, AppendEventsToExecution, AppendRequest,
         AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo, CancelOutcome,
-        ComponentMetadataRecord, ComponentUpgradeOutcome, ComponentUpgradeReason, CreateRequest,
-        DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead,
-        DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
-        DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentComponentDetail,
+        ComponentFileRole, ComponentMetadataRecord, ComponentUpgradeOutcome,
+        ComponentUpgradeReason, CreateRequest, DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection,
+        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite,
+        DbErrorWriteNonRetriable, DbExecutor, DbExternalApi, DbPool, DbPoolCloseable,
+        DeploymentComponentDetail, DeploymentComponentFileDetail, DeploymentComponentFileRecord,
         DeploymentComponentRecord, DeploymentExecutionCounts, DeploymentFileRecord,
         DeploymentRecord, DeploymentState, DeploymentStatus, EnqueueOutcome, ExecutionEvent,
         ExecutionListPagination, ExecutionRequest, ExecutionWithState,
@@ -346,6 +347,7 @@ fn deployment_record_from_pg_row(row: &Row) -> Result<DeploymentRecord, DbErrorR
         obelisk_version: get(row, "obelisk_version")?,
         created_by: get(row, "created_by")?,
         files: Vec::new(),
+        component_files: Vec::new(),
     })
 }
 
@@ -482,6 +484,20 @@ async fn insert_deployment_components_tx(
     Ok(())
 }
 
+async fn insert_deployment_component_files_tx(
+    tx: &Transaction<'_>,
+    deployment_id: DeploymentId,
+    records: &[DeploymentComponentFileRecord],
+) -> Result<(), DbErrorWrite> {
+    for record in records {
+        tx.execute(
+            "INSERT INTO t_deployment_component_file (deployment_id, component_name, path, role) VALUES ($1, $2, $3, $4)",
+            &[&deployment_id.to_string(), &record.component_name.to_string(), &record.path, &record.role.to_string()],
+        ).await?;
+    }
+    Ok(())
+}
+
 async fn deployment_record_with_files_tx(
     tx: &Transaction<'_>,
     mut record: DeploymentRecord,
@@ -512,6 +528,7 @@ fn deployment_component_detail_from_pg_row(
         imports,
         exports,
         wit,
+        files: Vec::new(),
     })
 }
 
@@ -4874,10 +4891,35 @@ impl DbExternalApi for PostgresConnection {
                 &[&deployment_id.to_string()],
             )
             .await?;
-        tx.commit().await?;
-        rows.iter()
+        let mut components = rows
+            .iter()
             .map(deployment_component_detail_from_pg_row)
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+        for component in &mut components {
+            let file_rows = tx
+                .query(
+                    "SELECT dcf.path, df.digest, f.size, dcf.role FROM t_deployment_component_file dcf \
+                     JOIN t_deployment_file df ON df.deployment_id = dcf.deployment_id AND df.path = dcf.path \
+                     JOIN t_file f ON f.digest = df.digest \
+                     WHERE dcf.deployment_id = $1 AND dcf.component_name = $2 ORDER BY dcf.path",
+                    &[&deployment_id.to_string(), &component.component_id.name.to_string()],
+                )
+                .await?;
+            component.files = file_rows
+                .iter()
+                .map(|row| {
+                    let role = get::<String, _>(row, "role")?
+                        .parse::<ComponentFileRole>()
+                        .map_err(|err| DbErrorRead::Generic(consistency_db_err(err.to_string())))?;
+                    Ok(DeploymentComponentFileDetail {
+                        file: deployment_file_record_from_pg_row(row)?,
+                        role,
+                    })
+                })
+                .collect::<Result<Vec<_>, DbErrorRead>>()?;
+        }
+        tx.commit().await?;
+        Ok(components)
     }
 
     #[instrument(skip_all)]
@@ -5077,6 +5119,7 @@ impl DbExternalApi for PostgresConnection {
         insert_deployment_tx(&tx, &record).await?;
         upsert_component_metadata_tx(&tx, &component_metadata).await?;
         insert_deployment_components_tx(&tx, deployment_id, &deployment_components).await?;
+        insert_deployment_component_files_tx(&tx, deployment_id, &record.component_files).await?;
         tx.commit().await?;
         Ok(())
     }

--- a/crates/db-sqlite/migrations/V15__component_file_references.sql
+++ b/crates/db-sqlite/migrations/V15__component_file_references.sql
@@ -1,0 +1,62 @@
+DROP TRIGGER t_deployment_file_bounded_text_insert;
+DROP TRIGGER t_deployment_file_bounded_text_update;
+
+ALTER TABLE t_deployment_file RENAME TO t_deployment_file_old;
+
+CREATE TABLE t_deployment_file (
+    deployment_id TEXT NOT NULL,
+    path          TEXT NOT NULL,
+    digest        TEXT NOT NULL,
+    PRIMARY KEY (deployment_id, path),
+    FOREIGN KEY (deployment_id) REFERENCES t_deployment(deployment_id)
+) STRICT;
+
+INSERT INTO t_deployment_file (deployment_id, path, digest)
+SELECT deployment_id, path, digest FROM t_deployment_file_old;
+DROP TABLE t_deployment_file_old;
+
+CREATE INDEX idx_t_deployment_file_digest ON t_deployment_file (digest);
+
+CREATE TRIGGER t_deployment_file_bounded_text_insert
+BEFORE INSERT ON t_deployment_file
+BEGIN
+    SELECT RAISE(ABORT, 't_deployment_file.deployment_id exceeds 30 characters')
+    WHERE length(NEW.deployment_id) > 30;
+    SELECT RAISE(ABORT, 't_deployment_file.digest exceeds 71 characters')
+    WHERE length(NEW.digest) > 71;
+END;
+
+CREATE TRIGGER t_deployment_file_bounded_text_update
+BEFORE UPDATE OF deployment_id, digest ON t_deployment_file
+BEGIN
+    SELECT RAISE(ABORT, 't_deployment_file.deployment_id exceeds 30 characters')
+    WHERE length(NEW.deployment_id) > 30;
+    SELECT RAISE(ABORT, 't_deployment_file.digest exceeds 71 characters')
+    WHERE length(NEW.digest) > 71;
+END;
+
+CREATE TABLE t_deployment_component_file (
+    deployment_id  TEXT NOT NULL,
+    component_name TEXT NOT NULL,
+    path           TEXT NOT NULL,
+    role           TEXT NOT NULL CHECK (role IN (
+        'wasm_component', 'exec_program', 'js_entrypoint', 'js_module', 'backtrace_source'
+    )),
+    PRIMARY KEY (deployment_id, component_name, path),
+    FOREIGN KEY (deployment_id, component_name)
+        REFERENCES t_deployment_component(deployment_id, component_name),
+    FOREIGN KEY (deployment_id, path)
+        REFERENCES t_deployment_file(deployment_id, path)
+) STRICT;
+
+CREATE INDEX idx_t_deployment_component_file_path
+ON t_deployment_component_file (deployment_id, path);
+
+CREATE TRIGGER t_deployment_component_file_bounded_text_insert
+BEFORE INSERT ON t_deployment_component_file
+BEGIN
+    SELECT RAISE(ABORT, 't_deployment_component_file.deployment_id exceeds 30 characters')
+    WHERE length(NEW.deployment_id) > 30;
+    SELECT RAISE(ABORT, 't_deployment_component_file.role exceeds 16 characters')
+    WHERE length(NEW.role) > 16;
+END;

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -10,10 +10,11 @@ use concepts::{
     storage::{
         AppendBatchResponse, AppendDelayResponseOutcome, AppendEventsToExecution, AppendRequest,
         AppendResponse, AppendResponseToExecution, BacktraceFilter, BacktraceInfo, CancelOutcome,
-        ComponentMetadataRecord, ComponentUpgradeOutcome, ComponentUpgradeReason, CreateRequest,
-        DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection, DbErrorGeneric, DbErrorRead,
-        DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite, DbErrorWriteNonRetriable,
-        DbExecutor, DbExternalApi, DbPool, DbPoolCloseable, DeploymentComponentDetail,
+        ComponentFileRole, ComponentMetadataRecord, ComponentUpgradeOutcome,
+        ComponentUpgradeReason, CreateRequest, DUMMY_CREATED, DUMMY_HISTORY_EVENT, DbConnection,
+        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite,
+        DbErrorWriteNonRetriable, DbExecutor, DbExternalApi, DbPool, DbPoolCloseable,
+        DeploymentComponentDetail, DeploymentComponentFileDetail, DeploymentComponentFileRecord,
         DeploymentComponentRecord, DeploymentExecutionCounts, DeploymentFileRecord,
         DeploymentRecord, DeploymentState, DeploymentStatus, EnqueueOutcome, ExecutionEvent,
         ExecutionListPagination, ExecutionRequest, ExecutionWithState,
@@ -456,6 +457,7 @@ fn deployment_record_from_row(row: &Row<'_>) -> rusqlite::Result<DeploymentRecor
         obelisk_version: row.get("obelisk_version")?,
         created_by: row.get("created_by")?,
         files: Vec::new(),
+        component_files: Vec::new(),
     })
 }
 
@@ -498,6 +500,7 @@ fn deployment_component_detail_from_row(
         imports,
         exports,
         wit,
+        files: Vec::new(),
     })
 }
 
@@ -3670,6 +3673,26 @@ impl SqlitePool {
         Ok(())
     }
 
+    fn insert_deployment_component_files_tx(
+        tx: &Transaction,
+        deployment_id: DeploymentId,
+        records: &[DeploymentComponentFileRecord],
+    ) -> Result<(), DbErrorWrite> {
+        let mut stmt = tx
+            .prepare("INSERT INTO t_deployment_component_file (deployment_id, component_name, path, role) VALUES (:deployment_id, :component_name, :path, :role)")
+            .map_err(RusqliteError::from)?;
+        for record in records {
+            stmt.execute(named_params! {
+                ":deployment_id": deployment_id.to_string(),
+                ":component_name": record.component_name.to_string(),
+                ":path": record.path,
+                ":role": record.role.to_string(),
+            })
+            .map_err(RusqliteError::from)?;
+        }
+        Ok(())
+    }
+
     fn compute_file_digest(content: &[u8]) -> ContentDigest {
         let hash: [u8; 32] = Sha256::digest(content).into();
         ContentDigest(Digest(hash))
@@ -4752,7 +4775,7 @@ impl DbExternalApi for SqlitePool {
                      WHERE dc.deployment_id = :deployment_id \
                      ORDER BY dc.component_type, dc.component_name",
                 )?;
-                let rows = stmt
+                let mut rows = stmt
                     .query_map(
                         named_params! { ":deployment_id": deployment_id.to_string() },
                         |row| {
@@ -4762,6 +4785,35 @@ impl DbExternalApi for SqlitePool {
                         },
                     )?
                     .collect::<Result<Vec<_>, _>>()?;
+                let mut file_stmt = tx.prepare(
+                    "SELECT dcf.path, df.digest, f.size, dcf.role FROM t_deployment_component_file dcf \
+                     JOIN t_deployment_file df ON df.deployment_id = dcf.deployment_id AND df.path = dcf.path \
+                     JOIN t_file f ON f.digest = df.digest \
+                     WHERE dcf.deployment_id = :deployment_id AND dcf.component_name = :component_name ORDER BY dcf.path",
+                )?;
+                for component in &mut rows {
+                    component.files = file_stmt
+                        .query_map(
+                            named_params! {
+                                ":deployment_id": deployment_id.to_string(),
+                                ":component_name": component.component_id.name.to_string(),
+                            },
+                            |row| {
+                                let role = row.get::<_, String>("role")?.parse::<ComponentFileRole>()
+                                    .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::other(err.to_string()))))?;
+                                Ok(DeploymentComponentFileDetail {
+                                    file: DeploymentFileRecord {
+                                        path: row.get("path")?,
+                                        digest: row.get("digest")?,
+                                        size: u64::try_from(row.get::<_, i64>("size")?)
+                                            .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?,
+                                    },
+                                    role,
+                                })
+                            },
+                        )?
+                        .collect::<Result<Vec<_>, _>>()?;
+                }
                 Ok(rows)
             },
             TxType::Other,
@@ -5001,7 +5053,13 @@ impl DbExternalApi for SqlitePool {
                 // Parent row first so the t_deployment_component FK is satisfied within the tx.
                 Self::insert_deployment_tx(tx, &record)?;
                 Self::upsert_component_metadata_tx(tx, &component_metadata)?;
-                Self::insert_deployment_components_tx(tx, deployment_id, &deployment_components)
+                Self::insert_deployment_components_tx(tx, deployment_id, &deployment_components)?;
+                Self::insert_deployment_component_files_tx(
+                    tx,
+                    deployment_id,
+                    &record.component_files,
+                )?;
+                Ok(())
             },
             TxType::MultipleWrites,
             "insert_deployment_with_components",

--- a/crates/testing/db-tests/tests/deployment_components.rs
+++ b/crates/testing/db-tests/tests/deployment_components.rs
@@ -1,7 +1,8 @@
 use concepts::component_id::ComponentDigest;
 use concepts::prefixed_ulid::DeploymentId;
 use concepts::storage::{
-    ComponentMetadataRecord, DbExternalApi, DbPoolCloseable, DeploymentComponentRecord,
+    ComponentFileRole, ComponentMetadataRecord, DbExternalApi, DbPoolCloseable,
+    DeploymentComponentFileRecord, DeploymentComponentRecord, DeploymentFileRecord,
     DeploymentRecord, DeploymentStatus, PersistedFunctionMetadata,
 };
 use concepts::time::ClockFn;
@@ -39,6 +40,7 @@ fn mk_deployment_record(
         obelisk_version: "0.0.0-test".to_string(),
         created_by: None,
         files: Vec::new(),
+        component_files: Vec::new(),
     }
 }
 
@@ -138,6 +140,7 @@ async fn deployment_components_roundtrip(database: Database) {
     assert_eq!(1, components[0].imports.len());
     assert_eq!(1, components[0].exports.len());
     assert_eq!("package testing:pkg;", components[0].wit);
+    assert!(components[0].files.is_empty());
 
     assert_eq!(
         ComponentType::Workflow,
@@ -149,6 +152,76 @@ async fn deployment_components_roundtrip(database: Database) {
     assert_eq!(1, components[1].exports.len());
     assert_eq!("package testing:pkg-b;", components[1].wit);
 
+    drop(api_conn);
+    db_close.close().await;
+}
+
+#[expand_enum_database]
+#[rstest]
+#[tokio::test]
+async fn deployment_component_files_roundtrip(database: Database) {
+    set_up();
+    let sim_clock = SimClock::default();
+    let (_guard, db_pool, db_close) = database.set_up().await;
+    let api_conn = db_pool.external_api_conn().await.unwrap();
+    let cas = db_pool.cas_conn().await.unwrap();
+    let deployment_id = DeploymentId::generate();
+    let component_digest: ComponentDigest =
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+    let file_digest = cas.write_blob(b"same bytes").await.unwrap();
+    let mut deployment = mk_deployment_record(deployment_id, sim_clock.now());
+    deployment.files = vec![
+        DeploymentFileRecord {
+            path: "a/lib.js".to_string(),
+            digest: file_digest.clone(),
+            size: 0,
+        },
+        DeploymentFileRecord {
+            path: "b/lib.js".to_string(),
+            digest: file_digest.clone(),
+            size: 0,
+        },
+    ];
+    deployment.component_files = vec![DeploymentComponentFileRecord {
+        component_name: "a".into(),
+        path: "a/lib.js".to_string(),
+        role: ComponentFileRole::JsEntrypoint,
+    }];
+
+    api_conn
+        .insert_deployment_with_components(
+            deployment,
+            vec![ComponentMetadataRecord {
+                component_digest: component_digest.clone(),
+                imports: Vec::new(),
+                exports: Vec::new(),
+                wit: "package testing:pkg;".to_string(),
+                wit_origin: "synthesized".to_string(),
+            }],
+            vec![DeploymentComponentRecord {
+                deployment_id,
+                component_name: "a".into(),
+                component_digest,
+                component_type: ComponentType::Activity,
+            }],
+        )
+        .await
+        .unwrap();
+
+    let deployment_files = api_conn.list_deployment_files(deployment_id).await.unwrap();
+    assert_eq!(deployment_files.len(), 2);
+    assert_eq!(deployment_files[0].digest, deployment_files[1].digest);
+    let components = api_conn
+        .list_deployment_components(deployment_id)
+        .await
+        .unwrap();
+    assert_eq!(components[0].files.len(), 1);
+    assert_eq!(components[0].files[0].file, deployment_files[0]);
+    assert_eq!(components[0].files[0].role, ComponentFileRole::JsEntrypoint);
+
+    drop(cas);
     drop(api_conn);
     db_close.close().await;
 }

--- a/crates/testing/db-tests/tests/deployment_pagination.rs
+++ b/crates/testing/db-tests/tests/deployment_pagination.rs
@@ -48,6 +48,7 @@ async fn create_deployment_with_execution(
                 obelisk_version: "0.0.0-test".to_string(),
                 created_by: None,
                 files: Vec::new(),
+                component_files: Vec::new(),
             })
             .await
             .unwrap();

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -4821,6 +4821,7 @@ async fn deployment_insert_and_get(database: Database) {
         obelisk_version: "0.0.0-test".to_string(),
         created_by: Some("test".to_string()),
         files: Vec::new(),
+        component_files: Vec::new(),
     };
     api_conn.insert_deployment(record).await.unwrap();
 
@@ -4873,6 +4874,7 @@ async fn deployment_files_roundtrip_and_missing_digests(database: Database) {
             obelisk_version: "0.0.0-test".to_string(),
             created_by: None,
             files: vec![file.clone()],
+            component_files: Vec::new(),
         })
         .await
         .unwrap();
@@ -4956,6 +4958,7 @@ async fn deployment_activate(database: Database) {
             obelisk_version: "0.0.0-test".to_string(),
             created_by: None,
             files: Vec::new(),
+            component_files: Vec::new(),
         })
         .await
         .unwrap();
@@ -4998,6 +5001,7 @@ async fn deployment_only_one_active_allowed(database: Database) {
             obelisk_version: "0.0.0-test".to_string(),
             created_by: None,
             files: Vec::new(),
+            component_files: Vec::new(),
         })
         .await
         .unwrap();
@@ -5017,6 +5021,7 @@ async fn deployment_only_one_active_allowed(database: Database) {
             obelisk_version: "0.0.0-test".to_string(),
             created_by: None,
             files: Vec::new(),
+            component_files: Vec::new(),
         })
         .await
         .unwrap();
@@ -5059,6 +5064,7 @@ async fn deployment_enqueue_active_clears_pending(database: Database) {
                 obelisk_version: "0.0.0-test".to_string(),
                 created_by: None,
                 files: Vec::new(),
+                component_files: Vec::new(),
             })
             .await
             .unwrap();
@@ -5127,6 +5133,7 @@ async fn deployment_list(database: Database) {
                 obelisk_version: "0.0.0-test".to_string(),
                 created_by: None,
                 files: Vec::new(),
+                component_files: Vec::new(),
             })
             .await
             .unwrap();

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -160,6 +160,21 @@ message Component {
     ComponentId component_id = 1;
     repeated FunctionDetail exports = 6; // Functions are sorted by their interface name
     repeated FunctionDetail imports = 7; // Functions are sorted by their interface name
+    repeated ComponentFileRef files = 8;
+}
+
+enum ComponentFileRole {
+    COMPONENT_FILE_ROLE_UNSPECIFIED = 0;
+    COMPONENT_FILE_ROLE_WASM_COMPONENT = 1;
+    COMPONENT_FILE_ROLE_EXEC_PROGRAM = 2;
+    COMPONENT_FILE_ROLE_JS_ENTRYPOINT = 3;
+    COMPONENT_FILE_ROLE_JS_MODULE = 4;
+    COMPONENT_FILE_ROLE_BACKTRACE_SOURCE = 5;
+}
+
+message ComponentFileRef {
+    FileRef file = 1;
+    ComponentFileRole role = 2;
 }
 
 enum ComponentType {

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1553,6 +1553,9 @@ async fn prepare_new_deployment_record(
 
     let now = Utc::now();
     let digest = DeploymentRecord::compute_digest(&deployment_toml);
+    let component_files =
+        DeploymentManifest::try_from_toml(&deployment_toml, &cas_deployment_dir())?
+            .component_file_records();
     Ok(DeploymentRecord {
         deployment_id,
         description,
@@ -1564,6 +1567,7 @@ async fn prepare_new_deployment_record(
         obelisk_version: PKG_VERSION.to_string(),
         created_by: Some("server".to_string()),
         files: file_records,
+        component_files,
     })
 }
 
@@ -2642,6 +2646,7 @@ pub(crate) async fn submit_deployment(
             created_by,
             deployment_toml: deployment_toml.to_string(),
             files: manifest.file_records(),
+            component_files: manifest.component_file_records(),
         },
         component_metadata,
         deployment_components,

--- a/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
+++ b/src/command/snapshots/obelisk__command__integration_tests__list_components.snap
@@ -8,419 +8,970 @@ expression: components
       "component_type": "activity",
       "name": "exec-add.add",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/exec/add.sh",
+          "digest": "sha256:<REDACTED>",
+          "size": 40
+        },
+        "role": "exec_program"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-args.echo-args",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-env.read-env",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/exec/read-env.sh",
+          "digest": "sha256:<REDACTED>",
+          "size": 37
+        },
+        "role": "exec_program"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-error.fail",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-greet.greet-include",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/exec/greet.sh",
+          "digest": "sha256:<REDACTED>",
+          "size": 167
+        },
+        "role": "exec_program"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-greet.greet-inline",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-record.make-record",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-stdin-args.echo-args",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-stdin.expose-secrets",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/exec/expose-secrets.sh",
+          "digest": "sha256:<REDACTED>",
+          "size": 59
+        },
+        "role": "exec_program"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-stream.stream-test",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-void.void-err",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "exec-void.void-ok",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_add_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/add.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 56
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_fetch_allowed_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/fetch_get.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 517
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_fetch_denied_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/fetch_get.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 517
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_greet_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/greet.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 113
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_hmac_sign_verify_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/hmac_sign_verify.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 631
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_make_record_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/make_record.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 84
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_multifile_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/multifile/index.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 169
+        },
+        "role": "js_entrypoint"
+      },
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/multifile/lib/greeter.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 108
+        },
+        "role": "js_module"
+      },
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/multifile/lib/util.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 63
+        },
+        "role": "js_module"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_read_env_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/read_env.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 176
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_throw_null_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/throw_null.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 57
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity",
       "name": "test_throw_variant_activity",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/activity/throw_variant.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 67
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "activity_stub",
       "name": "stubs.my-stub",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": []
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_body_form_data_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/body_form_data.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 125
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_body_json_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/body_json.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 135
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_body_text_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/body_text.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 201
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_call_activity_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/call_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 437
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_fetch_allowed_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/fetch_components.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 283
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_fetch_denied_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/fetch_components.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 283
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_generate_execution_id_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/generate_execution_id.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 272
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_get_status_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/get_status.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 203
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_headers_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/headers.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 211
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_hello_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/hello.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 295
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_import_call_activity_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/import_call_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 222
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_import_schedule_activity_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/import_schedule_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 265
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_multifile_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/multifile/index.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 175
+        },
+        "role": "js_entrypoint"
+      },
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/multifile/lib/render.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 75
+        },
+        "role": "js_module"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "webhook_endpoint",
       "name": "test_read_env_webhook",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/webhook/read_env.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 317
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_add_cancellable_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/add_workflow.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 73
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_add_via_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/add_via_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 539
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_add_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/add_workflow.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 73
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_call_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/call_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 236
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_call_stub_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/call_stub.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 339
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_cancel_child_error_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/cancel_child_error.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 1554
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_cancel_delay_error_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/cancel_delay_error.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 1026
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_cancel_sleep_error_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/cancel_sleep_error.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 1124
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_date_now_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/date_now.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 161
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_import_call_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/import_call_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 260
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_import_ext_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/import_ext_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 409
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_import_schedule_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/import_schedule_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 320
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_import_star_call_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/import_star_call_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 276
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_import_stub_activity_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/import_stub_activity.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 449
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_join_next_try_semantics_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/join_next_try_semantics.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 3379
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_make_record_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/make_record.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 84
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_math_random_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/math_random.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 274
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_multifile_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/multifile/index.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 208
+        },
+        "role": "js_entrypoint"
+      },
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/multifile/lib/math.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 141
+        },
+        "role": "js_module"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_rethrow_child_error_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/rethrow_child_error.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 808
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_return_wrong_type_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/return_wrong_type.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 75
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_sleep_cancellable_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/sleep_cancellable.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 327
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_throw_null_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/throw_null.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 57
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   },
   {
     "component_id": {
       "component_type": "workflow",
       "name": "test_throw_variant_workflow",
       "component_digest": "sha256:<REDACTED>"
-    }
+    },
+    "files": [
+      {
+        "file": {
+          "path": "crates/testing/test-programs/js/workflow/throw_variant.js",
+          "digest": "sha256:<REDACTED>",
+          "size": 67
+        },
+        "role": "js_entrypoint"
+      }
+    ]
   }
 ]

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -6,8 +6,8 @@ use crate::config::toml::{
 use anyhow::{Context, bail, ensure};
 use concepts::ContentDigest;
 use concepts::component_id::Digest;
-use concepts::storage::DeploymentFileRecord;
-use hashbrown::HashSet;
+use concepts::storage::{ComponentFileRole, DeploymentComponentFileRecord, DeploymentFileRecord};
+use hashbrown::{HashMap, HashSet};
 use sha2::{Digest as _, Sha256};
 use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
@@ -100,8 +100,18 @@ pub(crate) async fn prepare_deployment_manifest(
     collect_js_refs(&mut doc, "webhook_endpoint_js", deployment_dir, &mut files).await?;
     collect_script_refs(&mut doc, "activity_exec", deployment_dir, &mut files).await?;
 
+    let mut paths = HashMap::new();
+    for file in &files {
+        if let Some(previous) = paths.insert(file.path.clone(), file.digest.clone()) {
+            ensure!(
+                previous == file.digest,
+                "deployment path `{}` has conflicting content digests",
+                file.path
+            );
+        }
+    }
     let mut seen = HashSet::new();
-    files.retain(|file| seen.insert(file.digest.clone()));
+    files.retain(|file| seen.insert(file.path.clone()));
 
     let deployment_toml = doc.to_string();
     let digest = compute_manifest_digest(&deployment_toml);
@@ -128,6 +138,14 @@ pub(crate) struct DeploymentManifest {
     #[allow(dead_code)] // consumed by submit/storage paths in later phases
     pub(crate) deployment_toml: String,
     pub(crate) files: Vec<DeploymentFileRef>,
+    pub(crate) component_files: Vec<DeploymentComponentFileRef>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DeploymentComponentFileRef {
+    pub(crate) component_name: String,
+    pub(crate) path: String,
+    pub(crate) role: ComponentFileRole,
 }
 
 /// A deployment-owned file reference: a deployment-relative path and its required
@@ -192,7 +210,8 @@ impl DeploymentManifest {
         deployment_toml: &str,
         deployment_dir: &Path,
     ) -> anyhow::Result<Self> {
-        parse_manifest(deployment_toml, deployment_dir)?;
+        let validated = parse_manifest(deployment_toml, deployment_dir)?;
+        let names = resolved_component_names(&validated);
 
         let doc = deployment_toml
             .parse::<DocumentMut>()
@@ -201,28 +220,96 @@ impl DeploymentManifest {
         // Section order matches the historical record collection so digest
         // deduplication keeps the same first-seen path for colliding contents.
         let mut files = Vec::new();
-        collect_wasm_section(&doc, "activity_wasm", &mut files)?;
-        collect_wasm_section(&doc, "activity_stub", &mut files)?;
-        collect_wasm_section(&doc, "activity_external", &mut files)?;
-        collect_wasm_section(&doc, "workflow_wasm", &mut files)?;
-        collect_backtrace_section(&doc, "workflow_wasm", &mut files)?;
-        collect_wasm_section(&doc, "webhook_endpoint_wasm", &mut files)?;
-        collect_backtrace_section(&doc, "webhook_endpoint_wasm", &mut files)?;
-        collect_script_section(&doc, "activity_js", &mut files)?;
-        collect_script_section(&doc, "workflow_js", &mut files)?;
-        collect_script_section(&doc, "webhook_endpoint_js", &mut files)?;
-        collect_script_section(&doc, "activity_exec", &mut files)?;
+        let mut component_files = Vec::new();
+        collect_wasm_section(
+            &doc,
+            "activity_wasm",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_wasm_section(
+            &doc,
+            "activity_stub",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_wasm_section(
+            &doc,
+            "activity_external",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_wasm_section(
+            &doc,
+            "workflow_wasm",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_backtrace_section(
+            &doc,
+            "workflow_wasm",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_wasm_section(
+            &doc,
+            "webhook_endpoint_wasm",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_backtrace_section(
+            &doc,
+            "webhook_endpoint_wasm",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_script_section(
+            &doc,
+            "activity_js",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_script_section(
+            &doc,
+            "workflow_js",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_script_section(
+            &doc,
+            "webhook_endpoint_js",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
+        collect_script_section(
+            &doc,
+            "activity_exec",
+            &names,
+            &mut files,
+            &mut component_files,
+        )?;
 
         debug_assert!(
             WASM_SECTIONS.len() + SCRIPT_SECTIONS.len() + BACKTRACE_SECTIONS.len() == 11,
             "section lists drifted from collection order"
         );
 
-        let mut seen = HashSet::new();
-        files.retain(|file| seen.insert(file.digest.clone()));
+        deduplicate_files_by_path(&mut files)?;
+        deduplicate_component_files(&mut component_files)?;
         Ok(Self {
             deployment_toml: deployment_toml.to_string(),
             files,
+            component_files,
         })
     }
 
@@ -238,6 +325,130 @@ impl DeploymentManifest {
             })
             .collect()
     }
+
+    pub(crate) fn component_file_records(&self) -> Vec<DeploymentComponentFileRecord> {
+        self.component_files
+            .iter()
+            .map(|file| DeploymentComponentFileRecord {
+                component_name: file.component_name.clone().into(),
+                path: file.path.clone(),
+                role: file.role,
+            })
+            .collect()
+    }
+}
+
+fn resolved_component_names(
+    deployment: &crate::config::toml::DeploymentTomlValidated,
+) -> HashMap<&'static str, Vec<String>> {
+    HashMap::from([
+        (
+            "activity_wasm",
+            deployment
+                .activities_wasm
+                .iter()
+                .map(|c| c.common.name.to_string())
+                .collect(),
+        ),
+        (
+            "activity_stub",
+            deployment
+                .activities_stub
+                .iter()
+                .map(|(_, n)| n.to_string())
+                .collect(),
+        ),
+        (
+            "activity_external",
+            deployment
+                .activities_external
+                .iter()
+                .map(|(_, n)| n.to_string())
+                .collect(),
+        ),
+        (
+            "activity_js",
+            deployment
+                .activities_js
+                .iter()
+                .map(|(_, n)| n.to_string())
+                .collect(),
+        ),
+        (
+            "activity_exec",
+            deployment
+                .activities_exec
+                .iter()
+                .map(|(_, n)| n.to_string())
+                .collect(),
+        ),
+        (
+            "workflow_wasm",
+            deployment
+                .workflows_wasm
+                .iter()
+                .map(|c| c.common.name.to_string())
+                .collect(),
+        ),
+        (
+            "workflow_js",
+            deployment
+                .workflows_js
+                .iter()
+                .map(|(_, n)| n.to_string())
+                .collect(),
+        ),
+        (
+            "webhook_endpoint_wasm",
+            deployment
+                .webhooks_wasm
+                .iter()
+                .map(|c| c.common.name.to_string())
+                .collect(),
+        ),
+        (
+            "webhook_endpoint_js",
+            deployment
+                .webhooks_js
+                .iter()
+                .map(|c| c.name.to_string())
+                .collect(),
+        ),
+    ])
+}
+
+fn deduplicate_files_by_path(files: &mut Vec<DeploymentFileRef>) -> anyhow::Result<()> {
+    let mut paths = HashMap::new();
+    for file in files.iter() {
+        if let Some(previous) = paths.insert(file.path.clone(), file.digest.clone()) {
+            ensure!(
+                previous == file.digest,
+                "deployment path `{}` has conflicting content digests",
+                file.path
+            );
+        }
+    }
+    let mut seen = HashSet::new();
+    files.retain(|file| seen.insert(file.path.clone()));
+    Ok(())
+}
+
+fn deduplicate_component_files(files: &mut Vec<DeploymentComponentFileRef>) -> anyhow::Result<()> {
+    let mut roles = HashMap::new();
+    for file in files.iter() {
+        let key = (file.component_name.clone(), file.path.clone());
+        if let Some(previous) = roles.insert(key, file.role) {
+            ensure!(
+                previous == file.role,
+                "component `{}` uses `{}` with conflicting roles",
+                file.component_name,
+                file.path
+            );
+        }
+    }
+    let mut seen = HashSet::new();
+    files.retain(|file| seen.insert((file.component_name.clone(), file.path.clone())));
+    Ok(())
 }
 
 fn parse_manifest(
@@ -258,18 +469,19 @@ fn component_name(table: &toml_edit::Table) -> Option<String> {
 fn collect_script_section(
     doc: &DocumentMut,
     section: &str,
+    names: &HashMap<&str, Vec<String>>,
     files: &mut Vec<DeploymentFileRef>,
+    component_files: &mut Vec<DeploymentComponentFileRef>,
 ) -> anyhow::Result<()> {
     let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
         return Ok(());
     };
 
-    for table in components {
-        let name = component_name(table);
+    for (index, table) in components.iter().enumerate() {
+        let name = names[section][index].clone();
         match classify_script_location(table)? {
             ManifestScriptLocation::DeploymentFile { path, digest } => {
-                let field_path =
-                    format!("{section}[name={}].location", name.as_deref().unwrap_or(""));
+                let field_path = format!("{section}[name={name}].location");
                 if let Some(module_files) = table.get("module_files").and_then(Item::as_table_like)
                 {
                     ensure!(
@@ -288,23 +500,41 @@ fn collect_script_section(
                                 format!("invalid digest for module `{module_path}`")
                             })?;
                         files.push(DeploymentFileRef {
-                            path: module_path,
+                            path: module_path.clone(),
                             digest: module_digest,
                             field: ManifestFieldRef {
                                 section: section.to_string(),
-                                component_name: name.clone(),
+                                component_name: Some(name.clone()),
                                 field_path: format!("{field_path}.module_files"),
                             },
+                        });
+                        component_files.push(DeploymentComponentFileRef {
+                            component_name: name.clone(),
+                            role: if module_path == path {
+                                ComponentFileRole::JsEntrypoint
+                            } else {
+                                ComponentFileRole::JsModule
+                            },
+                            path: module_path,
                         });
                     }
                 } else {
                     files.push(DeploymentFileRef {
-                        path,
+                        path: path.clone(),
                         digest,
                         field: ManifestFieldRef {
                             section: section.to_string(),
-                            component_name: name,
+                            component_name: Some(name.clone()),
                             field_path,
+                        },
+                    });
+                    component_files.push(DeploymentComponentFileRef {
+                        component_name: name,
+                        path,
+                        role: if section == "activity_exec" {
+                            ComponentFileRole::ExecProgram
+                        } else {
+                            ComponentFileRole::JsEntrypoint
                         },
                     });
                 }
@@ -319,29 +549,35 @@ fn collect_script_section(
 fn collect_wasm_section(
     doc: &DocumentMut,
     section: &str,
+    names: &HashMap<&str, Vec<String>>,
     files: &mut Vec<DeploymentFileRef>,
+    component_files: &mut Vec<DeploymentComponentFileRef>,
 ) -> anyhow::Result<()> {
     let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
         return Ok(());
     };
 
-    for table in components {
-        let name = component_name(table);
+    for (index, table) in components.iter().enumerate() {
+        let name = names[section][index].clone();
         let Some(raw_location) = table.get("location").and_then(Item::as_str) else {
             continue;
         };
         match classify_wasm_location(raw_location, table.get("content_digest"))? {
             ManifestWasmLocation::DeploymentFile { path, digest } => {
-                let field_path =
-                    format!("{section}[name={}].location", name.as_deref().unwrap_or(""));
+                let field_path = format!("{section}[name={name}].location");
                 files.push(DeploymentFileRef {
-                    path,
+                    path: path.clone(),
                     digest,
                     field: ManifestFieldRef {
                         section: section.to_string(),
-                        component_name: name,
+                        component_name: Some(name.clone()),
                         field_path,
                     },
+                });
+                component_files.push(DeploymentComponentFileRef {
+                    component_name: name,
+                    path,
+                    role: ComponentFileRole::WasmComponent,
                 });
             }
             ManifestWasmLocation::Oci => {}
@@ -354,14 +590,16 @@ fn collect_wasm_section(
 fn collect_backtrace_section(
     doc: &DocumentMut,
     section: &str,
+    names: &HashMap<&str, Vec<String>>,
     files: &mut Vec<DeploymentFileRef>,
+    component_files: &mut Vec<DeploymentComponentFileRef>,
 ) -> anyhow::Result<()> {
     let Some(components) = doc.get(section).and_then(Item::as_array_of_tables) else {
         return Ok(());
     };
 
-    for table in components {
-        let name = component_name(table);
+    for (index, table) in components.iter().enumerate() {
+        let name = names[section][index].clone();
         let Some(sources) = table
             .get("backtrace")
             .and_then(Item::as_table_like)
@@ -385,16 +623,18 @@ fn collect_backtrace_section(
                 &path,
             )?;
             files.push(DeploymentFileRef {
-                path,
+                path: path.clone(),
                 digest,
                 field: ManifestFieldRef {
                     section: format!("{section}.backtrace.sources"),
-                    component_name: name.clone(),
-                    field_path: format!(
-                        "{section}[name={}].backtrace.sources[{key}]",
-                        name.as_deref().unwrap_or("")
-                    ),
+                    component_name: Some(name.clone()),
+                    field_path: format!("{section}[name={name}].backtrace.sources[{key}]"),
                 },
+            });
+            component_files.push(DeploymentComponentFileRef {
+                component_name: name.clone(),
+                path,
+                role: ComponentFileRole::BacktraceSource,
             });
         }
     }
@@ -860,6 +1100,41 @@ ffqn = "ns:pkg/ifc.fn"
     }
 
     #[tokio::test]
+    async fn prepare_preserves_distinct_paths_with_identical_content() {
+        let dir = tempfile::tempdir().unwrap();
+        for component in ["a", "b"] {
+            let component_dir = dir.path().join(component);
+            tokio::fs::create_dir_all(&component_dir).await.unwrap();
+            tokio::fs::write(component_dir.join("lib.js"), "export default 1;")
+                .await
+                .unwrap();
+        }
+        let manifest = r#"
+[[activity_js]]
+name = "a"
+location = "a/lib.js"
+ffqn = "ns:pkg/ifc.a"
+
+[[activity_js]]
+name = "b"
+location = "b/lib.js"
+ffqn = "ns:pkg/ifc.b"
+"#;
+
+        let prepared = prepare_deployment_manifest(manifest, dir.path())
+            .await
+            .unwrap();
+        assert_eq!(prepared.files.len(), 2);
+        assert_eq!(prepared.files[0].digest, prepared.files[1].digest);
+        assert_ne!(prepared.files[0].path, prepared.files[1].path);
+
+        let classified =
+            DeploymentManifest::try_from_toml(&prepared.deployment_toml, Path::new("")).unwrap();
+        assert_eq!(classified.files.len(), 2);
+        assert_eq!(classified.component_files.len(), 2);
+    }
+
+    #[tokio::test]
     async fn prepare_collects_js_module_graph() {
         let dir = tempfile::tempdir().unwrap();
         tokio::fs::create_dir_all(dir.path().join("src"))
@@ -890,6 +1165,15 @@ ffqn = "ns:pkg/ifc.fn"
         let classified =
             DeploymentManifest::try_from_toml(&prepared.deployment_toml, Path::new("")).unwrap();
         assert_eq!(classified.files.len(), 2);
+        assert_eq!(classified.component_files.len(), 2);
+        assert_eq!(
+            classified.component_files[0].role,
+            ComponentFileRole::JsEntrypoint
+        );
+        assert_eq!(
+            classified.component_files[1].role,
+            ComponentFileRole::JsModule
+        );
 
         let provider = DiskProvider {
             deployment_dir: dir.path().to_path_buf(),
@@ -925,6 +1209,14 @@ location = "components/a.wasm"
 
         assert_eq!(prepared.files.len(), 1);
         assert_eq!(prepared.files[0].path, "components/a.wasm");
+        let classified =
+            DeploymentManifest::try_from_toml(&prepared.deployment_toml, Path::new("")).unwrap();
+        assert_eq!(classified.component_files.len(), 1);
+        assert_eq!(classified.component_files[0].component_name, "a");
+        assert_eq!(
+            classified.component_files[0].role,
+            ComponentFileRole::WasmComponent
+        );
         assert_eq!(prepared.files[0].bytes, b"\0asm");
         assert!(
             prepared

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1553,6 +1553,34 @@ impl grpc_gen::function_repository_server::FunctionRepository for GrpcServer {
                 component_id: Some(component.component_id.clone().into()),
                 exports: list_fns(filtered_exports(&component, request.extensions)),
                 imports: list_fns(component.imports),
+                files: component
+                    .files
+                    .into_iter()
+                    .map(|entry| grpc_gen::ComponentFileRef {
+                        file: Some(grpc_gen::FileRef {
+                            path: entry.file.path,
+                            digest: entry.file.digest.to_string(),
+                            size: entry.file.size,
+                        }),
+                        role: match entry.role {
+                            concepts::storage::ComponentFileRole::WasmComponent => {
+                                grpc_gen::ComponentFileRole::WasmComponent as i32
+                            }
+                            concepts::storage::ComponentFileRole::ExecProgram => {
+                                grpc_gen::ComponentFileRole::ExecProgram as i32
+                            }
+                            concepts::storage::ComponentFileRole::JsEntrypoint => {
+                                grpc_gen::ComponentFileRole::JsEntrypoint as i32
+                            }
+                            concepts::storage::ComponentFileRole::JsModule => {
+                                grpc_gen::ComponentFileRole::JsModule as i32
+                            }
+                            concepts::storage::ComponentFileRole::BacktraceSource => {
+                                grpc_gen::ComponentFileRole::BacktraceSource as i32
+                            }
+                        },
+                    })
+                    .collect(),
             };
             grpc_components.push(res_component);
         }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -2625,7 +2625,10 @@ pub(crate) mod components {
         ComponentId, ComponentType, FunctionExtension, FunctionMetadata, ParameterType,
         component_id::ComponentDigest,
         prefixed_ulid::DeploymentId,
-        storage::{DeploymentComponentDetail, PersistedFunctionMetadata, PersistedParameterType},
+        storage::{
+            ComponentFileRole, DeploymentComponentDetail, DeploymentComponentFileDetail,
+            PersistedFunctionMetadata, PersistedParameterType,
+        },
     };
     use itertools::Itertools;
     use std::fmt::{Debug, Write as _};
@@ -2803,6 +2806,7 @@ pub(crate) mod components {
 
                 ComponentConfig {
                     component_id: c.component_id,
+                    files: c.files.into_iter().map(Into::into).collect(),
                     imports: if params.imports {
                         Some(
                             c.imports
@@ -2841,6 +2845,17 @@ pub(crate) mod components {
                             writeln!(output, "  {func}").expect("writing to string");
                         }
                     }
+                    if !component.files.is_empty() {
+                        writeln!(output, " files:").expect("writing to string");
+                        for entry in component.files {
+                            writeln!(
+                                output,
+                                "  {} {} {} {}",
+                                entry.file.path, entry.file.digest, entry.file.size, entry.role
+                            )
+                            .expect("writing to string");
+                        }
+                    }
                 }
                 output.into_response()
             }
@@ -2853,12 +2868,41 @@ pub(crate) mod components {
         /// Component identifier
         #[schema(value_type = Object)]
         component_id: ComponentId,
+        /// Deployment-owned files used by this component.
+        files: Vec<ComponentFileRef>,
         /// Imported functions
         #[serde(skip_serializing_if = "Option::is_none")]
         imports: Option<Vec<FunctionMetadataLite>>,
         /// Exported functions
         #[serde(skip_serializing_if = "Option::is_none")]
         exports: Option<Vec<FunctionMetadataLite>>,
+    }
+
+    #[derive(Serialize, ToSchema)]
+    pub(crate) struct ComponentFileRef {
+        file: ComponentFile,
+        #[schema(value_type = String)]
+        role: ComponentFileRole,
+    }
+
+    #[derive(Serialize, ToSchema)]
+    pub(crate) struct ComponentFile {
+        path: String,
+        digest: String,
+        size: u64,
+    }
+
+    impl From<DeploymentComponentFileDetail> for ComponentFileRef {
+        fn from(value: DeploymentComponentFileDetail) -> Self {
+            Self {
+                file: ComponentFile {
+                    path: value.file.path,
+                    digest: value.file.digest.to_string(),
+                    size: value.file.size,
+                },
+                role: value.role,
+            }
+        }
     }
 
     /// Lightweight function metadata


### PR DESCRIPTION
Expose the deployment CAS-backed files used by each component through the gRPC
and Web APIs. This lets clients, especially the WebUI, obtain component files,
hashes, imports, and exports from structured APIs instead of parsing the
deployment TOML.
