### PR TITLE
ci: strip custom sections from JS runtime WASMs before push

### DIFF
--- a/scripts/push-activity-js-runtime.sh
+++ b/scripts/push-activity-js-runtime.sh
@@ -10,18 +10,25 @@ if ! command -v obelisk >/dev/null; then
     exit 1
 fi
 
+if ! command -v wasm-tools >/dev/null; then
+    echo "error: wasm-tools must be on PATH" >&2
+    exit 1
+fi
+
 TAG="$1"
 OUTPUT_FILE="${2:-assets/activity-js-runtime-version.txt}"
 
 cargo check --package activity-js-runtime-builder # triggers build.rs of activity-js-runtime-builder
 
 if [ "$TAG" != "dry-run" ]; then
+    STRIPPED="target/release_wasm_runtime/wasm32-wasip2/release_wasm_runtime/activity_js_runtime.stripped.wasm"
+    wasm-tools strip --all "target/release_wasm_runtime/wasm32-wasip2/release_wasm_runtime/activity_js_runtime.wasm" -o "$STRIPPED"
     TMP_TOML="activity-deployment-for-push.toml"
     trap "rm -f $TMP_TOML" EXIT
     cat > "$TMP_TOML" <<EOF
 [[activity_wasm]]
 name = "target_component"
-location = "target/release_wasm_runtime/wasm32-wasip2/release_wasm_runtime/activity_js_runtime.wasm"
+location = "$STRIPPED"
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \
         target_component "oci://docker.io/getobelisk/activity-js-runtime:$TAG")

--- a/scripts/push-webhook-js-runtime.sh
+++ b/scripts/push-webhook-js-runtime.sh
@@ -10,18 +10,25 @@ if ! command -v obelisk >/dev/null; then
     exit 1
 fi
 
+if ! command -v wasm-tools >/dev/null; then
+    echo "error: wasm-tools must be on PATH" >&2
+    exit 1
+fi
+
 TAG="$1"
 OUTPUT_FILE="${2:-assets/webhook-js-runtime-version.txt}"
 
 cargo check --package webhook-js-runtime-builder # triggers build.rs of webhook-js-runtime-builder
 
 if [ "$TAG" != "dry-run" ]; then
+    STRIPPED="target/wasm-cache/webhook_js_runtime.stripped.wasm"
+    wasm-tools strip --all "target/wasm-cache/webhook_js_runtime.wasm" -o "$STRIPPED"
     TMP_TOML="webhook-deployment-for-push.toml"
     trap "rm -f $TMP_TOML" EXIT
     cat > "$TMP_TOML" <<EOF
 [[webhook_endpoint_wasm]]
 name = "target_component"
-location = "target/wasm-cache/webhook_js_runtime.wasm"
+location = "$STRIPPED"
 routes = [""]
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \

--- a/scripts/push-workflow-js-runtime.sh
+++ b/scripts/push-workflow-js-runtime.sh
@@ -10,18 +10,25 @@ if ! command -v obelisk >/dev/null; then
     exit 1
 fi
 
+if ! command -v wasm-tools >/dev/null; then
+    echo "error: wasm-tools must be on PATH" >&2
+    exit 1
+fi
+
 TAG="$1"
 OUTPUT_FILE="${2:-assets/workflow-js-runtime-version.txt}"
 
 cargo check --package workflow-js-runtime-builder # triggers build.rs of workflow-js-runtime-builder
 
 if [ "$TAG" != "dry-run" ]; then
+    STRIPPED="target/wasm-cache/workflow_js_runtime_component.stripped.wasm"
+    wasm-tools strip --all "target/wasm-cache/workflow_js_runtime_component.wasm" -o "$STRIPPED"
     TMP_TOML="workflow-deployment-for-push.toml"
     trap "rm -f $TMP_TOML" EXIT
     cat > "$TMP_TOML" <<EOF
 [[workflow_wasm]]
 name = "target_component"
-location = "target/wasm-cache/workflow_js_runtime_component.wasm"
+location = "$STRIPPED"
 EOF
     OUTPUT=$(obelisk component push --deployment "$TMP_TOML" \
         target_component "oci://docker.io/getobelisk/workflow-js-runtime:$TAG")


### PR DESCRIPTION
Run `wasm-tools strip --all` on the workflow/activity/webhook JS runtime
components before publishing, dropping the ~500KB `name` section plus
`producers`/`target_features`/`component-name`. Cuts each published image
by ~11% (500-640KB). These sections are non-semantic and the stripped
components still validate; JS backtraces come from Boa's interpreter
frames, not the WASM name section, so no diagnostic value is lost.
