### PR TITLE
refactor(toml): Add `response_refresh_interval` to cap misused busy loops

### DIFF
--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -727,6 +727,13 @@
           "format": "uint",
           "minimum": 1,
           "default": 100
+        },
+        "response_refresh_interval": {
+          "description": "Number of newly written non-blocking events between database response refreshes.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "default": 32
         }
       },
       "additionalProperties": false

--- a/crates/bench/benches/fibo.rs
+++ b/crates/bench/benches/fibo.rs
@@ -201,6 +201,7 @@ mod bench {
                         join_next_blocking_strategy,
                         lock_extension: None,
                         max_events_per_run: usize::MAX,
+                        response_refresh_interval: usize::MAX,
                     },
                 },
                 workflow_engine,

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -175,6 +175,8 @@ pub(crate) struct EventHistory {
     max_replay_captured_writes: Option<usize>,
     max_events_per_run: Option<usize>,
     written_events_this_run: usize,
+    response_refresh_interval: Option<usize>,
+    events_since_response_refresh: usize,
 }
 
 #[derive(Debug)]
@@ -229,6 +231,7 @@ impl EventHistory {
         replaying_unfinished_execution: bool,
         max_replay_captured_writes: Option<usize>,
         max_events_per_run: Option<usize>,
+        response_refresh_interval: Option<usize>,
     ) -> EventHistory {
         EventHistory {
             replaying_unfinished_execution,
@@ -259,6 +262,8 @@ impl EventHistory {
             max_replay_captured_writes,
             max_events_per_run,
             written_events_this_run: 0,
+            response_refresh_interval,
+            events_since_response_refresh: 0,
         }
     }
 
@@ -456,6 +461,20 @@ impl EventHistory {
                     )
                     .await?;
                 self.event_history.push((event, Unprocessed, version));
+                if self.response_refresh_interval.is_some() {
+                    self.events_since_response_refresh += 1;
+                }
+                let refreshed_responses = if self
+                    .response_refresh_interval
+                    .is_some_and(|interval| self.events_since_response_refresh >= interval)
+                {
+                    db_connection
+                        .flush_non_blocking_event_cache(called_at)
+                        .await?;
+                    Some(self.poll_responses(db_connection).await?)
+                } else {
+                    None
+                };
                 trace!("find_matching_atomic must mark the non-blocking event as Processed");
                 let stored_event_call = EventCall::new(
                     version_range.min_including.clone(),
@@ -465,6 +484,9 @@ impl EventHistory {
                 let non_blocking_resp = assert_matches!(
                     self.find_matching_atomic(&stored_event_call)?,
                     FindMatchingAtomicResponse::Found { value, .. } => value, "just stored the event as Unprocessed, it must be found");
+                if let Some(refreshed_responses) = refreshed_responses {
+                    self.extend_responses(refreshed_responses);
+                }
                 Ok(non_blocking_resp)
             }
             EventCallKind::Blocking(event_call) => {
@@ -496,6 +518,53 @@ impl EventHistory {
             ));
         }
         Ok(value)
+    }
+
+    async fn poll_responses(
+        &mut self,
+        db_connection: &mut dyn WorkflowDbConnection,
+    ) -> Result<Vec<ResponseWithCursor>, ApplyError> {
+        let last_response = self.last_response_cursor();
+        self.events_since_response_refresh = 0;
+        match db_connection
+            .subscribe_to_next_responses(
+                db_connection.execution_id(),
+                last_response,
+                Box::pin(std::future::ready(
+                    ResponseSubscriptionEnd::PollIntervalElapsed,
+                )),
+            )
+            .await
+        {
+            Ok(responses) => Ok(responses),
+            Err(SubscribeToResponsesError::DbErrorRead(err)) => {
+                Err(ApplyError::DbError(DbErrorWrite::from(err)))
+            }
+            Err(SubscribeToResponsesError::SubscriptionEnded(
+                ResponseSubscriptionEnd::PollIntervalElapsed
+                | ResponseSubscriptionEnd::LockDeadlineReached,
+            )) => Ok(Vec::new()),
+            Err(SubscribeToResponsesError::SubscriptionEnded(
+                ResponseSubscriptionEnd::ExecutorClosing,
+            )) => Err(ApplyError::Interrupt(InterruptKind::ExecutorClosing)),
+            Err(SubscribeToResponsesError::SubscriptionEnded(
+                ResponseSubscriptionEnd::ExecutionUpdated,
+            )) => Err(ApplyError::Interrupt(InterruptKind::PauseOrCancel)),
+        }
+    }
+
+    fn last_response_cursor(&self) -> ResponseCursor {
+        self.responses
+            .last()
+            .map(|(resp, _)| resp.cursor)
+            .unwrap_or(ResponseCursor(0))
+    }
+
+    fn extend_responses(&mut self, next_responses: Vec<ResponseWithCursor>) {
+        trace!("Got next responses {next_responses:?}");
+        self.responses
+            .extend(next_responses.into_iter().map(|resp| (resp, Unprocessed)));
+        trace!("All responses: {:?}", self.responses);
     }
 
     async fn persist_replayed_backtrace(
@@ -632,11 +701,8 @@ impl EventHistory {
                             return Err(ApplyError::Interrupt(InterruptKind::PauseOrCancel));
                         }
                     };
