### PR TITLE
feat(toml): Yield workflow on `max_events_per_run`

### DIFF
--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -720,6 +720,13 @@
           "format": "uint",
           "minimum": 0,
           "default": 100
+        },
+        "max_events_per_run": {
+          "description": "Maximum number of history events a real workflow run may write before yielding.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "default": 100
         }
       },
       "additionalProperties": false

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -200,6 +200,7 @@ mod bench {
                     mode: WorkflowConfigMode::Real {
                         join_next_blocking_strategy,
                         lock_extension: None,
+                        max_events_per_run: usize::MAX,
                     },
                 },
                 workflow_engine,

--- a/crates/executor/src/executor.rs
+++ b/crates/executor/src/executor.rs
@@ -1,5 +1,6 @@
 use crate::worker::{
-    FatalError, RunFinished, Worker, WorkerContext, WorkerError, WorkerResult, WorkerResultOk,
+    ExecutionYieldReason, FatalError, RunFinished, Worker, WorkerContext, WorkerError,
+    WorkerResult, WorkerResultOk,
 };
 use assert_matches::assert_matches;
 use chrono::{DateTime, Utc};
@@ -777,10 +778,15 @@ impl ExecTask {
                 let reason_generic = err.to_string(); // Override with err's reason if no information is lost.
 
                 let (primary_event, child_finished, version) = match err {
-                    WorkerError::ExecutorClosing(version) => {
+                    WorkerError::ExecutionYielded { version, reason } => {
                         let primary_event = ExecutionRequest::Unlocked(Unlocked {
                             unlocked_at: result_obtained_at,
-                            reason: "executor closing".into(),
+                            reason: match reason {
+                                ExecutionYieldReason::ExecutorClosing => "executor closing".into(),
+                                ExecutionYieldReason::WorkflowEventLimitReached => {
+                                    "workflow event limit reached".into()
+                                }
+                            },
                         });
                         (primary_event, None, version)
                     }

--- a/crates/executor/src/worker.rs
+++ b/crates/executor/src/worker.rs
@@ -37,6 +37,14 @@ pub enum WorkerResultOk {
     RunFinished(RunFinished),
 }
 
+#[derive(Debug, Clone, Copy, derive_more::Display)]
+pub enum ExecutionYieldReason {
+    #[display("executor closing")]
+    ExecutorClosing,
+    #[display("workflow event limit reached")]
+    WorkflowEventLimitReached,
+}
+
 #[derive(Debug, derive_more::Display)]
 #[display("finished at v{version}")]
 pub struct RunFinished {
@@ -85,8 +93,11 @@ pub enum WorkerError {
         http_client_traces: Option<Vec<HttpClientTrace>>,
         version: Version,
     },
-    #[error("executor closing")]
-    ExecutorClosing(Version),
+    #[error("execution yielded: {reason}")]
+    ExecutionYielded {
+        version: Version,
+        reason: ExecutionYieldReason,
+    },
     #[error(transparent)]
     DbError(DbErrorWrite),
     // non-retriable errors

--- a/crates/wasm-workers/src/activity/activity_worker.rs
+++ b/crates/wasm-workers/src/activity/activity_worker.rs
@@ -226,7 +226,10 @@ impl Worker for ActivityWorker {
                         Ok(worker_res_ok) => {
                             info!(duration = ?stopwatch_for_reporting.elapsed(), "Run finished: {worker_res_ok}");
                         }
-                        Err(WorkerError::ExecutorClosing(_)) => {
+                        Err(WorkerError::ExecutionYielded {
+                            reason: executor::worker::ExecutionYieldReason::ExecutorClosing,
+                            ..
+                        }) => {
                             info!("Executor closing");
                         }
                         Err(err) => {
@@ -266,7 +269,10 @@ impl Worker for ActivityWorker {
             _ = execution_interrupt_watcher.changed() => {
                 debug!("Executor closing");
                 // Executor will append the Unlocked event.
-                return WorkerResult::Err(WorkerError::ExecutorClosing(version.clone()))
+                return WorkerResult::Err(WorkerError::ExecutionYielded {
+                    version: version.clone(),
+                    reason: executor::worker::ExecutionYieldReason::ExecutorClosing,
+                })
             }
         }
     }

--- a/crates/wasm-workers/src/workflow/deadline_tracker.rs
+++ b/crates/wasm-workers/src/workflow/deadline_tracker.rs
@@ -7,8 +7,10 @@ use tracing::{trace, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterruptKind {
-    /// Send [`WorkerError::ExecutorClosing`]
+    /// Send an executor-closing execution yield.
     ExecutorClosing,
+    /// The real-run durable event budget was exhausted.
+    WorkflowEventLimitReached,
     /// Send [`WorkerResultOk::DbUpdatedByWorkerOrWatcher`], the pause/cancel RPC must have appended the event.
     PauseOrCancel,
 }
@@ -131,6 +133,7 @@ impl DeadlineTracker for DeadlineTrackerTokio {
             Err(match kind {
                 InterruptKind::ExecutorClosing => ResponseSubscriptionEnd::ExecutorClosing,
                 InterruptKind::PauseOrCancel => ResponseSubscriptionEnd::ExecutionUpdated,
+                InterruptKind::WorkflowEventLimitReached => unreachable!("not watcher-driven"),
             })
         } else {
             let (expiry, expiry_reason) = match max_duration {
@@ -295,6 +298,7 @@ impl DeadlineTracker for DeadlineTrackerSim {
             return Err(match kind {
                 InterruptKind::ExecutorClosing => ResponseSubscriptionEnd::ExecutorClosing,
                 InterruptKind::PauseOrCancel => ResponseSubscriptionEnd::ExecutionUpdated,
+                InterruptKind::WorkflowEventLimitReached => unreachable!("not watcher-driven"),
             });
         }
         let (expiry, expiry_reason) = match max_duration {

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -173,6 +173,8 @@ pub(crate) struct EventHistory {
 
     // Upper bound on captured writes a replay pass may collect. `None` outside replay.
     max_replay_captured_writes: Option<usize>,
+    max_events_per_run: Option<usize>,
+    written_events_this_run: usize,
 }
 
 #[derive(Debug)]
@@ -226,6 +228,7 @@ impl EventHistory {
         worker_span: Span,
         replaying_unfinished_execution: bool,
         max_replay_captured_writes: Option<usize>,
+        max_events_per_run: Option<usize>,
     ) -> EventHistory {
         EventHistory {
             replaying_unfinished_execution,
@@ -254,6 +257,8 @@ impl EventHistory {
             last_oneoff_id: None,
             last_direct_call_id: None,
             max_replay_captured_writes,
+            max_events_per_run,
+            written_events_this_run: 0,
         }
     }
 
@@ -437,7 +442,8 @@ impl EventHistory {
         }
 
         let version_range = event_call.version_range.clone();
-        match event_call.kind {
+        let event_history_len_before = self.event_history.len();
+        let value = match event_call.kind {
             EventCallKind::NonBlocking(event_call) => {
                 // Events that cannot block waiting for response.
                 let cloned_non_blocking = event_call.clone();
@@ -477,7 +483,19 @@ impl EventHistory {
                 )
                 .await
             }
+        }?;
+        let written_events = self.event_history.len() - event_history_len_before;
+        self.written_events_this_run += written_events;
+        if written_events > 0
+            && self
+                .max_events_per_run
+                .is_some_and(|max| self.written_events_this_run >= max)
+        {
+            return Err(ApplyError::Interrupt(
+                InterruptKind::WorkflowEventLimitReached,
+            ));
         }
+        Ok(value)
     }
 
     async fn persist_replayed_backtrace(
@@ -4586,6 +4604,7 @@ mod tests {
             info_span!("worker-test"),
             false, // replaying_unfinished_execution
             None,  // max_replay_captured_writes
+            None,  // max_events_per_run
         );
 
         (

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -899,6 +899,7 @@ impl WorkflowCtx {
         logs_storage_config: Option<LogStrageConfig>,
         is_replay: Option<ReplayKind>,
         max_replay_captured_writes: Option<usize>,
+        max_events_per_run: Option<usize>,
     ) -> Self {
         let mut wasi_ctx_builder = WasiCtxBuilder::new();
         wasi_ctx_builder.allow_tcp(false);
@@ -925,6 +926,7 @@ impl WorkflowCtx {
                 worker_span.clone(),
                 is_replay == Some(ReplayKind::Unfinished),
                 max_replay_captured_writes,
+                max_events_per_run,
             ),
             rng: StdRng::seed_from_u64(seed),
             clock_fn,
@@ -3258,6 +3260,7 @@ pub(crate) mod tests {
                 None,                         // logs_storage_config,
                 is_replay,
                 None, // max_replay_captured_writes
+                None, // max_events_per_run
             );
             for step in &self.steps {
                 info!("Processing step {step:?}");

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -923,6 +923,7 @@ mod tests {
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
                 lock_extension: Some(Duration::from_secs(1)),
+                max_events_per_run: usize::MAX,
             },
         };
 
@@ -1001,6 +1002,7 @@ mod tests {
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
                 lock_extension: None,
+                max_events_per_run: usize::MAX,
             },
         };
 
@@ -1298,6 +1300,7 @@ mod tests {
             join_next_blocking_strategy,
             deadline_factory,
             default_return_type(),
+            usize::MAX,
         )
     }
 
@@ -1313,6 +1316,7 @@ mod tests {
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         deadline_factory: Arc<dyn DeadlineTrackerFactory>,
         return_type: ReturnTypeExtendable,
+        max_events_per_run: usize,
     ) -> (WorkflowJsWorker, concepts::ComponentId, RunnableComponent) {
         let wasm_path = workflow_js_runtime_builder::WORKFLOW_JS_RUNTIME;
         let params = default_js_params();
@@ -1334,6 +1338,7 @@ mod tests {
             mode: WorkflowConfigMode::Real {
                 join_next_blocking_strategy,
                 lock_extension: None,
+                max_events_per_run,
             },
         };
 
@@ -1973,6 +1978,7 @@ mod tests {
                     join_next_blocking_strategy,
                     deadline_factory,
                     return_type,
+                    usize::MAX,
                 );
 
             let (workflow_exec, workflow_close_tx) =
@@ -4144,6 +4150,90 @@ mod tests {
         let replay2 = replay_worker.replay(execution_id, false).await.unwrap();
         let replay2 = assert_matches!(replay2, ReplayResponse::Advanceable(replay2) => replay2);
         assert_eq!(replay2.captured_writes.len(), MAX);
+
+        drop(db_connection);
+        db_close.close().await;
+    }
+
+    #[tokio::test]
+    async fn workflow_js_real_run_event_limit_yields_and_unlocks() {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+
+        const MAX: usize = 5;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = Database::Sqlite.set_up().await;
+        let js_source = r"
+        export default function loop_forever() {
+            const js = obelisk.createJoinSet();
+            js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            for (;;) {
+                js.joinNextTry();
+            }
+        }";
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "loop-forever");
+        let sim_clock = SimClock::epoch();
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+        let (worker, component_id, _) =
+            compile_js_workflow_worker_with_deployment_id_and_return_type(
+                js_source,
+                &user_ffqn,
+                db_pool.clone(),
+                &sim_clock,
+                fn_registry,
+                workflow_engine,
+                DEPLOYMENT_ID_DUMMY,
+                JoinNextBlockingStrategy::Await {
+                    non_blocking_event_batching: 10,
+                    subscription_interruption: None,
+                },
+                deadline_tracker_factory_test(&sim_clock),
+                default_return_type(),
+                MAX,
+            );
+        let (workflow_exec, _close_tx) =
+            new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
+        let execution_id = ExecutionId::from_parts(0, 42);
+        let db_connection = db_pool.connection_test().await.unwrap();
+        db_connection
+            .create(CreateRequest {
+                created_at: sim_clock.now(),
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: sim_clock.now(),
+                component_id,
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        for expected_history_events in [MAX, MAX * 2] {
+            assert_eq!(
+                1,
+                workflow_exec
+                    .tick_test_await(sim_clock.now(), RunId::generate())
+                    .await
+                    .len()
+            );
+            let log = db_connection.get(&execution_id).await.unwrap();
+            assert_eq!(expected_history_events, log.event_history().count());
+            assert_matches!(
+                &log.events.last().unwrap().event,
+                ExecutionRequest::Unlocked(unlocked)
+                    if unlocked.reason.as_ref() == "workflow event limit reached"
+            );
+            assert_matches!(log.pending_state, PendingState::PendingAt(..));
+        }
 
         drop(db_connection);
         db_close.close().await;

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -490,33 +490,29 @@ enum WorkflowError {
     },
     #[error("lock expired")]
     LockExpired(Version),
-    #[error("execution interrupt: {1:?}")]
-    Interrupt(Version, InterruptKind),
+    /// Executor will append `Unlocked` event
+    #[error("execution yielded: {reason:?}")]
+    ExecutionYielded {
+        version: Version,
+        reason: ExecutionYieldReason,
+    },
+    /// Executor will not append any more events
+    #[error("execution interrupted by pause/cancel")]
+    PauseOrCancel(Version),
 }
-impl From<WorkflowError> for WorkerError {
-    fn from(value: WorkflowError) -> Self {
-        match value {
-            WorkflowError::LimitReached { reason, version } => {
-                WorkerError::LimitReached { reason, version }
-            }
-            WorkflowError::DbError(db_err) => WorkerError::DbError(db_err),
-            WorkflowError::FatalError { err, version, .. } => WorkerError::FatalError(err, version),
-            WorkflowError::LockExpired(version) => WorkerError::TemporaryTimeout {
-                http_client_traces: None,
+
+impl WorkflowError {
+    fn interrupt(version: Version, kind: InterruptKind) -> Self {
+        match kind {
+            InterruptKind::ExecutorClosing => Self::ExecutionYielded {
                 version,
+                reason: ExecutionYieldReason::ExecutorClosing,
             },
-            // `PauseOrCancel` is intercepted in `run()` and turned into
-            // `DbUpdatedByWorkerOrWatcher`.
-            WorkflowError::Interrupt(version, kind) => WorkerError::ExecutionYielded {
+            InterruptKind::WorkflowEventLimitReached => Self::ExecutionYielded {
                 version,
-                reason: match kind {
-                    InterruptKind::ExecutorClosing => ExecutionYieldReason::ExecutorClosing,
-                    InterruptKind::WorkflowEventLimitReached => {
-                        ExecutionYieldReason::WorkflowEventLimitReached
-                    }
-                    InterruptKind::PauseOrCancel => unreachable!("intercepted in run"),
-                },
+                reason: ExecutionYieldReason::WorkflowEventLimitReached,
             },
+            InterruptKind::PauseOrCancel => Self::PauseOrCancel(version),
         }
     }
 }
@@ -543,7 +539,7 @@ impl JoinSetCloseError {
                 version,
                 db_connection,
             },
-            JoinSetCloseError::Interrupt(version, kind) => WorkflowError::Interrupt(version, kind),
+            JoinSetCloseError::Interrupt(version, kind) => WorkflowError::interrupt(version, kind),
         }
     }
 }
@@ -824,7 +820,7 @@ impl WorkflowWorker {
                         WorkflowFunctionError::Interrupt(kind) => {
                             let kind = *kind;
                             let version = store.into_data().version().clone();
-                            return Err(WorkflowError::Interrupt(version, kind));
+                            return Err(WorkflowError::interrupt(version, kind));
                         }
                         _ => {}
                     }
@@ -1045,14 +1041,14 @@ impl WorkflowWorker {
                 Err(WorkflowError::LockExpired(workflow_ctx.version().clone()))
             }
             WorkerResultRefactored::Interrupt(InterruptKind::PauseOrCancel, workflow_ctx) => {
-                Err(WorkflowError::Interrupt(
+                Err(WorkflowError::interrupt(
                     workflow_ctx.version().clone(),
                     InterruptKind::PauseOrCancel,
                 ))
             }
             WorkerResultRefactored::Interrupt(kind, mut workflow_ctx) => {
                 workflow_ctx.flush().await.map_err(WorkflowError::DbError)?;
-                Err(WorkflowError::Interrupt(
+                Err(WorkflowError::interrupt(
                     workflow_ctx.version().clone(),
                     kind,
                 ))
@@ -1264,9 +1260,10 @@ impl WorkflowWorker {
             }
             // Replay uses a never-firing deadline tracker, so any interrupt here is a
             // defensive `ExecutorClosing` (pause/cancel never reaches replay).
-            Err(WorkflowError::Interrupt(version, _kind)) => {
-                Err(ReplayInternalError::ExecutorClosing(version))
-            }
+            Err(
+                WorkflowError::ExecutionYielded { version, .. }
+                | WorkflowError::PauseOrCancel(version),
+            ) => Err(ReplayInternalError::ExecutorClosing(version)),
         }?;
 
         let Ok(mut replay_db_connection) = replay_db_connection
@@ -1782,20 +1779,39 @@ impl Worker for WorkflowWorker {
             local_interrupt_watcher,
         )
         .await;
-        worker_span.in_scope(|| match res {
-            Ok((Either::Left(ok), _)) => {
-                info!("Workflow run finished: {ok}");
-                WorkerResult::Ok(ok)
-            }
-            Ok((Either::Right(_), _)) => unreachable!("not replaying"),
-            // A pause or cancel already persisted its event out of band; append nothing.
-            Err(WorkflowError::Interrupt(_version, InterruptKind::PauseOrCancel)) => {
-                info!("Workflow run interrupted by pause/cancel, db already updated");
-                WorkerResult::Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
-            }
-            Err(workflow_err) => {
+        worker_span.in_scope(|| {
+            if let Err(workflow_err) = &res {
                 info!("Workflow run finished with error: {workflow_err}");
-                WorkerResult::Err(WorkerError::from(workflow_err))
+            }
+            match res {
+                Ok((Either::Left(ok), _)) => {
+                    info!("Workflow run finished: {ok}");
+                    WorkerResult::Ok(ok)
+                }
+                Ok((Either::Right(_), _)) => unreachable!("not replaying"),
+                // A pause or cancel already persisted its event out of band; append nothing.
+                Err(WorkflowError::PauseOrCancel(_version)) => {
+                    info!("Workflow run interrupted by pause/cancel, db already updated");
+                    WorkerResult::Ok(WorkerResultOk::DbUpdatedByWorkerOrWatcher)
+                }
+                Err(WorkflowError::LimitReached { reason, version }) => {
+                    WorkerResult::Err(WorkerError::LimitReached { reason, version })
+                }
+                Err(WorkflowError::DbError(db_err)) => {
+                    WorkerResult::Err(WorkerError::DbError(db_err))
+                }
+                Err(WorkflowError::FatalError { err, version, .. }) => {
+                    WorkerResult::Err(WorkerError::FatalError(err, version))
+                }
+                Err(WorkflowError::LockExpired(version)) => {
+                    WorkerResult::Err(WorkerError::TemporaryTimeout {
+                        http_client_traces: None,
+                        version,
+                    })
+                }
+                Err(WorkflowError::ExecutionYielded { version, reason }) => {
+                    WorkerResult::Err(WorkerError::ExecutionYielded { version, reason })
+                }
             }
         })
     }

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -31,8 +31,11 @@ use concepts::{
     FunctionMetadata, JoinSetId, PackageIfcFns, Params, ResultParsingError, StrVariant, TrapKind,
 };
 use concepts::{FunctionRegistry, SupportedFunctionReturnValue};
-use executor::worker::{FatalError, RunFinished, WorkerContext, WorkerResult, WorkerResultOk};
-use executor::worker::{Worker, WorkerError};
+use executor::worker::Worker;
+use executor::worker::{
+    ExecutionYieldReason, FatalError, RunFinished, WorkerContext, WorkerError, WorkerResult,
+    WorkerResultOk,
+};
 use itertools::Either;
 use std::future;
 use std::ops::Deref;
@@ -79,6 +82,7 @@ pub enum WorkflowConfigMode {
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
         lock_extension: Option<Duration>,
+        max_events_per_run: usize,
     },
     /// Replay/advance: writes are captured in memory instead of persisted, and the workflow always
     /// runs with the `Interrupt` strategy. `max_replay_captured_writes` bounds how many captured
@@ -127,6 +131,15 @@ impl WorkflowConfig {
             WorkflowConfigMode::Replay {
                 max_replay_captured_writes,
             } => Some(*max_replay_captured_writes),
+        }
+    }
+
+    fn max_events_per_run(&self) -> Option<usize> {
+        match &self.mode {
+            WorkflowConfigMode::Real {
+                max_events_per_run, ..
+            } => Some(*max_events_per_run),
+            WorkflowConfigMode::Replay { .. } => None,
         }
     }
 }
@@ -493,8 +506,17 @@ impl From<WorkflowError> for WorkerError {
                 version,
             },
             // `PauseOrCancel` is intercepted in `run()` and turned into
-            // `DbUpdatedByWorkerOrWatcher`; only `ExecutorClosing` reaches here.
-            WorkflowError::Interrupt(version, _kind) => WorkerError::ExecutorClosing(version),
+            // `DbUpdatedByWorkerOrWatcher`.
+            WorkflowError::Interrupt(version, kind) => WorkerError::ExecutionYielded {
+                version,
+                reason: match kind {
+                    InterruptKind::ExecutorClosing => ExecutionYieldReason::ExecutorClosing,
+                    InterruptKind::WorkflowEventLimitReached => {
+                        ExecutionYieldReason::WorkflowEventLimitReached
+                    }
+                    InterruptKind::PauseOrCancel => unreachable!("intercepted in run"),
+                },
+            },
         }
     }
 }
@@ -715,16 +737,21 @@ impl WorkflowWorker {
         let seed = ctx.execution_id.random_seed();
         // Replay always runs with the `Interrupt` strategy and ignores lock extension / subscription
         // interruption, regardless of whether the source config is `Real` (auto-upgrade) or `Replay`.
-        let (join_next_blocking_strategy, lock_extension, subscription_interruption) =
-            if is_replay.is_some() {
-                (JoinNextBlockingStrategy::Interrupt, None, None)
-            } else {
-                (
-                    view.config.join_next_blocking_strategy(),
-                    view.config.lock_extension(),
-                    view.config.subscription_interruption(),
-                )
-            };
+        let (
+            join_next_blocking_strategy,
+            lock_extension,
+            subscription_interruption,
+            max_events_per_run,
+        ) = if is_replay.is_some() {
+            (JoinNextBlockingStrategy::Interrupt, None, None, None)
+        } else {
+            (
+                view.config.join_next_blocking_strategy(),
+                view.config.lock_extension(),
+                view.config.subscription_interruption(),
+                view.config.max_events_per_run(),
+            )
+        };
         let workflow_ctx = WorkflowCtx::new(
             view.deployment_id,
             db_connection,
@@ -745,6 +772,7 @@ impl WorkflowWorker {
             view.logs_storage_config,
             is_replay,
             view.config.max_replay_captured_writes(),
+            max_events_per_run,
         );
 
         let mut store = Store::new(view.engine, workflow_ctx);
@@ -1563,9 +1591,10 @@ impl WorkflowWorker {
                     http_client_traces: None,
                     version,
                 },
-                ReplayInternalError::ExecutorClosing(version) => {
-                    WorkerError::ExecutorClosing(version)
-                }
+                ReplayInternalError::ExecutorClosing(version) => WorkerError::ExecutionYielded {
+                    version,
+                    reason: ExecutionYieldReason::ExecutorClosing,
+                },
             })?;
 
         // Explicit replay/advance may persist this fatal replay outcome as `Finished`.
@@ -1989,6 +2018,7 @@ pub(crate) mod tests {
                         mode: WorkflowConfigMode::Real {
                             join_next_blocking_strategy,
                             lock_extension: None,
+                            max_events_per_run: usize::MAX,
                         },
                     },
                     workflow_engine,

--- a/server-help.toml
+++ b/server-help.toml
@@ -102,6 +102,7 @@
 # lock_extension_leeway.milliseconds = 100 # Deprecated, removed in 0.42: set `lock_extension_leeway` on each `[[workflow_wasm]]` / `[[workflow_js]]` instead. While set, it overrides the per-workflow value for every workflow.
 # subscription_interruption.seconds = 1    # Interrupts listening for notifications periodically, needed for Postgres with a local-only subscription mechanism. Value can be "none" or a duration.
 # max_replay_captured_writes = 100         # Max captured writes a single replay pass returns; on reaching it replay stops and returns that many as an advanceable prefix (advance them, then replay again to resume). Keeps a non-terminating workflow (e.g. an unresolved `joinNextTry` poll loop) advanceable in bounded batches.
+# max_events_per_run = 100                 # Max history events a real workflow run writes before yielding and unlocking. Replay uses max_replay_captured_writes instead.
 
 # [wasm.codegen_cache]
 ## Defaults:

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1111,6 +1111,7 @@ pub(crate) async fn deployment_verify_config(
         server_verified.fuel,
         termination_watcher,
         server_verified.database_subscription_interruption,
+        server_verified.workflows_max_events_per_run,
         server_verified.api_addr_if_webui_enabled.clone(),
         server_verified.secret_registry.clone(),
         server_verified.global_http_config.clone(),
@@ -1989,6 +1990,7 @@ pub(crate) struct ServerVerified {
     fuel: Option<u64>,
     global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     database_subscription_interruption: Option<Duration>,
+    workflows_max_events_per_run: usize,
     api_addr_if_webui_enabled: Option<String>,
     max_deployment_file_bytes: u32,
     global_http_config: GlobalHttpConfig,
@@ -2061,6 +2063,10 @@ impl ServerVerified {
         }
         let workflows_max_replay_captured_writes =
             config.workflows_global_config.max_replay_captured_writes;
+        let workflows_max_events_per_run = config.workflows_global_config.max_events_per_run;
+        if workflows_max_events_per_run == 0 {
+            bail!("`workflows.max_events_per_run` must be greater than zero");
+        }
         let build_semaphore = config.wasm_global_config.build_semaphore.into();
         let global_executor_instance_limiter = config
             .wasm_global_config
@@ -2095,6 +2101,7 @@ impl ServerVerified {
             fuel,
             global_executor_instance_limiter,
             database_subscription_interruption,
+            workflows_max_events_per_run,
             api_addr_if_webui_enabled: if config.webui.enabled {
                 Some(config.api.listening_addr.to_string()) // `config.api.enabled` checked above
             } else {
@@ -3523,6 +3530,7 @@ impl DeploymentVerified {
         fuel: Option<u64>,
         termination_watcher: &mut watch::Receiver<()>,
         subscription_interruption: Option<Duration>,
+        max_events_per_run: usize,
         api_addr_if_webui_enabled: Option<String>,
         secret_registry: Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
@@ -3688,6 +3696,7 @@ impl DeploymentVerified {
                             global_executor_instance_limiter.clone(),
                             fuel,
                             subscription_interruption,
+                            max_events_per_run,
                         )
                         .in_current_span(),
                 )
@@ -3830,6 +3839,7 @@ impl DeploymentVerified {
                                 global_executor_instance_limiter.clone(),
                                 fuel,
                                 subscription_interruption,
+                                max_events_per_run,
                             ).await?
                         );
                     }
@@ -5687,6 +5697,7 @@ mod tests {
             server_verified.fuel,
             &mut termination_watcher,
             server_verified.database_subscription_interruption,
+            server_verified.workflows_max_events_per_run,
             webui_enabled,
             server_verified.secret_registry,
             server_verified.global_http_config,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -892,6 +892,10 @@ pub(crate) struct WorkflowsGlobalConfigToml {
     /// of collecting captured writes forever.
     #[serde(default = "default_max_replay_captured_writes")]
     pub(crate) max_replay_captured_writes: usize,
+    /// Maximum number of history events a real workflow run may write before yielding.
+    #[serde(default = "default_max_events_per_run")]
+    #[schemars(range(min = 1))]
+    pub(crate) max_events_per_run: usize,
 }
 
 impl Default for WorkflowsGlobalConfigToml {
@@ -899,11 +903,16 @@ impl Default for WorkflowsGlobalConfigToml {
         Self {
             lock_extension_leeway: None,
             max_replay_captured_writes: default_max_replay_captured_writes(),
+            max_events_per_run: default_max_events_per_run(),
         }
     }
 }
 
 const fn default_max_replay_captured_writes() -> usize {
+    100
+}
+
+const fn default_max_events_per_run() -> usize {
     100
 }
 
@@ -2459,6 +2468,7 @@ pub(crate) trait WorkflowWasmComponentConfigResolvedExt {
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
+        max_events_per_run: usize,
     ) -> Result<WorkflowConfigVerified, anyhow::Error>;
 }
 
@@ -2471,6 +2481,7 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
+        max_events_per_run: usize,
     ) -> Result<WorkflowConfigVerified, anyhow::Error> {
         let retry_exp_backoff = Duration::from(self.retry_exp_backoff);
         if retry_exp_backoff == Duration::ZERO {
@@ -2515,6 +2526,7 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
                     .blocking_strategy
                     .into_blocking_strategy(subscription_interruption),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
+                max_events_per_run,
             },
         };
         let frame_files_to_sources = self.backtrace.into_frame_files();
@@ -2545,6 +2557,7 @@ pub(crate) trait WorkflowJsComponentConfigResolvedExt {
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
+        max_events_per_run: usize,
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error>;
 }
 
@@ -2557,6 +2570,7 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
         global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
+        max_events_per_run: usize,
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error> {
         let verified = verify_function_interface(
             self.interface,
@@ -2607,6 +2621,7 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
                     .blocking_strategy
                     .into_blocking_strategy(subscription_interruption),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
+                max_events_per_run,
             },
         };
         let retry_config = ComponentRetryConfig {


### PR DESCRIPTION
- **feat(toml): Yield workflow on `max_events_per_run`**
- **refactor: Extract `WorkflowError::Interrupt` into `ExecutionYielded` and `PauseOrCancel`**
