### PR TITLE
perf: Fulfill already-due workflow sleep in a single transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(cli)* `deployment get` omits generated content digests and JavaScript module metadata from the
   exported TOML by default. Pass `--include-generated-metadata` to retain the stored server view.
   The gRPC and Web APIs accept `include_generated_metadata` when retrieving a deployment.
+- *(perf)* An already-due workflow sleep (e.g. `sleep(now)`) now appends its delay response in the
+  same transaction as the sleep, so the workflow resumes immediately instead of waiting for the
+  expired-timers watcher tick.
 
 ## [0.41.0](https://github.com/obeli-sk/obelisk/compare/v0.40.0...v0.41.0)
 

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -1851,6 +1851,51 @@
           {
             "type": "object",
             "required": [
+              "events",
+              "execution_id",
+              "version",
+              "join_set_id",
+              "delay_id",
+              "type"
+            ],
+            "properties": {
+              "backtraces": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BacktraceInfoSer"
+                }
+              },
+              "delay_id": {
+                "type": "string"
+              },
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "execution_id": {
+                "type": "string"
+              },
+              "join_set_id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "append_batch_with_delay_response"
+                ]
+              },
+              "version": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
               "execution_id",
               "version",
               "events",

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1133,6 +1133,15 @@ pub enum CapturedDbWrite {
         version: Version,
         backtraces: Vec<BacktraceInfo>,
     },
