### PR TITLE
feat(toml): Add `max_replay_captured_writes` to server config

### DIFF
--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -713,6 +713,13 @@
             }
           ],
           "default": null
+        },
+        "max_replay_captured_writes": {
+          "description": "Maximum number of captured writes a single replay pass returns. On reaching it, replay\nstops and returns that many writes as an advanceable prefix; advancing them and replaying\nagain resumes from the persisted tip. Keeps a non-terminating workflow (e.g. an unresolved\n`joinNextTry` poll loop, whose replay never blocks) advanceable in bounded batches instead\nof collecting captured writes forever.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "default": 100
         }
       },
       "additionalProperties": false

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -200,6 +200,7 @@ mod bench {
                     fuel: None,
                     lock_extension: None,
                     subscription_interruption: None,
+                    max_replay_captured_writes: None,
                 },
                 workflow_engine,
                 clock_fn.clone_box(),

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -200,7 +200,6 @@ mod bench {
                     mode: WorkflowConfigMode::Real {
                         join_next_blocking_strategy,
                         lock_extension: None,
-                        subscription_interruption: None,
                     },
                 },
                 workflow_engine,
@@ -304,6 +303,7 @@ mod bench {
             Now.clone_box(),
             JoinNextBlockingStrategy::Await {
                 non_blocking_event_batching: DEFAULT_NON_BLOCKING_EVENT_BATCHING,
+                subscription_interruption: None,
             },
             &fn_registry,
             engines.workflow_engine.clone(),

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -32,7 +32,7 @@ mod bench {
     use wasm_workers::workflow::deadline_tracker::DeadlineTrackerFactoryTokio;
     use wasm_workers::workflow::workflow_worker::{
         DEFAULT_NON_BLOCKING_EVENT_BATCHING, JoinNextBlockingStrategy, WorkflowConfig,
-        WorkflowWorkerCompiled,
+        WorkflowConfigMode, WorkflowWorkerCompiled,
     };
     use wasmtime::Engine;
 
@@ -195,12 +195,13 @@ mod bench {
                     .unwrap(),
                 WorkflowConfig {
                     component_id: component_id.clone(),
-                    join_next_blocking_strategy,
                     stub_wasi: false,
                     fuel: None,
-                    lock_extension: None,
-                    subscription_interruption: None,
-                    max_replay_captured_writes: None,
+                    mode: WorkflowConfigMode::Real {
+                        join_next_blocking_strategy,
+                        lock_extension: None,
+                        subscription_interruption: None,
+                    },
                 },
                 workflow_engine,
                 clock_fn.clone_box(),

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -50,7 +50,7 @@ pub struct ExecTask {
     db_pool: Arc<dyn DbPool>,
     locking_strategy_holder: LockingStrategyHolder,
     worker_count_tx: tokio::sync::watch::Sender<usize>,
-    executor_close_watcher: tokio::sync::watch::Receiver<bool>,
+    execution_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
 }
 
 #[derive(derive_more::Debug, Default)]
@@ -89,7 +89,7 @@ pub struct ExecutorTaskHandle {
     executor_id: ExecutorId,
     deployment_id: DeploymentId,
     // Signals close() -> workers to shut down
-    executor_closing_signal_sender: tokio::sync::watch::Sender<bool>,
+    execution_interrupt_sender: tokio::sync::watch::Sender<bool>,
     /// Tracks the number of worker tasks currently in-flight.
     worker_count_rx: tokio::sync::watch::Receiver<usize>,
 }
@@ -99,7 +99,7 @@ pub struct WorkerTasksHandle {
     executor_id: ExecutorId,
     deployment_id: DeploymentId,
     // Signals close() -> workers to shut down
-    executor_closing_signal_sender: tokio::sync::watch::Sender<bool>,
+    execution_interrupt_sender: tokio::sync::watch::Sender<bool>,
     /// Tracks the number of worker tasks currently in-flight.
     worker_count_rx: tokio::sync::watch::Receiver<usize>,
 }
@@ -128,7 +128,7 @@ impl ExecutorTaskHandle {
             component_id: self.component_id,
             executor_id: self.executor_id,
             deployment_id: self.deployment_id,
-            executor_closing_signal_sender: self.executor_closing_signal_sender,
+            execution_interrupt_sender: self.execution_interrupt_sender,
             worker_count_rx: self.worker_count_rx,
         }
     }
@@ -145,7 +145,7 @@ impl WorkerTasksHandle {
         deployment_id = %self.deployment_id))]
     pub async fn close(self) {
         debug!("Signaling worker tasks to unlock");
-        let _ = self.executor_closing_signal_sender.send(true);
+        let _ = self.execution_interrupt_sender.send(true);
         let mut worker_count_rx = self.worker_count_rx.clone();
         loop {
             tokio::select! {
@@ -213,7 +213,7 @@ impl ExecTask {
         ffqns: Arc<[FunctionFqn]>,
     ) -> (Self, tokio::sync::watch::Sender<bool>) {
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
-        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (close_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         (
             ExecTask {
                 worker,
@@ -222,7 +222,7 @@ impl ExecTask {
                 clock_fn,
                 db_pool,
                 worker_count_tx,
-                executor_close_watcher,
+                execution_interrupt_watcher,
             },
             close_tx,
         )
@@ -237,7 +237,7 @@ impl ExecTask {
     ) -> (Self, tokio::sync::watch::Sender<bool>) {
         let ffqns = extract_exported_ffqns_noext(worker.as_ref());
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
-        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (close_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         (
             Self {
                 worker,
@@ -246,19 +246,19 @@ impl ExecTask {
                 clock_fn,
                 db_pool,
                 worker_count_tx,
-                executor_close_watcher,
+                execution_interrupt_watcher,
             },
             close_tx,
         )
     }
 
     #[cfg(feature = "test")]
-    pub fn new_all_ffqns_test_with_close_watcher(
+    pub fn new_all_ffqns_test_with_interrupt_watcher(
         worker: Arc<dyn Worker>,
         config: ExecConfig,
         clock_fn: Box<dyn ClockFn>,
         db_pool: Arc<dyn DbPool>,
-        executor_close_watcher: tokio::sync::watch::Receiver<bool>,
+        execution_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
     ) -> Self {
         let ffqns = extract_exported_ffqns_noext(worker.as_ref());
         let (worker_count_tx, _) = tokio::sync::watch::channel(0usize);
@@ -269,7 +269,7 @@ impl ExecTask {
             clock_fn,
             db_pool,
             worker_count_tx,
-            executor_close_watcher,
+            execution_interrupt_watcher,
         }
     }
 
@@ -288,7 +288,7 @@ impl ExecTask {
         let component_id = config.component_id.clone();
         let executor_id = config.executor_id;
         let (worker_count_tx, worker_count_rx) = tokio::sync::watch::channel(0);
-        let (executor_closing_signal_sender, executor_close_watcher) =
+        let (execution_interrupt_sender, execution_interrupt_watcher) =
             tokio::sync::watch::channel(false);
         let join_handle = tokio::spawn(async move {
             debug!(executor_id = %config.executor_id, component_id = %config.component_id, "Spawned executor");
@@ -300,7 +300,7 @@ impl ExecTask {
                 locking_strategy_holder: lock_strategy_holder,
                 clock_fn: clock_fn.clone_box(),
                 worker_count_tx,
-                executor_close_watcher,
+                execution_interrupt_watcher,
             };
             let mut old_err = None;
             while !is_closing_inner.load(Ordering::Relaxed) {
@@ -361,7 +361,7 @@ impl ExecTask {
             component_id,
             executor_id,
             deployment_id,
-            executor_closing_signal_sender,
+            execution_interrupt_sender,
             worker_count_rx,
         }
     }
@@ -532,7 +532,7 @@ impl ExecTask {
                 let component_type = self.config.component_id.component_type;
                 let worker_count_tx = self.worker_count_tx.clone();
                 worker_count_tx.send_modify(|n| *n += 1);
-                let executor_close_watcher = self.executor_close_watcher.clone();
+                let execution_interrupt_watcher = self.execution_interrupt_watcher.clone();
                 tokio::spawn({
                     let worker_span2 = worker_span.clone();
                     let retry_config = self.config.retry_config;
@@ -546,7 +546,7 @@ impl ExecTask {
                             locked_execution,
                             retry_config,
                             worker_span2,
-                            executor_close_watcher
+                            execution_interrupt_watcher
                         )
                         .await;
                         debug!("run_worker finished with {res:?}");
@@ -572,7 +572,7 @@ impl ExecTask {
         locked_execution: LockedExecution,
         retry_config: ComponentRetryConfig,
         worker_span: Span,
-        executor_close_watcher: tokio::sync::watch::Receiver<bool>,
+        execution_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
     ) -> Result<(), DbErrorWrite> {
         debug!("Worker::run starting");
         trace!(
@@ -606,7 +606,7 @@ impl ExecTask {
             can_be_retried: can_be_retried.is_some(),
             locked_event: locked_execution.locked_event,
             worker_span,
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
         let worker_result = worker.run(ctx).await;
         debug!("Worker::run finished {worker_result:?}");
@@ -777,10 +777,10 @@ impl ExecTask {
                 let reason_generic = err.to_string(); // Override with err's reason if no information is lost.
 
                 let (primary_event, child_finished, version) = match err {
-                    WorkerError::ExecutorClosing(version) => {
+                    WorkerError::ExecutionInterrupt(version) => {
                         let primary_event = ExecutionRequest::Unlocked(Unlocked {
                             unlocked_at: result_obtained_at,
-                            reason: "executor closing".into(),
+                            reason: "execution interrupt".into(),
                         });
                         (primary_event, None, version)
                     }

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -59,7 +59,7 @@ pub struct WorkerContext {
     pub can_be_retried: bool,
     pub worker_span: Span,
     pub locked_event: Locked,
-    pub executor_close_watcher: tokio::sync::watch::Receiver<bool>,
+    pub execution_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -85,8 +85,8 @@ pub enum WorkerError {
         http_client_traces: Option<Vec<HttpClientTrace>>,
         version: Version,
     },
-    #[error("executor closing")]
-    ExecutorClosing(Version),
+    #[error("execution interrupt")]
+    ExecutionInterrupt(Version),
     #[error(transparent)]
     DbError(DbErrorWrite),
     // non-retriable errors

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -1839,7 +1839,7 @@ async fn append_unlocked_to_blocked_execution_updates_lock_expiry(database: Data
         .await
         .unwrap();
 
-    // The executor is closing, so it unlocks the blocked execution: the state stays
+    // The execution is interrupted, so it unlocks the blocked execution: the state stays
     // blocked but `lock_expires_at` drops to the unlock time, releasing the warm lease.
     let unlocked_at = sim_clock.now();
     db_connection
@@ -1850,7 +1850,7 @@ async fn append_unlocked_to_blocked_execution_updates_lock_expiry(database: Data
                 created_at: unlocked_at,
                 event: ExecutionRequest::Unlocked(Unlocked {
                     unlocked_at,
-                    reason: "executor closing".into(),
+                    reason: "execution interrupt".into(),
                 }),
             },
         )

--- a/crates/testing/test-programs/js/workflow/stub_join_next_try_loop.js
+++ b/crates/testing/test-programs/js/workflow/stub_join_next_try_loop.js
@@ -1,0 +1,16 @@
+// Submit a stub whose result is never injected, then poll forever with
+// joinNextTry(). The response stays pending, so joinNextTry() returns undefined
+// on every iteration and the workflow never terminates.
+import { myStubSubmit } from 'testing:integration-obelisk-ext/stubs';
+
+export default function stub_join_next_try_loop(id) {
+    const js = obelisk.createJoinSet();
+    myStubSubmit(js, id);
+    for (;;) {
+        const result = js.joinNextTry();
+        if (result !== undefined) {
+            throw `stub result was injected unexpectedly: ${JSON.stringify(result)}`;
+        }
+        // obelisk.sleep({ seconds: 1 });
+    }
+}

--- a/crates/wasm-workers/src/activity/activity_js_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_js_worker.rs
@@ -555,7 +555,7 @@ mod tests {
             COMPONENT_DIGEST_DUMMY,
         )
         .unwrap();
-        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (close_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: ExecutionMetadata::empty(),
@@ -576,7 +576,7 @@ mod tests {
                 lock_expires_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::seconds(60),
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
         (ctx, close_tx)
     }
@@ -591,7 +591,7 @@ mod tests {
             COMPONENT_DIGEST_DUMMY,
         )
         .unwrap();
-        let (close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (close_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: ExecutionMetadata::empty(),
@@ -612,7 +612,7 @@ mod tests {
                 lock_expires_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::seconds(60),
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
         (ctx, close_tx)
     }

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -1236,7 +1236,8 @@ pub(crate) mod tests {
 
         let executed_at = sim_clock.now();
         let version = Version::new(10);
-        let (_execution_interrupt_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
+        let (_execution_interrupt_tx, execution_interrupt_watcher) =
+            tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: concepts::ExecutionMetadata::empty(),
@@ -1294,7 +1295,8 @@ pub(crate) mod tests {
         let execution_deadline = sim_clock.now();
         sim_clock.move_time_forward(Duration::from_millis(100));
         let version = Version::new(10);
-        let (_execution_interrupt_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
+        let (_execution_interrupt_tx, execution_interrupt_watcher) =
+            tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: concepts::ExecutionMetadata::empty(),

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -197,7 +197,7 @@ impl Worker for ActivityWorker {
         let interrupt_token = self
             .cancel_registry
             .activity_obtain_interrupt_token(ctx.execution_id.clone());
-        let mut executor_close_watcher = ctx.executor_close_watcher.clone();
+        let mut execution_interrupt_watcher = ctx.execution_interrupt_watcher.clone();
 
         let (mut store, deadline_duration) = match self.create_store(ctx, started_at) {
             Ok(store) => store,
@@ -226,8 +226,8 @@ impl Worker for ActivityWorker {
                         Ok(worker_res_ok) => {
                             info!(duration = ?stopwatch_for_reporting.elapsed(), "Run finished: {worker_res_ok}");
                         }
-                        Err(WorkerError::ExecutorClosing(_)) => {
-                            info!("Executor closing");
+                        Err(WorkerError::ExecutionInterrupt(_)) => {
+                            info!("Execution interrupted");
                         }
                         Err(err) => {
                             info!(%err, duration = ?stopwatch_for_reporting.elapsed(), "Run finished with an error");
@@ -263,10 +263,10 @@ impl Worker for ActivityWorker {
                 debug!("Activity run interrupted, finalizing cancellation after dropping store");
                 return WorkerResult::Err(WorkerError::FatalError(FatalError::Cancelled, version));
             }
-            _ = executor_close_watcher.changed() => {
-                debug!("Executor is closing");
+            _ = execution_interrupt_watcher.changed() => {
+                debug!("Execution interrupted");
                 // Executor will append the Unlocked event.
-                return WorkerResult::Err(WorkerError::ExecutorClosing(version.clone()))
+                return WorkerResult::Err(WorkerError::ExecutionInterrupt(version.clone()))
             }
         }
     }
@@ -1061,7 +1061,7 @@ pub(crate) mod tests {
                 let fibo_worker = fibo_worker.clone();
                 let sim_clock = sim_clock.clone();
                 let execution_id = ExecutionId::generate();
-                let (executor_close_tx, executor_close_watcher) =
+                let (execution_interrupt_tx, execution_interrupt_watcher) =
                     tokio::sync::watch::channel(false);
                 let ctx = WorkerContext {
                     execution_id: execution_id.clone(),
@@ -1083,11 +1083,11 @@ pub(crate) mod tests {
                         lock_expires_at: sim_clock.now() + lock_expiry,
                         retry_config: ComponentRetryConfig::ZERO,
                     },
-                    executor_close_watcher,
+                    execution_interrupt_watcher,
                 };
                 tokio::spawn(async move {
                     let res = fibo_worker.run(ctx).await;
-                    drop(executor_close_tx);
+                    drop(execution_interrupt_tx);
                     res
                 })
             })
@@ -1236,7 +1236,7 @@ pub(crate) mod tests {
 
         let executed_at = sim_clock.now();
         let version = Version::new(10);
-        let (_executor_close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (_execution_interrupt_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: concepts::ExecutionMetadata::empty(),
@@ -1261,7 +1261,7 @@ pub(crate) mod tests {
                 lock_expires_at: executed_at + TIMEOUT,
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
         let WorkerResult::Err(err) = worker.run(ctx).await else {
             panic!()
@@ -1294,7 +1294,7 @@ pub(crate) mod tests {
         let execution_deadline = sim_clock.now();
         sim_clock.move_time_forward(Duration::from_millis(100));
         let version = Version::new(10);
-        let (_executor_close_tx, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (_execution_interrupt_tx, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         let ctx = WorkerContext {
             execution_id: ExecutionId::generate(),
             metadata: concepts::ExecutionMetadata::empty(),
@@ -1319,7 +1319,7 @@ pub(crate) mod tests {
                 lock_expires_at: execution_deadline,
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
         let WorkerResult::Err(err) = worker.run(ctx).await else {
             panic!()

--- a/crates/wasm-workers/src/cron/cron_worker.rs
+++ b/crates/wasm-workers/src/cron/cron_worker.rs
@@ -246,7 +246,7 @@ mod tests {
             can_be_retried: false,
             worker_span: tracing::info_span!("schedule_test"),
             locked_event,
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
         }
     }
 

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -123,6 +123,10 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
         &mut self,
         current_time: DateTime<Utc>,
     ) -> Result<(), DbErrorWrite>;
+
+    fn captured_writes_collected(&self) -> Option<usize> {
+        None
+    }
 }
 
 pub(crate) struct CachingDbConnection {

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -223,6 +223,7 @@ impl CachingBuffer {
         let non_blocking_event_batch_size = match join_next_blocking_strategy {
             JoinNextBlockingStrategy::Await {
                 non_blocking_event_batching,
+                subscription_interruption: _,
             } => non_blocking_event_batching as usize,
             JoinNextBlockingStrategy::Interrupt => 0,
         };

--- a/crates/wasm-workers/src/workflow/deadline_tracker.rs
+++ b/crates/wasm-workers/src/workflow/deadline_tracker.rs
@@ -7,7 +7,7 @@ use tracing::{trace, warn};
 
 #[async_trait]
 pub trait DeadlineTracker: Send + Sync {
-    /// Host functions must check whether the executor is closing.
+    /// Host functions must check whether the execution was interrupted.
     fn check_preempt(&self) -> Result<(), PreemptRequested>;
 
     /// Called after the workflow made progress and is now blocked waiting for a response.
@@ -29,15 +29,15 @@ pub trait DeadlineTracker: Send + Sync {
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum PreemptRequested {
-    #[error("executor is closing")]
-    ExecutorClosing,
+    #[error("execution interrupt")]
+    ExecutionInterrupt,
 }
 
 pub trait DeadlineTrackerFactory: Send + Sync {
     fn create(
         &self,
         lock_expires_at: DateTime<Utc>,
-        unlock_executor_close_watcher: watch::Receiver<bool>,
+        unlock_execution_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired>;
 
     /// True iff this factory produces trackers that never expire the lock.
@@ -57,8 +57,8 @@ pub struct LockAlreadyExpired {
 pub enum EpochCallbackError {
     #[error("lock expired")]
     LockExpired,
-    #[error("executor is closing")]
-    ExecutorClosing,
+    #[error("execution interrupt")]
+    ExecutionInterrupt,
 }
 
 pub(crate) struct DeadlineTrackerTokio {
@@ -66,15 +66,15 @@ pub(crate) struct DeadlineTrackerTokio {
     pub(crate) deadline_minus_leeway: tokio::time::Instant, // Tracked as instant because calling track happens later after creation.
     pub(crate) clock_fn: Box<dyn ClockFn>,
     pub(crate) leeway: Duration, // Fire this much sooner than requested.
-    executor_close_watcher: watch::Receiver<bool>,
+    execution_interrupt_watcher: watch::Receiver<bool>,
 }
 
 #[async_trait]
 impl DeadlineTracker for DeadlineTrackerTokio {
     fn check_preempt(&self) -> Result<(), PreemptRequested> {
-        let executor_closing = *self.executor_close_watcher.borrow();
-        if executor_closing {
-            Err(PreemptRequested::ExecutorClosing)
+        let interrupt_requested = *self.execution_interrupt_watcher.borrow();
+        if interrupt_requested {
+            Err(PreemptRequested::ExecutionInterrupt)
         } else {
             Ok(())
         }
@@ -86,7 +86,7 @@ impl DeadlineTracker for DeadlineTrackerTokio {
     ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TimeoutOutcome> {
         if self.deadline <= tokio::time::Instant::now() {
             Err(TimeoutOutcome::Timeout)
-        } else if *self.executor_close_watcher.borrow() {
+        } else if *self.execution_interrupt_watcher.borrow() {
             Err(TimeoutOutcome::Cancel)
         } else {
             let expiry = if let Some(max_duration) = max_duration {
@@ -95,11 +95,11 @@ impl DeadlineTracker for DeadlineTrackerTokio {
             } else {
                 self.deadline_minus_leeway
             };
-            let mut executor_close_watcher = self.executor_close_watcher.clone();
+            let mut execution_interrupt_watcher = self.execution_interrupt_watcher.clone();
             Ok(Box::pin(async move {
                 tokio::select! {
                     () = tokio::time::sleep_until(expiry) => TimeoutOutcome::Timeout,
-                    _ = executor_close_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
+                    _ = execution_interrupt_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
                 }
             }))
         }
@@ -110,9 +110,9 @@ impl DeadlineTracker for DeadlineTrackerTokio {
     }
 
     fn check_epoch_callback(&self) -> Result<(), EpochCallbackError> {
-        let executor_closing = *self.executor_close_watcher.borrow();
-        if executor_closing {
-            Err(EpochCallbackError::ExecutorClosing)
+        let interrupt_requested = *self.execution_interrupt_watcher.borrow();
+        if interrupt_requested {
+            Err(EpochCallbackError::ExecutionInterrupt)
         } else if self.deadline <= tokio::time::Instant::now() {
             Err(EpochCallbackError::LockExpired)
         } else {
@@ -161,7 +161,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactoryTokio {
     fn create(
         &self,
         lock_expires_at: DateTime<Utc>,
-        executor_close_watcher: watch::Receiver<bool>,
+        execution_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired> {
         let started_at = self.clock_fn.now();
         let Ok(deadline_duration) = (lock_expires_at - started_at).to_std() else {
@@ -183,7 +183,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactoryTokio {
             deadline_minus_leeway,
             clock_fn: self.clock_fn.clone_box(),
             leeway: self.leeway,
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
         Ok(Box::new(tracker))
     }
@@ -200,7 +200,7 @@ pub(crate) struct DeadlineTrackerSim {
     deadline_minus_leeway: DateTime<Utc>,
     leeway: Duration,
     clock: test_utils::sim_clock::SimClock,
-    executor_close_watcher: watch::Receiver<bool>,
+    execution_interrupt_watcher: watch::Receiver<bool>,
 }
 
 #[cfg(test)]
@@ -212,8 +212,8 @@ fn add_duration(time: DateTime<Utc>, duration: Duration) -> DateTime<Utc> {
 #[async_trait]
 impl DeadlineTracker for DeadlineTrackerSim {
     fn check_preempt(&self) -> Result<(), PreemptRequested> {
-        if *self.executor_close_watcher.borrow() {
-            Err(PreemptRequested::ExecutorClosing)
+        if *self.execution_interrupt_watcher.borrow() {
+            Err(PreemptRequested::ExecutionInterrupt)
         } else {
             Ok(())
         }
@@ -226,7 +226,7 @@ impl DeadlineTracker for DeadlineTrackerSim {
         let now = self.clock.now();
         if self.deadline <= now {
             return Err(TimeoutOutcome::Timeout);
-        } else if *self.executor_close_watcher.borrow() {
+        } else if *self.execution_interrupt_watcher.borrow() {
             return Err(TimeoutOutcome::Cancel);
         }
         let expiry = if let Some(max_duration) = max_duration {
@@ -238,7 +238,7 @@ impl DeadlineTracker for DeadlineTrackerSim {
         // Subscribe now, before the future is awaited, so time advances between
         // this call and the first poll are not missed.
         let mut time_watcher = self.clock.subscribe();
-        let mut executor_close_watcher = self.executor_close_watcher.clone();
+        let mut execution_interrupt_watcher = self.execution_interrupt_watcher.clone();
         Ok(Box::pin(async move {
             loop {
                 if clock.now() >= expiry {
@@ -249,7 +249,7 @@ impl DeadlineTracker for DeadlineTrackerSim {
                     res = time_watcher.changed() => if res.is_err() {
                         return TimeoutOutcome::Cancel;
                     },
-                    _ = executor_close_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
+                    _ = execution_interrupt_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
                 }
             }
         }))
@@ -260,8 +260,8 @@ impl DeadlineTracker for DeadlineTrackerSim {
     }
 
     fn check_epoch_callback(&self) -> Result<(), EpochCallbackError> {
-        if *self.executor_close_watcher.borrow() {
-            Err(EpochCallbackError::ExecutorClosing)
+        if *self.execution_interrupt_watcher.borrow() {
+            Err(EpochCallbackError::ExecutionInterrupt)
         } else if self.deadline <= self.clock.now() {
             Err(EpochCallbackError::LockExpired)
         } else {
@@ -297,7 +297,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactorySim {
     fn create(
         &self,
         lock_expires_at: DateTime<Utc>,
-        executor_close_watcher: watch::Receiver<bool>,
+        execution_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired> {
         let started_at = self.clock.now();
         let Ok(deadline_duration) = (lock_expires_at - started_at).to_std() else {
@@ -315,7 +315,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactorySim {
             deadline_minus_leeway,
             leeway: self.leeway,
             clock: self.clock.clone(),
-            executor_close_watcher,
+            execution_interrupt_watcher,
         }))
     }
 }
@@ -337,7 +337,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactoryForReplay {
     fn create(
         &self,
         _lock_expires_at: DateTime<Utc>,
-        _executor_close_watcher: watch::Receiver<bool>,
+        _execution_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired> {
         Ok(Box::new(DeadlineTrackerFactoryForReplay {}))
     }

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -171,6 +171,9 @@ pub(crate) struct EventHistory {
     last_oneoff_id: Option<JoinSetResponseId>,
     // Last one-off child execution (call-json / direct call), for `last-direct-call-id`.
     last_direct_call_id: Option<ExecutionIdDerived>,
+
+    // Upper bound on captured writes a replay pass may collect. `None` outside replay.
+    max_replay_captured_writes: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -223,6 +226,7 @@ impl EventHistory {
         subscription_interruption: Option<Duration>,
         worker_span: Span,
         replaying_unfinished_execution: bool,
+        max_replay_captured_writes: Option<usize>,
     ) -> EventHistory {
         EventHistory {
             replaying_unfinished_execution,
@@ -250,6 +254,7 @@ impl EventHistory {
             last_response_by_join_set: HashMap::default(),
             last_oneoff_id: None,
             last_direct_call_id: None,
+            max_replay_captured_writes,
         }
     }
 
@@ -394,6 +399,19 @@ impl EventHistory {
         called_at: DateTime<Utc>,
     ) -> Result<ChildReturnValue, ApplyError> {
         debug!("applying {event_call:?}");
+
+        // A non-terminating workflow (e.g. a `joinNextTry` busy loop on a response that is never
+        // injected) would collect captured writes forever during replay, since the replay deadline
+        // never expires the lock. Once the collection hits the bound, interrupt replay so the writes
+        // gathered so far are returned as an advanceable prefix; advancing them and replaying again
+        // resumes collection from the persisted tip, stepping the workflow forward N writes at a time.
+        if let Some(max) = self.max_replay_captured_writes
+            && let Some(collected) = db_connection.captured_writes_collected()
+            && collected >= max
+        {
+            debug!("Reached replay captured-write limit of {max}, interrupting replay");
+            return Err(ApplyError::ReplayInterrupt);
+        }
 
         let wasm_backtrace = event_call.wasm_backtrace().cloned();
         match self.find_matching_atomic(&event_call)? {
@@ -4546,6 +4564,7 @@ mod tests {
             None, // subscription_interruption
             info_span!("worker-test"),
             false, // replaying_unfinished_execution
+            None,  // max_replay_captured_writes
         );
 
         (

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -3592,6 +3592,7 @@ mod tests {
                 deadline_tracker_factory_test(&sim_clock),
                 JoinNextBlockingStrategy::Await {
                     non_blocking_event_batching: 100,
+                    subscription_interruption: None,
                 },
                 TestingFnRegistry::new_from_components(vec![]),
             )
@@ -3637,7 +3638,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn regular_join_next_child(
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0}, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 100})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None }, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 100, subscription_interruption: None })]
         second_run_strategy: JoinNextBlockingStrategy,
     ) {
         test_utils::set_up();
@@ -3744,7 +3745,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn start_async_respond_then_join_next(
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0}, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 10})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None }, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 10, subscription_interruption: None })]
         join_next_blocking_strategy: JoinNextBlockingStrategy,
     ) {
         const CHILD_RESP: SupportedFunctionReturnValue =
@@ -4166,6 +4167,7 @@ mod tests {
                     deadline_tracker_factory_test(&sim_clock),
                     JoinNextBlockingStrategy::Await {
                         non_blocking_event_batching: 0,
+                        subscription_interruption: None,
                     },
                     fn_registry.clone(),
                 )
@@ -4267,6 +4269,7 @@ mod tests {
                     deadline_tracker_factory_test(&sim_clock),
                     JoinNextBlockingStrategy::Await {
                         non_blocking_event_batching: 0,
+                        subscription_interruption: None,
                     },
                     fn_registry.clone(),
                 )
@@ -4324,6 +4327,7 @@ mod tests {
                     deadline_tracker_factory_test(&sim_clock),
                     JoinNextBlockingStrategy::Await {
                         non_blocking_event_batching: 0,
+                        subscription_interruption: None,
                     },
                     fn_registry.clone(),
                 )
@@ -4365,7 +4369,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn trimmed_second_execution_should_result_in_nondeterminism_detected(
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0}, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 100})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None }, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 100, subscription_interruption: None })]
         second_run_strategy: JoinNextBlockingStrategy,
     ) {
         test_utils::set_up();

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -104,8 +104,8 @@ pub(crate) enum ApplyError {
     DbError(#[from] DbErrorWrite),
     #[error("constraint violation: {0}")]
     ConstraintViolation(StrVariant),
-    #[error("executor closing")]
-    ExecutorClosing,
+    #[error("execution interrupt")]
+    ExecutionInterrupt,
     #[error("replay interrupt")]
     ReplayInterrupt,
 }
@@ -374,9 +374,9 @@ impl EventHistory {
     ) -> Result<ChildReturnValue, ApplyError> {
         match self.deadline_tracker.check_preempt() {
             Ok(()) => {}
-            Err(PreemptRequested::ExecutorClosing) => {
-                info!("Executor closing detected in check_preempt");
-                return Err(ApplyError::ExecutorClosing);
+            Err(PreemptRequested::ExecutionInterrupt) => {
+                info!("Execution interrupt detected in check_preempt");
+                return Err(ApplyError::ExecutionInterrupt);
             }
         }
 
@@ -602,7 +602,7 @@ impl EventHistory {
             let key = join_next_variant.as_key();
 
             // Subscribe to the next response.
-            // Break on `executor_close_watcher` or when timeout is reached.
+            // Break on `execution_interrupt_watcher` or when timeout is reached.
             while let Ok(timeout_fut) = self.deadline_tracker.track(self.subscription_interruption)
             {
                 let last_response = self
@@ -646,8 +646,8 @@ impl EventHistory {
                         // if this was caused by `subscription_interruption` or deadline.
                     }
                     Err(DbErrorReadWithTimeout::Timeout(TimeoutOutcome::Cancel)) => {
-                        info!("Executor is closing detected in subscribe_to_next_responses");
-                        return Err(ApplyError::ExecutorClosing);
+                        info!("Execution interrupt detected in subscribe_to_next_responses");
+                        return Err(ApplyError::ExecutionInterrupt);
                     }
                 }
             }

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -141,8 +141,8 @@ pub enum AdvanceError {
     // Errors from ReplayInternalError
     #[error("limit reached: {reason}")]
     LimitReached { reason: String, version: Version },
-    #[error("executor closing")]
-    ExecutorClosing,
+    #[error("execution interrupt")]
+    ExecutionInterrupt,
 }
 impl From<ReplayInternalError> for AdvanceError {
     fn from(value: ReplayInternalError) -> Self {
@@ -156,7 +156,7 @@ impl From<ReplayInternalError> for AdvanceError {
                     "advance() asserts DeadlineTrackerFactoryForReplay, which never expires the lock"
                 )
             }
-            ReplayInternalError::ExecutorClosing(_) => Self::ExecutorClosing,
+            ReplayInternalError::ExecutionInterrupt(_) => Self::ExecutionInterrupt,
         }
     }
 }
@@ -185,8 +185,8 @@ pub enum ReplayError {
     #[error("limit reached: {reason}")]
     LimitReached { reason: String, version: Version },
     // Transient error
-    #[error("executor closing")]
-    ExecutorClosing,
+    #[error("execution interrupt")]
+    ExecutionInterrupt,
     /// Replay failed.
     /// `captured_writes` is non-empty iff execution has not finished yet, and therefore can be advanced to an execution error.
     #[error("fatal error: {err}")]
@@ -205,8 +205,8 @@ pub(crate) enum ReplayInternalError {
     LimitReached { reason: String, version: Version },
     #[error("lock expired")]
     LockExpired(Version),
-    #[error("executor closing")]
-    ExecutorClosing(Version),
+    #[error("execution interrupt")]
+    ExecutionInterrupt(Version),
 }
 impl From<ReplayInternalError> for ReplayError {
     fn from(value: ReplayInternalError) -> Self {
@@ -220,7 +220,7 @@ impl From<ReplayInternalError> for ReplayError {
                     "replay() asserts DeadlineTrackerFactoryForReplay, which never expires the lock"
                 )
             }
-            ReplayInternalError::ExecutorClosing(_) => Self::ExecutorClosing,
+            ReplayInternalError::ExecutionInterrupt(_) => Self::ExecutionInterrupt,
         }
     }
 }

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -864,6 +864,7 @@ mod tests {
                 parent_execution_id.clone(),
                 CachingBuffer::new(JoinNextBlockingStrategy::Await {
                     non_blocking_event_batching: 100,
+                    subscription_interruption: None,
                 }),
             )),
             ConnectionMode::Replay => Box::new(ReplayWorkflowDbConnection::new(

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -790,6 +790,10 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         // noop
         Ok(())
     }
+
+    fn captured_writes_collected(&self) -> Option<usize> {
+        Some(self.collector.preview.len())
+    }
 }
 
 #[cfg(test)]

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -73,8 +73,8 @@ pub(crate) enum WorkflowFunctionError {
     DbError(DbErrorWrite),
     #[error("lock expired")]
     LockExpired,
-    #[error("executor closing")]
-    ExecutorClosing,
+    #[error("execution interrupt")]
+    ExecutionInterrupt,
     #[error("replay interrupt")]
     ReplayInterrupt,
 }
@@ -86,7 +86,7 @@ pub(crate) enum WorkerPartialResult {
     // retriable:
     InterruptDbUpdated,
     LockExpired,
-    ExecutorClosing,
+    ExecutionInterrupt,
     DbError(DbErrorWrite),
 }
 
@@ -118,7 +118,7 @@ impl WorkflowFunctionError {
                 WorkerPartialResult::FatalError(FatalError::ConstraintViolation { reason }, version)
             }
             WorkflowFunctionError::LockExpired => WorkerPartialResult::LockExpired,
-            WorkflowFunctionError::ExecutorClosing => WorkerPartialResult::ExecutorClosing,
+            WorkflowFunctionError::ExecutionInterrupt => WorkerPartialResult::ExecutionInterrupt,
             WorkflowFunctionError::ReplayInterrupt => WorkerPartialResult::ReplayWaitingForResponse,
         }
     }
@@ -135,7 +135,7 @@ impl From<ApplyError> for WorkflowFunctionError {
             ApplyError::ConstraintViolation(reason) => {
                 WorkflowFunctionError::ConstraintViolation(reason)
             }
-            ApplyError::ExecutorClosing => WorkflowFunctionError::ExecutorClosing,
+            ApplyError::ExecutionInterrupt => WorkflowFunctionError::ExecutionInterrupt,
             ApplyError::ReplayInterrupt => WorkflowFunctionError::ReplayInterrupt,
         }
     }
@@ -3122,7 +3122,7 @@ pub(crate) mod tests {
                 WorkerPartialResult::DbError(db_err) => {
                     Err(executor::worker::WorkerError::DbError(db_err))
                 }
-                WorkerPartialResult::LockExpired | WorkerPartialResult::ExecutorClosing => {
+                WorkerPartialResult::LockExpired | WorkerPartialResult::ExecutionInterrupt => {
                     unreachable!()
                 }
             }
@@ -3519,7 +3519,7 @@ pub(crate) mod tests {
                             lock_expires_at: sim_clock.now() + Duration::from_secs(1),
                             retry_config: ComponentRetryConfig::ZERO,
                         },
-                        executor_close_watcher: tokio::sync::watch::channel(false).1,
+                        execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
                     })
                     .await;
                 if let WorkerResult::Ok(WorkerResultOk::RunFinished(RunFinished {
@@ -3784,7 +3784,7 @@ pub(crate) mod tests {
                         lock_expires_at: sim_clock.now() + Duration::from_secs(1),
                         retry_config: ComponentRetryConfig::ZERO,
                     },
-                    executor_close_watcher: tokio::sync::watch::channel(false).1,
+                    execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
                 })
                 .await;
             let cancel_registry = CancelRegistry::new();
@@ -3841,7 +3841,7 @@ pub(crate) mod tests {
                             lock_expires_at: sim_clock.now() + Duration::from_secs(1),
                             retry_config: ComponentRetryConfig::ZERO,
                         },
-                        executor_close_watcher: tokio::sync::watch::channel(false).1,
+                        execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
                     })
                     .await;
             }
@@ -3900,7 +3900,7 @@ pub(crate) mod tests {
                     lock_expires_at: sim_clock.now() + Duration::from_secs(1),
                     retry_config: ComponentRetryConfig::ZERO,
                 },
-                executor_close_watcher: tokio::sync::watch::channel(false).1,
+                execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
             })
             .await;
         assert_matches!(worker_result, WorkerResult::Ok(..), "should be finished");

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -898,6 +898,7 @@ impl WorkflowCtx {
         subscription_interruption: Option<Duration>,
         logs_storage_config: Option<LogStrageConfig>,
         is_replay: Option<ReplayKind>,
+        max_replay_captured_writes: Option<usize>,
     ) -> Self {
         let mut wasi_ctx_builder = WasiCtxBuilder::new();
         wasi_ctx_builder.allow_tcp(false);
@@ -923,6 +924,7 @@ impl WorkflowCtx {
                 subscription_interruption,
                 worker_span.clone(),
                 is_replay == Some(ReplayKind::Unfinished),
+                max_replay_captured_writes,
             ),
             rng: StdRng::seed_from_u64(seed),
             clock_fn,
@@ -3254,6 +3256,7 @@ pub(crate) mod tests {
                 None,                         // subscription_interruption
                 None,                         // logs_storage_config,
                 is_replay,
+                None, // max_replay_captured_writes
             );
             for step in &self.steps {
                 info!("Processing step {step:?}");

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -850,6 +850,7 @@ mod tests {
         clock_fn: Box<dyn concepts::time::ClockFn>,
         js_source: String,
         user_return_type: ReturnTypeExtendable,
+        max_replay_captured_writes: Option<usize>,
     ) -> WorkflowJsWorker {
         use crate::workflow::deadline_tracker::DeadlineTrackerFactoryForReplay;
         let config = WorkflowConfig {
@@ -859,6 +860,7 @@ mod tests {
             fuel: None,
             lock_extension: None,
             subscription_interruption: None,
+            max_replay_captured_writes,
         };
         let compiled = WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),
@@ -919,6 +921,7 @@ mod tests {
             fuel: None,
             lock_extension: Some(Duration::from_secs(1)),
             subscription_interruption: None,
+            max_replay_captured_writes: None,
         };
 
         let compiled = WorkflowWorkerCompiled::new_with_config(
@@ -996,6 +999,7 @@ mod tests {
             fuel: None,
             lock_extension: None,
             subscription_interruption: None,
+            max_replay_captured_writes: None,
         };
 
         let compiled =
@@ -1328,6 +1332,7 @@ mod tests {
             fuel: None,
             lock_extension: None,
             subscription_interruption: None,
+            max_replay_captured_writes: None,
         };
 
         let compiled = WorkflowWorkerCompiled::new_with_config(
@@ -1804,6 +1809,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         replay_worker.replay(execution_id, false).await.unwrap();
         // Drop the worker so the log_sender is closed; otherwise `recv_many` blocks indefinitely.
@@ -3713,6 +3719,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         let replay = replay_worker
             .replay(execution_id.clone(), false)
@@ -3879,6 +3886,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         let replay = replay_worker
             .replay(execution_id.clone(), false)
@@ -3917,6 +3925,108 @@ mod tests {
             .expect("retval should be computed");
         let retval = assert_matches!(retval, SupportedFunctionReturnValue::Ok(Some(WastValWithType{ r#type: _, value })) => value);
         assert_eq!(WastVal::String("hello".into()), *retval);
+        drop(db_connection);
+        db_close.close().await;
+    }
+
+    /// A workflow that submits a stub whose response is never injected, then polls it forever with
+    /// `joinNextTry()`. During replay the poll never blocks, so replay would collect captured writes
+    /// indefinitely. `max_replay_captured_writes` bounds a single pass: replay returns the first N
+    /// writes as an advanceable prefix (instead of looping forever or erroring), and advancing them
+    /// then replaying again resumes from the persisted tip, stepping the workflow forward N at a time.
+    #[tokio::test]
+    async fn workflow_js_replay_join_next_try_loop_bounds_captured_writes() {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+
+        const MAX: usize = 5;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
+
+        let js_source = r"
+        export default function loop_forever() {
+            const js = obelisk.createJoinSet();
+            js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            for (;;) {
+                const result = js.joinNextTry();
+                if (result !== undefined) {
+                    throw 'stub result was injected unexpectedly';
+                }
+            }
+        }";
+
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "loop-forever");
+        let sim_clock = SimClock::epoch();
+
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+
+        let (_worker, component_id, runnable_component) = compile_js_workflow_worker(
+            js_source,
+            &user_ffqn,
+            db_pool.clone(),
+            sim_clock.clone_box(),
+            fn_registry.clone(),
+            workflow_engine.clone(),
+        );
+
+        let execution_id = ExecutionId::from_parts(0, 0);
+        let created_at = sim_clock.now();
+        let db_connection = db_pool.connection_test().await.unwrap();
+        db_connection
+            .create(CreateRequest {
+                created_at,
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: component_id.clone(),
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: true,
+            })
+            .await
+            .unwrap();
+
+        let replay_worker = build_js_replay_worker(
+            DeploymentId::generate(),
+            component_id,
+            &runnable_component,
+            workflow_engine,
+            fn_registry,
+            db_pool,
+            None,
+            sim_clock.clone_box(),
+            js_source.to_string(),
+            default_return_type(),
+            Some(MAX),
+        );
+
+        // Replay bounds the pass to MAX captured writes and returns them as an advanceable prefix
+        // rather than looping forever.
+        let replay = replay_worker
+            .replay(execution_id.clone(), false)
+            .await
+            .unwrap();
+        let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
+        assert_eq!(replay.captured_writes.len(), MAX);
+
+        // Advancing the prefix persists it; a fresh replay resumes past the tip and yields the next
+        // bounded batch, so the never-terminating workflow keeps making progress without erroring.
+        replay_worker
+            .advance(execution_id.clone(), replay, false)
+            .await
+            .unwrap();
+        let replay2 = replay_worker.replay(execution_id, false).await.unwrap();
+        let replay2 = assert_matches!(replay2, ReplayResponse::Advanceable(replay2) => replay2);
+        assert_eq!(replay2.captured_writes.len(), MAX);
+
         drop(db_connection);
         db_close.close().await;
     }
@@ -4003,6 +4113,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         ));
         let result = workflow_js_step_execution_until_finished(
             &*db_connection,
@@ -4102,6 +4213,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
 
         // The paused workflow has not executed, so every backtrace the replay captures belongs to a
@@ -4209,6 +4321,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         ));
         let result = workflow_js_step_execution_until_finished(
             &*db_connection,
@@ -4306,6 +4419,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         let replay = replay_worker
             .replay(execution_id.clone(), false)
@@ -4405,6 +4519,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         let mut forwarded = Vec::new();
         for expected_len in [3_usize, 2, 1] {
@@ -4644,6 +4759,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         let replay = replay_worker
             .replay(execution_id.clone(), false)
@@ -4784,6 +4900,7 @@ mod tests {
             sim_clock.clone_box(),
             js_source.to_string(),
             default_return_type(),
+            None, // max_replay_captured_writes
         );
         let replay = replay_worker
             .replay(execution_id.clone(), false)

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -743,7 +743,9 @@ mod tests {
         DeadlineTrackerFactory, DeadlineTrackerFactoryTokio, deadline_tracker_factory_test,
     };
     use crate::workflow::workflow_worker::tests::write_stub_response;
-    use crate::workflow::workflow_worker::{JoinNextBlockingStrategy, WorkflowConfig};
+    use crate::workflow::workflow_worker::{
+        JoinNextBlockingStrategy, WorkflowConfig, WorkflowConfigMode,
+    };
     use assert_matches::assert_matches;
     use chrono::DateTime;
     use concepts::component_id::{COMPONENT_DIGEST_DUMMY, ComponentDigest, Digest};
@@ -855,12 +857,12 @@ mod tests {
         use crate::workflow::deadline_tracker::DeadlineTrackerFactoryForReplay;
         let config = WorkflowConfig {
             component_id,
-            join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
             stub_wasi: true,
             fuel: None,
-            lock_extension: None,
-            subscription_interruption: None,
-            max_replay_captured_writes,
+            mode: WorkflowConfigMode::Replay {
+                // `None` in tests means effectively unbounded.
+                max_replay_captured_writes: max_replay_captured_writes.unwrap_or(usize::MAX),
+            },
         };
         let compiled = WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),
@@ -916,12 +918,13 @@ mod tests {
 
         let config = WorkflowConfig {
             component_id: component_id.clone(),
-            join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
             stub_wasi: false,
             fuel: None,
-            lock_extension: Some(Duration::from_secs(1)),
-            subscription_interruption: None,
-            max_replay_captured_writes: None,
+            mode: WorkflowConfigMode::Real {
+                join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
+                lock_extension: Some(Duration::from_secs(1)),
+                subscription_interruption: None,
+            },
         };
 
         let compiled = WorkflowWorkerCompiled::new_with_config(
@@ -994,12 +997,13 @@ mod tests {
 
         let config = WorkflowConfig {
             component_id,
-            join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
             stub_wasi: false,
             fuel: None,
-            lock_extension: None,
-            subscription_interruption: None,
-            max_replay_captured_writes: None,
+            mode: WorkflowConfigMode::Real {
+                join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
+                lock_extension: None,
+                subscription_interruption: None,
+            },
         };
 
         let compiled =
@@ -1327,12 +1331,13 @@ mod tests {
 
         let config = WorkflowConfig {
             component_id: component_id.clone(),
-            join_next_blocking_strategy,
             stub_wasi: false,
             fuel: None,
-            lock_extension: None,
-            subscription_interruption: None,
-            max_replay_captured_writes: None,
+            mode: WorkflowConfigMode::Real {
+                join_next_blocking_strategy,
+                lock_extension: None,
+                subscription_interruption: None,
+            },
         };
 
         let compiled = WorkflowWorkerCompiled::new_with_config(

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -1053,7 +1053,7 @@ mod tests {
                 lock_expires_at: chrono::DateTime::UNIX_EPOCH + chrono::Duration::seconds(60),
                 retry_config: ComponentRetryConfig::WORKFLOW,
             },
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
         }
     }
 
@@ -1419,7 +1419,7 @@ mod tests {
         ExecTask::new_all_ffqns_test(Arc::new(worker), exec_config, clock_fn, db_pool)
     }
 
-    fn new_js_workflow_exec_task_with_close_watcher(
+    fn new_js_workflow_exec_task_with_interrupt_watcher(
         worker: WorkflowJsWorker,
         clock_fn: Box<dyn ClockFn>,
         db_pool: Arc<dyn DbPool>,
@@ -1436,7 +1436,7 @@ mod tests {
             retry_config: ComponentRetryConfig::WORKFLOW,
             locking_strategy: LockingStrategy::ByComponentDigest,
         };
-        ExecTask::new_all_ffqns_test_with_close_watcher(
+        ExecTask::new_all_ffqns_test_with_interrupt_watcher(
             Arc::new(worker),
             exec_config,
             clock_fn,
@@ -2716,7 +2716,7 @@ mod tests {
     #[expand_enum_database]
     #[rstest]
     #[tokio::test]
-    async fn executor_close_writes_unlocked_event(database: Database) {
+    async fn execution_interrupt_writes_unlocked_event(database: Database) {
         test_utils::set_up();
         let (_guard, db_pool, db_close) = database.set_up().await;
 
@@ -2746,7 +2746,7 @@ mod tests {
             workflow_engine,
         );
 
-        let exec_task = new_js_workflow_exec_task_with_close_watcher(
+        let exec_task = new_js_workflow_exec_task_with_interrupt_watcher(
             worker,
             sim_clock.clone_box(),
             db_pool.clone(),

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -923,7 +923,6 @@ mod tests {
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
                 lock_extension: Some(Duration::from_secs(1)),
-                subscription_interruption: None,
             },
         };
 
@@ -1002,7 +1001,6 @@ mod tests {
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
                 lock_extension: None,
-                subscription_interruption: None,
             },
         };
 
@@ -1336,7 +1334,6 @@ mod tests {
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy,
                 lock_extension: None,
-                subscription_interruption: None,
             },
         };
 
@@ -2360,6 +2357,7 @@ mod tests {
             "session",
             JoinNextBlockingStrategy::Await {
                 non_blocking_event_batching,
+                subscription_interruption: None,
             },
         )
         .await;

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -60,17 +60,68 @@ pub use deployment_config::config::DEFAULT_NON_BLOCKING_EVENT_BATCHING;
 #[derive(Clone, Debug)]
 pub struct WorkflowConfig {
     pub component_id: ComponentId,
-    pub join_next_blocking_strategy: JoinNextBlockingStrategy,
     pub stub_wasi: bool,
     pub fuel: Option<u64>,
-    // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
-    pub lock_extension: Option<Duration>,
-    // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
-    pub subscription_interruption: Option<Duration>,
-    /// Upper bound on captured writes collected during a single replay pass. Only set on
-    /// replay-purposed configs (`JoinNextBlockingStrategy::Interrupt`); `None` disables the
-    /// bound. Stops a non-terminating workflow from collecting captured writes forever.
-    pub max_replay_captured_writes: Option<usize>,
+    /// Fields that differ between a normal run and a replay pass. `stub_wasi` and `fuel` are
+    /// shared (a replay-purposed config inherits them from the real config).
+    pub mode: WorkflowConfigMode,
+}
+
+#[derive(Clone, Debug)]
+pub enum WorkflowConfigMode {
+    /// Normal execution: writes are persisted to the database.
+    Real {
+        join_next_blocking_strategy: JoinNextBlockingStrategy,
+        // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
+        lock_extension: Option<Duration>,
+        // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
+        subscription_interruption: Option<Duration>,
+    },
+    /// Replay/advance: writes are captured in memory instead of persisted, and the workflow always
+    /// runs with the `Interrupt` strategy. `max_replay_captured_writes` bounds how many captured
+    /// writes a single pass returns, keeping a non-terminating workflow advanceable in batches.
+    Replay { max_replay_captured_writes: usize },
+}
+
+impl WorkflowConfig {
+    /// Blocking strategy for a normal run. Replay always uses `Interrupt`, forced in `prepare_func`.
+    fn join_next_blocking_strategy(&self) -> JoinNextBlockingStrategy {
+        match &self.mode {
+            WorkflowConfigMode::Real {
+                join_next_blocking_strategy,
+                ..
+            } => *join_next_blocking_strategy,
+            WorkflowConfigMode::Replay { .. } => JoinNextBlockingStrategy::Interrupt,
+        }
+    }
+
+    fn lock_extension(&self) -> Option<Duration> {
+        match &self.mode {
+            WorkflowConfigMode::Real { lock_extension, .. } => *lock_extension,
+            WorkflowConfigMode::Replay { .. } => None,
+        }
+    }
+
+    fn subscription_interruption(&self) -> Option<Duration> {
+        match &self.mode {
+            WorkflowConfigMode::Real {
+                subscription_interruption,
+                ..
+            } => *subscription_interruption,
+            WorkflowConfigMode::Replay { .. } => None,
+        }
+    }
+
+    /// Captured-write bound. `None` for a real config (an unbounded auto-upgrade replay); `Some`
+    /// only for a replay-purposed config.
+    fn max_replay_captured_writes(&self) -> Option<usize> {
+        match &self.mode {
+            WorkflowConfigMode::Real { .. } => None,
+            WorkflowConfigMode::Replay {
+                max_replay_captured_writes,
+            } => Some(*max_replay_captured_writes),
+        }
+    }
 }
 
 pub struct WorkflowWorkerCompiled {
@@ -650,6 +701,18 @@ impl WorkflowWorker {
         };
 
         let seed = ctx.execution_id.random_seed();
+        // Replay always runs with the `Interrupt` strategy and ignores lock extension / subscription
+        // interruption, regardless of whether the source config is `Real` (auto-upgrade) or `Replay`.
+        let (join_next_blocking_strategy, lock_extension, subscription_interruption) =
+            if is_replay.is_some() {
+                (JoinNextBlockingStrategy::Interrupt, None, None)
+            } else {
+                (
+                    view.config.join_next_blocking_strategy(),
+                    view.config.lock_extension(),
+                    view.config.subscription_interruption(),
+                )
+            };
         let workflow_ctx = WorkflowCtx::new(
             view.deployment_id,
             db_connection,
@@ -658,18 +721,18 @@ impl WorkflowWorker {
             ctx.responses,
             seed,
             view.clock_fn,
-            view.config.join_next_blocking_strategy,
+            join_next_blocking_strategy,
             ctx.worker_span,
             backtrace_capture,
             deadline_tracker,
             view.fn_registry,
             view.cancel_registry,
             ctx.locked_event,
-            view.config.lock_extension,
-            view.config.subscription_interruption,
+            lock_extension,
+            subscription_interruption,
             view.logs_storage_config,
             is_replay,
-            view.config.max_replay_captured_writes,
+            view.config.max_replay_captured_writes(),
         );
 
         let mut store = Store::new(view.engine, workflow_ctx);
@@ -1078,11 +1141,11 @@ impl WorkflowWorker {
         ),
         ReplayInternalError,
     > {
-        let mut replay_config = self.config.clone();
-        replay_config.join_next_blocking_strategy = JoinNextBlockingStrategy::Interrupt;
+        // `prepare_func` forces the `Interrupt` strategy for replay (`is_replay.is_some()`), so a
+        // `Real` config (auto-upgrade) and a `Replay` config both replay correctly without cloning.
         let view = WorkflowWorkerView {
             deployment_id: self.deployment_id,
-            config: &replay_config,
+            config: &self.config,
             engine: &self.engine,
             clock_fn: self.clock_fn.clone_box(),
             exported_ffqn_to_index: &self.exported_ffqn_to_index,
@@ -1617,7 +1680,7 @@ impl Worker for WorkflowWorker {
         let db_connection = Box::new(CachingDbConnection::new(
             self.db_pool.connection().await.unwrap(),
             ctx.execution_id.clone(),
-            CachingBuffer::new(self.config.join_next_blocking_strategy),
+            CachingBuffer::new(self.config.join_next_blocking_strategy()),
         ));
         let worker_span = ctx.worker_span.clone();
         worker_span.in_scope(|| {
@@ -1869,12 +1932,13 @@ pub(crate) mod tests {
                     runnable_component.clone(),
                     WorkflowConfig {
                         component_id,
-                        join_next_blocking_strategy,
                         stub_wasi: false,
                         fuel: None,
-                        lock_extension: None,
-                        subscription_interruption: None,
-                        max_replay_captured_writes: None,
+                        mode: WorkflowConfigMode::Real {
+                            join_next_blocking_strategy,
+                            lock_extension: None,
+                            subscription_interruption: None,
+                        },
                     },
                     workflow_engine,
                     clock_fn.clone_box(),
@@ -1909,12 +1973,11 @@ pub(crate) mod tests {
     ) -> WorkflowWorker {
         let config = WorkflowConfig {
             component_id,
-            join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
             stub_wasi: true,
             fuel: None,
-            lock_extension: None,
-            subscription_interruption: None,
-            max_replay_captured_writes: None,
+            mode: WorkflowConfigMode::Replay {
+                max_replay_captured_writes: usize::MAX, // effectively unbounded for tests
+            },
         };
         WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -519,7 +519,9 @@ impl JoinSetCloseError {
                 version,
                 db_connection,
             },
-            JoinSetCloseError::ExecutionInterrupt(version) => WorkflowError::ExecutionInterrupt(version),
+            JoinSetCloseError::ExecutionInterrupt(version) => {
+                WorkflowError::ExecutionInterrupt(version)
+            }
         }
     }
 }
@@ -586,7 +588,8 @@ impl WorkflowWorker {
         };
         debug!("Execution replay of kind `{replay_kind}` started");
 
-        let (_execution_interrupt_sender, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
+        let (_execution_interrupt_sender, execution_interrupt_watcher) =
+            tokio::sync::watch::channel(false);
         let parent = log.parent();
 
         let ctx = WorkerContext {
@@ -693,10 +696,10 @@ impl WorkflowWorker {
         backtrace_capture: bool,
     ) -> Result<PrepareFuncFinished, WorkflowError> {
         assert_eq!(view.config.component_id, ctx.locked_event.component_id);
-        let deadline_tracker = match view
-            .deadline_factory
-            .create(ctx.locked_event.lock_expires_at, ctx.execution_interrupt_watcher)
-        {
+        let deadline_tracker = match view.deadline_factory.create(
+            ctx.locked_event.lock_expires_at,
+            ctx.execution_interrupt_watcher,
+        ) {
             Ok(deadline_tracker) => deadline_tracker,
             Err(lock_already_expired) => {
                 ctx.worker_span.in_scope(|| {

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -456,7 +456,7 @@ enum WorkerResultRefactored {
     FatalError(FatalError, WorkflowCtx),
     DbError(DbErrorWrite),
     LockExpired(WorkflowCtx),
-    ExecutorClosing(WorkflowCtx),
+    ExecutionInterrupt(WorkflowCtx),
     ReplayInterrupt(WorkflowCtx),
 }
 
@@ -477,8 +477,8 @@ enum WorkflowError {
     },
     #[error("lock expired")]
     LockExpired(Version),
-    #[error("executor closing")]
-    ExecutorClosing(Version),
+    #[error("execution interrupt")]
+    ExecutionInterrupt(Version),
 }
 impl From<WorkflowError> for WorkerError {
     fn from(value: WorkflowError) -> Self {
@@ -492,7 +492,7 @@ impl From<WorkflowError> for WorkerError {
                 http_client_traces: None,
                 version,
             },
-            WorkflowError::ExecutorClosing(version) => WorkerError::ExecutorClosing(version),
+            WorkflowError::ExecutionInterrupt(version) => WorkerError::ExecutionInterrupt(version),
         }
     }
 }
@@ -503,8 +503,8 @@ pub enum JoinSetCloseError {
     DbError(DbErrorWrite),
     #[error("fatal error: {err}")]
     FatalError { err: FatalError },
-    #[error("executor closing")]
-    ExecutorClosing(Version),
+    #[error("execution interrupt")]
+    ExecutionInterrupt(Version),
 }
 impl JoinSetCloseError {
     fn into_workflow_error(
@@ -519,7 +519,7 @@ impl JoinSetCloseError {
                 version,
                 db_connection,
             },
-            JoinSetCloseError::ExecutorClosing(version) => WorkflowError::ExecutorClosing(version),
+            JoinSetCloseError::ExecutionInterrupt(version) => WorkflowError::ExecutionInterrupt(version),
         }
     }
 }
@@ -586,7 +586,7 @@ impl WorkflowWorker {
         };
         debug!("Execution replay of kind `{replay_kind}` started");
 
-        let (_executor_close_sender, executor_close_watcher) = tokio::sync::watch::channel(false);
+        let (_execution_interrupt_sender, execution_interrupt_watcher) = tokio::sync::watch::channel(false);
         let parent = log.parent();
 
         let ctx = WorkerContext {
@@ -609,7 +609,7 @@ impl WorkflowWorker {
                 lock_expires_at: self.clock_fn.now(),
                 retry_config: concepts::ComponentRetryConfig::WORKFLOW,
             },
-            executor_close_watcher,
+            execution_interrupt_watcher,
         };
 
         self.replay_internal(
@@ -695,7 +695,7 @@ impl WorkflowWorker {
         assert_eq!(view.config.component_id, ctx.locked_event.component_id);
         let deadline_tracker = match view
             .deadline_factory
-            .create(ctx.locked_event.lock_expires_at, ctx.executor_close_watcher)
+            .create(ctx.locked_event.lock_expires_at, ctx.execution_interrupt_watcher)
         {
             Ok(deadline_tracker) => deadline_tracker,
             Err(lock_already_expired) => {
@@ -767,10 +767,10 @@ impl WorkflowWorker {
                     info!("Deadline reached in epoch callback");
                     Err(wasmtime::Error::from(WorkflowFunctionError::LockExpired))
                 }
-                Err(EpochCallbackError::ExecutorClosing) => {
-                    info!("Executor closing detected in epoch callback");
+                Err(EpochCallbackError::ExecutionInterrupt) => {
+                    info!("Execution interrupt detected in epoch callback");
                     Err(wasmtime::Error::from(
-                        WorkflowFunctionError::ExecutorClosing,
+                        WorkflowFunctionError::ExecutionInterrupt,
                     ))
                 }
             }
@@ -788,9 +788,9 @@ impl WorkflowWorker {
                             let version = store.into_data().version().clone();
                             return Err(WorkflowError::LockExpired(version));
                         }
-                        WorkflowFunctionError::ExecutorClosing => {
+                        WorkflowFunctionError::ExecutionInterrupt => {
                             let version = store.into_data().version().clone();
-                            return Err(WorkflowError::ExecutorClosing(version));
+                            return Err(WorkflowError::ExecutionInterrupt(version));
                         }
                         _ => {}
                     }
@@ -1010,9 +1010,9 @@ impl WorkflowWorker {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
                 Err(WorkflowError::LockExpired(workflow_ctx.version().clone()))
             }
-            WorkerResultRefactored::ExecutorClosing(mut workflow_ctx) => {
+            WorkerResultRefactored::ExecutionInterrupt(mut workflow_ctx) => {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
-                Err(WorkflowError::ExecutorClosing(
+                Err(WorkflowError::ExecutionInterrupt(
                     workflow_ctx.version().clone(),
                 ))
             }
@@ -1081,9 +1081,9 @@ impl WorkflowWorker {
                         // logged in epoch callback
                         WorkerResultRefactored::LockExpired(workflow_ctx)
                     }
-                    WorkerPartialResult::ExecutorClosing => {
+                    WorkerPartialResult::ExecutionInterrupt => {
                         // logged in epoch callback
-                        WorkerResultRefactored::ExecutorClosing(workflow_ctx)
+                        WorkerResultRefactored::ExecutionInterrupt(workflow_ctx)
                     }
                     WorkerPartialResult::ReplayWaitingForResponse => {
                         WorkerResultRefactored::ReplayInterrupt(workflow_ctx)
@@ -1119,7 +1119,7 @@ impl WorkflowWorker {
             Err(ApplyError::ConstraintViolation(reason)) => Err(JoinSetCloseError::FatalError {
                 err: FatalError::ConstraintViolation { reason },
             }),
-            Err(ApplyError::ExecutorClosing) => Err(JoinSetCloseError::ExecutorClosing(
+            Err(ApplyError::ExecutionInterrupt) => Err(JoinSetCloseError::ExecutionInterrupt(
                 workflow_ctx.version().clone(),
             )),
             Err(ApplyError::ReplayInterrupt) => Ok(Either::Right(ReplayInterrupt)),
@@ -1210,8 +1210,8 @@ impl WorkflowWorker {
             Err(WorkflowError::LockExpired(version)) => {
                 Err(ReplayInternalError::LockExpired(version))
             }
-            Err(WorkflowError::ExecutorClosing(version)) => {
-                Err(ReplayInternalError::ExecutorClosing(version))
+            Err(WorkflowError::ExecutionInterrupt(version)) => {
+                Err(ReplayInternalError::ExecutionInterrupt(version))
             }
         }?;
 
@@ -1529,8 +1529,8 @@ impl WorkflowWorker {
                     http_client_traces: None,
                     version,
                 },
-                ReplayInternalError::ExecutorClosing(version) => {
-                    WorkerError::ExecutorClosing(version)
+                ReplayInternalError::ExecutionInterrupt(version) => {
+                    WorkerError::ExecutionInterrupt(version)
                 }
             })?;
 
@@ -2782,7 +2782,7 @@ pub(crate) mod tests {
                 lock_expires_at: execution_deadline,
                 retry_config: ComponentRetryConfig::ZERO,
             },
-            executor_close_watcher: tokio::sync::watch::channel(false).1,
+            execution_interrupt_watcher: tokio::sync::watch::channel(false).1,
         };
         let worker_result = worker.run(ctx).await;
         assert_matches!(

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -67,6 +67,10 @@ pub struct WorkflowConfig {
     pub lock_extension: Option<Duration>,
     // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
     pub subscription_interruption: Option<Duration>,
+    /// Upper bound on captured writes collected during a single replay pass. Only set on
+    /// replay-purposed configs (`JoinNextBlockingStrategy::Interrupt`); `None` disables the
+    /// bound. Stops a non-terminating workflow from collecting captured writes forever.
+    pub max_replay_captured_writes: Option<usize>,
 }
 
 pub struct WorkflowWorkerCompiled {
@@ -665,6 +669,7 @@ impl WorkflowWorker {
             view.config.subscription_interruption,
             view.logs_storage_config,
             is_replay,
+            view.config.max_replay_captured_writes,
         );
 
         let mut store = Store::new(view.engine, workflow_ctx);
@@ -1869,6 +1874,7 @@ pub(crate) mod tests {
                         fuel: None,
                         lock_extension: None,
                         subscription_interruption: None,
+                        max_replay_captured_writes: None,
                     },
                     workflow_engine,
                     clock_fn.clone_box(),
@@ -1908,6 +1914,7 @@ pub(crate) mod tests {
             fuel: None,
             lock_extension: None,
             subscription_interruption: None,
+            max_replay_captured_writes: None,
         };
         WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -52,7 +52,12 @@ pub enum JoinNextBlockingStrategy {
     /// Shut down the current runtime. When the [`JoinSetResponse`] is appended, workflow is reexecuted with a new `RunId`.
     Interrupt,
     /// Keep the execution hot. Worker will poll the database until the execution lock expires.
-    Await { non_blocking_event_batching: u32 },
+    Await {
+        non_blocking_event_batching: u32,
+        /// Caps how long a blocking `join-next` waits before re-polling the database for
+        /// responses; needed as a fallback for Postgres' local-only subscription mechanism.
+        subscription_interruption: Option<Duration>,
+    },
 }
 
 pub use deployment_config::config::DEFAULT_NON_BLOCKING_EVENT_BATCHING;
@@ -74,8 +79,6 @@ pub enum WorkflowConfigMode {
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
         lock_extension: Option<Duration>,
-        // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
-        subscription_interruption: Option<Duration>,
     },
     /// Replay/advance: writes are captured in memory instead of persisted, and the workflow always
     /// runs with the `Interrupt` strategy. `max_replay_captured_writes` bounds how many captured
@@ -105,10 +108,14 @@ impl WorkflowConfig {
     fn subscription_interruption(&self) -> Option<Duration> {
         match &self.mode {
             WorkflowConfigMode::Real {
-                subscription_interruption,
+                join_next_blocking_strategy:
+                    JoinNextBlockingStrategy::Await {
+                        subscription_interruption,
+                        ..
+                    },
                 ..
             } => *subscription_interruption,
-            WorkflowConfigMode::Replay { .. } => None,
+            WorkflowConfigMode::Real { .. } | WorkflowConfigMode::Replay { .. } => None,
         }
     }
 
@@ -1937,7 +1944,6 @@ pub(crate) mod tests {
                         mode: WorkflowConfigMode::Real {
                             join_next_blocking_strategy,
                             lock_extension: None,
-                            subscription_interruption: None,
                         },
                     },
                     workflow_engine,
@@ -2057,7 +2063,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn fibo_workflow_should_schedule_fibo_activity(
         db: Database,
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0}, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 10})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None }, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 10, subscription_interruption: None })]
         join_next_blocking_strategy: JoinNextBlockingStrategy,
     ) {
         let sim_clock = SimClock::default();
@@ -2191,7 +2197,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn fiboa_submit_json_workflow(
         db: Database,
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None })]
         join_next_blocking_strategy: JoinNextBlockingStrategy,
     ) {
         let sim_clock = SimClock::default();
@@ -2918,7 +2924,7 @@ pub(crate) mod tests {
     // TODO: Test await interleaving with timer - execution should finished in one go.
     async fn sleep_should_be_persisted_after_executor_restart(
         database: Database,
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None })]
         join_next_blocking_strategy: JoinNextBlockingStrategy,
     ) {
         const SLEEP_MILLIS: u32 = 100;
@@ -3402,7 +3408,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn scheduling_should_work(
         db: db_tests::Database,
-        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0}, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 10})]
+        #[values(JoinNextBlockingStrategy::Interrupt, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 0, subscription_interruption: None }, JoinNextBlockingStrategy::Await { non_blocking_event_batching: 10, subscription_interruption: None })]
         join_next_strategy: JoinNextBlockingStrategy,
     ) {
         const SLEEP_DURATION: Duration = Duration::from_millis(100);

--- a/deployment-testing-js-local.toml
+++ b/deployment-testing-js-local.toml
@@ -156,6 +156,14 @@ params = [
 ]
 return_type = "result<string, string>"
 
+[[workflow_js]]
+location = "crates/testing/test-programs/js/workflow/stub_join_next_try_loop.js"
+ffqn = "testing:integration/workflow-stub-loop.stub-join-next-try-loop"
+params = [
+  { name = "id", type = "u64" },
+]
+return_type = "result<string, string>"
+
 [[activity_stub]]
 ffqn = "testing:integration/stubs.my-stub"
 params = [

--- a/server-help.toml
+++ b/server-help.toml
@@ -101,6 +101,7 @@
 # [workflows]
 # lock_extension_leeway.milliseconds = 100 # Deprecated, removed in 0.42: set `lock_extension_leeway` on each `[[workflow_wasm]]` / `[[workflow_js]]` instead. While set, it overrides the per-workflow value for every workflow.
 # subscription_interruption.seconds = 1    # Interrupts listening for notifications periodically, needed for Postgres with a local-only subscription mechanism. Value can be "none" or a duration.
+# max_replay_captured_writes = 100         # Max captured writes a single replay pass returns; on reaching it replay stops and returns that many as an advanceable prefix (advance them, then replay again to resume). Keeps a non-terminating workflow (e.g. an unresolved `joinNextTry` poll loop) advanceable in bounded batches.
 
 # [wasm.codegen_cache]
 ## Defaults:

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -3828,6 +3828,8 @@ impl DeploymentVerified {
                                 workflow_js_wasm_path.clone(),
                                 wasm_cache_dir.clone(),
                                 global_executor_instance_limiter.clone(),
+                                fuel,
+                                subscription_interruption,
                             ).await?
                         );
                     }

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -185,8 +185,8 @@ use wasm_workers::workflow::deadline_tracker::{
 use wasm_workers::workflow::host_exports::history_event_schedule_at_from_wast_val;
 use wasm_workers::workflow::workflow_js_worker::WorkflowJsWorkerCompiled;
 use wasm_workers::workflow::workflow_js_worker::WorkflowJsWorkerLinked;
-use wasm_workers::workflow::workflow_worker::JoinNextBlockingStrategy;
 use wasm_workers::workflow::workflow_worker::WorkflowConfig;
+use wasm_workers::workflow::workflow_worker::WorkflowConfigMode;
 use wasm_workers::workflow::workflow_worker::WorkflowWorkerCompiled;
 use wasm_workers::workflow::workflow_worker::WorkflowWorkerLinked;
 use wasmtime::Engine;
@@ -4801,7 +4801,7 @@ fn prespawn_workflow_js(
 
     let replay_inner = WorkflowWorkerCompiled::new_with_config(
         runnable_component.clone(),
-        replay_workflow_config(&component_id, max_replay_captured_writes),
+        replay_workflow_config(&workflow_js.workflow_config, max_replay_captured_writes),
         engine.clone(),
         Now.clone_box(),
     )
@@ -4866,20 +4866,20 @@ fn prespawn_workflow_js(
     ))
 }
 
-/// Replay-purposed [`WorkflowConfig`]: Interrupt strategy, stubbed WASI, no lock
-/// extension, no subscription interruption, no fuel limit.
+/// Replay-purposed [`WorkflowConfig`] derived from the real config: `Replay` mode (forces the
+/// `Interrupt` strategy) bounded by `max_replay_captured_writes`, inheriting `stub_wasi` and `fuel`
+/// from the real config so replay behaves like the real run.
 fn replay_workflow_config(
-    component_id: &ComponentId,
+    real_config: &WorkflowConfig,
     max_replay_captured_writes: usize,
 ) -> WorkflowConfig {
     WorkflowConfig {
-        component_id: component_id.clone(),
-        join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
-        stub_wasi: true,
-        fuel: None,
-        lock_extension: None, // does not matter for the `Interrupt` strategy.
-        subscription_interruption: None, // does not matter for the `Interrupt` strategy.
-        max_replay_captured_writes: Some(max_replay_captured_writes),
+        component_id: real_config.component_id.clone(),
+        stub_wasi: real_config.stub_wasi,
+        fuel: real_config.fuel,
+        mode: WorkflowConfigMode::Replay {
+            max_replay_captured_writes,
+        },
     }
 }
 
@@ -5007,10 +5007,7 @@ impl WorkerCompiled {
     > {
         let replay_compiled = WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),
-            replay_workflow_config(
-                &workflow.workflow_config.component_id,
-                max_replay_captured_writes,
-            ),
+            replay_workflow_config(&workflow.workflow_config, max_replay_captured_writes),
             engine.clone(),
             Now.clone_box(),
         )?;

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2012,6 +2012,9 @@ struct ServerVerifiedLaunch {
     /// Deprecated server-wide override; when set, applies to every workflow. See
     /// `WorkflowsGlobalConfigToml::lock_extension_leeway`.
     deprecated_workflows_lock_extension_leeway: Option<Duration>,
+    /// Bound on captured writes collected during a single replay pass. See
+    /// `WorkflowsGlobalConfigToml::max_replay_captured_writes`.
+    workflows_max_replay_captured_writes: usize,
 }
 
 impl ServerVerified {
@@ -2056,6 +2059,8 @@ impl ServerVerified {
                  instead. While set, it overrides the per-workflow value for every workflow."
             );
         }
+        let workflows_max_replay_captured_writes =
+            config.workflows_global_config.max_replay_captured_writes;
         let build_semaphore = config.wasm_global_config.build_semaphore.into();
         let global_executor_instance_limiter = config
             .wasm_global_config
@@ -2083,6 +2088,7 @@ impl ServerVerified {
                 engines,
                 build_semaphore,
                 deprecated_workflows_lock_extension_leeway,
+                workflows_max_replay_captured_writes,
             },
             allow_exec_activities: config.allow_exec_activities,
             http_servers,
@@ -2165,6 +2171,7 @@ impl ServerCompiledLinked {
             global_http_config,
             server_verified.build_semaphore,
             server_verified.deprecated_workflows_lock_extension_leeway,
+            server_verified.workflows_max_replay_captured_writes,
             termination_watcher,
             suppress_linking_errors,
         )
@@ -3937,6 +3944,7 @@ async fn compile_and_link(
     global_http_config: GlobalHttpConfig,
     build_semaphore: Option<u64>,
     deprecated_workflows_lock_extension_leeway: Option<Duration>,
+    workflows_max_replay_captured_writes: usize,
     termination_watcher: &mut watch::Receiver<()>,
     suppress_linking_errors: bool,
 ) -> Result<Linked, anyhow::Error> {
@@ -4118,7 +4126,12 @@ async fn compile_and_link(
                 span.in_scope(|| {
                     let leeway = deprecated_workflows_lock_extension_leeway
                         .unwrap_or(workflow.lock_extension_leeway);
-                    prespawn_workflow_wasm(workflow, &engines, leeway)
+                    prespawn_workflow_wasm(
+                        workflow,
+                        &engines,
+                        leeway,
+                        workflows_max_replay_captured_writes,
+                    )
                     .map(|(worker, component_config, frame_files)| {
                         CompiledComponent::ActivityOrWorkflow {
                             worker,
@@ -4139,7 +4152,13 @@ async fn compile_and_link(
                 span.in_scope(|| {
                     let leeway = deprecated_workflows_lock_extension_leeway
                         .unwrap_or(workflow_js.lock_extension_leeway);
-                    prespawn_workflow_js(workflow_js, &engines, workflow_js_runnable, leeway)
+                    prespawn_workflow_js(
+                        workflow_js,
+                        &engines,
+                        workflow_js_runnable,
+                        leeway,
+                        workflows_max_replay_captured_writes,
+                    )
                         .map(|(worker, component_config, frame_files)| {
                             CompiledComponent::ActivityOrWorkflow {
                                 worker,
@@ -4737,6 +4756,7 @@ fn prespawn_workflow_wasm(
     workflow: WorkflowConfigVerified,
     engines: &Engines,
     workflows_lock_extension_leeway: Duration,
+    max_replay_captured_writes: usize,
 ) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSourceContent), anyhow::Error> {
     let component_id = workflow.component_id().clone();
     assert!(component_id.component_type == ComponentType::Workflow);
@@ -4753,6 +4773,7 @@ fn prespawn_workflow_wasm(
         workflow,
         wit,
         workflows_lock_extension_leeway,
+        max_replay_captured_writes,
     )
     .with_context(|| format!("cannot compile {component_id}"))
 }
@@ -4767,6 +4788,7 @@ fn prespawn_workflow_js(
     engines: &Engines,
     runnable_component: RunnableComponent,
     workflows_lock_extension_leeway: Duration,
+    max_replay_captured_writes: usize,
 ) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSourceContent), anyhow::Error> {
     let component_id = workflow_js.component_id().clone();
     assert!(component_id.component_type == ComponentType::Workflow);
@@ -4779,7 +4801,7 @@ fn prespawn_workflow_js(
 
     let replay_inner = WorkflowWorkerCompiled::new_with_config(
         runnable_component.clone(),
-        replay_workflow_config(&component_id),
+        replay_workflow_config(&component_id, max_replay_captured_writes),
         engine.clone(),
         Now.clone_box(),
     )
@@ -4846,7 +4868,10 @@ fn prespawn_workflow_js(
 
 /// Replay-purposed [`WorkflowConfig`]: Interrupt strategy, stubbed WASI, no lock
 /// extension, no subscription interruption, no fuel limit.
-fn replay_workflow_config(component_id: &ComponentId) -> WorkflowConfig {
+fn replay_workflow_config(
+    component_id: &ComponentId,
+    max_replay_captured_writes: usize,
+) -> WorkflowConfig {
     WorkflowConfig {
         component_id: component_id.clone(),
         join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
@@ -4854,6 +4879,7 @@ fn replay_workflow_config(component_id: &ComponentId) -> WorkflowConfig {
         fuel: None,
         lock_extension: None, // does not matter for the `Interrupt` strategy.
         subscription_interruption: None, // does not matter for the `Interrupt` strategy.
+        max_replay_captured_writes: Some(max_replay_captured_writes),
     }
 }
 
@@ -4974,13 +5000,17 @@ impl WorkerCompiled {
         workflow: WorkflowConfigVerified,
         wit: String,
         workflows_lock_extension_leeway: Duration,
+        max_replay_captured_writes: usize,
     ) -> Result<
         (WorkerCompiled, ComponentConfig, FrameFilesToSourceContent),
         utils::wasm_tools::DecodeError,
     > {
         let replay_compiled = WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),
-            replay_workflow_config(&workflow.workflow_config.component_id),
+            replay_workflow_config(
+                &workflow.workflow_config.component_id,
+                max_replay_captured_writes,
+            ),
             engine.clone(),
             Now.clone_box(),
         )?;

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -2140,10 +2140,16 @@ pub(crate) struct WorkflowWasmComponentConfigToml {
 }
 
 pub(crate) trait BlockingStrategyConfigTomlExt {
-    fn into_blocking_strategy(self) -> JoinNextBlockingStrategy;
+    fn into_blocking_strategy(
+        self,
+        subscription_interruption: Option<Duration>,
+    ) -> JoinNextBlockingStrategy;
 }
 impl BlockingStrategyConfigTomlExt for BlockingStrategyConfigToml {
-    fn into_blocking_strategy(self) -> JoinNextBlockingStrategy {
+    fn into_blocking_strategy(
+        self,
+        subscription_interruption: Option<Duration>,
+    ) -> JoinNextBlockingStrategy {
         use deployment_config::config::{
             BlockingStrategyAwaitConfig, BlockingStrategyConfigCustomized,
             BlockingStrategyConfigSimple,
@@ -2155,6 +2161,7 @@ impl BlockingStrategyConfigTomlExt for BlockingStrategyConfigToml {
                 },
             )) => JoinNextBlockingStrategy::Await {
                 non_blocking_event_batching,
+                subscription_interruption,
             },
             BlockingStrategyConfigToml::Simple(BlockingStrategyConfigSimple::Interrupt) => {
                 JoinNextBlockingStrategy::Interrupt
@@ -2162,6 +2169,7 @@ impl BlockingStrategyConfigTomlExt for BlockingStrategyConfigToml {
             BlockingStrategyConfigToml::Simple(BlockingStrategyConfigSimple::Await) => {
                 JoinNextBlockingStrategy::Await {
                     non_blocking_event_batching: DEFAULT_NON_BLOCKING_EVENT_BATCHING,
+                    subscription_interruption,
                 }
             }
         }
@@ -2503,9 +2511,10 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
             stub_wasi: self.stub_wasi,
             fuel,
             mode: WorkflowConfigMode::Real {
-                join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
+                join_next_blocking_strategy: self
+                    .blocking_strategy
+                    .into_blocking_strategy(subscription_interruption),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
-                subscription_interruption,
             },
         };
         let frame_files_to_sources = self.backtrace.into_frame_files();
@@ -2594,9 +2603,10 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
             stub_wasi: false,
             fuel,
             mode: WorkflowConfigMode::Real {
-                join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
+                join_next_blocking_strategy: self
+                    .blocking_strategy
+                    .into_blocking_strategy(subscription_interruption),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
-                subscription_interruption,
             },
         };
         let retry_config = ComponentRetryConfig {
@@ -4236,7 +4246,7 @@ strategy = "interrupt"
 
             // Verify From impl result
             assert_eq!(
-                actual.strategy.into_blocking_strategy(),
+                actual.strategy.into_blocking_strategy(None),
                 JoinNextBlockingStrategy::Interrupt
             );
         }
@@ -4256,9 +4266,10 @@ strategy = "await"
 
             // Verify From impl result (uses default batching)
             assert_eq!(
-                actual.strategy.into_blocking_strategy(),
+                actual.strategy.into_blocking_strategy(None),
                 JoinNextBlockingStrategy::Await {
-                    non_blocking_event_batching: DEFAULT_NON_BLOCKING_EVENT_BATCHING
+                    non_blocking_event_batching: DEFAULT_NON_BLOCKING_EVENT_BATCHING,
+                    subscription_interruption: None,
                 }
             );
         }
@@ -4281,9 +4292,10 @@ strategy = { kind = "await" }
 
             // Verify From impl result (uses default batching)
             assert_eq!(
-                actual.strategy.into_blocking_strategy(),
+                actual.strategy.into_blocking_strategy(None),
                 JoinNextBlockingStrategy::Await {
-                    non_blocking_event_batching: DEFAULT_NON_BLOCKING_EVENT_BATCHING
+                    non_blocking_event_batching: DEFAULT_NON_BLOCKING_EVENT_BATCHING,
+                    subscription_interruption: None,
                 }
             );
         }
@@ -4306,9 +4318,10 @@ strategy = { kind = "await", non_blocking_event_batching = 99 }
 
             // Verify From impl result (uses custom batching)
             assert_eq!(
-                actual.strategy.into_blocking_strategy(),
+                actual.strategy.into_blocking_strategy(None),
                 JoinNextBlockingStrategy::Await {
-                    non_blocking_event_batching: 99
+                    non_blocking_event_batching: 99,
+                    subscription_interruption: None,
                 }
             );
         }

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -878,13 +878,32 @@ impl WasmGlobalConfigToml {
 
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields)]
-#[derive(Default)]
 pub(crate) struct WorkflowsGlobalConfigToml {
     /// Deprecated: set `lock_extension_leeway` on each `[[workflow_wasm]]` / `[[workflow_js]]`
     /// instead. When set, it overrides the per-workflow value for every workflow. Will be
     /// removed in 0.42.
     #[serde(default)]
     pub(crate) lock_extension_leeway: Option<DurationConfig>,
+    /// Maximum number of captured writes a single replay pass returns. On reaching it, replay
+    /// stops and returns that many writes as an advanceable prefix; advancing them and replaying
+    /// again resumes from the persisted tip. Keeps a non-terminating workflow (e.g. an unresolved
+    /// `joinNextTry` poll loop, whose replay never blocks) advanceable in bounded batches instead
+    /// of collecting captured writes forever.
+    #[serde(default = "default_max_replay_captured_writes")]
+    pub(crate) max_replay_captured_writes: usize,
+}
+
+impl Default for WorkflowsGlobalConfigToml {
+    fn default() -> Self {
+        Self {
+            lock_extension_leeway: None,
+            max_replay_captured_writes: default_max_replay_captured_writes(),
+        }
+    }
+}
+
+const fn default_max_replay_captured_writes() -> usize {
+    100
 }
 
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
@@ -2485,6 +2504,8 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
             fuel,
             lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
             subscription_interruption,
+            // Only the replay-purposed config bounds captured writes; see `replay_workflow_config`.
+            max_replay_captured_writes: None,
         };
         let frame_files_to_sources = self.backtrace.into_frame_files();
         let retry_config = ComponentRetryConfig {
@@ -2570,6 +2591,8 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
             fuel: None,
             lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
             subscription_interruption: None,
+            // Only the replay-purposed config bounds captured writes; see `replay_workflow_config`.
+            max_replay_captured_writes: None,
         };
         let retry_config = ComponentRetryConfig {
             max_retries: None,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -56,6 +56,7 @@ use wasm_workers::{
     std_output_stream::StdOutputConfig,
     workflow::workflow_worker::{
         DEFAULT_NON_BLOCKING_EVENT_BATCHING, JoinNextBlockingStrategy, WorkflowConfig,
+        WorkflowConfigMode,
     },
 };
 use webhook::{HttpServer, WebhookJsComponentConfigToml, WebhookWasmComponentConfigToml};
@@ -2499,13 +2500,13 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
         )?;
         let workflow_config = WorkflowConfig {
             component_id: component_id.clone(),
-            join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
             stub_wasi: self.stub_wasi,
             fuel,
-            lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
-            subscription_interruption,
-            // Only the replay-purposed config bounds captured writes; see `replay_workflow_config`.
-            max_replay_captured_writes: None,
+            mode: WorkflowConfigMode::Real {
+                join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
+                lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
+                subscription_interruption,
+            },
         };
         let frame_files_to_sources = self.backtrace.into_frame_files();
         let retry_config = ComponentRetryConfig {
@@ -2586,13 +2587,13 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
         )?;
         let workflow_config = WorkflowConfig {
             component_id: component_id.clone(),
-            join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
             stub_wasi: false,
             fuel: None,
-            lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
-            subscription_interruption: None,
-            // Only the replay-purposed config bounds captured writes; see `replay_workflow_config`.
-            max_replay_captured_writes: None,
+            mode: WorkflowConfigMode::Real {
+                join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
+                lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
+                subscription_interruption: None,
+            },
         };
         let retry_config = ComponentRetryConfig {
             max_retries: None,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -2534,6 +2534,8 @@ pub(crate) trait WorkflowJsComponentConfigResolvedExt {
         wasm_path: Arc<Path>,
         wasm_cache_dir: Arc<Path>,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
+        fuel: Option<u64>,
+        subscription_interruption: Option<Duration>,
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error>;
 }
 
@@ -2544,6 +2546,8 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
         wasm_path: Arc<Path>,
         wasm_cache_dir: Arc<Path>,
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
+        fuel: Option<u64>,
+        subscription_interruption: Option<Duration>,
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error> {
         let verified = verify_function_interface(
             self.interface,
@@ -2588,11 +2592,11 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
         let workflow_config = WorkflowConfig {
             component_id: component_id.clone(),
             stub_wasi: false,
-            fuel: None,
+            fuel,
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy: self.blocking_strategy.into_blocking_strategy(),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
-                subscription_interruption: None,
+                subscription_interruption,
             },
         };
         let retry_config = ComponentRetryConfig {

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1049,7 +1049,8 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                             grpc_gen::advance_execution_response::error::ReplayMismatch {},
                         )
                     }
-                    err @ (AdvanceError::ExecutionInterrupt | AdvanceError::LimitReached { .. }) => {
+                    err
+                    @ (AdvanceError::ExecutionInterrupt | AdvanceError::LimitReached { .. }) => {
                         grpc_gen::advance_execution_response::error::Error::TransientError(
                             grpc_gen::advance_execution_response::error::TransientError {
                                 message: err.to_string(),

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1049,7 +1049,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                             grpc_gen::advance_execution_response::error::ReplayMismatch {},
                         )
                     }
-                    err @ (AdvanceError::ExecutorClosing | AdvanceError::LimitReached { .. }) => {
+                    err @ (AdvanceError::ExecutionInterrupt | AdvanceError::LimitReached { .. }) => {
                         grpc_gen::advance_execution_response::error::Error::TransientError(
                             grpc_gen::advance_execution_response::error::TransientError {
                                 message: err.to_string(),

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -2416,7 +2416,7 @@ async fn execution_advance(
                 AdvanceError::DbError(db_err) => {
                     return Err(ErrorWrapper(db_err, accept).into());
                 }
-                err @ (AdvanceError::ExecutorClosing | AdvanceError::LimitReached { .. }) => {
+                err @ (AdvanceError::ExecutionInterrupt | AdvanceError::LimitReached { .. }) => {
                     AdvanceErrorSer::Transient(err.to_string())
                 }
             };


### PR DESCRIPTION
- **test: Add a join-next-try in a loop workflow**
- **feat(toml): Add `max_replay_captured_writes` to server config**
- **refactor: Extract `WorkflowConfigMode`**
- **fix(toml): Wire fuel and subscription_interruption into JS workflows**
- **refactor: Move `subscription_interruption` under `JoinNextBlockingStrategy::Await`**
- **refactor: rename ExecutorClosing notification to ExecutionInterrupt**