-                let last_response = self
-                    .responses
-                    .last()
-                    .map(|(resp, _)| resp.cursor)
-                    .unwrap_or(ResponseCursor(0));
+                let last_response = self.last_response_cursor();
+                self.events_since_response_refresh = 0;
                 match db_connection
                     .subscribe_to_next_responses(
                         db_connection.execution_id(),
@@ -653,10 +719,7 @@ impl EventHistory {
                             first = next_responses.first(),
                             last = next_responses.last(),
                         );
-                        trace!("Got next responses {next_responses:?}");
-                        self.responses
-                            .extend(next_responses.into_iter().map(|resp| (resp, Unprocessed)));
-                        trace!("All responses: {:?}", self.responses);
+                        self.extend_responses(next_responses);
                         if let FindMatchingResponse::Found {
                             value: accept_resp, ..
                         } = self.process_event_by_key(&key)?
@@ -4612,6 +4675,7 @@ mod tests {
             false, // replaying_unfinished_execution
             None,  // max_replay_captured_writes
             None,  // max_events_per_run
+            None,  // response_refresh_interval
         );
 
         (

--- a/crates/wasm-workers/src/workflow/workflow_ctx.rs
+++ b/crates/wasm-workers/src/workflow/workflow_ctx.rs
@@ -918,6 +918,7 @@ impl WorkflowCtx {
         is_replay: Option<ReplayKind>,
         max_replay_captured_writes: Option<usize>,
         max_events_per_run: Option<usize>,
+        response_refresh_interval: Option<usize>,
     ) -> Self {
         let mut wasi_ctx_builder = WasiCtxBuilder::new();
         wasi_ctx_builder.allow_tcp(false);
@@ -945,6 +946,7 @@ impl WorkflowCtx {
                 is_replay == Some(ReplayKind::Unfinished),
                 max_replay_captured_writes,
                 max_events_per_run,
+                response_refresh_interval,
             ),
             rng: StdRng::seed_from_u64(seed),
             clock_fn,
@@ -3280,6 +3282,7 @@ pub(crate) mod tests {
                 is_replay,
                 None, // max_replay_captured_writes
                 None, // max_events_per_run
+                None, // response_refresh_interval
             );
             for step in &self.steps {
                 info!("Processing step {step:?}");

--- a/crates/wasm-workers/src/workflow/workflow_js_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_js_worker.rs
@@ -931,6 +931,7 @@ mod tests {
                 join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
                 lock_extension: Some(Duration::from_secs(1)),
                 max_events_per_run: usize::MAX,
+                response_refresh_interval: usize::MAX,
             },
         };
 
@@ -1010,6 +1011,7 @@ mod tests {
                 join_next_blocking_strategy: JoinNextBlockingStrategy::Interrupt,
                 lock_extension: None,
                 max_events_per_run: usize::MAX,
+                response_refresh_interval: usize::MAX,
             },
         };
 
@@ -1308,6 +1310,7 @@ mod tests {
             deadline_factory,
             default_return_type(),
             usize::MAX,
+            usize::MAX,
         )
     }
 
@@ -1324,6 +1327,7 @@ mod tests {
         deadline_factory: Arc<dyn DeadlineTrackerFactory>,
         return_type: ReturnTypeExtendable,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
     ) -> (WorkflowJsWorker, concepts::ComponentId, RunnableComponent) {
         let wasm_path = workflow_js_runtime_builder::WORKFLOW_JS_RUNTIME;
         let params = default_js_params();
@@ -1346,6 +1350,7 @@ mod tests {
                 join_next_blocking_strategy,
                 lock_extension: None,
                 max_events_per_run,
+                response_refresh_interval,
             },
         };
 
@@ -1988,6 +1993,7 @@ mod tests {
                     join_next_blocking_strategy,
                     deadline_factory,
                     return_type,
+                    usize::MAX,
                     usize::MAX,
                 );
 
@@ -4208,6 +4214,7 @@ mod tests {
                 deadline_tracker_factory_test(&sim_clock),
                 default_return_type(),
                 MAX,
+                usize::MAX,
             );
         let (workflow_exec, _close_tx) =
             new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
@@ -4247,6 +4254,133 @@ mod tests {
             );
             assert_matches!(log.pending_state, PendingState::PendingAt(..));
         }
