### PR TITLE
perf(replay): skip backtrace capture for the replayed prefix

### DIFF
--- a/crates/wasm-workers/src/registry.rs
+++ b/crates/wasm-workers/src/registry.rs
@@ -3,7 +3,7 @@
 use crate::workflow::replay_advance::AdvanceResponse;
 use crate::workflow::workflow_js_worker::WorkflowJsWorker;
 use crate::workflow::workflow_worker::{
-    AdvanceError, ReplayAdvanceable, ReplayError, ReplayResponse, WorkflowWorker,
+    AdvanceError, BacktraceCapture, ReplayAdvanceable, ReplayError, ReplayResponse, WorkflowWorker,
 };
 use concepts::ComponentId;
 use concepts::ComponentType;
@@ -56,7 +56,7 @@ impl ReplayWorker {
     pub async fn replay(
         &self,
         execution_id: ExecutionId,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<ReplayResponse, ReplayError> {
         match self {
             Self::Wasm(worker) => worker.replay(execution_id, backtrace_capture).await,
@@ -78,7 +78,7 @@ impl ReplayWorker {
         &self,
         execution_id: ExecutionId,
         requested: ReplayAdvanceable,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<AdvanceResponse, AdvanceError> {
         match self {
             Self::Wasm(worker) => {

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -2545,6 +2545,7 @@ struct EventCall {
 
 pub(crate) struct EventCallCursor {
     next_version: Version,
+    // Starts with whole replay history, pops front upon consuming each event.
     replay_versions: VecDeque<Version>,
 }
 
@@ -2561,6 +2562,12 @@ impl EventCallCursor {
 
     pub(crate) fn version(&self) -> &Version {
         &self.next_version
+    }
+
+    /// True while there are still persisted events to replay before the cursor reaches the
+    /// live tip. Once exhausted, subsequent calls produce brand-new events.
+    pub(crate) fn is_replaying_persisted(&self) -> bool {
+        !self.replay_versions.is_empty()
     }
 
     fn next(&mut self, kind: EventCallKind) -> EventCall {

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -150,7 +150,7 @@ pub(crate) struct WorkflowCtx {
     pub(crate) db_connection: Box<dyn WorkflowDbConnection>,
     component_logger: ComponentLogger,
     pub(crate) resource_table: wasmtime::component::ResourceTable,
-    backtrace_capture: bool,
+    backtrace_capture: BacktraceCapture,
     wasi_ctx: WasiCtx,
     is_replay: Option<ReplayKind>,
 }
@@ -685,7 +685,7 @@ impl<'a> ImportedFnCall<'a> {
         params: &'a [Val],
         fn_registry: &dyn FunctionRegistry,
     ) -> Result<ImportedFnCall<'a>, WorkflowFunctionError> {
-        let wasm_backtrace = if store_ctx.data().backtrace_capture {
+        let wasm_backtrace = if store_ctx.data().should_capture_backtrace() {
             let wasm_backtrace = wasmtime::WasmBacktrace::capture(&store_ctx);
             concepts::storage::WasmBacktrace::maybe_from(&wasm_backtrace)
         } else {
@@ -873,9 +873,27 @@ pub(crate) enum ReplayKind {
     Unfinished,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BacktraceCapture {
+    /// Do not capture backtraces (normal execution run).
+    Disabled,
+    /// Capture only for events past the persisted tip, i.e. the writes a replay would append.
+    NewEventsOnly,
+    /// Capture for every replayed event, including the already-persisted prefix (`persist_backtraces`).
+    Full,
+}
+
 impl WorkflowCtx {
     pub(crate) fn version(&self) -> &Version {
         self.event_call_cursor.version()
+    }
+
+    fn should_capture_backtrace(&self) -> bool {
+        match self.backtrace_capture {
+            BacktraceCapture::Disabled => false,
+            BacktraceCapture::Full => true,
+            BacktraceCapture::NewEventsOnly => !self.event_call_cursor.is_replaying_persisted(),
+        }
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -889,7 +907,7 @@ impl WorkflowCtx {
         clock_fn: Box<dyn ClockFn>,
         join_next_blocking_strategy: JoinNextBlockingStrategy,
         worker_span: Span,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
         deadline_tracker: Box<dyn DeadlineTracker>,
         fn_registry: Arc<dyn FunctionRegistry>,
         cancel_registry: CancelRegistry,
@@ -1033,7 +1051,7 @@ impl WorkflowCtx {
         caller: &'a mut wasmtime::StoreContextMut<'_, Self>,
         wit_backtrace: Option<typesTypes::backtrace::WasmBacktrace>,
     ) -> (&'a mut WorkflowCtx, Option<storage::WasmBacktrace>) {
-        let backtrace = if caller.data().backtrace_capture {
+        let backtrace = if caller.data().should_capture_backtrace() {
             wit_backtrace
                 .and_then(Self::wit_wasm_backtrace_to_storage)
                 .or_else(|| {
@@ -3035,6 +3053,7 @@ impl log_activities::obelisk::log::log::Host for WorkflowCtx {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use super::BacktraceCapture;
     use crate::activity::cancel_registry::CancelRegistry;
     use crate::cancellation_driver;
     use crate::testing_fn_registry::fn_registry_dummy;
@@ -3244,7 +3263,7 @@ pub(crate) mod tests {
                 self.clock_fn.clone_box(),
                 join_next_blocking_strategy,
                 tracing::info_span!("workflow-test"),
-                false,
+                BacktraceCapture::Disabled,
                 DeadlineTrackerFactoryTokio::new(Duration::ZERO, self.clock_fn.clone_box())
                     .create(
                         ctx.locked_event.lock_expires_at,

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -4,7 +4,7 @@
 //! This wrapper translates the user's typed interface `func(params) -> result<T, E>`
 //! into calls to the Boa component, deserializing the JSON-encoded ok string as the configured type.
 
-use super::workflow_worker::{WorkflowWorker, WorkflowWorkerCompiled};
+use super::workflow_worker::{BacktraceCapture, WorkflowWorker, WorkflowWorkerCompiled};
 use crate::activity::cancel_registry::CancelRegistry;
 use crate::component_logger::LogStrageConfig;
 use crate::workflow::deadline_tracker::DeadlineTrackerFactory;
@@ -236,7 +236,14 @@ impl WorkflowJsWorker {
         );
         let (writes, backtraces, _fatal_error, _db_conn) = self
             .inner
-            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn, true)
+            .capture_replay_writes_from_log(
+                execution_id,
+                log,
+                ffqn,
+                params,
+                db_conn,
+                BacktraceCapture::Full,
+            )
             .await?;
         Ok(WorkflowWorker::collect_write_backtraces(writes, backtraces))
     }
@@ -573,7 +580,7 @@ impl WorkflowJsWorker {
     pub async fn replay(
         &self,
         execution_id: ExecutionId,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<ReplayResponse, ReplayError> {
         assert!(
             self.inner.deadline_factory.is_for_replay(),
@@ -595,7 +602,7 @@ impl WorkflowJsWorker {
             self.js_entry_path.clone(),
             &self.js_files,
             &self.resolved_imports,
-            backtrace_capture,
+            backtrace_capture != BacktraceCapture::Disabled,
         );
 
         let (captured_writes, _backtraces, mut fatal_error, _db_conn) = self
@@ -653,7 +660,7 @@ impl WorkflowJsWorker {
         &self,
         execution_id: ExecutionId,
         requested: ReplayAdvanceable,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<AdvanceResponse, AdvanceError> {
         assert!(
             self.inner.deadline_factory.is_for_replay(),
@@ -687,7 +694,7 @@ impl WorkflowJsWorker {
             self.js_entry_path.clone(),
             &self.js_files,
             &self.resolved_imports,
-            backtrace_capture,
+            backtrace_capture != BacktraceCapture::Disabled,
         );
         let log_forwarder_sender = self
             .inner
@@ -1818,7 +1825,10 @@ mod tests {
             default_return_type(),
             None, // max_replay_captured_writes
         );
-        replay_worker.replay(execution_id, false).await.unwrap();
+        replay_worker
+            .replay(execution_id, BacktraceCapture::Disabled)
+            .await
+            .unwrap();
         // Drop the worker so the log_sender is closed; otherwise `recv_many` blocks indefinitely.
         drop(replay_worker);
         let mut buffer = Vec::new();
@@ -3846,7 +3856,7 @@ mod tests {
             None, // max_replay_captured_writes
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -3883,7 +3893,7 @@ mod tests {
             .unwrap();
 
         let replay2 = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -3924,7 +3934,7 @@ mod tests {
         );
 
         let replay3 = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -4013,7 +4023,7 @@ mod tests {
             None, // max_replay_captured_writes
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -4039,7 +4049,7 @@ mod tests {
         );
         // Replay should return the return value
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -4135,7 +4145,7 @@ mod tests {
         // Replay bounds the pass to MAX captured writes and returns them as an advanceable prefix
         // rather than looping forever.
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
@@ -4144,10 +4154,13 @@ mod tests {
         // Advancing the prefix persists it; a fresh replay resumes past the tip and yields the next
         // bounded batch, so the never-terminating workflow keeps making progress without erroring.
         replay_worker
-            .advance(execution_id.clone(), replay, false)
+            .advance(execution_id.clone(), replay, BacktraceCapture::Disabled)
             .await
             .unwrap();
-        let replay2 = replay_worker.replay(execution_id, false).await.unwrap();
+        let replay2 = replay_worker
+            .replay(execution_id, BacktraceCapture::Disabled)
+            .await
+            .unwrap();
         let replay2 = assert_matches!(replay2, ReplayResponse::Advanceable(replay2) => replay2);
         assert_eq!(replay2.captured_writes.len(), MAX);
 
@@ -4630,7 +4643,7 @@ mod tests {
             None, // max_replay_captured_writes
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
@@ -4640,7 +4653,7 @@ mod tests {
         );
 
         replay_worker
-            .advance(execution_id, replay, false)
+            .advance(execution_id, replay, BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -4732,14 +4745,18 @@ mod tests {
         let mut forwarded = Vec::new();
         for expected_len in [3_usize, 2, 1] {
             let replay = replay_worker
-                .replay(execution_id.clone(), false)
+                .replay(execution_id.clone(), BacktraceCapture::Disabled)
                 .await
                 .unwrap();
             let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
             assert_eq!(replay.captured_writes.len(), expected_len);
 
             replay_worker
-                .advance(execution_id.clone(), replay.truncate_to(1), false)
+                .advance(
+                    execution_id.clone(),
+                    replay.truncate_to(1),
+                    BacktraceCapture::Disabled,
+                )
                 .await
                 .unwrap();
 
@@ -4750,7 +4767,10 @@ mod tests {
             forwarded,
             vec!["before create", "before delay", "before join"]
         );
-        let replay = replay_worker.replay(execution_id, false).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id, BacktraceCapture::Disabled)
+            .await
+            .unwrap();
         assert_matches!(replay, ReplayResponse::Blocked);
     }
 
@@ -4790,7 +4810,7 @@ mod tests {
             .await;
             let replay = harness
                 .replay_worker
-                .replay(harness.execution_id.clone(), false)
+                .replay(harness.execution_id.clone(), BacktraceCapture::Disabled)
                 .await
                 .unwrap();
             let replay = match replay {
@@ -4852,7 +4872,11 @@ mod tests {
 
             let advance = harness
                 .replay_worker
-                .advance(harness.execution_id.clone(), requested.clone(), false)
+                .advance(
+                    harness.execution_id.clone(),
+                    requested.clone(),
+                    BacktraceCapture::Disabled,
+                )
                 .await
                 .unwrap();
             assert_eq!(advance.finished, requested.get_return_value().cloned());
@@ -4970,7 +4994,7 @@ mod tests {
             None, // max_replay_captured_writes
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -5014,7 +5038,7 @@ mod tests {
         sim_clock.move_time_forward(Duration::from_millis(100));
 
         let advance = replay_worker
-            .advance(execution_id, requested, false)
+            .advance(execution_id, requested, BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -5111,7 +5135,7 @@ mod tests {
             None, // max_replay_captured_writes
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -5157,7 +5181,7 @@ mod tests {
         sim_clock.move_time_forward(Duration::from_millis(100));
 
         let advance = replay_worker
-            .advance(execution_id, requested, false)
+            .advance(execution_id, requested, BacktraceCapture::Disabled)
             .await
             .unwrap();
 

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -15,6 +15,7 @@ use crate::workflow::replay_advance::{AdvanceFromLogError, AdvanceResponse, Repl
 use crate::workflow::replay_db_proxy::{
     InternalCapturedWrite, ReplayWorkflowDbConnection, apply_writes, bump_versions_for_execution,
 };
+pub use crate::workflow::workflow_ctx::BacktraceCapture;
 use crate::workflow::workflow_ctx::{ImportedFnCall, ReplayKind, WorkerPartialResult};
 use crate::{RunnableComponent, WasmFileError};
 use assert_matches::assert_matches;
@@ -589,7 +590,7 @@ impl WorkflowWorker {
         ffqn: FunctionFqn,
         params: Params,
         db_conn: Box<dyn DbConnection>,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<
         (
             Vec<InternalCapturedWrite>,
@@ -711,7 +712,7 @@ impl WorkflowWorker {
         db_connection: Box<dyn WorkflowDbConnection>,
         is_replay: Option<ReplayKind>,
         view: WorkflowWorkerView<'_>,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
         local_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
     ) -> Result<PrepareFuncFinished, WorkflowError> {
         assert_eq!(view.config.component_id, ctx.locked_event.component_id);
@@ -1185,7 +1186,7 @@ impl WorkflowWorker {
         execution_id: ExecutionId,
         real_connection: Box<dyn DbConnection>,
         parent: Option<(ExecutionId, JoinSetId)>,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<
         (
             Vec<InternalCapturedWrite>,
@@ -1302,7 +1303,7 @@ impl WorkflowWorker {
         db_connection: Box<dyn WorkflowDbConnection>,
         is_replay: Option<ReplayKind>,
         view: WorkflowWorkerView<'_>,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
         local_interrupt_watcher: tokio::sync::watch::Receiver<bool>,
     ) -> Result<
         (
@@ -1361,7 +1362,14 @@ impl WorkflowWorker {
         let ffqn = log.ffqn().clone();
         let params = log.params().clone();
         let (writes, backtraces, _fatal_error, _db_conn) = self
-            .capture_replay_writes_from_log(execution_id, log, ffqn, params, db_conn, true)
+            .capture_replay_writes_from_log(
+                execution_id,
+                log,
+                ffqn,
+                params,
+                db_conn,
+                BacktraceCapture::Full,
+            )
             .await?;
         Ok(Self::collect_write_backtraces(writes, backtraces))
     }
@@ -1415,7 +1423,7 @@ impl WorkflowWorker {
     pub async fn replay(
         &self,
         execution_id: ExecutionId,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<ReplayResponse, ReplayError> {
         assert!(
             self.deadline_factory.is_for_replay(),
@@ -1481,7 +1489,7 @@ impl WorkflowWorker {
         &self,
         execution_id: ExecutionId,
         requested: ReplayAdvanceable,
-        backtrace_capture: bool,
+        backtrace_capture: BacktraceCapture,
     ) -> Result<AdvanceResponse, AdvanceError> {
         assert!(
             self.deadline_factory.is_for_replay(),
@@ -1576,7 +1584,7 @@ impl WorkflowWorker {
                     .await
                     .map_err(|err| WorkerError::DbError(err.into()))?,
                 parent,
-                false,
+                BacktraceCapture::Disabled,
             )
             .await
             .map_err(|err| match err {
@@ -1775,7 +1783,7 @@ impl Worker for WorkflowWorker {
             db_connection,
             None, // is_replay
             view,
-            false,
+            BacktraceCapture::Disabled,
             local_interrupt_watcher,
         )
         .await;
@@ -4096,7 +4104,7 @@ pub(crate) mod tests {
             cancellation_driver::tick_test(db_connection, &cancel_registry, sim_clock.now()).await;
             let replay = harness
                 .replay_worker
-                .replay(harness.execution_id.clone(), false)
+                .replay(harness.execution_id.clone(), BacktraceCapture::Disabled)
                 .await
                 .unwrap();
 
@@ -4114,7 +4122,11 @@ pub(crate) mod tests {
             let expected_finished = replay.get_return_value().cloned();
             let advance = harness
                 .replay_worker
-                .advance(harness.execution_id.clone(), replay, false)
+                .advance(
+                    harness.execution_id.clone(),
+                    replay,
+                    BacktraceCapture::Disabled,
+                )
                 .await
                 .unwrap();
             assert_eq!(advance.finished, expected_finished);
@@ -4851,7 +4863,7 @@ pub(crate) mod tests {
         // Replay just after creating - execution is unfinished with no events,
         // preview should return the first event(s) the workflow would produce.
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
@@ -4906,7 +4918,10 @@ pub(crate) mod tests {
         assert_eq!(FIBO_10_OUTPUT, fibo);
 
         // Replay after workflow was finished - return_value is present.
-        let replay = replay_worker.replay(execution_id, false).await.unwrap();
+        let replay = replay_worker
+            .replay(execution_id, BacktraceCapture::Disabled)
+            .await
+            .unwrap();
         let result = assert_matches!(replay, ReplayResponse::Finished { result } => result);
         assert_matches!(result, SupportedFunctionReturnValue::Ok(_));
     }
@@ -4966,7 +4981,7 @@ pub(crate) mod tests {
             sim_clock.clone_box(),
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
         let replay = assert_matches!(replay, ReplayResponse::Advanceable(replay) => replay);
@@ -4976,7 +4991,7 @@ pub(crate) mod tests {
         );
 
         replay_worker
-            .advance(execution_id, replay, false)
+            .advance(execution_id, replay, BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -5241,7 +5256,7 @@ pub(crate) mod tests {
             cancellation_driver::tick_test(db_connection, &cancel_registry, sim_clock.now()).await;
             let replay = harness
                 .replay_worker
-                .replay(harness.execution_id.clone(), false)
+                .replay(harness.execution_id.clone(), BacktraceCapture::Disabled)
                 .await
                 .unwrap();
 
@@ -5286,7 +5301,11 @@ pub(crate) mod tests {
 
             let advance = harness
                 .replay_worker
-                .advance(harness.execution_id.clone(), requested.clone(), false)
+                .advance(
+                    harness.execution_id.clone(),
+                    requested.clone(),
+                    BacktraceCapture::Disabled,
+                )
                 .await
                 .unwrap();
             assert_eq!(advance.finished, requested.get_return_value().cloned());
@@ -5400,7 +5419,7 @@ pub(crate) mod tests {
 
         // Step 1: Replay to get expected events and version.
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -5432,7 +5451,11 @@ pub(crate) mod tests {
             }
         };
         let advance_result = replay_worker
-            .advance(execution_id.clone(), wrong_replay, false)
+            .advance(
+                execution_id.clone(),
+                wrong_replay,
+                BacktraceCapture::Disabled,
+            )
             .await
             .unwrap_err();
         assert_matches!(
@@ -5447,7 +5470,7 @@ pub(crate) mod tests {
                 ReplayAdvanceable {
                     captured_writes: vec![], // empty writes
                 },
-                false,
+                BacktraceCapture::Disabled,
             )
             .await
             .unwrap_err();
@@ -5607,7 +5630,7 @@ pub(crate) mod tests {
             sim_clock.clone_box(),
         );
         let replay = replay_worker
-            .replay(execution_id.clone(), false)
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
             .await
             .unwrap();
 
@@ -5651,7 +5674,7 @@ pub(crate) mod tests {
         sim_clock.move_time_forward(Duration::from_millis(100));
 
         let advance = replay_worker
-            .advance(execution_id, requested, false)
+            .advance(execution_id, requested, BacktraceCapture::Disabled)
             .await
             .unwrap();
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -80,7 +80,9 @@ use tracing::info_span;
 use tracing::instrument;
 use val_json::wast_val_ser::deserialize_slice;
 use wasm_workers::activity::cancel_registry::CancelRegistry;
-use wasm_workers::workflow::workflow_worker::{AdvanceError, ReplayAdvanceable, ReplayResponse};
+use wasm_workers::workflow::workflow_worker::{
+    AdvanceError, BacktraceCapture, ReplayAdvanceable, ReplayResponse,
+};
 
 pub(crate) struct GrpcServer {
     server_verified: ServerVerified,
@@ -871,8 +873,11 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 ))
             })?;
 
-        // Always capture backtrace so that advance can persist it
-        let replay_res = replay_worker.replay(execution_id.clone(), true).await;
+        // Capture backtraces for the newly produced writes only; the already-persisted prefix
+        // does not need them (and re-deriving them for a long log is expensive).
+        let replay_res = replay_worker
+            .replay(execution_id.clone(), BacktraceCapture::NewEventsOnly)
+            .await;
         let outcome = match replay_res {
             Ok(ReplayResponse::Advanceable(replay)) => {
                 grpc_gen::replay_execution_response::Outcome::Advanceable(
@@ -1024,8 +1029,13 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 .collect::<Result<Vec<_>, _>>()?,
         };
 
+        let backtrace_capture = if request.persist_backtrace {
+            BacktraceCapture::NewEventsOnly
+        } else {
+            BacktraceCapture::Disabled
+        };
         let advance_res = replay_worker
-            .advance(execution_id.clone(), expected, request.persist_backtrace)
+            .advance(execution_id.clone(), expected, backtrace_capture)
             .await;
 
         let result = match advance_res {
@@ -1102,7 +1112,9 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 tonic::Status::not_found(format!("new component '{new}' not found in registry"))
             })?;
             // no backtrace capture on upgrade
-            let replay_res = replay_worker.replay(execution_id.clone(), false).await;
+            let replay_res = replay_worker
+                .replay(execution_id.clone(), BacktraceCapture::Disabled)
+                .await;
             if let Err(err) = replay_res {
                 info!("Replay failed: {err:?}");
                 return Err(tonic::Status::internal(format!("replay failed: {err}")));

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -49,8 +49,9 @@ use tracing::{Instrument as _, Span, debug, info, info_span, instrument, trace, 
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use val_json::{wast_val::WastVal, wast_val_ser::deserialize_value};
 use wasm_workers::{
-    activity::cancel_registry::CancelRegistry, registry::ReplayWorker,
-    workflow::workflow_worker::AdvanceError,
+    activity::cancel_registry::CancelRegistry,
+    registry::ReplayWorker,
+    workflow::workflow_worker::{AdvanceError, BacktraceCapture},
 };
 
 #[derive(Clone)]
@@ -2408,12 +2409,13 @@ async fn execution_advance(
         ));
     }
 
+    let backtrace_capture = if payload.persist_backtrace {
+        BacktraceCapture::NewEventsOnly
+    } else {
+        BacktraceCapture::Disabled
+    };
     let advance_res = replay_worker
-        .advance(
-            execution_id.clone(),
-            captured_writes,
-            payload.persist_backtrace,
-        )
+        .advance(execution_id.clone(), captured_writes, backtrace_capture)
         .await;
 
     let advance_response = match advance_res {
@@ -2607,8 +2609,11 @@ async fn replay_execution_internal(
             }
         };
 
-    // Always capture backtrace so that advance can persist it
-    let replay_res = replay_worker.replay(execution_id.clone(), true).await;
+    // Capture backtraces for the newly produced writes only; the already-persisted prefix
+    // does not need them (and re-deriving them for a long log is expensive).
+    let replay_res = replay_worker
+        .replay(execution_id.clone(), BacktraceCapture::NewEventsOnly)
+        .await;
     match replay_res {
         Ok(response) => Ok(ReplayResponseSer::from(response)),
         Err(err) => map_replay_err(err),
@@ -2660,7 +2665,9 @@ async fn execution_upgrade(
             .get(&payload.new)
             .ok_or_else(|| HttpResponse::not_found(accept, Some("new component")))?;
         // no backtrace capture on upgrade
-        let replay_res = replay_worker.replay(execution_id.clone(), false).await;
+        let replay_res = replay_worker
+            .replay(execution_id.clone(), BacktraceCapture::Disabled)
+            .await;
         if let Err(err) = replay_res {
             info!("Replay failed: {err:?}");
             return Err(HttpResponse {


### PR DESCRIPTION
Previously the Replay RPC would capture all backtraces, although all but
those contained in new captured writes are discarded.

All backtraces are still captured only when Persist Bactraces RPC is
called.
