### PR TITLE
feat(workflow): Interrupt workflow when cancellation request is persisted

### DIFF
--- a/crates/concepts/src/error_conversions.rs
+++ b/crates/concepts/src/error_conversions.rs
@@ -2,7 +2,8 @@ use crate::{
     JoinSetIdParseError,
     prefixed_ulid::{DerivedIdParseError, ExecutionIdParseError, PrefixedUlidParseError},
     storage::{
-        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite, VersionParseError,
+        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite,
+        SubscribeToResponsesError, VersionParseError,
     },
 };
 use std::{panic::Location, sync::Arc};
@@ -85,6 +86,12 @@ impl From<DerivedIdParseError> for DbErrorGeneric {
 
 impl From<DbErrorGeneric> for DbErrorReadWithTimeout {
     fn from(value: DbErrorGeneric) -> DbErrorReadWithTimeout {
+        Self::from(DbErrorRead::from(value))
+    }
+}
+
+impl From<DbErrorGeneric> for SubscribeToResponsesError {
+    fn from(value: DbErrorGeneric) -> Self {
         Self::from(DbErrorRead::from(value))
     }
 }

--- a/crates/concepts/src/postgres_ext.rs
+++ b/crates/concepts/src/postgres_ext.rs
@@ -1,6 +1,6 @@
 use crate::storage::{
     DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite,
-    DbErrorWriteNonRetriable,
+    DbErrorWriteNonRetriable, SubscribeToResponsesError,
 };
 use std::{panic::Location, sync::Arc};
 use tokio_postgres::error::SqlState;
@@ -32,6 +32,13 @@ impl From<tokio_postgres::Error> for DbErrorRead {
 }
 
 impl From<tokio_postgres::Error> for DbErrorReadWithTimeout {
+    #[track_caller]
+    fn from(err: tokio_postgres::Error) -> Self {
+        Self::from(DbErrorRead::from(err))
+    }
+}
+
+impl From<tokio_postgres::Error> for SubscribeToResponsesError {
     #[track_caller]
     fn from(err: tokio_postgres::Error) -> Self {
         Self::from(DbErrorRead::from(err))

--- a/crates/concepts/src/rusqlite_ext.rs
+++ b/crates/concepts/src/rusqlite_ext.rs
@@ -2,7 +2,8 @@ use crate::{
     ExecutionId, JoinSetId,
     prefixed_ulid::{DelayId, DeploymentId, ExecutionIdDerived, ExecutorId, RunId},
     storage::{
-        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite, DbErrorWriteNonRetriable,
+        DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite,
+        DbErrorWriteNonRetriable, SubscribeToResponsesError,
     },
 };
 use rusqlite::{
@@ -129,6 +130,12 @@ impl From<rusqlite::Error> for DbErrorRead {
     }
 }
 impl From<rusqlite::Error> for DbErrorReadWithTimeout {
+    #[track_caller]
+    fn from(err: rusqlite::Error) -> Self {
+        Self::from(DbErrorRead::from(err))
+    }
+}
+impl From<rusqlite::Error> for SubscribeToResponsesError {
     #[track_caller]
     fn from(err: rusqlite::Error) -> Self {
         Self::from(DbErrorRead::from(err))

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1614,9 +1614,10 @@ pub trait DbExternalApi: DbConnection {
         pagination: Pagination<Option<DeploymentId>>,
     ) -> Result<Vec<DeploymentRecord>, DbErrorRead>;
 
-    /// Pause an execution. Only pending executions can be paused.
+    /// Pause an execution.
     /// If the execution is an activity and is currently in `PendingState::Locked`, implementations must
-    /// append `ExecutionRequest::Unlocked` to avoid affecting failed attempt count, before appending `ExecutionRequest::Paused`.
+    /// reject the write, otherwise a running activity will be considered terminated, which can break
+    /// structured concurrency guarantees.
     async fn pause_execution(
         &self,
         execution_id: &ExecutionId,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1013,6 +1013,22 @@ pub enum DbErrorReadWithTimeout {
     DbErrorRead(#[from] DbErrorRead),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseSubscriptionEnd {
+    PollIntervalElapsed,
+    LockDeadlineReached,
+    ExecutorClosing,
+    ExecutionUpdated,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum SubscribeToResponsesError {
+    #[error("response subscription ended: {0:?}")]
+    SubscriptionEnded(ResponseSubscriptionEnd),
+    #[error(transparent)]
+    DbErrorRead(#[from] DbErrorRead),
+}
+
 // Represents next version after successfuly appended to execution log.
 // TODO: Convert to struct with next_version
 pub type AppendResponse = Version;
@@ -2103,7 +2119,8 @@ pub trait DbConnection: DbExecutor {
 
     /// Notification mechainism with no strict guarantees for getting notified when a new response arrives.
     /// Parameter `start_idx` must be at most be equal to current size of responses in the execution log.
-    /// If no response arrives immediately and `interrupt_after` resolves, `DbErrorReadWithTimeout::Timeout` is returned.
+    /// If no response arrives immediately and `subscription_end_fut` resolves,
+    /// `SubscribeToResponsesError::SubscriptionEnded` is returned.
     /// Implementations with no pubsub support should use polling.
     /// Callers are expected to call this function in a loop with a reasonable timeout
     /// to support less stellar implementations.
@@ -2111,8 +2128,8 @@ pub trait DbConnection: DbExecutor {
         &self,
         execution_id: &ExecutionId,
         last_response: ResponseCursor,
-        timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
-    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout>;
+        subscription_end_fut: Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, SubscribeToResponsesError>;
 
     /// First, attempt to fetch the finished value. If the execution is not finished yet, poll
     /// periodically or subscribe to db changes, racing with `timeout_fut`.

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -26,9 +26,10 @@ use concepts::{
         LockedExecution, LogCursor, LogEntry, LogEntryRow, LogFilter, LogInfoAppendRow, LogLevel,
         LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
         PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateMerged,
-        RESULT_KIND_JSON_ERROR, RESULT_KIND_JSON_OK, ResponseCursor, ResponseWithCursor,
-        STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED, STATE_PENDING_AT, TimeoutOutcome,
-        Unlocked, Version, VersionType, WasmBacktrace,
+        RESULT_KIND_JSON_ERROR, RESULT_KIND_JSON_OK, ResponseCursor, ResponseSubscriptionEnd,
+        ResponseWithCursor, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED,
+        STATE_PENDING_AT, SubscribeToResponsesError, TimeoutOutcome, Unlocked, Version,
+        VersionType, WasmBacktrace,
     },
 };
 use db_common::{
@@ -4371,13 +4372,13 @@ impl DbConnection for PostgresConnection {
         Ok(version)
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, timeout_fut))]
+    #[instrument(level = Level::DEBUG, skip(self, subscription_end_fut))]
     async fn subscribe_to_next_responses(
         &self,
         execution_id: &ExecutionId,
         last_response: ResponseCursor,
-        timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
-    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout> {
+        subscription_end_fut: Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, SubscribeToResponsesError> {
         debug!("next_responses");
         let unique_tag: u64 = rand::random();
         let execution_id_clone = execution_id.clone();
@@ -4427,9 +4428,9 @@ impl DbConnection for PostgresConnection {
         let woken = tokio::select! {
             resp = receiver => match resp {
                 Ok(()) => Ok(()),
-                Err(_) => Err(DbErrorReadWithTimeout::from(DbErrorGeneric::Close)),
+                Err(_) => Err(SubscribeToResponsesError::from(DbErrorGeneric::Close)),
             },
-            outcome = timeout_fut => Err(DbErrorReadWithTimeout::Timeout(outcome)),
+            reason = subscription_end_fut => Err(SubscribeToResponsesError::SubscriptionEnded(reason)),
         };
 
         cleanup();

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -26,9 +26,10 @@ use concepts::{
         LockedExecution, LogCursor, LogEntry, LogEntryRow, LogFilter, LogInfoAppendRow, LogLevel,
         LogStreamType, Pagination, PendingState, PendingStateBlockedByJoinSet,
         PendingStateFinishedError, PendingStateFinishedResultKind, PendingStateMerged,
-        RESULT_KIND_JSON_ERROR, RESULT_KIND_JSON_OK, ResponseCursor, ResponseWithCursor,
-        STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED, STATE_PENDING_AT, TimeoutOutcome,
-        Unlocked, Version, VersionType,
+        RESULT_KIND_JSON_ERROR, RESULT_KIND_JSON_OK, ResponseCursor, ResponseSubscriptionEnd,
+        ResponseWithCursor, STATE_BLOCKED_BY_JOIN_SET, STATE_FINISHED, STATE_LOCKED,
+        STATE_PENDING_AT, SubscribeToResponsesError, TimeoutOutcome, Unlocked, Version,
+        VersionType,
     },
 };
 use conversions::{JsonWrapper, consistency_db_err, consistency_rusqlite, from_generic_error};
@@ -123,6 +124,7 @@ mod conversions {
         StrVariant,
         storage::{
             DbErrorGeneric, DbErrorRead, DbErrorReadWithTimeout, DbErrorStubResponse, DbErrorWrite,
+            SubscribeToResponsesError,
         },
     };
     use rusqlite::{
@@ -185,6 +187,11 @@ mod conversions {
         }
     }
     impl From<RusqliteError> for DbErrorReadWithTimeout {
+        fn from(err: RusqliteError) -> Self {
+            Self::from(DbErrorRead::from(err))
+        }
+    }
+    impl From<RusqliteError> for SubscribeToResponsesError {
         fn from(err: RusqliteError) -> Self {
             Self::from(DbErrorRead::from(err))
         }
@@ -5597,13 +5604,13 @@ impl DbConnection for SqlitePool {
     // Supports only one subscriber per execution id.
     // A new call will overwrite the old subscriber, the old one will end
     // with a timeout, which is fine.
-    #[instrument(level = Level::DEBUG, skip(self, timeout_fut))]
+    #[instrument(level = Level::DEBUG, skip(self, subscription_end_fut))]
     async fn subscribe_to_next_responses(
         &self,
         execution_id: &ExecutionId,
         last_response: ResponseCursor,
-        timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
-    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout> {
+        subscription_end_fut: Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, SubscribeToResponsesError> {
         debug!("next_responses");
         let unique_tag: u64 = rand::random();
         let execution_id = execution_id.clone();
@@ -5633,7 +5640,7 @@ impl DbConnection for SqlitePool {
                             .lock()
                             .unwrap()
                             .insert(execution_id.clone(), (sender, unique_tag));
-                        Ok::<_, DbErrorReadWithTimeout>(itertools::Either::Right(receiver))
+                        Ok::<_, SubscribeToResponsesError>(itertools::Either::Right(receiver))
                     } else {
                         Ok(itertools::Either::Left(responses))
                     }
@@ -5652,9 +5659,9 @@ impl DbConnection for SqlitePool {
                 let woken = tokio::select! {
                     resp = receiver => match resp {
                         Ok(()) => Ok(()),
-                        Err(_) => Err(DbErrorReadWithTimeout::from(DbErrorGeneric::Close)),
+                        Err(_) => Err(SubscribeToResponsesError::from(DbErrorGeneric::Close)),
                     },
-                    outcome = timeout_fut => Err(DbErrorReadWithTimeout::Timeout(outcome)),
+                    reason = subscription_end_fut => Err(SubscribeToResponsesError::SubscriptionEnded(reason)),
                 };
                 cleanup();
                 woken?;
@@ -5663,7 +5670,7 @@ impl DbConnection for SqlitePool {
                 self.transaction(
                     move |tx| {
                         Self::get_responses_after(tx, &execution_id, last_response)
-                            .map_err(DbErrorReadWithTimeout::from)
+                            .map_err(SubscribeToResponsesError::from)
                     },
                     TxType::Other, // read only
                     "subscribe_to_next_responses_refetch",

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -777,10 +777,10 @@ impl ExecTask {
                 let reason_generic = err.to_string(); // Override with err's reason if no information is lost.
 
                 let (primary_event, child_finished, version) = match err {
-                    WorkerError::ExecutionInterrupt(version) => {
+                    WorkerError::ExecutorClosing(version) => {
                         let primary_event = ExecutionRequest::Unlocked(Unlocked {
                             unlocked_at: result_obtained_at,
-                            reason: "execution interrupt".into(),
+                            reason: "executor closing".into(),
                         });
                         (primary_event, None, version)
                     }

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -85,8 +85,8 @@ pub enum WorkerError {
         http_client_traces: Option<Vec<HttpClientTrace>>,
         version: Version,
     },
-    #[error("execution interrupt")]
-    ExecutionInterrupt(Version),
+    #[error("executor closing")]
+    ExecutorClosing(Version),
     #[error(transparent)]
     DbError(DbErrorWrite),
     // non-retriable errors

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -1839,7 +1839,7 @@ async fn append_unlocked_to_blocked_execution_updates_lock_expiry(database: Data
         .await
         .unwrap();
 
-    // The execution is interrupted, so it unlocks the blocked execution: the state stays
+    // The executor is closing, so it unlocks the blocked execution: the state stays
     // blocked but `lock_expires_at` drops to the unlock time, releasing the warm lease.
     let unlocked_at = sim_clock.now();
     db_connection
@@ -1850,7 +1850,7 @@ async fn append_unlocked_to_blocked_execution_updates_lock_expiry(database: Data
                 created_at: unlocked_at,
                 event: ExecutionRequest::Unlocked(Unlocked {
                     unlocked_at,
-                    reason: "execution interrupt".into(),
+                    reason: "executor closing".into(),
                 }),
             },
         )

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -226,8 +226,8 @@ impl Worker for ActivityWorker {
                         Ok(worker_res_ok) => {
                             info!(duration = ?stopwatch_for_reporting.elapsed(), "Run finished: {worker_res_ok}");
                         }
-                        Err(WorkerError::ExecutionInterrupt(_)) => {
-                            info!("Execution interrupted");
+                        Err(WorkerError::ExecutorClosing(_)) => {
+                            info!("Executor closing");
                         }
                         Err(err) => {
                             info!(%err, duration = ?stopwatch_for_reporting.elapsed(), "Run finished with an error");
@@ -264,9 +264,9 @@ impl Worker for ActivityWorker {
                 return WorkerResult::Err(WorkerError::FatalError(FatalError::Cancelled, version));
             }
             _ = execution_interrupt_watcher.changed() => {
-                debug!("Execution interrupted");
+                debug!("Executor closing");
                 // Executor will append the Unlocked event.
-                return WorkerResult::Err(WorkerError::ExecutionInterrupt(version.clone()))
+                return WorkerResult::Err(WorkerError::ExecutorClosing(version.clone()))
             }
         }
     }

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -18,10 +18,9 @@ use tracing::{Instrument, debug, info, info_span};
 /// cancellation intent to db (whether registered or not) and triggers the token.
 /// Workflow worker tasks register a per-execution interrupt watch (pruned by `tick`
 /// once the run drops its receiver); the pause and cancel RPCs call
-/// `signal_workflow_interrupt` to give up the lock of a locally-running workflow
-/// (`ExecutionInterrupt`) without waiting for the lock deadline. The durable pause
-/// or cancel write is what makes the outcome correct; this signal only saves the
-/// wasted work on this node.
+/// `signal_workflow_interrupt` after their durable write. The write is what takes
+/// effect (it dooms the run's next db append); the signal only stops the run early so
+/// it stops burning CPU, returning `DbUpdatedByWorkerOrWatcher` without appending.
 pub struct CancelRegistry {
     tokens: Arc<Mutex<hashbrown::HashMap<ExecutionId, ActivityInfo>>>,
     running_workflows: Arc<Mutex<hashbrown::HashMap<ExecutionId, watch::Sender<bool>>>>,

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -16,9 +16,12 @@ use tracing::{Instrument, debug, info, info_span};
 /// Activity worker tasks register themselves and listen on an interruption token;
 /// cancel RPCs and workflow workers call `cancel_activity`, which writes durable
 /// cancellation intent to db (whether registered or not) and triggers the token.
-/// Workflow worker tasks register a per-execution pause watch (pruned by `tick`
-/// once the run drops its receiver); the pause RPC calls `signal_pause` to
-/// interrupt a locally-running workflow (`ExecutionInterrupt`).
+/// Workflow worker tasks register a per-execution interrupt watch (pruned by `tick`
+/// once the run drops its receiver); the pause and cancel RPCs call
+/// `signal_workflow_interrupt` to give up the lock of a locally-running workflow
+/// (`ExecutionInterrupt`) without waiting for the lock deadline. The durable pause
+/// or cancel write is what makes the outcome correct; this signal only saves the
+/// wasted work on this node.
 pub struct CancelRegistry {
     tokens: Arc<Mutex<hashbrown::HashMap<ExecutionId, ActivityInfo>>>,
     running_workflows: Arc<Mutex<hashbrown::HashMap<ExecutionId, watch::Sender<bool>>>>,
@@ -83,9 +86,9 @@ impl CancelRegistry {
         receiver
     }
 
-    /// Register a locked workflow run so a `signal_pause` can interrupt it same-node.
-    /// The returned receiver is threaded into the deadline tracker; the entry is
-    /// pruned by `tick` once the run drops it (completion, trap, or panic).
+    /// Register a locked workflow run so `signal_workflow_interrupt` can interrupt it
+    /// same-node. The returned receiver is threaded into the deadline tracker; the
+    /// entry is pruned by `tick` once the run drops it (completion, trap, or panic).
     #[must_use]
     pub fn register_running_workflow(&self, execution_id: ExecutionId) -> watch::Receiver<bool> {
         let (sender, receiver) = watch::channel(false);
@@ -96,10 +99,10 @@ impl CancelRegistry {
         receiver
     }
 
-    /// Best-effort interrupt of a locally-running workflow after its durable pause
-    /// write. A no-op if the workflow is not running in this process (another node,
-    /// or not currently locked).
-    pub fn signal_pause(&self, execution_id: &ExecutionId) {
+    /// Best-effort interrupt of a locally-running workflow after its durable pause or
+    /// cancel write. A no-op if the workflow is not running in this process (another
+    /// node, or not currently locked).
+    pub fn signal_workflow_interrupt(&self, execution_id: &ExecutionId) {
         if let Some(sender) = self.running_workflows.lock().unwrap().get(execution_id) {
             let _ = sender.send(true);
         }

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -13,8 +13,8 @@ use concepts::{
     prefixed_ulid::{DelayId, ExecutionIdDerived},
     storage::{
         self, AppendRequest, AppendResponseToExecution, BacktraceInfo, CreateRequest, DbConnection,
-        DbErrorRead, DbErrorReadWithTimeout, DbErrorWrite, LogInfoAppendRow, ResponseCursor,
-        ResponseWithCursor, TimeoutOutcome, Version,
+        DbErrorRead, DbErrorWrite, LogInfoAppendRow, ResponseCursor, ResponseSubscriptionEnd,
+        ResponseWithCursor, SubscribeToResponsesError, Version,
     },
 };
 use db_common::JoinSetResponseId;
@@ -116,8 +116,8 @@ pub(crate) trait WorkflowDbConnection: Send + Any {
         &self,
         execution_id: &ExecutionId,
         last_response: ResponseCursor,
-        timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
-    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout>;
+        subscription_end_fut: Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, SubscribeToResponsesError>;
 
     async fn flush_non_blocking_event_cache(
         &mut self,
@@ -559,10 +559,10 @@ impl WorkflowDbConnection for CachingDbConnection {
         &self,
         execution_id: &ExecutionId,
         last_response: ResponseCursor,
-        timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
-    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout> {
+        subscription_end_fut: Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, SubscribeToResponsesError> {
         self.db_connection
-            .subscribe_to_next_responses(execution_id, last_response, timeout_fut)
+            .subscribe_to_next_responses(execution_id, last_response, subscription_end_fut)
             .await
     }
 

--- a/crates/wasm-workers/src/workflow/deadline_tracker.rs
+++ b/crates/wasm-workers/src/workflow/deadline_tracker.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use concepts::{storage::TimeoutOutcome, time::ClockFn};
-use std::{cmp::min, pin::Pin, time::Duration};
+use concepts::{storage::ResponseSubscriptionEnd, time::ClockFn};
+use std::{pin::Pin, time::Duration};
 use tokio::sync::watch;
 use tracing::{trace, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum InterruptKind {
+pub enum InterruptKind {
     /// Send [`WorkerError::ExecutorClosing`]
     ExecutorClosing,
     /// Send [`WorkerResultOk::DbUpdatedByWorkerOrWatcher`], the pause/cancel RPC must have appended the event.
@@ -19,16 +19,15 @@ pub trait DeadlineTracker: Send + Sync {
     fn check_preempt(&self) -> Result<(), PreemptRequested>;
 
     /// Called after the workflow made progress and is now blocked waiting for a response.
-    /// Returns a future that resolves once the caller should stop waiting (deadline, or
-    /// an interrupt via the generic `TimeoutOutcome::Cancel`); the caller then re-calls
-    /// `track`, whose `Err` reports the concrete reason. If `max_duration` is specified,
-    /// the future resolves at deadline or after this duration, whichever comes first.
-    /// `Err` means the caller must not block: the lock deadline already passed, or the
-    /// run is being interrupted (`TrackPrecheck::Interrupt` carries the kind).
+    /// Returns a future that reports why the caller should stop waiting. If
+    /// `max_duration` is specified, it can also end for periodic polling.
     fn track(
         &self,
         max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck>;
+    ) -> Result<
+        Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+        ResponseSubscriptionEnd,
+    >;
 
     fn close_to_expired(&self) -> bool;
 
@@ -40,15 +39,6 @@ pub trait DeadlineTracker: Send + Sync {
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum PreemptRequested {
-    #[error("execution interrupt: {0:?}")]
-    Interrupt(InterruptKind),
-}
-
-/// Reason `track` declined to return a waiting future.
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum TrackPrecheck {
-    #[error("lock deadline reached")]
-    LockDeadlineReached,
     #[error("execution interrupt: {0:?}")]
     Interrupt(InterruptKind),
 }
@@ -130,25 +120,36 @@ impl DeadlineTracker for DeadlineTrackerTokio {
     fn track(
         &self,
         max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck> {
-        if self.deadline <= tokio::time::Instant::now() {
-            Err(TrackPrecheck::LockDeadlineReached)
+    ) -> Result<
+        Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+        ResponseSubscriptionEnd,
+    > {
+        let now = tokio::time::Instant::now();
+        if self.deadline_minus_leeway <= now {
+            Err(ResponseSubscriptionEnd::LockDeadlineReached)
         } else if let Some(kind) = self.interrupt_kind() {
-            Err(TrackPrecheck::Interrupt(kind))
+            Err(match kind {
+                InterruptKind::ExecutorClosing => ResponseSubscriptionEnd::ExecutorClosing,
+                InterruptKind::PauseOrCancel => ResponseSubscriptionEnd::ExecutionUpdated,
+            })
         } else {
-            let expiry = if let Some(max_duration) = max_duration {
-                let max_instant = tokio::time::Instant::now() + max_duration;
-                min(max_instant, self.deadline_minus_leeway)
-            } else {
-                self.deadline_minus_leeway
+            let (expiry, expiry_reason) = match max_duration {
+                Some(max_duration) if now + max_duration < self.deadline_minus_leeway => (
+                    now + max_duration,
+                    ResponseSubscriptionEnd::PollIntervalElapsed,
+                ),
+                _ => (
+                    self.deadline_minus_leeway,
+                    ResponseSubscriptionEnd::LockDeadlineReached,
+                ),
             };
             let mut execution_interrupt_watcher = self.execution_interrupt_watcher.clone();
             let mut local_interrupt_watcher = self.local_interrupt_watcher.clone();
             Ok(Box::pin(async move {
                 tokio::select! {
-                    () = tokio::time::sleep_until(expiry) => TimeoutOutcome::Timeout,
-                    _ = execution_interrupt_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
-                    _ = local_interrupt_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
+                    () = tokio::time::sleep_until(expiry) => expiry_reason,
+                    _ = execution_interrupt_watcher.wait_for(|&v| v) => ResponseSubscriptionEnd::ExecutorClosing,
+                    _ = local_interrupt_watcher.wait_for(|&v| v) => ResponseSubscriptionEnd::ExecutionUpdated,
                 }
             }))
         }
@@ -283,17 +284,28 @@ impl DeadlineTracker for DeadlineTrackerSim {
     fn track(
         &self,
         max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck> {
+    ) -> Result<
+        Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+        ResponseSubscriptionEnd,
+    > {
         let now = self.clock.now();
-        if self.deadline <= now {
-            return Err(TrackPrecheck::LockDeadlineReached);
+        if self.deadline_minus_leeway <= now {
+            return Err(ResponseSubscriptionEnd::LockDeadlineReached);
         } else if let Some(kind) = self.interrupt_kind() {
-            return Err(TrackPrecheck::Interrupt(kind));
+            return Err(match kind {
+                InterruptKind::ExecutorClosing => ResponseSubscriptionEnd::ExecutorClosing,
+                InterruptKind::PauseOrCancel => ResponseSubscriptionEnd::ExecutionUpdated,
+            });
         }
-        let expiry = if let Some(max_duration) = max_duration {
-            min(add_duration(now, max_duration), self.deadline_minus_leeway)
-        } else {
-            self.deadline_minus_leeway
+        let (expiry, expiry_reason) = match max_duration {
+            Some(max_duration) if add_duration(now, max_duration) < self.deadline_minus_leeway => (
+                add_duration(now, max_duration),
+                ResponseSubscriptionEnd::PollIntervalElapsed,
+            ),
+            _ => (
+                self.deadline_minus_leeway,
+                ResponseSubscriptionEnd::LockDeadlineReached,
+            ),
         };
         let clock = self.clock.clone();
         // Subscribe now, before the future is awaited, so time advances between
@@ -304,15 +316,15 @@ impl DeadlineTracker for DeadlineTrackerSim {
         Ok(Box::pin(async move {
             loop {
                 if clock.now() >= expiry {
-                    return TimeoutOutcome::Timeout;
+                    return expiry_reason;
                 }
                 tokio::select! {
                     // `Err` means the `SimClock` was dropped: time will never advance again.
                     res = time_watcher.changed() => if res.is_err() {
-                        return TimeoutOutcome::Cancel;
+                        return ResponseSubscriptionEnd::PollIntervalElapsed;
                     },
-                    _ = execution_interrupt_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
-                    _ = local_interrupt_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
+                    _ = execution_interrupt_watcher.wait_for(|&v| v) => return ResponseSubscriptionEnd::ExecutorClosing,
+                    _ = local_interrupt_watcher.wait_for(|&v| v) => return ResponseSubscriptionEnd::ExecutionUpdated,
                 }
             }
         }))
@@ -420,7 +432,10 @@ impl DeadlineTracker for DeadlineTrackerFactoryForReplay {
     fn track(
         &self,
         _max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck> {
+    ) -> Result<
+        Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+        ResponseSubscriptionEnd,
+    > {
         unreachable!("`track` is not called for the interrupt strategy")
     }
 

--- a/crates/wasm-workers/src/workflow/deadline_tracker.rs
+++ b/crates/wasm-workers/src/workflow/deadline_tracker.rs
@@ -5,19 +5,30 @@ use std::{cmp::min, pin::Pin, time::Duration};
 use tokio::sync::watch;
 use tracing::{trace, warn};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InterruptKind {
+    /// Send [`WorkerError::ExecutorClosing`]
+    ExecutorClosing,
+    /// Send [`WorkerResultOk::DbUpdatedByWorkerOrWatcher`], the pause/cancel RPC must have appended the event.
+    PauseOrCancel,
+}
+
 #[async_trait]
 pub trait DeadlineTracker: Send + Sync {
     /// Host functions must check whether the execution was interrupted.
     fn check_preempt(&self) -> Result<(), PreemptRequested>;
 
     /// Called after the workflow made progress and is now blocked waiting for a response.
-    /// Return a future that resolves on deadline. If `max_duration` is specified, the future resolves
-    /// at deadline or after this duration, whatever expires first.
-    /// Return `None` if expired.
+    /// Returns a future that resolves once the caller should stop waiting (deadline, or
+    /// an interrupt via the generic `TimeoutOutcome::Cancel`); the caller then re-calls
+    /// `track`, whose `Err` reports the concrete reason. If `max_duration` is specified,
+    /// the future resolves at deadline or after this duration, whichever comes first.
+    /// `Err` means the caller must not block: the lock deadline already passed, or the
+    /// run is being interrupted (`TrackPrecheck::Interrupt` carries the kind).
     fn track(
         &self,
         max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TimeoutOutcome>;
+    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck>;
 
     fn close_to_expired(&self) -> bool;
 
@@ -29,14 +40,24 @@ pub trait DeadlineTracker: Send + Sync {
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum PreemptRequested {
-    #[error("execution interrupt")]
-    ExecutionInterrupt,
+    #[error("execution interrupt: {0:?}")]
+    Interrupt(InterruptKind),
+}
+
+/// Reason `track` declined to return a waiting future.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum TrackPrecheck {
+    #[error("lock deadline reached")]
+    LockDeadlineReached,
+    #[error("execution interrupt: {0:?}")]
+    Interrupt(InterruptKind),
 }
 
 pub trait DeadlineTrackerFactory: Send + Sync {
-    /// `execution_interrupt_watcher` is the executor-wide shutdown signal;
-    /// `local_interrupt_watcher` is the per-execution pause/cancel signal. Either
-    /// firing interrupts the run as `ExecutionInterrupt`.
+    /// `execution_interrupt_watcher` is the executor-wide shutdown signal
+    /// (`InterruptKind::ExecutorClosing`); `local_interrupt_watcher` is the
+    /// per-execution pause/cancel signal (`InterruptKind::PauseOrCancel`). Either
+    /// firing interrupts the run; the kind decides the disposition.
     fn create(
         &self,
         lock_expires_at: DateTime<Utc>,
@@ -58,11 +79,11 @@ pub struct LockAlreadyExpired {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum EpochCallbackError {
+pub(crate) enum EpochCallbackError {
     #[error("lock expired")]
     LockExpired,
-    #[error("execution interrupt")]
-    ExecutionInterrupt,
+    #[error("execution interrupt: {0:?}")]
+    Interrupt(InterruptKind),
 }
 
 pub(crate) struct DeadlineTrackerTokio {
@@ -74,17 +95,33 @@ pub(crate) struct DeadlineTrackerTokio {
     local_interrupt_watcher: watch::Receiver<bool>,
 }
 
+fn interrupt_kind_from_watchers(
+    execution_interrupt_watcher: &watch::Receiver<bool>,
+    local_interrupt_watcher: &watch::Receiver<bool>,
+) -> Option<InterruptKind> {
+    if *execution_interrupt_watcher.borrow() {
+        Some(InterruptKind::ExecutorClosing)
+    } else if *local_interrupt_watcher.borrow() {
+        Some(InterruptKind::PauseOrCancel)
+    } else {
+        None
+    }
+}
+
 impl DeadlineTrackerTokio {
-    fn interrupt_requested(&self) -> bool {
-        *self.execution_interrupt_watcher.borrow() || *self.local_interrupt_watcher.borrow()
+    fn interrupt_kind(&self) -> Option<InterruptKind> {
+        interrupt_kind_from_watchers(
+            &self.execution_interrupt_watcher,
+            &self.local_interrupt_watcher,
+        )
     }
 }
 
 #[async_trait]
 impl DeadlineTracker for DeadlineTrackerTokio {
     fn check_preempt(&self) -> Result<(), PreemptRequested> {
-        if self.interrupt_requested() {
-            Err(PreemptRequested::ExecutionInterrupt)
+        if let Some(kind) = self.interrupt_kind() {
+            Err(PreemptRequested::Interrupt(kind))
         } else {
             Ok(())
         }
@@ -93,11 +130,11 @@ impl DeadlineTracker for DeadlineTrackerTokio {
     fn track(
         &self,
         max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TimeoutOutcome> {
+    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck> {
         if self.deadline <= tokio::time::Instant::now() {
-            Err(TimeoutOutcome::Timeout)
-        } else if self.interrupt_requested() {
-            Err(TimeoutOutcome::Cancel)
+            Err(TrackPrecheck::LockDeadlineReached)
+        } else if let Some(kind) = self.interrupt_kind() {
+            Err(TrackPrecheck::Interrupt(kind))
         } else {
             let expiry = if let Some(max_duration) = max_duration {
                 let max_instant = tokio::time::Instant::now() + max_duration;
@@ -122,8 +159,8 @@ impl DeadlineTracker for DeadlineTrackerTokio {
     }
 
     fn check_epoch_callback(&self) -> Result<(), EpochCallbackError> {
-        if self.interrupt_requested() {
-            Err(EpochCallbackError::ExecutionInterrupt)
+        if let Some(kind) = self.interrupt_kind() {
+            Err(EpochCallbackError::Interrupt(kind))
         } else if self.deadline <= tokio::time::Instant::now() {
             Err(EpochCallbackError::LockExpired)
         } else {
@@ -224,8 +261,11 @@ fn add_duration(time: DateTime<Utc>, duration: Duration) -> DateTime<Utc> {
 
 #[cfg(test)]
 impl DeadlineTrackerSim {
-    fn interrupt_requested(&self) -> bool {
-        *self.execution_interrupt_watcher.borrow() || *self.local_interrupt_watcher.borrow()
+    fn interrupt_kind(&self) -> Option<InterruptKind> {
+        interrupt_kind_from_watchers(
+            &self.execution_interrupt_watcher,
+            &self.local_interrupt_watcher,
+        )
     }
 }
 
@@ -233,8 +273,8 @@ impl DeadlineTrackerSim {
 #[async_trait]
 impl DeadlineTracker for DeadlineTrackerSim {
     fn check_preempt(&self) -> Result<(), PreemptRequested> {
-        if self.interrupt_requested() {
-            Err(PreemptRequested::ExecutionInterrupt)
+        if let Some(kind) = self.interrupt_kind() {
+            Err(PreemptRequested::Interrupt(kind))
         } else {
             Ok(())
         }
@@ -243,12 +283,12 @@ impl DeadlineTracker for DeadlineTrackerSim {
     fn track(
         &self,
         max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TimeoutOutcome> {
+    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck> {
         let now = self.clock.now();
         if self.deadline <= now {
-            return Err(TimeoutOutcome::Timeout);
-        } else if self.interrupt_requested() {
-            return Err(TimeoutOutcome::Cancel);
+            return Err(TrackPrecheck::LockDeadlineReached);
+        } else if let Some(kind) = self.interrupt_kind() {
+            return Err(TrackPrecheck::Interrupt(kind));
         }
         let expiry = if let Some(max_duration) = max_duration {
             min(add_duration(now, max_duration), self.deadline_minus_leeway)
@@ -283,8 +323,8 @@ impl DeadlineTracker for DeadlineTrackerSim {
     }
 
     fn check_epoch_callback(&self) -> Result<(), EpochCallbackError> {
-        if self.interrupt_requested() {
-            Err(EpochCallbackError::ExecutionInterrupt)
+        if let Some(kind) = self.interrupt_kind() {
+            Err(EpochCallbackError::Interrupt(kind))
         } else if self.deadline <= self.clock.now() {
             Err(EpochCallbackError::LockExpired)
         } else {
@@ -380,7 +420,7 @@ impl DeadlineTracker for DeadlineTrackerFactoryForReplay {
     fn track(
         &self,
         _max_duration: Option<Duration>,
-    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TimeoutOutcome> {
+    ) -> Result<Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>, TrackPrecheck> {
         unreachable!("`track` is not called for the interrupt strategy")
     }
 

--- a/crates/wasm-workers/src/workflow/deadline_tracker.rs
+++ b/crates/wasm-workers/src/workflow/deadline_tracker.rs
@@ -35,13 +35,13 @@ pub enum PreemptRequested {
 
 pub trait DeadlineTrackerFactory: Send + Sync {
     /// `execution_interrupt_watcher` is the executor-wide shutdown signal;
-    /// `pause_watcher` is the per-execution pause signal. Either firing interrupts
-    /// the run as `ExecutionInterrupt`.
+    /// `local_interrupt_watcher` is the per-execution pause/cancel signal. Either
+    /// firing interrupts the run as `ExecutionInterrupt`.
     fn create(
         &self,
         lock_expires_at: DateTime<Utc>,
         execution_interrupt_watcher: watch::Receiver<bool>,
-        pause_watcher: watch::Receiver<bool>,
+        local_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired>;
 
     /// True iff this factory produces trackers that never expire the lock.
@@ -71,12 +71,12 @@ pub(crate) struct DeadlineTrackerTokio {
     pub(crate) clock_fn: Box<dyn ClockFn>,
     pub(crate) leeway: Duration, // Fire this much sooner than requested.
     execution_interrupt_watcher: watch::Receiver<bool>,
-    pause_watcher: watch::Receiver<bool>,
+    local_interrupt_watcher: watch::Receiver<bool>,
 }
 
 impl DeadlineTrackerTokio {
     fn interrupt_requested(&self) -> bool {
-        *self.execution_interrupt_watcher.borrow() || *self.pause_watcher.borrow()
+        *self.execution_interrupt_watcher.borrow() || *self.local_interrupt_watcher.borrow()
     }
 }
 
@@ -106,12 +106,12 @@ impl DeadlineTracker for DeadlineTrackerTokio {
                 self.deadline_minus_leeway
             };
             let mut execution_interrupt_watcher = self.execution_interrupt_watcher.clone();
-            let mut pause_watcher = self.pause_watcher.clone();
+            let mut local_interrupt_watcher = self.local_interrupt_watcher.clone();
             Ok(Box::pin(async move {
                 tokio::select! {
                     () = tokio::time::sleep_until(expiry) => TimeoutOutcome::Timeout,
                     _ = execution_interrupt_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
-                    _ = pause_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
+                    _ = local_interrupt_watcher.wait_for(|&v| v) => TimeoutOutcome::Cancel,
                 }
             }))
         }
@@ -173,7 +173,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactoryTokio {
         &self,
         lock_expires_at: DateTime<Utc>,
         execution_interrupt_watcher: watch::Receiver<bool>,
-        pause_watcher: watch::Receiver<bool>,
+        local_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired> {
         let started_at = self.clock_fn.now();
         let Ok(deadline_duration) = (lock_expires_at - started_at).to_std() else {
@@ -196,7 +196,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactoryTokio {
             clock_fn: self.clock_fn.clone_box(),
             leeway: self.leeway,
             execution_interrupt_watcher,
-            pause_watcher,
+            local_interrupt_watcher,
         };
         Ok(Box::new(tracker))
     }
@@ -214,7 +214,7 @@ pub(crate) struct DeadlineTrackerSim {
     leeway: Duration,
     clock: test_utils::sim_clock::SimClock,
     execution_interrupt_watcher: watch::Receiver<bool>,
-    pause_watcher: watch::Receiver<bool>,
+    local_interrupt_watcher: watch::Receiver<bool>,
 }
 
 #[cfg(test)]
@@ -225,7 +225,7 @@ fn add_duration(time: DateTime<Utc>, duration: Duration) -> DateTime<Utc> {
 #[cfg(test)]
 impl DeadlineTrackerSim {
     fn interrupt_requested(&self) -> bool {
-        *self.execution_interrupt_watcher.borrow() || *self.pause_watcher.borrow()
+        *self.execution_interrupt_watcher.borrow() || *self.local_interrupt_watcher.borrow()
     }
 }
 
@@ -260,7 +260,7 @@ impl DeadlineTracker for DeadlineTrackerSim {
         // this call and the first poll are not missed.
         let mut time_watcher = self.clock.subscribe();
         let mut execution_interrupt_watcher = self.execution_interrupt_watcher.clone();
-        let mut pause_watcher = self.pause_watcher.clone();
+        let mut local_interrupt_watcher = self.local_interrupt_watcher.clone();
         Ok(Box::pin(async move {
             loop {
                 if clock.now() >= expiry {
@@ -272,7 +272,7 @@ impl DeadlineTracker for DeadlineTrackerSim {
                         return TimeoutOutcome::Cancel;
                     },
                     _ = execution_interrupt_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
-                    _ = pause_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
+                    _ = local_interrupt_watcher.wait_for(|&v| v) => return TimeoutOutcome::Timeout,
                 }
             }
         }))
@@ -321,7 +321,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactorySim {
         &self,
         lock_expires_at: DateTime<Utc>,
         execution_interrupt_watcher: watch::Receiver<bool>,
-        pause_watcher: watch::Receiver<bool>,
+        local_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired> {
         let started_at = self.clock.now();
         let Ok(deadline_duration) = (lock_expires_at - started_at).to_std() else {
@@ -340,7 +340,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactorySim {
             leeway: self.leeway,
             clock: self.clock.clone(),
             execution_interrupt_watcher,
-            pause_watcher,
+            local_interrupt_watcher,
         }))
     }
 }
@@ -363,7 +363,7 @@ impl DeadlineTrackerFactory for DeadlineTrackerFactoryForReplay {
         &self,
         _lock_expires_at: DateTime<Utc>,
         _execution_interrupt_watcher: watch::Receiver<bool>,
-        _pause_watcher: watch::Receiver<bool>,
+        _local_interrupt_watcher: watch::Receiver<bool>,
     ) -> Result<Box<dyn DeadlineTracker>, LockAlreadyExpired> {
         Ok(Box::new(DeadlineTrackerFactoryForReplay {}))
     }

--- a/crates/wasm-workers/src/workflow/deadline_tracker.rs
+++ b/crates/wasm-workers/src/workflow/deadline_tracker.rs
@@ -69,7 +69,7 @@ pub struct LockAlreadyExpired {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
-pub(crate) enum EpochCallbackError {
+pub enum EpochCallbackError {
     #[error("lock expired")]
     LockExpired,
     #[error("execution interrupt: {0:?}")]

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -7,7 +7,7 @@ use super::host_exports::latest::obelisk::types::execution::GetExtensionError;
 use super::workflow_ctx::WorkflowFunctionError;
 use super::workflow_worker::JoinNextBlockingStrategy;
 use crate::activity::cancel_registry::CancelRegistry;
-use crate::workflow::deadline_tracker::PreemptRequested;
+use crate::workflow::deadline_tracker::{InterruptKind, PreemptRequested, TrackPrecheck};
 use crate::workflow::host_exports::ffqn_into_wast_val;
 use crate::workflow::host_exports::latest;
 use crate::workflow::host_exports::latest::obelisk::types::execution as types_execution;
@@ -39,7 +39,6 @@ use concepts::storage::ResponseWithCursor;
 use concepts::storage::ScheduleRequestError;
 use concepts::storage::StubError;
 use concepts::storage::StubRetValHash;
-use concepts::storage::TimeoutOutcome;
 use concepts::storage::{
     AppendRequest, CreateRequest, ExecutionRequest, JoinSetResponse, JoinSetResponseEvent, Version,
 };
@@ -104,8 +103,8 @@ pub(crate) enum ApplyError {
     DbError(#[from] DbErrorWrite),
     #[error("constraint violation: {0}")]
     ConstraintViolation(StrVariant),
-    #[error("execution interrupt")]
-    ExecutionInterrupt,
+    #[error("execution interrupt: {0:?}")]
+    Interrupt(InterruptKind),
     #[error("replay interrupt")]
     ReplayInterrupt,
 }
@@ -374,9 +373,9 @@ impl EventHistory {
     ) -> Result<ChildReturnValue, ApplyError> {
         match self.deadline_tracker.check_preempt() {
             Ok(()) => {}
-            Err(PreemptRequested::ExecutionInterrupt) => {
-                info!("Execution interrupt detected in check_preempt");
-                return Err(ApplyError::ExecutionInterrupt);
+            Err(PreemptRequested::Interrupt(kind)) => {
+                info!("Execution interrupt detected in check_preempt: {kind:?}");
+                return Err(ApplyError::Interrupt(kind));
             }
         }
 
@@ -601,10 +600,18 @@ impl EventHistory {
             debug!(join_set_id = %join_next_variant.join_set_id(), "Waiting for {join_next_variant:?}");
             let key = join_next_variant.as_key();
 
-            // Subscribe to the next response.
-            // Break on `execution_interrupt_watcher` or when timeout is reached.
-            while let Ok(timeout_fut) = self.deadline_tracker.track(self.subscription_interruption)
-            {
+            // Subscribe to the next response, waking on an interrupt or the deadline.
+            loop {
+                // `track` reports the concrete reason it declines to wait; its future
+                // (below) resolves opaquely, so re-`track` after each wake to classify.
+                let timeout_fut = match self.deadline_tracker.track(self.subscription_interruption) {
+                    Ok(timeout_fut) => timeout_fut,
+                    Err(TrackPrecheck::LockDeadlineReached) => break,
+                    Err(TrackPrecheck::Interrupt(kind)) => {
+                        info!("Execution interrupt detected while waiting for a response: {kind:?}");
+                        return Err(ApplyError::Interrupt(kind));
+                    }
+                };
                 let last_response = self
                     .responses
                     .last()
@@ -641,14 +648,8 @@ impl EventHistory {
                     Err(DbErrorReadWithTimeout::DbErrorRead(err)) => {
                         return Err(ApplyError::DbError(DbErrorWrite::from(err)));
                     }
-                    Err(DbErrorReadWithTimeout::Timeout(TimeoutOutcome::Timeout)) => {
-                        // Let the next iteration of the loop decide
-                        // if this was caused by `subscription_interruption` or deadline.
-                    }
-                    Err(DbErrorReadWithTimeout::Timeout(TimeoutOutcome::Cancel)) => {
-                        info!("Execution interrupt detected in subscribe_to_next_responses");
-                        return Err(ApplyError::ExecutionInterrupt);
-                    }
+                    // Woke on deadline or interrupt; the next `track` classifies which.
+                    Err(DbErrorReadWithTimeout::Timeout(_)) => {}
                 }
             }
             debug!("Giving up on waiting for response");

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -7,7 +7,7 @@ use super::host_exports::latest::obelisk::types::execution::GetExtensionError;
 use super::workflow_ctx::WorkflowFunctionError;
 use super::workflow_worker::JoinNextBlockingStrategy;
 use crate::activity::cancel_registry::CancelRegistry;
-use crate::workflow::deadline_tracker::{InterruptKind, PreemptRequested, TrackPrecheck};
+use crate::workflow::deadline_tracker::{InterruptKind, PreemptRequested};
 use crate::workflow::host_exports::ffqn_into_wast_val;
 use crate::workflow::host_exports::latest;
 use crate::workflow::host_exports::latest::obelisk::types::execution as types_execution;
@@ -29,7 +29,6 @@ use concepts::storage;
 use concepts::storage::AppendResponseToExecution;
 use concepts::storage::BacktraceInfo;
 use concepts::storage::ChildExecutionRequestError;
-use concepts::storage::DbErrorReadWithTimeout;
 use concepts::storage::DbErrorWrite;
 use concepts::storage::HistoryEventScheduleAt;
 use concepts::storage::Locked;
@@ -43,6 +42,7 @@ use concepts::storage::{
     AppendRequest, CreateRequest, ExecutionRequest, JoinSetResponse, JoinSetResponseEvent, Version,
 };
 use concepts::storage::{HistoryEvent, JoinNextTryOutcome, JoinSetRequest};
+use concepts::storage::{ResponseSubscriptionEnd, SubscribeToResponsesError};
 use concepts::{ExecutionId, StrVariant};
 use concepts::{FunctionFqn, Params};
 use db_common::{JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId};
@@ -602,16 +602,18 @@ impl EventHistory {
 
             // Subscribe to the next response, waking on an interrupt or the deadline.
             loop {
-                // `track` reports the concrete reason it declines to wait; its future
-                // (below) resolves opaquely, so re-`track` after each wake to classify.
-                let timeout_fut = match self.deadline_tracker.track(self.subscription_interruption) {
-                    Ok(timeout_fut) => timeout_fut,
-                    Err(TrackPrecheck::LockDeadlineReached) => break,
-                    Err(TrackPrecheck::Interrupt(kind)) => {
-                        info!("Execution interrupt detected while waiting for a response: {kind:?}");
-                        return Err(ApplyError::Interrupt(kind));
-                    }
-                };
+                let subscription_end_fut =
+                    match self.deadline_tracker.track(self.subscription_interruption) {
+                        Ok(subscription_end_fut) => subscription_end_fut,
+                        Err(ResponseSubscriptionEnd::PollIntervalElapsed) => continue,
+                        Err(ResponseSubscriptionEnd::LockDeadlineReached) => break,
+                        Err(ResponseSubscriptionEnd::ExecutorClosing) => {
+                            return Err(ApplyError::Interrupt(InterruptKind::ExecutorClosing));
+                        }
+                        Err(ResponseSubscriptionEnd::ExecutionUpdated) => {
+                            return Err(ApplyError::Interrupt(InterruptKind::PauseOrCancel));
+                        }
+                    };
                 let last_response = self
                     .responses
                     .last()
@@ -621,7 +623,7 @@ impl EventHistory {
                     .subscribe_to_next_responses(
                         db_connection.execution_id(),
                         last_response,
-                        timeout_fut,
+                        subscription_end_fut,
                     )
                     .await
                 {
@@ -645,11 +647,21 @@ impl EventHistory {
                             return Ok(accept_resp);
                         } // this did not unblock the execution, loop
                     }
-                    Err(DbErrorReadWithTimeout::DbErrorRead(err)) => {
+                    Err(SubscribeToResponsesError::DbErrorRead(err)) => {
                         return Err(ApplyError::DbError(DbErrorWrite::from(err)));
                     }
-                    // Woke on deadline or interrupt; the next `track` classifies which.
-                    Err(DbErrorReadWithTimeout::Timeout(_)) => {}
+                    Err(SubscribeToResponsesError::SubscriptionEnded(
+                        ResponseSubscriptionEnd::PollIntervalElapsed,
+                    )) => {}
+                    Err(SubscribeToResponsesError::SubscriptionEnded(
+                        ResponseSubscriptionEnd::LockDeadlineReached,
+                    )) => break,
+                    Err(SubscribeToResponsesError::SubscriptionEnded(
+                        ResponseSubscriptionEnd::ExecutorClosing,
+                    )) => return Err(ApplyError::Interrupt(InterruptKind::ExecutorClosing)),
+                    Err(SubscribeToResponsesError::SubscriptionEnded(
+                        ResponseSubscriptionEnd::ExecutionUpdated,
+                    )) => return Err(ApplyError::Interrupt(InterruptKind::PauseOrCancel)),
                 }
             }
             debug!("Giving up on waiting for response");

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -141,8 +141,8 @@ pub enum AdvanceError {
     // Errors from ReplayInternalError
     #[error("limit reached: {reason}")]
     LimitReached { reason: String, version: Version },
-    #[error("execution interrupt")]
-    ExecutionInterrupt,
+    #[error("executor closing")]
+    ExecutorClosing,
 }
 impl From<ReplayInternalError> for AdvanceError {
     fn from(value: ReplayInternalError) -> Self {
@@ -156,7 +156,7 @@ impl From<ReplayInternalError> for AdvanceError {
                     "advance() asserts DeadlineTrackerFactoryForReplay, which never expires the lock"
                 )
             }
-            ReplayInternalError::ExecutionInterrupt(_) => Self::ExecutionInterrupt,
+            ReplayInternalError::ExecutorClosing(_) => Self::ExecutorClosing,
         }
     }
 }
@@ -185,8 +185,8 @@ pub enum ReplayError {
     #[error("limit reached: {reason}")]
     LimitReached { reason: String, version: Version },
     // Transient error
-    #[error("execution interrupt")]
-    ExecutionInterrupt,
+    #[error("executor closing")]
+    ExecutorClosing,
     /// Replay failed.
     /// `captured_writes` is non-empty iff execution has not finished yet, and therefore can be advanced to an execution error.
     #[error("fatal error: {err}")]
@@ -205,8 +205,8 @@ pub(crate) enum ReplayInternalError {
     LimitReached { reason: String, version: Version },
     #[error("lock expired")]
     LockExpired(Version),
-    #[error("execution interrupt")]
-    ExecutionInterrupt(Version),
+    #[error("executor closing")]
+    ExecutorClosing(Version),
 }
 impl From<ReplayInternalError> for ReplayError {
     fn from(value: ReplayInternalError) -> Self {
@@ -220,7 +220,7 @@ impl From<ReplayInternalError> for ReplayError {
                     "replay() asserts DeadlineTrackerFactoryForReplay, which never expires the lock"
                 )
             }
-            ReplayInternalError::ExecutionInterrupt(_) => Self::ExecutionInterrupt,
+            ReplayInternalError::ExecutorClosing(_) => Self::ExecutorClosing,
         }
     }
 }

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -16,9 +16,9 @@ use concepts::{
     prefixed_ulid::{DelayId, ExecutionIdDerived},
     storage::{
         self, AppendEventsToExecution, AppendRequest, AppendResponseToExecution, BacktraceInfo,
-        CapturedDbWrite, CreateRequest, DbConnection, DbErrorRead, DbErrorReadWithTimeout,
-        DbErrorWrite, DbErrorWriteNonRetriable, ExecutionRequest, LogInfoAppendRow, ResponseCursor,
-        ResponseWithCursor, TimeoutOutcome, Version,
+        CapturedDbWrite, CreateRequest, DbConnection, DbErrorRead, DbErrorWrite,
+        DbErrorWriteNonRetriable, ExecutionRequest, LogInfoAppendRow, ResponseCursor,
+        ResponseSubscriptionEnd, ResponseWithCursor, SubscribeToResponsesError, Version,
     },
 };
 use db_common::JoinSetResponseId;
@@ -777,10 +777,12 @@ impl WorkflowDbConnection for ReplayWorkflowDbConnection {
         &self,
         _execution_id: &ExecutionId,
         _last_response: ResponseCursor,
-        _timeout_fut: Pin<Box<dyn Future<Output = TimeoutOutcome> + Send>>,
-    ) -> Result<Vec<ResponseWithCursor>, DbErrorReadWithTimeout> {
+        _subscription_end_fut: Pin<Box<dyn Future<Output = ResponseSubscriptionEnd> + Send>>,
+    ) -> Result<Vec<ResponseWithCursor>, SubscribeToResponsesError> {
         // During replay, there are no new responses to subscribe to.
-        Err(DbErrorReadWithTimeout::Timeout(TimeoutOutcome::Timeout))
+        Err(SubscribeToResponsesError::SubscriptionEnded(
+            ResponseSubscriptionEnd::LockDeadlineReached,
+        ))
     }
 
     async fn flush_non_blocking_event_cache(

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -14,7 +14,7 @@ use super::workflow_worker::JoinNextBlockingStrategy;
 use crate::WasmFileError;
 use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::{ComponentLogger, LogStrageConfig, log_activities};
-use crate::workflow::deadline_tracker::EpochCallbackError;
+use crate::workflow::deadline_tracker::{EpochCallbackError, InterruptKind};
 use crate::workflow::event_history::{
     JoinSetCreate, ScheduleIntent, StubIntent, StubIntentErr, StubParams, SubmitChildIntent,
 };
@@ -73,8 +73,8 @@ pub(crate) enum WorkflowFunctionError {
     DbError(DbErrorWrite),
     #[error("lock expired")]
     LockExpired,
-    #[error("execution interrupt")]
-    ExecutionInterrupt,
+    #[error("execution interrupt: {0:?}")]
+    Interrupt(InterruptKind),
     #[error("replay interrupt")]
     ReplayInterrupt,
 }
@@ -86,7 +86,7 @@ pub(crate) enum WorkerPartialResult {
     // retriable:
     InterruptDbUpdated,
     LockExpired,
-    ExecutionInterrupt,
+    Interrupt(InterruptKind),
     DbError(DbErrorWrite),
 }
 
@@ -118,7 +118,7 @@ impl WorkflowFunctionError {
                 WorkerPartialResult::FatalError(FatalError::ConstraintViolation { reason }, version)
             }
             WorkflowFunctionError::LockExpired => WorkerPartialResult::LockExpired,
-            WorkflowFunctionError::ExecutionInterrupt => WorkerPartialResult::ExecutionInterrupt,
+            WorkflowFunctionError::Interrupt(kind) => WorkerPartialResult::Interrupt(kind),
             WorkflowFunctionError::ReplayInterrupt => WorkerPartialResult::ReplayWaitingForResponse,
         }
     }
@@ -135,7 +135,7 @@ impl From<ApplyError> for WorkflowFunctionError {
             ApplyError::ConstraintViolation(reason) => {
                 WorkflowFunctionError::ConstraintViolation(reason)
             }
-            ApplyError::ExecutionInterrupt => WorkflowFunctionError::ExecutionInterrupt,
+            ApplyError::Interrupt(kind) => WorkflowFunctionError::Interrupt(kind),
             ApplyError::ReplayInterrupt => WorkflowFunctionError::ReplayInterrupt,
         }
     }
@@ -3122,7 +3122,7 @@ pub(crate) mod tests {
                 WorkerPartialResult::DbError(db_err) => {
                     Err(executor::worker::WorkerError::DbError(db_err))
                 }
-                WorkerPartialResult::LockExpired | WorkerPartialResult::ExecutionInterrupt => {
+                WorkerPartialResult::LockExpired | WorkerPartialResult::Interrupt(_) => {
                     unreachable!()
                 }
             }

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2875,6 +2875,14 @@ mod tests {
             .tick_test(sim_clock.now(), RunId::generate())
             .await;
 
+        db_pool
+            .external_api_conn()
+            .await
+            .unwrap()
+            .pause_execution(&execution_id, sim_clock.now())
+            .await
+            .unwrap();
+
         // `signal_workflow_interrupt` is a no-op until `run()` registers the execution,
         // so retry until the worker (blocked in the first `obelisk.sleep`) observes it
         // and returns; the loop is aborted once the worker task exits.
@@ -2891,21 +2899,18 @@ mod tests {
         progress.wait_for_tasks().await;
         signaller.abort();
 
-        // A `PauseOrCancel` interrupt appends nothing; an `Unlocked` would be the
-        // executor-closing disposition.
+        // Pausing the locked workflow appends one `Unlocked`; the worker must not
+        // append another one when it observes the local interrupt.
         let log = db_connection.get(&execution_id).await.unwrap();
-        let has_unlocked = log
+        let unlocked_count = log
             .events
             .iter()
-            .any(|e| matches!(e.event, ExecutionRequest::Unlocked(_)));
+            .filter(|e| matches!(e.event, ExecutionRequest::Unlocked(_)))
+            .count();
+        assert_eq!(unlocked_count, 1, "unexpected events: {:?}", log.events);
         assert!(
-            !has_unlocked,
-            "pause/cancel interrupt must not append Unlocked, got: {:?}",
-            log.events
-        );
-        assert!(
-            !log.pending_state.is_finished(),
-            "execution must not be finished, got: {:?}",
+            log.pending_state.is_paused(),
+            "execution must remain paused, got: {:?}",
             log.pending_state
         );
         drop(db_connection);

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2803,11 +2803,11 @@ mod tests {
     }
 
     /// When a pause or cancel RPC signals a locally-running JS workflow via
-    /// `signal_workflow_interrupt`, the worker must be interrupted
-    /// (`ExecutionInterrupt`) and write an `Unlocked` event, exactly like the
-    /// executor-close signal, without waiting for the lock deadline. This drives the
-    /// per-execution `CancelRegistry` interrupt path rather than the executor-wide
-    /// close watcher.
+    /// `signal_workflow_interrupt` (`InterruptKind::PauseOrCancel`), the worker must
+    /// stop promptly without waiting for the lock deadline and append nothing
+    /// (`WorkerResultOk::DbUpdatedByWorkerOrWatcher`): the durable Paused/Cancelling
+    /// event is written out of band by the endpoint, so unlike the executor-close
+    /// signal the worker must not append an `Unlocked`.
     #[expand_enum_database]
     #[rstest]
     #[tokio::test]
@@ -2876,8 +2876,8 @@ mod tests {
             .await;
 
         // `signal_workflow_interrupt` is a no-op until `run()` registers the execution,
-        // so retry until the worker observes it (blocked in the first `obelisk.sleep`),
-        // wakes, and writes `Unlocked`. The loop is aborted once the worker task exits.
+        // so retry until the worker (blocked in the first `obelisk.sleep`) observes it
+        // and returns; the loop is aborted once the worker task exits.
         let signaller = tokio::spawn({
             let cancel_registry = cancel_registry.clone();
             let execution_id = execution_id.clone();
@@ -2891,15 +2891,22 @@ mod tests {
         progress.wait_for_tasks().await;
         signaller.abort();
 
+        // A `PauseOrCancel` interrupt appends nothing; an `Unlocked` would be the
+        // executor-closing disposition.
         let log = db_connection.get(&execution_id).await.unwrap();
         let has_unlocked = log
             .events
             .iter()
             .any(|e| matches!(e.event, ExecutionRequest::Unlocked(_)));
         assert!(
-            has_unlocked,
-            "expected Unlocked event from pause interrupt, got: {:?}",
+            !has_unlocked,
+            "pause/cancel interrupt must not append Unlocked, got: {:?}",
             log.events
+        );
+        assert!(
+            !log.pending_state.is_finished(),
+            "execution must not be finished, got: {:?}",
+            log.pending_state
         );
         drop(db_connection);
         db_close.close().await;

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -2802,15 +2802,16 @@ mod tests {
         db_close.close().await;
     }
 
-    /// When the pause RPC signals a locally-running JS workflow via `signal_pause`,
-    /// the worker must be interrupted (`ExecutionInterrupt`) and write an `Unlocked`
-    /// event, exactly like the executor-close signal, without waiting for the lock
-    /// deadline. This drives the per-execution `CancelRegistry` pause path rather
-    /// than the executor-wide close watcher.
+    /// When a pause or cancel RPC signals a locally-running JS workflow via
+    /// `signal_workflow_interrupt`, the worker must be interrupted
+    /// (`ExecutionInterrupt`) and write an `Unlocked` event, exactly like the
+    /// executor-close signal, without waiting for the lock deadline. This drives the
+    /// per-execution `CancelRegistry` interrupt path rather than the executor-wide
+    /// close watcher.
     #[expand_enum_database]
     #[rstest]
     #[tokio::test]
-    async fn signal_pause_interrupts_running_workflow(database: Database) {
+    async fn signal_workflow_interrupt_interrupts_running_workflow(database: Database) {
         test_utils::set_up();
         let (_guard, db_pool, db_close) = database.set_up().await;
 
@@ -2824,7 +2825,7 @@ mod tests {
         ";
         let ffqn = FunctionFqn::new_static("test:pkg/ifc", "busy");
 
-        // Never-set close watcher: the interrupt can only come from `signal_pause`.
+        // Never-set close watcher: the interrupt can only come from `signal_workflow_interrupt`.
         let (_close_sender, close_receiver) = tokio::sync::watch::channel(false);
 
         let sim_clock = SimClock::epoch();
@@ -2840,7 +2841,7 @@ mod tests {
             fn_registry,
             workflow_engine,
         );
-        // Share the worker's registry so the test can drive `signal_pause`.
+        // Share the worker's registry so the test can drive `signal_workflow_interrupt`.
         let cancel_registry = worker.inner.cancel_registry.clone();
 
         let exec_task = new_js_workflow_exec_task_with_interrupt_watcher(
@@ -2874,15 +2875,15 @@ mod tests {
             .tick_test(sim_clock.now(), RunId::generate())
             .await;
 
-        // `signal_pause` is a no-op until `run()` registers the execution, so retry
-        // until the worker observes it (blocked in the first `obelisk.sleep`), wakes,
-        // and writes `Unlocked`. The loop is aborted once the worker task exits.
+        // `signal_workflow_interrupt` is a no-op until `run()` registers the execution,
+        // so retry until the worker observes it (blocked in the first `obelisk.sleep`),
+        // wakes, and writes `Unlocked`. The loop is aborted once the worker task exits.
         let signaller = tokio::spawn({
             let cancel_registry = cancel_registry.clone();
             let execution_id = execution_id.clone();
             async move {
                 loop {
-                    cancel_registry.signal_pause(&execution_id);
+                    cancel_registry.signal_workflow_interrupt(&execution_id);
                     tokio::time::sleep(Duration::from_millis(10)).await;
                 }
             }

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -500,7 +500,7 @@ impl From<WorkflowError> for WorkerError {
 }
 
 #[derive(derive_more::Debug, thiserror::Error)]
-pub enum JoinSetCloseError {
+pub(crate) enum JoinSetCloseError {
     #[error(transparent)]
     DbError(DbErrorWrite),
     #[error("fatal error: {err}")]
@@ -521,9 +521,7 @@ impl JoinSetCloseError {
                 version,
                 db_connection,
             },
-            JoinSetCloseError::Interrupt(version, kind) => {
-                WorkflowError::Interrupt(version, kind)
-            }
+            JoinSetCloseError::Interrupt(version, kind) => WorkflowError::Interrupt(version, kind),
         }
     }
 }
@@ -1018,6 +1016,12 @@ impl WorkflowWorker {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
                 Err(WorkflowError::LockExpired(workflow_ctx.version().clone()))
             }
+            WorkerResultRefactored::Interrupt(InterruptKind::PauseOrCancel, workflow_ctx) => {
+                Err(WorkflowError::Interrupt(
+                    workflow_ctx.version().clone(),
+                    InterruptKind::PauseOrCancel,
+                ))
+            }
             WorkerResultRefactored::Interrupt(kind, mut workflow_ctx) => {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
                 Err(WorkflowError::Interrupt(
@@ -1070,6 +1074,15 @@ impl WorkflowWorker {
                 )
             }
             Err(RunError::WorkerPartialResult(worker_partial_result, mut workflow_ctx)) => {
+                if matches!(
+                    worker_partial_result,
+                    WorkerPartialResult::Interrupt(InterruptKind::PauseOrCancel)
+                ) {
+                    return WorkerResultRefactored::Interrupt(
+                        InterruptKind::PauseOrCancel,
+                        workflow_ctx,
+                    );
+                }
                 if let Err(db_err) = workflow_ctx.flush().await {
                     worker_span.in_scope(||
                         error!("Database flush error: {db_err:?} while handling WorkerPartialResult: {worker_partial_result:?}")

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -7,7 +7,7 @@ use crate::component_logger::LogStrageConfig;
 use crate::workflow::caching_db_connection::{
     CachingBuffer, CachingDbConnection, WorkflowDbConnection,
 };
-use crate::workflow::deadline_tracker::EpochCallbackError;
+use crate::workflow::deadline_tracker::{EpochCallbackError, InterruptKind};
 pub use crate::workflow::replay_advance::{
     AdvanceError, ReplayAdvanceable, ReplayError, ReplayResponse,
 };
@@ -456,7 +456,7 @@ enum WorkerResultRefactored {
     FatalError(FatalError, WorkflowCtx),
     DbError(DbErrorWrite),
     LockExpired(WorkflowCtx),
-    ExecutionInterrupt(WorkflowCtx),
+    Interrupt(InterruptKind, WorkflowCtx),
     ReplayInterrupt(WorkflowCtx),
 }
 
@@ -477,8 +477,8 @@ enum WorkflowError {
     },
     #[error("lock expired")]
     LockExpired(Version),
-    #[error("execution interrupt")]
-    ExecutionInterrupt(Version),
+    #[error("execution interrupt: {1:?}")]
+    Interrupt(Version, InterruptKind),
 }
 impl From<WorkflowError> for WorkerError {
     fn from(value: WorkflowError) -> Self {
@@ -492,7 +492,9 @@ impl From<WorkflowError> for WorkerError {
                 http_client_traces: None,
                 version,
             },
-            WorkflowError::ExecutionInterrupt(version) => WorkerError::ExecutionInterrupt(version),
+            // `PauseOrCancel` is intercepted in `run()` and turned into
+            // `DbUpdatedByWorkerOrWatcher`; only `ExecutorClosing` reaches here.
+            WorkflowError::Interrupt(version, _kind) => WorkerError::ExecutorClosing(version),
         }
     }
 }
@@ -503,8 +505,8 @@ pub enum JoinSetCloseError {
     DbError(DbErrorWrite),
     #[error("fatal error: {err}")]
     FatalError { err: FatalError },
-    #[error("execution interrupt")]
-    ExecutionInterrupt(Version),
+    #[error("execution interrupt: {1:?}")]
+    Interrupt(Version, InterruptKind),
 }
 impl JoinSetCloseError {
     fn into_workflow_error(
@@ -519,8 +521,8 @@ impl JoinSetCloseError {
                 version,
                 db_connection,
             },
-            JoinSetCloseError::ExecutionInterrupt(version) => {
-                WorkflowError::ExecutionInterrupt(version)
+            JoinSetCloseError::Interrupt(version, kind) => {
+                WorkflowError::Interrupt(version, kind)
             }
         }
     }
@@ -772,11 +774,11 @@ impl WorkflowWorker {
                     info!("Deadline reached in epoch callback");
                     Err(wasmtime::Error::from(WorkflowFunctionError::LockExpired))
                 }
-                Err(EpochCallbackError::ExecutionInterrupt) => {
-                    info!("Execution interrupt detected in epoch callback");
-                    Err(wasmtime::Error::from(
-                        WorkflowFunctionError::ExecutionInterrupt,
-                    ))
+                Err(EpochCallbackError::Interrupt(kind)) => {
+                    info!("Execution interrupt detected in epoch callback: {kind:?}");
+                    Err(wasmtime::Error::from(WorkflowFunctionError::Interrupt(
+                        kind,
+                    )))
                 }
             }
         });
@@ -793,9 +795,10 @@ impl WorkflowWorker {
                             let version = store.into_data().version().clone();
                             return Err(WorkflowError::LockExpired(version));
                         }
-                        WorkflowFunctionError::ExecutionInterrupt => {
+                        WorkflowFunctionError::Interrupt(kind) => {
+                            let kind = *kind;
                             let version = store.into_data().version().clone();
-                            return Err(WorkflowError::ExecutionInterrupt(version));
+                            return Err(WorkflowError::Interrupt(version, kind));
                         }
                         _ => {}
                     }
@@ -1015,10 +1018,11 @@ impl WorkflowWorker {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
                 Err(WorkflowError::LockExpired(workflow_ctx.version().clone()))
             }
-            WorkerResultRefactored::ExecutionInterrupt(mut workflow_ctx) => {
+            WorkerResultRefactored::Interrupt(kind, mut workflow_ctx) => {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
-                Err(WorkflowError::ExecutionInterrupt(
+                Err(WorkflowError::Interrupt(
                     workflow_ctx.version().clone(),
+                    kind,
                 ))
             }
             WorkerResultRefactored::ReplayInterrupt(workflow_ctx) => {
@@ -1086,9 +1090,9 @@ impl WorkflowWorker {
                         // logged in epoch callback
                         WorkerResultRefactored::LockExpired(workflow_ctx)
                     }
-                    WorkerPartialResult::ExecutionInterrupt => {
+                    WorkerPartialResult::Interrupt(kind) => {
                         // logged in epoch callback
-                        WorkerResultRefactored::ExecutionInterrupt(workflow_ctx)
+                        WorkerResultRefactored::Interrupt(kind, workflow_ctx)
                     }
                     WorkerPartialResult::ReplayWaitingForResponse => {
                         WorkerResultRefactored::ReplayInterrupt(workflow_ctx)
@@ -1124,8 +1128,9 @@ impl WorkflowWorker {
             Err(ApplyError::ConstraintViolation(reason)) => Err(JoinSetCloseError::FatalError {
                 err: FatalError::ConstraintViolation { reason },
             }),
-            Err(ApplyError::ExecutionInterrupt) => Err(JoinSetCloseError::ExecutionInterrupt(
+            Err(ApplyError::Interrupt(kind)) => Err(JoinSetCloseError::Interrupt(
                 workflow_ctx.version().clone(),
+                kind,
             )),
             Err(ApplyError::ReplayInterrupt) => Ok(Either::Right(ReplayInterrupt)),
         }
@@ -1216,8 +1221,10 @@ impl WorkflowWorker {
             Err(WorkflowError::LockExpired(version)) => {
                 Err(ReplayInternalError::LockExpired(version))
             }
-            Err(WorkflowError::ExecutionInterrupt(version)) => {
-                Err(ReplayInternalError::ExecutionInterrupt(version))
+            // Replay uses a never-firing deadline tracker, so any interrupt here is a
+            // defensive `ExecutorClosing` (pause/cancel never reaches replay).
+            Err(WorkflowError::Interrupt(version, _kind)) => {
+                Err(ReplayInternalError::ExecutorClosing(version))
             }
         }?;
 
@@ -1543,8 +1550,8 @@ impl WorkflowWorker {
                     http_client_traces: None,
                     version,
                 },
-                ReplayInternalError::ExecutionInterrupt(version) => {
-                    WorkerError::ExecutionInterrupt(version)
+                ReplayInternalError::ExecutorClosing(version) => {
+                    WorkerError::ExecutorClosing(version)
                 }
             })?;
 
@@ -1739,6 +1746,11 @@ impl Worker for WorkflowWorker {
                 WorkerResult::Ok(ok)
             }
             Ok((Either::Right(_), _)) => unreachable!("not replaying"),
+            // A pause or cancel already persisted its event out of band; append nothing.
+            Err(WorkflowError::Interrupt(_version, InterruptKind::PauseOrCancel)) => {
+                info!("Workflow run interrupted by pause/cancel, db already updated");
+                WorkerResult::Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
+            }
             Err(workflow_err) => {
                 info!("Workflow run finished with error: {workflow_err}");
                 WorkerResult::Err(WorkerError::from(workflow_err))

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -694,13 +694,13 @@ impl WorkflowWorker {
         is_replay: Option<ReplayKind>,
         view: WorkflowWorkerView<'_>,
         backtrace_capture: bool,
-        pause_watcher: tokio::sync::watch::Receiver<bool>,
+        local_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
     ) -> Result<PrepareFuncFinished, WorkflowError> {
         assert_eq!(view.config.component_id, ctx.locked_event.component_id);
         let deadline_tracker = match view.deadline_factory.create(
             ctx.locked_event.lock_expires_at,
             ctx.execution_interrupt_watcher,
-            pause_watcher,
+            local_interrupt_watcher,
         ) {
             Ok(deadline_tracker) => deadline_tracker,
             Err(lock_already_expired) => {
@@ -1175,7 +1175,7 @@ impl WorkflowWorker {
             Some(replay_kind),
             view,
             backtrace_capture,
-            tokio::sync::watch::channel(false).1, // replay is never paused
+            tokio::sync::watch::channel(false).1, // replay is never interrupted here
         )
         .await
         {
@@ -1258,7 +1258,7 @@ impl WorkflowWorker {
         is_replay: Option<ReplayKind>,
         view: WorkflowWorkerView<'_>,
         backtrace_capture: bool,
-        pause_watcher: tokio::sync::watch::Receiver<bool>,
+        local_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
     ) -> Result<
         (
             Either<WorkerResultOk, ReplayInterrupt>,
@@ -1280,7 +1280,7 @@ impl WorkflowWorker {
             is_replay,
             view,
             backtrace_capture,
-            pause_watcher,
+            local_interrupt_watcher,
         )
         .await?;
         Self::call_func_convert_result(
@@ -1719,9 +1719,9 @@ impl Worker for WorkflowWorker {
             deadline_factory: self.deadline_factory.as_ref(),
             logs_storage_config: self.logs_storage_config.clone(),
         };
-        // Register for same-node pause interruption; the cancel watcher prunes the
-        // entry once this run drops the receiver (held in the deadline tracker).
-        let pause_watcher = self
+        // Register for same-node pause/cancel interruption; the cancel watcher prunes
+        // the entry once this run drops the receiver (held in the deadline tracker).
+        let local_interrupt_watcher = self
             .cancel_registry
             .register_running_workflow(ctx.execution_id.clone());
         let res = Self::run_internal(
@@ -1730,7 +1730,7 @@ impl Worker for WorkflowWorker {
             None, // is_replay
             view,
             false,
-            pause_watcher,
+            local_interrupt_watcher,
         )
         .await;
         worker_span.in_scope(|| match res {

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -130,10 +130,15 @@ impl GrpcServer {
                 .cancel_activity(conn.as_ref(), execution_id, executed_at)
                 .await
                 .to_status(),
-            ComponentType::Workflow => conn
-                .cancel_workflow_with_retries(execution_id, executed_at)
-                .await
-                .to_status(),
+            ComponentType::Workflow => {
+                let outcome = conn
+                    .cancel_workflow_with_retries(execution_id, executed_at)
+                    .await
+                    .to_status()?;
+                // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
+                self.cancel_registry.signal_workflow_interrupt(execution_id);
+                Ok(outcome)
+            }
             _ => Err(tonic::Status::invalid_argument(
                 "cancelled execution must be an activity or cancellable workflow",
             )),
@@ -1268,7 +1273,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             .await
             .to_status()?;
         // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
-        self.cancel_registry.signal_pause(&execution_id);
+        self.cancel_registry.signal_workflow_interrupt(&execution_id);
         Ok(tonic::Response::new(grpc_gen::PauseExecutionResponse {}))
     }
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -135,7 +135,8 @@ impl GrpcServer {
                     .cancel_workflow_with_retries(execution_id, executed_at)
                     .await
                     .to_status()?;
-                // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
+                // Best-effort CPU saver: the write above already cancels it; a locally-running
+                // workflow would otherwise burn CPU until its next db append fails on that write.
                 self.cancel_registry.signal_workflow_interrupt(execution_id);
                 Ok(outcome)
             }
@@ -1055,7 +1056,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                         )
                     }
                     err
-                    @ (AdvanceError::ExecutionInterrupt | AdvanceError::LimitReached { .. }) => {
+                    @ (AdvanceError::ExecutorClosing | AdvanceError::LimitReached { .. }) => {
                         grpc_gen::advance_execution_response::error::Error::TransientError(
                             grpc_gen::advance_execution_response::error::TransientError {
                                 message: err.to_string(),
@@ -1272,8 +1273,10 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
         conn.pause_execution(&execution_id, executed_at)
             .await
             .to_status()?;
-        // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
-        self.cancel_registry.signal_workflow_interrupt(&execution_id);
+        // Best-effort CPU saver: the write above already pauses it; a locally-running
+        // workflow would otherwise burn CPU until its next db append fails on that write.
+        self.cancel_registry
+            .signal_workflow_interrupt(&execution_id);
         Ok(tonic::Response::new(grpc_gen::PauseExecutionResponse {}))
     }
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1055,8 +1055,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                             grpc_gen::advance_execution_response::error::ReplayMismatch {},
                         )
                     }
-                    err
-                    @ (AdvanceError::ExecutorClosing | AdvanceError::LimitReached { .. }) => {
+                    err @ (AdvanceError::ExecutorClosing | AdvanceError::LimitReached { .. }) => {
                         grpc_gen::advance_execution_response::error::Error::TransientError(
                             grpc_gen::advance_execution_response::error::TransientError {
                                 message: err.to_string(),

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -664,7 +664,8 @@ async fn execution_cancel(
                 .cancel_workflow_with_retries(&execution_id, executed_at)
                 .await;
             if outcome.is_ok() {
-                // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
+                // Best-effort CPU saver: the write above already cancels it; a locally-running
+                // workflow would otherwise burn CPU until its next db append fails on that write.
                 state
                     .cancel_registry
                     .signal_workflow_interrupt(&execution_id);
@@ -712,7 +713,8 @@ async fn execution_pause(
     conn.pause_execution(&execution_id, paused_at)
         .await
         .map_err(|e| ErrorWrapper(e, accept))?;
-    // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
+    // Best-effort CPU saver: the write above already pauses it; a locally-running
+    // workflow would otherwise burn CPU until its next db append fails on that write.
     state
         .cancel_registry
         .signal_workflow_interrupt(&execution_id);
@@ -2428,7 +2430,7 @@ async fn execution_advance(
                 AdvanceError::DbError(db_err) => {
                     return Err(ErrorWrapper(db_err, accept).into());
                 }
-                err @ (AdvanceError::ExecutionInterrupt | AdvanceError::LimitReached { .. }) => {
+                err @ (AdvanceError::ExecutorClosing | AdvanceError::LimitReached { .. }) => {
                     AdvanceErrorSer::Transient(err.to_string())
                 }
             };

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -660,8 +660,16 @@ async fn execution_cancel(
                 .await
         }
         ComponentType::Workflow => {
-            conn.cancel_workflow_with_retries(&execution_id, executed_at)
-                .await
+            let outcome = conn
+                .cancel_workflow_with_retries(&execution_id, executed_at)
+                .await;
+            if outcome.is_ok() {
+                // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
+                state
+                    .cancel_registry
+                    .signal_workflow_interrupt(&execution_id);
+            }
+            outcome
         }
         _ => {
             return Err(HttpResponse {
@@ -705,7 +713,9 @@ async fn execution_pause(
         .await
         .map_err(|e| ErrorWrapper(e, accept))?;
     // Best-effort interrupt of a locally-running workflow (`ExecutionInterrupt`).
-    state.cancel_registry.signal_pause(&execution_id);
+    state
+        .cancel_registry
+        .signal_workflow_interrupt(&execution_id);
     Ok(HttpResponse {
         status: StatusCode::OK,
         message: "paused".to_string(),


### PR DESCRIPTION
- **feat(workflow): Interrupt workflow when cancellation request is persisted**
- **refactor: Split `ExecutionInterrupt` to `ExecutorClosing` and `DbUpdatedByWorkerOrWatcher`**
- **refactor: Return more specific outcomes in `subscribe_to_next_responses`**