+
+        drop(db_connection);
+        db_close.close().await;
+    }
+
+    #[expand_enum_database]
+    #[rstest]
+    #[tokio::test]
+    async fn workflow_js_hot_run_refreshes_responses(database: Database) {
+        use crate::activity::activity_worker::test::compile_activity_stub;
+
+        const MAX_EVENTS_PER_RUN: usize = 10_000;
+        const RESPONSE_REFRESH_INTERVAL: usize = 4;
+
+        test_utils::set_up();
+        let (_guard, db_pool, db_close) = database.set_up().await;
+        let js_source = r"
+        export default function poll_until_ready() {
+            const js = obelisk.createJoinSet();
+            js.submit('testing:stub-activity/activity.foo', ['test-input']);
+            for (;;) {
+                if (js.joinNextTry() !== undefined) {
+                    return 'refreshed';
+                }
+            }
+        }";
+        let user_ffqn = FunctionFqn::new_static("test:pkg/ifc", "poll-until-ready");
+        let sim_clock = SimClock::epoch();
+        let fn_registry: Arc<dyn FunctionRegistry> = TestingFnRegistry::new_from_components(vec![
+            compile_activity_stub(test_programs_stub_activity_builder::TEST_PROGRAMS_STUB_ACTIVITY)
+                .await,
+        ]);
+        let workflow_engine =
+            Engines::get_workflow_engine_test(EngineConfig::on_demand_testing()).unwrap();
+        let (worker, component_id, _) =
+            compile_js_workflow_worker_with_deployment_id_and_return_type(
+                js_source,
+                &user_ffqn,
+                db_pool.clone(),
+                &sim_clock,
+                fn_registry,
+                workflow_engine,
+                DEPLOYMENT_ID_DUMMY,
+                JoinNextBlockingStrategy::Await {
+                    non_blocking_event_batching: 100,
+                    subscription_interruption: None,
+                },
+                deadline_tracker_factory_test(&sim_clock),
+                default_return_type(),
+                MAX_EVENTS_PER_RUN,
+                RESPONSE_REFRESH_INTERVAL,
+            );
+        let (workflow_exec, _close_tx) =
+            new_js_workflow_exec_task(worker, sim_clock.clone_box(), db_pool.clone());
+        let execution_id = ExecutionId::from_parts(0, 43);
+        let db_connection = db_pool.connection_test().await.unwrap();
+        db_connection
+            .create(CreateRequest {
+                created_at: sim_clock.now(),
+                execution_id: execution_id.clone(),
+                ffqn: user_ffqn,
+                params: Params::from_json_values_test(vec![json!(Vec::<String>::new())]),
+                parent: None,
+                metadata: ExecutionMetadata::empty(),
+                scheduled_at: sim_clock.now(),
+                component_id,
+                deployment_id: DEPLOYMENT_ID_DUMMY,
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        let progress = workflow_exec
+            .tick_test(sim_clock.now(), RunId::generate())
+            .await;
+        let stub_execution_id = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let log = db_connection.get(&execution_id).await.unwrap();
+                if let Some(child_execution_id) = log.events.iter().find_map(|event| {
+                    if let ExecutionRequest::HistoryEvent {
+                        event:
+                            HistoryEvent::JoinSetRequest {
+                                request:
+                                    JoinSetRequest::ChildExecutionRequest {
+                                        child_execution_id, ..
+                                    },
+                                ..
+                            },
+                    } = &event.event
+                    {
+                        Some(child_execution_id.clone())
+                    } else {
+                        None
+                    }
+                }) {
+                    break child_execution_id;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("response refresh must flush the submitted child");
+        write_stub_response(
+            db_connection.as_ref(),
+            sim_clock.now(),
+            stub_execution_id,
+            SupportedFunctionReturnValue::Ok(None),
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), progress.wait_for_tasks())
+            .await
+            .expect("hot workflow must observe the refreshed response");
+        let log = db_connection.get(&execution_id).await.unwrap();
+        assert!(
+            log.pending_state.is_finished(),
+            "state: {:?}",
+            log.pending_state
+        );
+        assert!(
+            log.events
+                .iter()
+                .all(|event| !matches!(event.event, ExecutionRequest::Unlocked(_))),
+            "the workflow should finish within one run: {:?}",
+            log.events
+        );
 
         drop(db_connection);
         db_close.close().await;

--- a/crates/wasm-workers/src/workflow/workflow_worker.rs
+++ b/crates/wasm-workers/src/workflow/workflow_worker.rs
@@ -84,6 +84,7 @@ pub enum WorkflowConfigMode {
         // Only applicable if `join_next_blocking_strategy` is `JoinNextBlockingStrategy::Await`.
         lock_extension: Option<Duration>,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
     },
     /// Replay/advance: writes are captured in memory instead of persisted, and the workflow always
     /// runs with the `Interrupt` strategy. `max_replay_captured_writes` bounds how many captured
@@ -140,6 +141,16 @@ impl WorkflowConfig {
             WorkflowConfigMode::Real {
                 max_events_per_run, ..
             } => Some(*max_events_per_run),
+            WorkflowConfigMode::Replay { .. } => None,
+        }
+    }
+
+    fn response_refresh_interval(&self) -> Option<usize> {
+        match &self.mode {
+            WorkflowConfigMode::Real {
+                response_refresh_interval,
+                ..
+            } => Some(*response_refresh_interval),
             WorkflowConfigMode::Replay { .. } => None,
         }
     }
@@ -739,14 +750,16 @@ impl WorkflowWorker {
             lock_extension,
             subscription_interruption,
             max_events_per_run,
+            response_refresh_interval,
         ) = if is_replay.is_some() {
-            (JoinNextBlockingStrategy::Interrupt, None, None, None)
+            (JoinNextBlockingStrategy::Interrupt, None, None, None, None)
         } else {
             (
                 view.config.join_next_blocking_strategy(),
                 view.config.lock_extension(),
                 view.config.subscription_interruption(),
                 view.config.max_events_per_run(),
+                view.config.response_refresh_interval(),
             )
         };
         let workflow_ctx = WorkflowCtx::new(
@@ -770,6 +783,7 @@ impl WorkflowWorker {
             is_replay,
             view.config.max_replay_captured_writes(),
             max_events_per_run,
+            response_refresh_interval,
         );
 
         let mut store = Store::new(view.engine, workflow_ctx);
@@ -2043,6 +2057,7 @@ pub(crate) mod tests {
                             join_next_blocking_strategy,
                             lock_extension: None,
                             max_events_per_run: usize::MAX,
+                            response_refresh_interval: usize::MAX,
                         },
                     },
                     workflow_engine,

--- a/server-help.toml
+++ b/server-help.toml
@@ -103,6 +103,7 @@
 # subscription_interruption.seconds = 1    # Interrupts listening for notifications periodically, needed for Postgres with a local-only subscription mechanism. Value can be "none" or a duration.
 # max_replay_captured_writes = 100         # Max captured writes a single replay pass returns; on reaching it replay stops and returns that many as an advanceable prefix (advance them, then replay again to resume). Keeps a non-terminating workflow (e.g. an unresolved `joinNextTry` poll loop) advanceable in bounded batches.
 # max_events_per_run = 100                 # Max history events a real workflow run writes before yielding and unlocking. Replay uses max_replay_captured_writes instead.
+# response_refresh_interval = 32           # Refresh responses from the database after this many newly written non-blocking events while a workflow remains running. Usually set lower than max_events_per_run. Replay ignores it.
 
 # [wasm.codegen_cache]
 ## Defaults:

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1112,6 +1112,7 @@ pub(crate) async fn deployment_verify_config(
         termination_watcher,
         server_verified.database_subscription_interruption,
         server_verified.workflows_max_events_per_run,
+        server_verified.workflows_response_refresh_interval,
         server_verified.api_addr_if_webui_enabled.clone(),
         server_verified.secret_registry.clone(),
         server_verified.global_http_config.clone(),
@@ -1991,6 +1992,7 @@ pub(crate) struct ServerVerified {
     global_executor_instance_limiter: Option<Arc<tokio::sync::Semaphore>>,
     database_subscription_interruption: Option<Duration>,
     workflows_max_events_per_run: usize,
+    workflows_response_refresh_interval: usize,
     api_addr_if_webui_enabled: Option<String>,
     max_deployment_file_bytes: u32,
     global_http_config: GlobalHttpConfig,
@@ -2067,6 +2069,18 @@ impl ServerVerified {
         if workflows_max_events_per_run == 0 {
             bail!("`workflows.max_events_per_run` must be greater than zero");
         }
+        let workflows_response_refresh_interval =
+            config.workflows_global_config.response_refresh_interval;
+        if workflows_response_refresh_interval == 0 {
+            bail!("`workflows.response_refresh_interval` must be greater than zero");
+        }
+        if workflows_response_refresh_interval >= workflows_max_events_per_run {
+            warn!(
+                "`workflows.response_refresh_interval` should normally be lower than \
+                 `workflows.max_events_per_run`; otherwise hot-run refreshes will usually be \
+                 preempted by the run limit"
+            );
+        }
         let build_semaphore = config.wasm_global_config.build_semaphore.into();
         let global_executor_instance_limiter = config
             .wasm_global_config
@@ -2102,6 +2116,7 @@ impl ServerVerified {
             global_executor_instance_limiter,
             database_subscription_interruption,
             workflows_max_events_per_run,
+            workflows_response_refresh_interval,
             api_addr_if_webui_enabled: if config.webui.enabled {
                 Some(config.api.listening_addr.to_string()) // `config.api.enabled` checked above
             } else {
@@ -3531,6 +3546,7 @@ impl DeploymentVerified {
         termination_watcher: &mut watch::Receiver<()>,
         subscription_interruption: Option<Duration>,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
         api_addr_if_webui_enabled: Option<String>,
         secret_registry: Arc<SecretRegistry>,
         global_http_config: GlobalHttpConfig,
@@ -3697,6 +3713,7 @@ impl DeploymentVerified {
                             fuel,
                             subscription_interruption,
                             max_events_per_run,
+                            response_refresh_interval,
                         )
                         .in_current_span(),
                 )
@@ -3840,6 +3857,7 @@ impl DeploymentVerified {
                                 fuel,
                                 subscription_interruption,
                                 max_events_per_run,
+                                response_refresh_interval,
                             ).await?
                         );
                     }
@@ -5698,6 +5716,7 @@ mod tests {
             &mut termination_watcher,
             server_verified.database_subscription_interruption,
             server_verified.workflows_max_events_per_run,
+            server_verified.workflows_response_refresh_interval,
             webui_enabled,
             server_verified.secret_registry,
             server_verified.global_http_config,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -896,6 +896,10 @@ pub(crate) struct WorkflowsGlobalConfigToml {
     #[serde(default = "default_max_events_per_run")]
     #[schemars(range(min = 1))]
     pub(crate) max_events_per_run: usize,
+    /// Number of newly written non-blocking events between database response refreshes.
+    #[serde(default = "default_response_refresh_interval")]
+    #[schemars(range(min = 1))]
+    pub(crate) response_refresh_interval: usize,
 }
 
 impl Default for WorkflowsGlobalConfigToml {
@@ -904,6 +908,7 @@ impl Default for WorkflowsGlobalConfigToml {
             lock_extension_leeway: None,
             max_replay_captured_writes: default_max_replay_captured_writes(),
             max_events_per_run: default_max_events_per_run(),
+            response_refresh_interval: default_response_refresh_interval(),
         }
     }
 }
@@ -914,6 +919,10 @@ const fn default_max_replay_captured_writes() -> usize {
 
 const fn default_max_events_per_run() -> usize {
     100
+}
+
+const fn default_response_refresh_interval() -> usize {
+    32
 }
 
 #[derive(Debug, Deserialize, JsonSchema, Clone)]
@@ -2461,6 +2470,7 @@ impl ActivityJsComponentConfigResolvedExt for ActivityJsComponentConfigResolved 
 }
 
 pub(crate) trait WorkflowWasmComponentConfigResolvedExt {
+    #[expect(clippy::too_many_arguments)]
     async fn fetch_and_verify(
         self,
         wasm_cache_dir: Arc<Path>,
@@ -2469,6 +2479,7 @@ pub(crate) trait WorkflowWasmComponentConfigResolvedExt {
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
     ) -> Result<WorkflowConfigVerified, anyhow::Error>;
 }
 
@@ -2482,6 +2493,7 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
     ) -> Result<WorkflowConfigVerified, anyhow::Error> {
         let retry_exp_backoff = Duration::from(self.retry_exp_backoff);
         if retry_exp_backoff == Duration::ZERO {
@@ -2527,6 +2539,7 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
                     .into_blocking_strategy(subscription_interruption),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
                 max_events_per_run,
+                response_refresh_interval,
             },
         };
         let frame_files_to_sources = self.backtrace.into_frame_files();
@@ -2550,6 +2563,7 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
 }
 
 pub(crate) trait WorkflowJsComponentConfigResolvedExt {
+    #[expect(clippy::too_many_arguments)]
     async fn fetch_and_verify(
         self,
         wasm_path: Arc<Path>,
@@ -2558,6 +2572,7 @@ pub(crate) trait WorkflowJsComponentConfigResolvedExt {
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error>;
 }
 
@@ -2571,6 +2586,7 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
         fuel: Option<u64>,
         subscription_interruption: Option<Duration>,
         max_events_per_run: usize,
+        response_refresh_interval: usize,
     ) -> Result<WorkflowJsConfigVerified, anyhow::Error> {
         let verified = verify_function_interface(
             self.interface,
@@ -2622,6 +2638,7 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
                     .into_blocking_strategy(subscription_interruption),
                 lock_extension: self.lock_extension.then_some(self.exec.lock_expiry.into()),
                 max_events_per_run,
+                response_refresh_interval,
             },
         };
         let retry_config = ComponentRetryConfig {


### PR DESCRIPTION
Problem: loop with `join-next-try` would never finish.
Because of `max_events_per_run` the workflow already unlocks and therefore the
loop will be broken on next lock. This change periodically loads responses
even if no blocking request is encountered, therefore minimizing
number of needless `join-next-try` events even more.