+    AppendBatchWithDelayResponse {
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        version: Version,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
+        backtraces: Vec<BacktraceInfo>,
+    },
     AppendBatchCreateNewExecution {
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
@@ -1974,6 +1983,20 @@ pub trait DbConnection: DbExecutor {
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
         version: Version,
+    ) -> Result<AppendBatchResponse, DbErrorWrite>;
+
+    /// Append a blocking one-off delay batch (`JoinSetCreate`, `DelayRequest`, `JoinNext`)
+    /// for a delay that is already due (e.g. `sleep(now)`) together with its `DelayFinished`
+    /// response, in a single transaction. This unblocks the `JoinNext` immediately, so the
+    /// workflow resumes without a round trip through the expired-timers watcher.
+    async fn append_batch_with_delay_response(
+        &self,
+        current_time: DateTime<Utc>, // not persisted, can be used for unblocking `subscribe_to_pending`
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        version: Version,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
     ) -> Result<AppendBatchResponse, DbErrorWrite>;
 
     /// Append one or more events to the parent execution log, and create zero or more child execution logs.

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -4211,6 +4211,58 @@ impl DbConnection for PostgresConnection {
     }
 
     #[instrument(level = Level::DEBUG, skip_all, fields(%execution_id, %version))]
+    async fn append_batch_with_delay_response(
+        &self,
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        version: Version,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
+    ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        debug!("append_batch_with_delay_response");
+        trace!(?batch, "append_batch_with_delay_response");
+        assert!(!batch.is_empty(), "Empty batch request");
+
+        let mut client_guard = self.client.lock().await;
+        let tx = client_guard.transaction().await?;
+
+        let mut version = version;
+        let mut notifiers = Vec::new();
+
+        for append_request in batch {
+            let (v, n) = append(&tx, &execution_id, append_request, version).await?;
+            version = v;
+            notifiers.push(n);
+        }
+
+        // Appending the response unblocks the just-written `JoinNext` and deletes
+        // the `t_delay` row the `DelayRequest` inserted, all in this transaction.
+        let response_notifier = append_response(
+            &tx,
+            &execution_id,
+            JoinSetResponseEventOuter {
+                created_at: current_time,
+                event: JoinSetResponseEvent {
+                    join_set_id,
+                    event: JoinSetResponse::DelayFinished {
+                        delay_id,
+                        result: Ok(()),
+                    },
+                },
+            },
+        )
+        .await?;
+        notifiers.push(response_notifier);
+
+        tx.commit().await?;
+        drop(client_guard);
+
+        self.notify_all(notifiers, current_time);
+        Ok(version)
+    }
+
+    #[instrument(level = Level::DEBUG, skip_all, fields(%execution_id, %version))]
     async fn append_batch_create_new_execution(
         &self,
         current_time: DateTime<Utc>,

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -5420,6 +5420,64 @@ impl DbConnection for SqlitePool {
     }
 
     #[instrument(level = Level::DEBUG, skip_all, fields(%execution_id, %version))]
+    async fn append_batch_with_delay_response(
+        &self,
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        version: Version,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
+    ) -> Result<AppendBatchResponse, DbErrorWrite> {
+        debug!("append_batch_with_delay_response");
+        trace!(?batch, "append_batch_with_delay_response");
+        assert!(!batch.is_empty(), "Empty batch request");
+
+        let (version, notifiers) = self
+            .transaction(
+                move |tx| {
+                    let mut version = version.clone();
+                    let mut notifier = None;
+                    for append_request in &batch {
+                        let (v, n) =
+                            Self::append(tx, &execution_id, append_request.clone(), version)?;
+                        version = v;
+                        notifier = Some(n);
+                    }
+                    // Appending the response unblocks the just-written `JoinNext` and deletes
+                    // the `t_delay` row the `DelayRequest` inserted, all in this transaction.
+                    let response_notifier = Self::append_response(
+                        tx,
+                        &execution_id,
+                        JoinSetResponseEventOuter {
+                            created_at: current_time,
+                            event: JoinSetResponseEvent {
+                                join_set_id: join_set_id.clone(),
+                                event: JoinSetResponse::DelayFinished {
+                                    delay_id: delay_id.clone(),
+                                    result: Ok(()),
+                                },
+                            },
+                        },
+                    )?;
+                    Ok::<_, DbErrorWrite>((
+                        version,
+                        vec![
+                            notifier.expect("checked that the batch is not empty"),
+                            response_notifier,
+                        ],
+                    ))
+                },
+                TxType::MultipleWrites,
+                "append_batch_with_delay_response",
+            )
+            .await?;
+
+        self.notify_all(notifiers, current_time);
+        Ok(version)
+    }
+
+    #[instrument(level = Level::DEBUG, skip_all, fields(%execution_id, %version))]
     async fn append_batch_create_new_execution(
         &self,
         current_time: DateTime<Utc>,

--- a/crates/grpc/src/grpc_mapping.rs
+++ b/crates/grpc/src/grpc_mapping.rs
@@ -2087,6 +2087,26 @@ pub fn captured_write_to_grpc(write: CapturedDbWrite) -> grpc_gen::CapturedWrite
                     backtraces: backtraces.into_iter().map(Into::into).collect(),
                 },
             ),
+            CapturedDbWrite::AppendBatchWithDelayResponse {
+                current_time: _,
+                batch,
+                execution_id,
+                version,
+                join_set_id,
+                delay_id,
+                backtraces,
+            } => grpc_gen::captured_write::Write::AppendBatchWithDelayResponse(
+                grpc_gen::captured_write::AppendBatchWithDelayResponse {
+                    events: append_requests_to_grpc_events(batch, version.0),
+                    execution_id: Some(grpc_gen::ExecutionId {
+                        id: execution_id.to_string(),
+                    }),
+                    version: version.0,
+                    join_set_id: Some(join_set_id.into()),
+                    delay_id: delay_id.to_string(),
+                    backtraces: backtraces.into_iter().map(Into::into).collect(),
+                },
+            ),
             CapturedDbWrite::AppendStubResponse {
                 events,
                 response,
@@ -2201,6 +2221,33 @@ pub fn captured_write_from_grpc(
                     .into_iter()
                     .map(CreateRequest::try_from)
                     .collect::<Result<Vec<_>, _>>()?,
+                backtraces: batch
+                    .backtraces
+                    .into_iter()
+                    .map(BacktraceInfo::try_from)
+                    .collect::<Result<Vec<BacktraceInfo>, _>>()?,
+            })
+        }
+        grpc_gen::captured_write::Write::AppendBatchWithDelayResponse(batch) => {
+            Ok(CapturedDbWrite::AppendBatchWithDelayResponse {
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
+                batch: batch
+                    .events
+                    .into_iter()
+                    .map(append_request_from_grpc_event)
+                    .collect::<Result<Vec<_>, _>>()?,
+                execution_id: batch
+                    .execution_id
+                    .argument_must_exist("execution_id")?
+                    .try_into()?,
+                version: Version::new(batch.version),
+                join_set_id: batch
+                    .join_set_id
+                    .argument_must_exist("join_set_id")?
+                    .try_into()?,
+                delay_id: DelayId::from_str(&batch.delay_id).map_err(|err| {
+                    tonic::Status::invalid_argument(format!("invalid delay_id - {err}"))
+                })?,
                 backtraces: batch
                     .backtraces
                     .into_iter()

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -562,6 +562,8 @@ impl WorkflowDbConnection for CachingDbConnection {
     }
 
     #[instrument(level = tracing::Level::DEBUG, skip(self))]
+    // A write needs flushing when continuing requires an actor outside the in-memory
+    // workflow state to observe it.
     async fn flush_non_blocking_event_cache(
         &mut self,
         current_time: DateTime<Utc>,

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -193,9 +193,24 @@ pub(crate) enum CacheableDbEvent {
     },
 }
 
+#[expect(
+    clippy::large_enum_variant,
+    reason = "boxing every non-blocking event would add an allocation to the hot path"
+)]
+enum CachedDbWrite {
+    NonBlocking(CacheableDbEvent),
+    BatchWithDelayResponse {
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        version: Version,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
+    },
+}
+
 pub(crate) struct CachingBuffer {
-    pub(crate) non_blocking_event_batch_size: usize,
-    pub(crate) non_blocking_event_batch: Vec<CacheableDbEvent>,
+    write_batch_size: usize,
+    writes: Vec<CachedDbWrite>,
 }
 impl CachingBuffer {
     pub(crate) fn new(
@@ -211,8 +226,8 @@ impl CachingBuffer {
             None
         } else {
             Some(CachingBuffer {
-                non_blocking_event_batch_size,
-                non_blocking_event_batch: Vec::with_capacity(non_blocking_event_batch_size),
+                write_batch_size: non_blocking_event_batch_size,
+                writes: Vec::with_capacity(non_blocking_event_batch_size),
             })
         }
     }
@@ -243,8 +258,8 @@ impl WorkflowDbConnection for CachingDbConnection {
     ) -> Result<(), DbErrorWrite> {
         if let Some(caching_buffer) = &mut self.caching_buffer {
             caching_buffer
-                .non_blocking_event_batch
-                .push(non_blocking_event);
+                .writes
+                .push(CachedDbWrite::NonBlocking(non_blocking_event));
             self.flush_non_blocking_event_cache_if_full(called_at)
                 .await?;
         } else {
@@ -361,17 +376,30 @@ impl WorkflowDbConnection for CachingDbConnection {
         _wasm_backtrace: Option<storage::WasmBacktrace>,
         _component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
-        self.flush_non_blocking_event_cache(current_time).await?;
-        self.db_connection
-            .append_batch_with_delay_response(
-                current_time,
-                batch,
-                execution_id,
-                version,
-                join_set_id,
-                delay_id,
-            )
-            .await?;
+        if let Some(caching_buffer) = &mut self.caching_buffer {
+            caching_buffer
+                .writes
+                .push(CachedDbWrite::BatchWithDelayResponse {
+                    current_time,
+                    batch,
+                    version,
+                    join_set_id,
+                    delay_id,
+                });
+            self.flush_non_blocking_event_cache_if_full(current_time)
+                .await?;
+        } else {
+            self.db_connection
+                .append_batch_with_delay_response(
+                    current_time,
+                    batch,
+                    execution_id,
+                    version,
+                    join_set_id,
+                    delay_id,
+                )
+                .await?;
+        }
         Ok(())
     }
 
@@ -506,18 +534,15 @@ impl WorkflowDbConnection for CachingDbConnection {
         execution_id: &ExecutionId,
     ) -> Result<CreateRequest, DbErrorRead> {
         if let Some(caching_buffer) = &self.caching_buffer
-            && let Some(found) = caching_buffer
-                .non_blocking_event_batch
-                .iter()
-                .find_map(|event| match event {
-                    CacheableDbEvent::SubmitChildExecution {
-                        request,
-                        version,
-                        child_req,
-                        backtrace,
-                    } if child_req.execution_id == *execution_id => Some(child_req.clone()),
-                    _ => None,
-                })
+            && let Some(found) = caching_buffer.writes.iter().find_map(|event| match event {
+                CachedDbWrite::NonBlocking(CacheableDbEvent::SubmitChildExecution {
+                    request: _,
+                    version: _,
+                    child_req,
+                    backtrace: _,
+                }) if child_req.execution_id == *execution_id => Some(child_req.clone()),
+                _ => None,
+            })
         {
             return Ok(found);
         }
@@ -542,79 +567,39 @@ impl WorkflowDbConnection for CachingDbConnection {
         current_time: DateTime<Utc>,
     ) -> Result<(), DbErrorWrite> {
         if let Some(caching_buffer) = &mut self.caching_buffer
-            && !caching_buffer.non_blocking_event_batch.is_empty()
+            && !caching_buffer.writes.is_empty()
         {
             debug!("Flushing the non-blocking event cache started");
-            let mut batches = Vec::with_capacity(caching_buffer.non_blocking_event_batch.len());
-            let mut childs = Vec::with_capacity(caching_buffer.non_blocking_event_batch.len());
-            let mut first_version = None;
-            for non_blocking in caching_buffer.non_blocking_event_batch.drain(..) {
-                match non_blocking {
-                    CacheableDbEvent::SubmitChildExecution {
-                        request,
-                        version,
-                        child_req,
-                        backtrace: _,
+            let cached_writes = std::mem::take(&mut caching_buffer.writes);
+            let mut non_blocking_batch = Vec::new();
+            for cached_write in cached_writes {
+                match cached_write {
+                    CachedDbWrite::NonBlocking(non_blocking) => {
+                        non_blocking_batch.push(non_blocking);
                     }
-                    | CacheableDbEvent::Schedule {
-                        request,
+                    CachedDbWrite::BatchWithDelayResponse {
+                        current_time,
+                        batch,
                         version,
-                        child_req,
-                        backtrace: _,
+                        join_set_id,
+                        delay_id,
                     } => {
-                        if first_version.is_none() {
-                            first_version.replace(version);
-                        }
-                        childs.push(child_req);
-                        batches.push(request);
-                    }
-                    CacheableDbEvent::JoinSetCreate {
-                        request,
-                        version,
-                        backtrace: _,
-                    }
-                    | CacheableDbEvent::Persist {
-                        request,
-                        version,
-                        backtrace: _,
-                    }
-                    | CacheableDbEvent::SubmitDelay {
-                        request,
-                        version,
-                        backtrace: _,
-                    }
-                    | CacheableDbEvent::JoinNextTry {
-                        request,
-                        version,
-                        backtrace: _,
-                    }
-                    | CacheableDbEvent::ScheduleError {
-                        request,
-                        version,
-                        backtrace: _,
-                    }
-                    | CacheableDbEvent::SubmitChildExecutionError {
-                        request,
-                        version,
-                        backtrace: _,
-                    } => {
-                        if first_version.is_none() {
-                            first_version.replace(version);
-                        }
-                        batches.push(request);
+                        self.flush_non_blocking_batch(current_time, &mut non_blocking_batch)
+                            .await?;
+                        self.db_connection
+                            .append_batch_with_delay_response(
+                                current_time,
+                                batch,
+                                self.execution_id.clone(),
+                                version,
+                                join_set_id,
+                                delay_id,
+                            )
+                            .await?;
                     }
                 }
             }
-            assert!(!batches.is_empty());
-            self.db_connection
-                .append_batch_create_new_execution(
-                    current_time,
-                    batches,
-                    self.execution_id.clone(),
-                    first_version.expect("checked that !non_blocking_event_batch.is_empty()"),
-                    childs,
-                    vec![],
-                )
+            self.flush_non_blocking_batch(current_time, &mut non_blocking_batch)
                 .await?;
 
             debug!("Flushing the non-blocking event cache finished");
@@ -623,14 +608,99 @@ impl WorkflowDbConnection for CachingDbConnection {
     }
 }
 
+impl CachingDbConnection {
+    async fn flush_non_blocking_batch(
+        &self,
+        current_time: DateTime<Utc>,
+        non_blocking_batch: &mut Vec<CacheableDbEvent>,
+    ) -> Result<(), DbErrorWrite> {
+        if non_blocking_batch.is_empty() {
+            return Ok(());
+        }
+
+        let mut batches = Vec::with_capacity(non_blocking_batch.len());
+        let mut childs = Vec::with_capacity(non_blocking_batch.len());
+        let mut first_version = None;
+        for non_blocking in non_blocking_batch.drain(..) {
+            match non_blocking {
+                CacheableDbEvent::SubmitChildExecution {
+                    request,
+                    version,
+                    child_req,
+                    backtrace: _,
+                }
+                | CacheableDbEvent::Schedule {
+                    request,
+                    version,
+                    child_req,
+                    backtrace: _,
+                } => {
+                    if first_version.is_none() {
+                        first_version.replace(version);
+                    }
+                    childs.push(child_req);
+                    batches.push(request);
+                }
+                CacheableDbEvent::JoinSetCreate {
+                    request,
+                    version,
+                    backtrace: _,
+                }
+                | CacheableDbEvent::Persist {
+                    request,
+                    version,
+                    backtrace: _,
+                }
+                | CacheableDbEvent::SubmitDelay {
+                    request,
+                    version,
+                    backtrace: _,
+                }
+                | CacheableDbEvent::JoinNextTry {
+                    request,
+                    version,
+                    backtrace: _,
+                }
+                | CacheableDbEvent::ScheduleError {
+                    request,
+                    version,
+                    backtrace: _,
+                }
+                | CacheableDbEvent::SubmitChildExecutionError {
+                    request,
+                    version,
+                    backtrace: _,
+                } => {
+                    if first_version.is_none() {
+                        first_version.replace(version);
+                    }
+                    batches.push(request);
+                }
+            }
+        }
+        assert!(!batches.is_empty());
+        self.db_connection
+            .append_batch_create_new_execution(
+                current_time,
+                batches,
+                self.execution_id.clone(),
+                first_version.expect("checked that non_blocking_batch is not empty"),
+                childs,
+                vec![],
+            )
+            .await?;
+        Ok(())
+    }
+}
+
 impl Drop for CachingDbConnection {
     fn drop(&mut self) {
         if let Some(caching_buffer) = &self.caching_buffer
-            && !caching_buffer.non_blocking_event_batch.is_empty()
+            && !caching_buffer.writes.is_empty()
         {
             warn!(
                 execution_id = %self.execution_id,
-                cache_len = caching_buffer.non_blocking_event_batch.len(),
+                cache_len = caching_buffer.writes.len(),
                 "CachingDbConnection dropped with non-empty cache"
             );
         }
@@ -643,8 +713,7 @@ impl CachingDbConnection {
         current_time: DateTime<Utc>,
     ) -> Result<(), DbErrorWrite> {
         if let Some(caching_buffer) = &self.caching_buffer {
-            let too_many = caching_buffer.non_blocking_event_batch.len()
-                >= caching_buffer.non_blocking_event_batch_size;
+            let too_many = caching_buffer.writes.len() >= caching_buffer.write_batch_size;
             if too_many {
                 self.flush_non_blocking_event_cache(current_time).await?;
             }

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -9,8 +9,8 @@ use crate::{
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use concepts::{
-    ComponentId, ExecutionId,
-    prefixed_ulid::ExecutionIdDerived,
+    ComponentId, ExecutionId, JoinSetId,
+    prefixed_ulid::{DelayId, ExecutionIdDerived},
     storage::{
         self, AppendRequest, AppendResponseToExecution, BacktraceInfo, CreateRequest, DbConnection,
         DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite, LogInfoAppendRow, ResponseCursor,
@@ -66,6 +66,19 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
         current_time: DateTime<Utc>,
         batch: Vec<AppendRequest>,
         execution_id: ExecutionId,
+        wasm_backtrace: Option<storage::WasmBacktrace>,
+        component_id: &ComponentId,
+    ) -> Result<(), DbErrorWrite>;
+
+    #[expect(clippy::too_many_arguments)]
+    async fn append_batch_with_delay_response(
+        &mut self,
+        version: Version,
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite>;
@@ -333,6 +346,31 @@ impl WorkflowDbConnection for CachingDbConnection {
         self.flush_non_blocking_event_cache(current_time).await?;
         self.db_connection
             .append_batch(current_time, batch, execution_id, version)
+            .await?;
+        Ok(())
+    }
+
+    async fn append_batch_with_delay_response(
+        &mut self,
+        version: Version,
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
+        _wasm_backtrace: Option<storage::WasmBacktrace>,
+        _component_id: &ComponentId,
+    ) -> Result<(), DbErrorWrite> {
+        self.flush_non_blocking_event_cache(current_time).await?;
+        self.db_connection
+            .append_batch_with_delay_response(
+                current_time,
+                batch,
+                execution_id,
+                version,
+                join_set_id,
+                delay_id,
+            )
             .await?;
         Ok(())
     }

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -81,6 +81,11 @@ enum ChildReturnValue {
     Persist,
 }
 
+struct AppendedBlockingEvents {
+    history_events: Vec<(HistoryEvent, Version)>,
+    known_response: Option<ChildReturnValue>,
+}
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 enum ProcessingStatus {
     Unprocessed,
@@ -515,7 +520,10 @@ impl EventHistory {
         let join_next_variant = event_call.join_next_variant();
         let keys = event_call.as_keys();
         // Create and append HistoryEvents.
-        let history_events = self
+        let AppendedBlockingEvents {
+            history_events,
+            mut known_response,
+        } = self
             .append_to_db_blocking(
                 event_call,
                 version,
@@ -537,19 +545,31 @@ impl EventHistory {
 
         let last_key_idx = keys.len() - 1;
         for (idx, key) in keys.into_iter().enumerate() {
-            let res = self.process_event_by_key(&key)?;
-            if idx == last_key_idx
-                && let FindMatchingResponse::Found { value: res, .. } = res
-            {
-                // Last key was marked as processed.
-                assert_eq!(
-                    Processed,
-                    self.event_history
-                        .last()
-                        .expect("checked that `history_events` is not empty")
-                        .1
-                );
-                return Ok(res);
+            let response = self.process_event_by_key(&key)?;
+            if idx == last_key_idx {
+                match (response, known_response.take()) {
+                    (FindMatchingResponse::Found { value, .. }, None) => {
+                        assert_eq!(
+                            Processed,
+                            self.event_history
+                                .last()
+                                .expect("checked that `history_events` is not empty")
+                                .1
+                        );
+                        return Ok(value);
+                    }
+                    (FindMatchingResponse::FoundRequestButNotResponse { .. }, Some(value)) => {
+                        self.event_history
+                            .last_mut()
+                            .expect("checked that `history_events` is not empty")
+                            .1 = Processed;
+                        return Ok(value);
+                    }
+                    (_, Some(_)) => {
+                        unreachable!("a locally resolved blocking event must await its response")
+                    }
+                    _ => {}
+                }
             }
         }
         // Now either wait or interrupt.
@@ -1764,7 +1784,7 @@ impl EventHistory {
         db_connection: &mut dyn WorkflowDbConnection,
         called_at: DateTime<Utc>,
         lock_expires_at: DateTime<Utc>,
-    ) -> Result<Vec<(HistoryEvent, Version)>, DbErrorWrite> {
+    ) -> Result<AppendedBlockingEvents, DbErrorWrite> {
         trace!("append_to_db_blocking {}", version);
         match event_call {
             EventCallBlocking::JoinNext(JoinNext {
@@ -1800,7 +1820,10 @@ impl EventHistory {
                         &self.locked_event.component_id,
                     )
                     .await?;
-                Ok(history_events)
+                Ok(AppendedBlockingEvents {
+                    history_events,
+                    known_response: None,
+                })
             }
 
             EventCallBlocking::JoinSetClose(JoinSetClose {
@@ -1842,7 +1865,10 @@ impl EventHistory {
                         &self.locked_event.component_id,
                     )
                     .await?;
-                Ok(history_events)
+                Ok(AppendedBlockingEvents {
+                    history_events,
+                    known_response: None,
+                })
             }
 
             EventCallBlocking::JoinNextRequestingFfqn(JoinNextRequestingFfqn {
@@ -1881,7 +1907,10 @@ impl EventHistory {
                     )
                     .await?;
 
-                Ok(history_events)
+                Ok(AppendedBlockingEvents {
+                    history_events,
+                    known_response: None,
+                })
             }
 
             EventCallBlocking::OneOffChildExecutionRequest(OneOffChildExecutionRequest {
@@ -1962,7 +1991,10 @@ impl EventHistory {
                     )
                     .await?;
 
-                Ok(history_events)
+                Ok(AppendedBlockingEvents {
+                    history_events,
+                    known_response: None,
+                })
             }
 
             EventCallBlocking::OneOffDelayRequest(OneOffDelayRequest {
@@ -2047,7 +2079,20 @@ impl EventHistory {
                         .await?;
                 }
 
-                Ok(history_events)
+                let known_response = (already_due
+                    && matches!(
+                        self.join_next_blocking_strategy,
+                        JoinNextBlockingStrategy::Await { .. }
+                    ))
+                .then_some(ChildReturnValue::OneOffDelay {
+                    scheduled_at: expires_at_if_new,
+                    result: Ok(()),
+                });
+
+                Ok(AppendedBlockingEvents {
+                    history_events,
+                    known_response,
+                })
             }
         }
     }
@@ -3478,8 +3523,8 @@ mod tests {
     use crate::workflow::deadline_tracker::deadline_tracker_factory_test;
     use crate::workflow::event_history::{
         ApplyError, AwaitNextExtensionError, ChildReturnValue, JoinNextRequestingFfqn, JoinNextTry,
-        JoinNextTryError, JoinSetCreate, Schedule, ScheduleIntent, Stub, StubIntent, StubParams,
-        SubmitChildIntent, SubmitDelay,
+        JoinNextTryError, JoinSetCreate, OneOffDelayRequest, Schedule, ScheduleIntent, Stub,
+        StubIntent, StubParams, SubmitChildIntent, SubmitDelay,
     };
     use assert_matches::assert_matches;
     use chrono::{DateTime, Utc};
@@ -3510,6 +3555,66 @@ mod tests {
 
     pub const MOCK_FFQN: FunctionFqn = FunctionFqn::new_static("namespace:pkg/ifc", "fn1");
     pub const MOCK_FFQN_2: FunctionFqn = FunctionFqn::new_static("namespace:pkg/ifc", "fn2");
+
+    #[tokio::test]
+    async fn already_due_one_off_delays_are_resolved_before_cache_flush() {
+        test_utils::set_up();
+        let sim_clock = SimClock::new(DateTime::default());
+        let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
+        let db_connection = db_pool.connection_test().await.unwrap();
+        let execution_id = create_execution(db_connection.as_ref(), &sim_clock).await;
+        let initial_version = db_connection.get(&execution_id).await.unwrap().next_version;
+
+        let (mut event_history, mut event_call_cursor, mut caching_db_connection) =
+            load_event_history(
+                db_pool.connection_test().await.unwrap(),
+                execution_id.clone(),
+                sim_clock.now(),
+                Duration::from_secs(1),
+                deadline_tracker_factory_test(&sim_clock),
+                JoinNextBlockingStrategy::Await {
+                    non_blocking_event_batching: 100,
+                },
+                TestingFnRegistry::new_from_components(vec![]),
+            )
+            .await;
+
+        for name in ["first", "second"] {
+            let result = OneOffDelayRequest::apply(
+                HistoryEventScheduleAt::Now,
+                Some(name.to_owned()),
+                sim_clock.now(),
+                None,
+                &mut event_history,
+                &mut event_call_cursor,
+                &mut *caching_db_connection,
+                sim_clock.now(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(Ok(sim_clock.now()), result);
+        }
+
+        let unflushed_log = db_connection.get(&execution_id).await.unwrap();
+        assert_eq!(initial_version, unflushed_log.next_version);
+        assert!(unflushed_log.responses.is_empty());
+
+        caching_db_connection
+            .flush_non_blocking_event_cache(sim_clock.now())
+            .await
+            .unwrap();
+
+        let flushed_log = db_connection.get(&execution_id).await.unwrap();
+        assert_eq!(
+            Version::new(initial_version.0 + 6),
+            flushed_log.next_version
+        );
+        assert_eq!(2, flushed_log.responses.len());
+
+        drop(db_connection);
+        drop(caching_db_connection);
+        db_close.close().await;
+    }
 
     #[rstest]
     #[tokio::test]

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -1972,7 +1972,11 @@ impl EventHistory {
                 expires_at_if_new,
                 wasm_backtrace,
             }) => {
-                debug!(%delay_id, %join_set_id, "BlockingDelayRequest: Flushing and appending JoinSet,DelayRequest,JoinNext");
+                // An already-due delay (e.g. `sleep(now)`) is fulfilled in the same
+                // transaction, so the workflow resumes without waiting for the
+                // expired-timers watcher to append the delay response.
+                let already_due = expires_at_if_new <= called_at;
+                debug!(%delay_id, %join_set_id, already_due, "BlockingDelayRequest: Flushing and appending JoinSet,DelayRequest,JoinNext");
                 let mut history_events = Vec::with_capacity(3);
                 let event = HistoryEvent::JoinSetCreate {
                     join_set_id: join_set_id.clone(),
@@ -1986,7 +1990,7 @@ impl EventHistory {
                 let event = HistoryEvent::JoinSetRequest {
                     join_set_id: join_set_id.clone(),
                     request: JoinSetRequest::DelayRequest {
-                        delay_id,
+                        delay_id: delay_id.clone(),
                         expires_at: expires_at_if_new,
                         schedule_at,
                         paused: false,
@@ -1999,7 +2003,7 @@ impl EventHistory {
                     event: ExecutionRequest::HistoryEvent { event },
                 };
                 let event = HistoryEvent::JoinNext {
-                    join_set_id,
+                    join_set_id: join_set_id.clone(),
                     run_expires_at: lock_expires_at,
                     closing: false,
                     requested_ffqn: None,
@@ -2011,20 +2015,37 @@ impl EventHistory {
                     event: ExecutionRequest::HistoryEvent { event },
                 };
 
-                db_connection
-                    .append_batch(
-                        history_events
-                            .first()
-                            .expect("blocking delay has three events")
-                            .1
-                            .clone(),
-                        called_at,
-                        vec![join_set, delay_req, join_next],
-                        db_connection.execution_id().clone(),
-                        wasm_backtrace,
-                        &self.locked_event.component_id,
-                    )
-                    .await?;
+                let batch_version = history_events
+                    .first()
+                    .expect("blocking delay has three events")
+                    .1
+                    .clone();
+                let batch = vec![join_set, delay_req, join_next];
+                if already_due {
+                    db_connection
+                        .append_batch_with_delay_response(
+                            batch_version,
+                            called_at,
+                            batch,
+                            db_connection.execution_id().clone(),
+                            join_set_id,
+                            delay_id,
+                            wasm_backtrace,
+                            &self.locked_event.component_id,
+                        )
+                        .await?;
+                } else {
+                    db_connection
+                        .append_batch(
+                            batch_version,
+                            called_at,
+                            batch,
+                            db_connection.execution_id().clone(),
+                            wasm_backtrace,
+                            &self.locked_event.component_id,
+                        )
+                        .await?;
+                }
 
                 Ok(history_events)
             }

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -27,6 +27,24 @@ pub enum ReplayResponse {
 }
 
 /// Preview writes captured by replay that can be supplied to `advance`.
+///
+/// Replay stops collecting when later captured writes could depend on information
+/// that is authoritative only after the preceding write is applied.
+///
+/// For `sleep(now)`, advance does not trust the timestamp supplied in the captured
+/// write. It recomputes and applies the actual time, so the sleep write ends the
+/// captured-write list. A subsequent replay observes that authoritative time before
+/// continuing.
+///
+/// For a stub response, replay cannot predict whether writing the response will
+/// succeed or conflict. It captures the stub-response write and stops. Only after
+/// that write succeeds does a subsequent replay capture the parent stub history
+/// event.
+///
+/// Ordinary non-blocking writes can remain in the same captured-write list when they
+/// expose no unapplied result to subsequent workflow code. `JoinNextTry` can also
+/// continue because its result is derived from already trusted replay state and its
+/// recorded outcome is validated exactly.
 #[derive(Debug, Clone)]
 #[cfg_attr(any(test, feature = "test"), derive(serde::Serialize))]
 pub struct ReplayAdvanceable {

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -43,6 +43,7 @@ impl ReplayAdvanceable {
         self.captured_writes.iter().find_map(|w| match w {
             CapturedDbWrite::Append { version, .. }
             | CapturedDbWrite::AppendBatch { version, .. }
+            | CapturedDbWrite::AppendBatchWithDelayResponse { version, .. }
             | CapturedDbWrite::AppendBatchCreateNewExecution { version, .. }
             | CapturedDbWrite::AppendFinished { version, .. } => Some(version),
             CapturedDbWrite::AppendStubResponse { .. } => None,
@@ -73,6 +74,7 @@ impl ReplayAdvanceable {
                 let requests: &[concepts::storage::AppendRequest] = match w {
                     CapturedDbWrite::Append { req, .. } => std::slice::from_ref(req),
                     CapturedDbWrite::AppendBatch { batch, .. }
+                    | CapturedDbWrite::AppendBatchWithDelayResponse { batch, .. }
                     | CapturedDbWrite::AppendBatchCreateNewExecution { batch, .. } => batch,
                     CapturedDbWrite::AppendStubResponse { events, .. } => &events.batch,
                     CapturedDbWrite::AppendFinished { .. } => &[],
@@ -279,6 +281,26 @@ fn normalize_captured_write_for_matching(write: CapturedDbWrite) -> CapturedDbWr
                 .collect(),
             execution_id,
             version,
+            backtraces: vec![],
+        },
+        CapturedDbWrite::AppendBatchWithDelayResponse {
+            current_time: _,
+            batch,
+            execution_id,
+            version,
+            join_set_id,
+            delay_id,
+            backtraces: _,
+        } => CapturedDbWrite::AppendBatchWithDelayResponse {
+            current_time: DateTime::UNIX_EPOCH,
+            batch: batch
+                .into_iter()
+                .map(normalize_append_request_for_matching)
+                .collect(),
+            execution_id,
+            version,
+            join_set_id,
+            delay_id,
             backtraces: vec![],
         },
         CapturedDbWrite::AppendBatchCreateNewExecution {

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 use concepts::storage::DbErrorStubResponse;
 use concepts::{
     ComponentId, ExecutionId, JoinSetId,
-    prefixed_ulid::ExecutionIdDerived,
+    prefixed_ulid::{DelayId, ExecutionIdDerived},
     storage::{
         self, AppendEventsToExecution, AppendRequest, AppendResponseToExecution, BacktraceInfo,
         CapturedDbWrite, CreateRequest, DbConnection, DbErrorRead, DbErrorReadWithTimeout,
@@ -144,6 +144,11 @@ pub(crate) fn bump_versions_for_execution(
                 version,
                 ..
             }
+            | CapturedDbWrite::AppendBatchWithDelayResponse {
+                execution_id,
+                version,
+                ..
+            }
             | CapturedDbWrite::AppendBatchCreateNewExecution {
                 execution_id,
                 version,
@@ -225,6 +230,30 @@ async fn apply_captured_write(
         } => {
             let result = conn
                 .append_batch(current_time, batch, execution_id, version)
+                .await?;
+            if !backtraces.is_empty() {
+                conn.append_backtrace_batch(backtraces).await?;
+            }
+            Ok(Some(result))
+        }
+        CapturedDbWrite::AppendBatchWithDelayResponse {
+            current_time,
+            batch,
+            execution_id,
+            version,
+            join_set_id,
+            delay_id,
+            backtraces,
+        } => {
+            let result = conn
+                .append_batch_with_delay_response(
+                    current_time,
+                    batch,
+                    execution_id,
+                    version,
+                    join_set_id,
+                    delay_id,
+                )
                 .await?;
             if !backtraces.is_empty() {
                 conn.append_backtrace_batch(backtraces).await?;
@@ -601,6 +630,40 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
             version,
             backtraces,
         });
+        Ok(())
+    }
+
+    async fn append_batch_with_delay_response(
+        &mut self,
+        version: Version,
+        current_time: DateTime<Utc>,
+        batch: Vec<AppendRequest>,
+        execution_id: ExecutionId,
+        join_set_id: JoinSetId,
+        delay_id: DelayId,
+        wasm_backtrace: Option<storage::WasmBacktrace>,
+        component_id: &ComponentId,
+    ) -> Result<(), DbErrorWrite> {
+        assert_eq!(self.execution_id, execution_id);
+        let next = next_version(&version, batch.len());
+        for request in &batch {
+            assert!(
+                !is_closing_join_next(request),
+                "closing join next is not appended using `append_batch_with_delay_response`"
+            );
+        }
+        let backtraces =
+            make_backtrace(&execution_id, component_id, &version, &next, wasm_backtrace);
+        self.collector
+            .push_write(CapturedDbWrite::AppendBatchWithDelayResponse {
+                current_time,
+                batch,
+                execution_id,
+                version,
+                join_set_id,
+                delay_id,
+                backtraces,
+            });
         Ok(())
     }
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -492,6 +492,7 @@ impl WorkflowWorker {
         backtraces.extend(writes.into_iter().flat_map(|write| match write.write {
             CapturedDbWrite::Append { backtraces, .. }
             | CapturedDbWrite::AppendBatch { backtraces, .. }
+            | CapturedDbWrite::AppendBatchWithDelayResponse { backtraces, .. }
             | CapturedDbWrite::AppendBatchCreateNewExecution { backtraces, .. }
             | CapturedDbWrite::AppendStubResponse { backtraces, .. } => backtraces,
             CapturedDbWrite::AppendFinished { .. } => Vec::new(),
@@ -2798,21 +2799,23 @@ pub(crate) mod tests {
                 .len();
             assert_eq!(1, worker_tasks);
         }
-        let blocked_until = {
+        // An already-due `sleep(now)` is fulfilled in the same transaction, so the
+        // execution is immediately pending instead of blocked on the join set.
+        let scheduled_at = {
             let pending_state = db_connection
                 .get_pending_state(&execution_id)
                 .await
                 .unwrap()
                 .pending_state;
-            assert_matches!(pending_state, PendingState::BlockedByJoinSet(PendingStateBlockedByJoinSet {lock_expires_at, .. }) => lock_expires_at)
+            assert_matches!(pending_state, PendingState::PendingAt(PendingStatePendingAt { scheduled_at, .. }) => scheduled_at)
         };
-        assert_eq!(sim_clock.now(), blocked_until);
-        // expired_timers_watcher should see the AsyncDelay and send the response.
+        assert_eq!(sim_clock.now(), scheduled_at);
+        // The delay response is already appended, so the watcher has nothing to do.
         {
             let timer = expired_timers_watcher::tick_test(db_connection.as_ref(), sim_clock.now())
                 .await
                 .unwrap();
-            assert_eq!(1, timer.expired_async_timers);
+            assert_eq!(0, timer.expired_async_timers);
         }
         // Reexecute the worker
         {

--- a/proto/obelisk.proto
+++ b/proto/obelisk.proto
@@ -875,6 +875,14 @@ message CapturedWrite {
     repeated CreateExecutionRequest child_requests = 5;
     repeated CapturedBacktrace backtraces = 6;
   }
+  message AppendBatchWithDelayResponse {
+    repeated ExecutionEvent events = 1;
+    ExecutionId execution_id = 2;
+    uint32 version = 3;
+    JoinSetId join_set_id = 4;
+    string delay_id = 5;
+    repeated CapturedBacktrace backtraces = 6;
+  }
   message AppendStubResponse {
     ExecutionId execution_id = 1;
     uint32 version = 2;
@@ -900,6 +908,7 @@ message CapturedWrite {
     AppendBatchCreateNewExecution append_batch_create_new_execution = 3;
     AppendStubResponse append_stub_response = 4;
     AppendFinished append_finished = 5;
+    AppendBatchWithDelayResponse append_batch_with_delay_response = 6;
   }
 }
 

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -998,7 +998,12 @@ fn pause_delays_in_replay(advance_request: &mut AdvanceRequestSer) {
             | crate::server::web_api_server::CapturedWriteSer::AppendStubResponse {
                 events, ..
             } => pause_delays_in_events(events),
-            crate::server::web_api_server::CapturedWriteSer::AppendFinished { .. } => {}
+            // An already-due `sleep(now)` is resolved in the same transaction; there is
+            // no pending delay to pause.
+            crate::server::web_api_server::CapturedWriteSer::AppendBatchWithDelayResponse {
+                ..
+            }
+            | crate::server::web_api_server::CapturedWriteSer::AppendFinished { .. } => {}
         }
     }
 }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1675,6 +1675,16 @@ pub(crate) enum CapturedWriteSer {
         child_requests: Vec<CreateRequestSer>,
         backtraces: Vec<backtrace::BacktraceInfoSer>,
     },
+    AppendBatchWithDelayResponse {
+        #[schema(value_type = Vec<Object>)]
+        events: Vec<concepts::storage::AppendRequest>,
+        execution_id: String,
+        version: u32,
+        join_set_id: String,
+        delay_id: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        backtraces: Vec<backtrace::BacktraceInfoSer>,
+    },
     AppendStubResponse {
         execution_id: String,
         version: u32,
@@ -1741,6 +1751,25 @@ impl From<concepts::storage::CapturedDbWrite> for CapturedWriteSer {
                 execution_id: execution_id.to_string(),
                 version: version.0,
                 child_requests: child_req.into_iter().map(CreateRequestSer::from).collect(),
+                backtraces: backtraces
+                    .into_iter()
+                    .map(backtrace::BacktraceInfoSer::from)
+                    .collect(),
+            },
+            CapturedDbWrite::AppendBatchWithDelayResponse {
+                current_time: _,
+                batch,
+                execution_id,
+                version,
+                join_set_id,
+                delay_id,
+                backtraces,
+            } => CapturedWriteSer::AppendBatchWithDelayResponse {
+                events: batch,
+                execution_id: execution_id.to_string(),
+                version: version.0,
+                join_set_id: join_set_id.to_string(),
+                delay_id: delay_id.to_string(),
                 backtraces: backtraces
                     .into_iter()
                     .map(backtrace::BacktraceInfoSer::from)
@@ -1833,6 +1862,31 @@ impl TryFrom<CapturedWriteSer> for concepts::storage::CapturedDbWrite {
                     .into_iter()
                     .map(concepts::storage::CreateRequest::try_from)
                     .collect::<Result<Vec<_>, _>>()?,
+                backtraces: backtraces
+                    .into_iter()
+                    .map(concepts::storage::BacktraceInfo::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            }),
+            CapturedWriteSer::AppendBatchWithDelayResponse {
+                events,
+                execution_id,
+                version,
+                join_set_id,
+                delay_id,
+                backtraces,
+            } => Ok(Self::AppendBatchWithDelayResponse {
+                current_time: DateTime::UNIX_EPOCH, // will be replaced in `advance`
+                batch: events,
+                execution_id: execution_id
+                    .parse()
+                    .map_err(|err| format!("invalid execution_id - {err}"))?,
+                version: Version::new(version),
+                join_set_id: join_set_id
+                    .parse()
+                    .map_err(|err| format!("invalid join_set_id - {err}"))?,
+                delay_id: delay_id
+                    .parse()
+                    .map_err(|err| format!("invalid delay_id - {err}"))?,
                 backtraces: backtraces
                     .into_iter()
                     .map(concepts::storage::BacktraceInfo::try_from)


### PR DESCRIPTION
An already-due one-off delay (e.g. `sleep(now)`) previously persisted a
JoinSet/DelayRequest/JoinNext batch, suspended the workflow, and waited for
the expired-timers watcher (default 200ms tick) to append the delay response
before re-scheduling and replaying.

Append the `DelayFinished` response in the same transaction as the batch when
the delay is already due (`expires_at_if_new <= called_at`). This unblocks the
JoinNext immediately: in Await mode the workflow finishes the sleep in a single
tick, and in Interrupt mode it is left pending (re-picked at once) rather than
blocked. The response's existing t_delay delete removes the row the
DelayRequest inserted, so the watcher is not involved.

Only the blocking one-off sleep path is affected; `submitDelay` is unchanged.
Replay is unaffected: the append path runs only on first execution, and the
persisted event/response shapes are identical to the watcher-produced ones, so
old in-flight sleeps still drain through the unchanged watcher and t_delay.

Adds `DbConnection::append_batch_with_delay_response` (sqlite + postgres),
plumbed through the caching and replay workflow db connections, plus a new
`CapturedDbWrite::AppendBatchWithDelayResponse` captured-write variant with its
gRPC and web-API serialization.
