### PR TITLE
fix: Send `ExecutorClosing` when `subscribe_to_next_responses` signals

### DIFF
--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -2566,12 +2566,15 @@ async fn append(
 
         ExecutionRequest::Unlocked(unlocked) => {
             match &combined_state.execution_with_state.pending_state {
-                PendingState::PendingAt(_) => {
+                PendingState::PendingAt(pending_at)
+                    if unlocked.unlocked_at >= pending_at.scheduled_at =>
+                // proposed unlock is equal or later than pending_at, no need to write it.
+                {
                     return Err(DbErrorWrite::NonRetriable(
                         DbErrorWriteNonRetriable::UnlockedCannotBeAppended("pending"),
                     ));
                 }
-                PendingState::Locked(_) => {
+                PendingState::Locked(_) | PendingState::PendingAt(_) => {
                     let (next_version, notifier) = update_state_unlocked_from_locked(
                         tx,
                         execution_id,

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -2270,12 +2270,15 @@ impl SqlitePool {
 
             ExecutionRequest::Unlocked(unlocked) => {
                 match &combined_state.execution_with_state.pending_state {
-                    PendingState::PendingAt(_) => {
+                    PendingState::PendingAt(pending_at)
+                        if unlocked.unlocked_at >= pending_at.scheduled_at =>
+                    // proposed unlock is equal or later than pending_at, no need to write it.
+                    {
                         return Err(DbErrorWrite::NonRetriable(
                             DbErrorWriteNonRetriable::UnlockedCannotBeAppended("pending"),
                         ));
                     }
-                    PendingState::Locked(_) => {
+                    PendingState::Locked(_) | PendingState::PendingAt(_) => {
                         let (next_version, notifier) =
                             Self::update_state_pending_after_event_appended(
                                 tx,

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -549,6 +549,7 @@ impl ExecTask {
                             executor_close_watcher
                         )
                         .await;
+                        debug!("run_worker finished with {res:?}");
                         if let Err(db_error) = res {
                             error!("Got db error `{db_error:?}`, expecting watcher to mark execution as timed out");
                         }
@@ -639,7 +640,7 @@ impl ExecTask {
             unlock_expiry_on_limit_reached,
         )? {
             Some(append) => {
-                trace!("Appending {append:?}");
+                debug!("Appending {append:?}");
                 let db_exec = db_pool.db_exec_conn().await?;
                 append.append(db_exec.as_ref()).await
             }
@@ -984,22 +985,24 @@ impl Append {
 
             db_exec
                 .append_batch_respond_to_parent(events, response, self.created_at)
-                .await?;
+                .await
+                .map(|_| ())
         } else {
             let res = db_exec
                 .append(self.execution_id, self.version, self.primary_event)
                 .await;
             match res {
-                Ok(_)
-                | Err(DbErrorWrite::NonRetriable(
-                    DbErrorWriteNonRetriable::UnlockedCannotBeAppended(_),
+                Ok(_) => Ok(()),
+                Err(DbErrorWrite::NonRetriable(
+                    DbErrorWriteNonRetriable::UnlockedCannotBeAppended(reason),
                 )) => {
                     // Ignore unsuccessful `Unlocked`
+                    debug!("Ignoring unlock failed - {reason}");
+                    Ok(())
                 }
-                Err(err) => return Err(err),
+                Err(err) => Err(err),
             }
         }
-        Ok(())
     }
 }
 

--- a/crates/executor/src/expired_timers_watcher.rs
+++ b/crates/executor/src/expired_timers_watcher.rs
@@ -21,6 +21,7 @@ use std::{sync::Arc, time::Duration};
 use tracing::Instrument;
 use tracing::Level;
 use tracing::info_span;
+use tracing::trace;
 use tracing::warn;
 use tracing::{debug, info, instrument};
 
@@ -188,7 +189,7 @@ pub(crate) async fn tick(
                 join_set_id,
                 delay_id,
             }) => {
-                debug!(%execution_id, %join_set_id, %delay_id, created_at = %executed_at, "Appending delay response");
+                trace!(%execution_id, %join_set_id, %delay_id, created_at = %executed_at, "Appending delay response");
                 let res = db_connection
                     .append_delay_response(
                         executed_at,

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -30,7 +30,7 @@ pub type WorkerResult = Result<WorkerResultOk, WorkerError>;
 
 #[derive(Debug, derive_more::Display)]
 pub enum WorkerResultOk {
-    #[display("db updated by worker or watcher")]
+    #[display("db updated, not finished")]
     DbUpdatedByWorkerOrWatcher,
     /// The execution run has returned a valid `retval`. Activity with retry budget returning `err` will be retried by the executor.
     #[display("{_0}")]
@@ -38,7 +38,7 @@ pub enum WorkerResultOk {
 }
 
 #[derive(Debug, derive_more::Display)]
-#[display("{retval}")]
+#[display("finished at v{version}")]
 pub struct RunFinished {
     pub retval: SupportedFunctionReturnValue,
     pub version: Version,

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -370,7 +370,7 @@ impl EventHistory {
         match self.deadline_tracker.check_preempt() {
             Ok(()) => {}
             Err(PreemptRequested::ExecutorClosing) => {
-                info!("Executor closing detected in host function call");
+                info!("Executor closing detected in check_preempt");
                 return Err(ApplyError::ExecutorClosing);
             }
         }

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -628,8 +628,8 @@ impl EventHistory {
                         // if this was caused by `subscription_interruption` or deadline.
                     }
                     Err(DbErrorReadWithTimeout::Timeout(TimeoutOutcome::Cancel)) => {
-                        debug!("Executor is closing");
-                        return Err(ApplyError::InterruptDbUpdated);
+                        info!("Executor is closing detected in subscribe_to_next_responses");
+                        return Err(ApplyError::ExecutorClosing);
                     }
                 }
             }

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -1640,12 +1640,12 @@ impl Worker for WorkflowWorker {
         .await;
         worker_span.in_scope(|| match res {
             Ok((Either::Left(ok), _)) => {
-                info!("Execution run finished");
+                info!("Workflow run finished: {ok}");
                 WorkerResult::Ok(ok)
             }
             Ok((Either::Right(_), _)) => unreachable!("not replaying"),
             Err(workflow_err) => {
-                info!("Execution run finished with an error");
+                info!("Workflow run finished with error: {workflow_err}");
                 WorkerResult::Err(WorkerError::from(workflow_err))
             }
         })


### PR DESCRIPTION
- **fix: Send `ExecutorClosing` when `subscribe_to_next_responses` signals**
- **logging: Print unlock failed reason**
- **fix(db): Allow unlocking `pending` if unlocked_at is before pending_at**
