### PR TITLE
ci: Add `-embedded` binaries to release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,21 @@ jobs:
       - name: Check JS runtime version pins are newer than their sources
         run: ./scripts/check-js-runtime-freshness.sh
 
+  check-embedded-assets:
+    name: Embedded asset hash
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify embedded asset hash
+        run: |
+          ./scripts/update-embedded-assets-hash.sh
+          git diff --exit-code -- flake.nix
+
   deny:
     name: cargo deny
     runs-on: ubuntu-24.04

--- a/.github/workflows/push-js-runtime.yml
+++ b/.github/workflows/push-js-runtime.yml
@@ -70,6 +70,9 @@ jobs:
           RUNTIME_TYPE: ${{ github.event.inputs.runtime_type }}
           TAG: ${{ github.event.inputs.tag }}
 
+      - name: Update embedded asset hash
+        run: ./scripts/update-embedded-assets-hash.sh
+
       - name: Configure git before push
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release-3.1-upload-artifacts.yml
+++ b/.github/workflows/release-3.1-upload-artifacts.yml
@@ -57,16 +57,28 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-24.04
 
+          - target: x86_64-unknown-linux-musl-embedded
+            os: ubuntu-24.04
+
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04
 
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04
 
+          - target: aarch64-unknown-linux-musl-embedded
+            os: ubuntu-24.04
+
           - target: x86_64-apple-darwin
             os: ubuntu-24.04
 
+          - target: x86_64-apple-darwin-embedded
+            os: ubuntu-24.04
+
           - target: aarch64-apple-darwin
+            os: ubuntu-24.04
+
+          - target: aarch64-apple-darwin-embedded
             os: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/release-5-verify-github-release.yml
+++ b/.github/workflows/release-5-verify-github-release.yml
@@ -32,10 +32,16 @@ jobs:
             file: obelisk-x86_64-unknown-linux-gnu.tar.gz
           - runner: ubuntu-22.04
             file: obelisk-x86_64-unknown-linux-musl.tar.gz
+          - runner: ubuntu-22.04
+            file: obelisk-x86_64-unknown-linux-musl-embedded.tar.gz
           - runner: macos-14
             file: obelisk-x86_64-apple-darwin.tar.gz
           - runner: macos-14
+            file: obelisk-x86_64-apple-darwin-embedded.tar.gz
+          - runner: macos-14
             file: obelisk-aarch64-apple-darwin.tar.gz
+          - runner: macos-14
+            file: obelisk-aarch64-apple-darwin-embedded.tar.gz
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test-codegen-cache
 obelisk.log
 /.claude/
 /meta
+result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,6 +1508,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "embedded-assets"
+version = "0.41.0"
+dependencies = [
+ "anyhow",
+ "oci-client",
+ "oci-wasm",
+ "reqwest",
+ "rustls",
+ "sha2 0.10.9",
+ "tokio",
+]
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,6 +3478,7 @@ dependencies = [
  "derive_more",
  "directories",
  "docker_credential",
+ "embedded-assets",
  "futures-util",
  "hashbrown 0.16.1",
  "hmac 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ wasm-workers.workspace = true
 activity-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 webhook-js-runtime-builder = { workspace = true, optional = true } # Only for local development
 workflow-js-runtime-builder = { workspace = true, optional = true } # Only for local development
+embedded-assets = { workspace = true, optional = true }
 
 anyhow.workspace = true
 assert_matches.workspace = true
@@ -134,6 +135,7 @@ otlp = [
 "activity-js-local" = ["dep:activity-js-runtime-builder"]
 "webhook-js-local" = ["dep:webhook-js-runtime-builder"]
 "workflow-js-local" = ["dep:workflow-js-runtime-builder"]
+"embed-assets" = ["dep:embedded-assets", "embedded-assets/download"]
 default = ["otlp"]
 
 [lints]
@@ -153,6 +155,7 @@ members = [
     "crates/deployment-config",
     "crates/db-postgres",
     "crates/db-sqlite",
+    "crates/embedded-assets",
     "crates/executor",
     "crates/grpc",
     "crates/testing/component-builder",
@@ -213,6 +216,7 @@ db-postgres = { package = "obeli-sk-db-postgres", path = "crates/db-postgres", v
 db-sqlite = { package = "obeli-sk-db-sqlite", path = "crates/db-sqlite", version = "0.41.0" }
 deployment-config = { package = "obeli-sk-deployment-config", path = "crates/deployment-config", version = "0.41.0" }
 db-tests = { package = "obeli-db-tests", path = "crates/testing/db-tests" }
+embedded-assets = { path = "crates/embedded-assets" }
 executor = { package = "obeli-sk-executor", path = "crates/executor", version = "0.41.0" }
 grpc = { package = "obeli-sk-grpc", path = "crates/grpc", version = "0.41.0" }
 obelisk-component-builder = { path = "crates/testing/component-builder", features = [

--- a/crates/embedded-assets/Cargo.toml
+++ b/crates/embedded-assets/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "embedded-assets"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[features]
+download = []
+
+[build-dependencies]
+anyhow.workspace = true
+oci-client.workspace = true
+oci-wasm.workspace = true
+reqwest.workspace = true
+rustls.workspace = true
+sha2.workspace = true
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/embedded-assets/build.rs
+++ b/crates/embedded-assets/build.rs
@@ -1,0 +1,151 @@
+//! Materialize the four operator-owned WASM assets into `OUT_DIR` so `src/lib.rs`
+//! can `include_bytes!` them.
+//!
+//! The assets are the exact pinned artifacts referenced from `assets/*version*.txt`
+//! (three JS runtimes + the web UI). They are obtained one of two ways:
+//!
+//! * `OBELISK_EMBED_ASSETS_DIR` set: read pre-fetched `<name>.wasm` files from that
+//!   directory (the Nix fixed-output derivation path, fully offline).
+//! * otherwise: pull the single WASM layer of each pinned OCI image over the network,
+//!   mirroring `obelisk/src/oci.rs::pull_to_cache_dir`.
+//!
+//! Both paths verify each file against the layer digest, so the two acquisition
+//! methods produce byte-identical embeds.
+
+use anyhow::{Context, bail};
+use oci_client::secrets::RegistryAuth;
+use oci_wasm::WasmClient;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+/// (generated const name, `<name>.wasm` file stem, `assets/<version file>`).
+const ASSETS: &[(&str, &str, &str)] = &[
+    (
+        "ACTIVITY_JS_RUNTIME_WASM",
+        "activity",
+        "activity-js-runtime-version.txt",
+    ),
+    (
+        "WORKFLOW_JS_RUNTIME_WASM",
+        "workflow",
+        "workflow-js-runtime-version.txt",
+    ),
+    (
+        "WEBHOOK_JS_RUNTIME_WASM",
+        "webhook",
+        "webhook-js-runtime-version.txt",
+    ),
+    ("WEBUI_WASM", "webui", "webui-version.txt"),
+];
+
+const OCI_SCHEMA_PREFIX: &str = "oci://";
+
+fn main() -> anyhow::Result<()> {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").context("OUT_DIR must be set")?);
+
+    // Without the `download` feature (e.g. a plain `cargo build --workspace`) this crate
+    // is compiled as a bare workspace member but never referenced; emit empty stub consts
+    // so `src/lib.rs` still compiles, and do no network I/O.
+    if std::env::var_os("CARGO_FEATURE_DOWNLOAD").is_none() {
+        let mut stubs = String::new();
+        for (const_name, ..) in ASSETS {
+            writeln!(stubs, "pub const {const_name}: &[u8] = &[];")?;
+        }
+        std::fs::write(out_dir.join("gen.rs"), stubs)?;
+        return Ok(());
+    }
+
+    println!("cargo:rerun-if-env-changed=OBELISK_EMBED_ASSETS_DIR");
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../assets");
+    let prefetched = std::env::var_os("OBELISK_EMBED_ASSETS_DIR").map(PathBuf::from);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    let mut generated = String::new();
+    for (const_name, stem, version_file) in ASSETS {
+        let version_path = assets_dir.join(version_file);
+        println!("cargo:rerun-if-changed={}", version_path.display());
+        let reference = read_reference(&version_path)?;
+
+        let dst = out_dir.join(format!("{stem}.wasm"));
+        let bytes = if let Some(prefetched) = &prefetched {
+            let src = prefetched.join(format!("{stem}.wasm"));
+            std::fs::read(&src)
+                .with_context(|| format!("cannot read pre-fetched asset {}", src.display()))?
+        } else {
+            runtime
+                .block_on(pull_wasm_layer(&reference))
+                .with_context(|| format!("cannot pull {reference}"))?
+        };
+        std::fs::write(&dst, &bytes).with_context(|| format!("cannot write {}", dst.display()))?;
+
+        writeln!(
+            generated,
+            "pub const {const_name}: &[u8] = include_bytes!(r\"{}\");",
+            dst.display()
+        )?;
+    }
+    std::fs::write(out_dir.join("gen.rs"), generated)?;
+    Ok(())
+}
+
+/// Read `assets/<name>-version.txt`, strip the `oci://` scheme, parse the OCI reference.
+fn read_reference(version_path: &Path) -> anyhow::Result<oci_client::Reference> {
+    let content = std::fs::read_to_string(version_path)
+        .with_context(|| format!("cannot read {}", version_path.display()))?;
+    let trimmed = content.trim();
+    let reference = trimmed.strip_prefix(OCI_SCHEMA_PREFIX).with_context(|| {
+        format!(
+            "{} must start with `{OCI_SCHEMA_PREFIX}`",
+            version_path.display()
+        )
+    })?;
+    reference
+        .parse()
+        .with_context(|| format!("invalid OCI reference `{reference}`"))
+}
+
+/// Pull the single WASM layer of a pinned image and verify it against the layer digest.
+async fn pull_wasm_layer(reference: &oci_client::Reference) -> anyhow::Result<Vec<u8>> {
+    // reqwest is built with `rustls-no-provider`; install the process-global provider,
+    // mirroring `obelisk/src/main.rs`. Ignore the error if already installed.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let client = WasmClient::new(oci_client::Client::default());
+    let (mut manifest, _config, _digest) = client
+        .pull_manifest_and_config(reference, &RegistryAuth::Anonymous)
+        .await
+        .context("pulling manifest and config")?;
+    let layer = manifest
+        .layers
+        .pop()
+        .context("wasm image must have exactly one layer")?;
+
+    let mut buf = Vec::new();
+    client
+        .as_ref()
+        .pull_blob(reference, &layer, &mut buf)
+        .await
+        .context("pulling layer blob")?;
+
+    let actual = sha256_hex(&buf);
+    let expected = layer
+        .digest
+        .strip_prefix("sha256:")
+        .unwrap_or(&layer.digest);
+    if actual != expected {
+        bail!("digest mismatch for {reference}: expected {expected}, got {actual}");
+    }
+    Ok(buf)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        write!(out, "{b:02x}").expect("writing to a String is infallible");
+    }
+    out
+}

--- a/crates/embedded-assets/src/lib.rs
+++ b/crates/embedded-assets/src/lib.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/gen.rs"));

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,44 @@
             inherit system overlays;
           };
 
-          makeObelisk = buildType: customTarget: rustToolchainToml:
+          # Fixed-output derivation that pre-fetches the four pinned operator-owned WASM
+          # assets (three JS runtimes + web UI) referenced from `assets/*version*.txt`,
+          # so the `embed-assets` build.rs can read them offline inside the Nix sandbox.
+          # Update `outputHash` whenever any version file changes with
+          # `scripts/update-embedded-assets-hash.sh`.
+          embeddedAssets =
+            let
+              assetsDir = ./assets;
+            in
+            pkgs.stdenv.mkDerivation {
+              pname = "obelisk-embedded-assets";
+              version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+              nativeBuildInputs = with pkgs; [ skopeo jq cacert ];
+              outputHashMode = "recursive";
+              outputHashAlgo = "sha256";
+              outputHash = "sha256-larIAt/bRGGa3Y2Pz2dQ8YMhtKbySQ7DzsY6vtYKGz0=";
+              SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+              buildCommand = ''
+                mkdir -p "$out"
+                export HOME="$TMPDIR"
+                fetch() {
+                  name="$1"; versionFile="$2"
+                  # Strip the `oci://` scheme and drop the `:tag` (skopeo rejects tag+digest;
+                  # the `@sha256:` digest is the authoritative pin).
+                  ref=$(tr -d '[:space:]' < "$versionFile" | sed 's|^oci://||' | sed -E 's|:[^:@]*@sha256:|@sha256:|')
+                  echo "Fetching $name from $ref"
+                  skopeo --insecure-policy copy "docker://$ref" "dir:$TMPDIR/$name"
+                  layer=$(jq -r '.layers[0].digest' "$TMPDIR/$name/manifest.json" | sed 's|^sha256:||')
+                  cp "$TMPDIR/$name/$layer" "$out/$name.wasm"
+                }
+                fetch activity ${assetsDir}/activity-js-runtime-version.txt
+                fetch workflow ${assetsDir}/workflow-js-runtime-version.txt
+                fetch webhook  ${assetsDir}/webhook-js-runtime-version.txt
+                fetch webui    ${assetsDir}/webui-version.txt
+              '';
+            };
+
+          makeObelisk = buildType: customTarget: rustToolchainToml: embedAssets:
             let
               cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
               version = cargoToml.workspace.package.version;
@@ -125,8 +162,8 @@
                   manualMacOSSdk
                 ];
 
-                # Only used when not cross compiling.
-                cargoBuildFlags = [ ];
+                # Also spliced into the cross (zigbuild) build command below.
+                cargoBuildFlags = pkgs.lib.optionals embedAssets [ "--features" "embed-assets" ];
 
                 installPhase = ''
                   runHook preInstall
@@ -165,8 +202,12 @@
                   runHook postBuild
                 '';
               };
+              # Feed the pre-fetched assets to the `embed-assets` build.rs offline.
+              embedAssetsEnv = pkgs.lib.optionalAttrs embedAssets {
+                OBELISK_EMBED_ASSETS_DIR = "${embeddedAssets}";
+              };
             in
-            pkgs.rustPlatform.buildRustPackage (commonArgs // zigbuildArgs);
+            pkgs.rustPlatform.buildRustPackage (commonArgs // zigbuildArgs // embedAssetsEnv);
 
         in
         {
@@ -214,26 +255,33 @@
               ];
           };
           packages = rec {
-            obeliskLibcNixDev = makeObelisk "dev" null ./rust-toolchain.toml;
-            obeliskLibcNix = makeObelisk "release" null ./rust-toolchain.toml;
+            inherit embeddedAssets;
+            obeliskLibcNixDev = makeObelisk "dev" null ./rust-toolchain.toml false;
+            obeliskLibcNix = makeObelisk "release" null ./rust-toolchain.toml false;
+            obeliskLibcNixDev-embedded = makeObelisk "dev" null ./rust-toolchain.toml true;
+            obeliskLibcNix-embedded = makeObelisk "release" null ./rust-toolchain.toml true;
             # Linux
             ## x86_64
-            obeliskCrossDev-x86_64-unknown-linux-musl = makeObelisk "dev" "x86_64-unknown-linux-musl" ./rust-toolchain-cross.toml;
-            obeliskCross-x86_64-unknown-linux-musl = makeObelisk "release" "x86_64-unknown-linux-musl" ./rust-toolchain-cross.toml;
-            obeliskCrossDev-x86_64-unknown-linux-gnu = makeObelisk "dev" "x86_64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml;
-            obeliskCross-x86_64-unknown-linux-gnu = makeObelisk "release" "x86_64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml;
+            obeliskCrossDev-x86_64-unknown-linux-musl = makeObelisk "dev" "x86_64-unknown-linux-musl" ./rust-toolchain-cross.toml false;
+            obeliskCross-x86_64-unknown-linux-musl = makeObelisk "release" "x86_64-unknown-linux-musl" ./rust-toolchain-cross.toml false;
+            obeliskCross-x86_64-unknown-linux-musl-embedded = makeObelisk "release" "x86_64-unknown-linux-musl" ./rust-toolchain-cross.toml true;
+            obeliskCrossDev-x86_64-unknown-linux-gnu = makeObelisk "dev" "x86_64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml false;
+            obeliskCross-x86_64-unknown-linux-gnu = makeObelisk "release" "x86_64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml false;
             ## aarch64
-            obeliskCrossDev-aarch64-unknown-linux-musl = makeObelisk "dev" "aarch64-unknown-linux-musl" ./rust-toolchain-cross.toml;
-            obeliskCross-aarch64-unknown-linux-musl = makeObelisk "release" "aarch64-unknown-linux-musl" ./rust-toolchain-cross.toml;
-            obeliskCrossDev-aarch64-unknown-linux-gnu = makeObelisk "dev" "aarch64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml;
-            obeliskCross-aarch64-unknown-linux-gnu = makeObelisk "release" "aarch64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml;
+            obeliskCrossDev-aarch64-unknown-linux-musl = makeObelisk "dev" "aarch64-unknown-linux-musl" ./rust-toolchain-cross.toml false;
+            obeliskCross-aarch64-unknown-linux-musl = makeObelisk "release" "aarch64-unknown-linux-musl" ./rust-toolchain-cross.toml false;
+            obeliskCross-aarch64-unknown-linux-musl-embedded = makeObelisk "release" "aarch64-unknown-linux-musl" ./rust-toolchain-cross.toml true;
+            obeliskCrossDev-aarch64-unknown-linux-gnu = makeObelisk "dev" "aarch64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml false;
+            obeliskCross-aarch64-unknown-linux-gnu = makeObelisk "release" "aarch64-unknown-linux-gnu.2.35" ./rust-toolchain-cross.toml false;
             # MacOS
             ## x86_64
-            obeliskCrossDev-x86_64-apple-darwin = makeObelisk "dev" "x86_64-apple-darwin" ./rust-toolchain-cross.toml;
-            obeliskCross-x86_64-apple-darwin = makeObelisk "release" "x86_64-apple-darwin" ./rust-toolchain-cross.toml;
+            obeliskCrossDev-x86_64-apple-darwin = makeObelisk "dev" "x86_64-apple-darwin" ./rust-toolchain-cross.toml false;
+            obeliskCross-x86_64-apple-darwin = makeObelisk "release" "x86_64-apple-darwin" ./rust-toolchain-cross.toml false;
+            obeliskCross-x86_64-apple-darwin-embedded = makeObelisk "release" "x86_64-apple-darwin" ./rust-toolchain-cross.toml true;
             ## aarch64
-            obeliskCrossDev-aarch64-apple-darwin = makeObelisk "dev" "aarch64-apple-darwin" ./rust-toolchain-cross.toml;
-            obeliskCross-aarch64-apple-darwin = makeObelisk "release" "aarch64-apple-darwin" ./rust-toolchain-cross.toml;
+            obeliskCrossDev-aarch64-apple-darwin = makeObelisk "dev" "aarch64-apple-darwin" ./rust-toolchain-cross.toml false;
+            obeliskCross-aarch64-apple-darwin = makeObelisk "release" "aarch64-apple-darwin" ./rust-toolchain-cross.toml false;
+            obeliskCross-aarch64-apple-darwin-embedded = makeObelisk "release" "aarch64-apple-darwin" ./rust-toolchain-cross.toml true;
 
             default = obeliskLibcNix;
           };

--- a/scripts/strip-js-local-deps.sh
+++ b/scripts/strip-js-local-deps.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Remove *-js-runtime-builder optional deps and *-js-local features from publishable crates.
-# These are local-development-only and must not appear in published manifests.
+# Remove *-js-runtime-builder / embedded-assets optional deps and their features from
+# publishable crates. These are local-build-only and must not appear in published manifests.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-JS_BUILDER_OPTIONAL_PATTERN='activity-js-runtime-builder.*optional\|webhook-js-runtime-builder.*optional\|workflow-js-runtime-builder.*optional'
+JS_BUILDER_OPTIONAL_PATTERN='activity-js-runtime-builder.*optional\|webhook-js-runtime-builder.*optional\|workflow-js-runtime-builder.*optional\|embedded-assets.*optional'
 
 # Root Cargo.toml: remove optional dep entries for builders from [dependencies]
 sed -i "/${JS_BUILDER_OPTIONAL_PATTERN}/d" Cargo.toml
@@ -13,6 +13,7 @@ sed -i "/${JS_BUILDER_OPTIONAL_PATTERN}/d" Cargo.toml
 sed -i 's/"activity-js-local" = \["dep:activity-js-runtime-builder"\]/"activity-js-local" = []/' Cargo.toml
 sed -i 's/"webhook-js-local" = \["dep:webhook-js-runtime-builder"\]/"webhook-js-local" = []/' Cargo.toml
 sed -i 's/"workflow-js-local" = \["dep:workflow-js-runtime-builder"\]/"workflow-js-local" = []/' Cargo.toml
+sed -i 's#"embed-assets" = \["dep:embedded-assets", "embedded-assets/download"\]#"embed-assets" = []#' Cargo.toml
 
 # Remove the js-local test matrix entry from check-test.yml
 sed -i '/- name: test-js-local.sh/,+2d' .github/workflows/check-test.yml

--- a/scripts/update-embedded-assets-hash.sh
+++ b/scripts/update-embedded-assets-hash.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+if nix build .#embeddedAssets --no-link >"$log" 2>&1; then
+    if nix build .#embeddedAssets --no-link --rebuild >"$log" 2>&1; then
+        echo "embeddedAssets outputHash is up to date"
+        exit 0
+    fi
+fi
+
+actual=$(sed -n 's/^[[:space:]]*got:[[:space:]]*\(sha256-[A-Za-z0-9+\/=]*\).*$/\1/p' "$log" | tail -n 1)
+if [ -z "$actual" ]; then
+    cat "$log" >&2
+    exit 1
+fi
+
+current=$(sed -n 's/^[[:space:]]*outputHash = "\([^"]*\)";$/\1/p' flake.nix)
+if [ -z "$current" ]; then
+    echo "cannot find embeddedAssets outputHash in flake.nix" >&2
+    exit 1
+fi
+
+sed -i "s|outputHash = \"$current\";|outputHash = \"$actual\";|" flake.nix
+echo "updated embeddedAssets outputHash: $current -> $actual"
+nix build .#embeddedAssets --no-link

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -31,6 +31,7 @@ use crate::config::toml::ActivityWasmConfigVerified;
 use crate::config::toml::AllowExecActivities;
 use crate::config::toml::CancelWatcherTomlConfig;
 use crate::config::toml::ComponentCommon;
+#[cfg(not(feature = "embed-assets"))] // Only the OCI fetch arms below use `.fetch()`.
 use crate::config::toml::ComponentLocationFetchExt as _;
 use crate::config::toml::ComponentLocationToml;
 use crate::config::toml::ComponentStdOutputToml;
@@ -392,14 +393,15 @@ const EPOCH_MILLIS: u64 = 10;
 const CANCELLATION_DRIVER_BATCH_SIZE: u32 = 100;
 /// Default number of concurrent deployment submits the switch manager accepts.
 const DEFAULT_SUBMIT_CONCURRENCY: u32 = 1;
+#[cfg(not(feature = "embed-assets"))]
 const WEBUI_LOCATION: &str = include_str!("../../assets/webui-version.txt");
-#[cfg(not(feature = "activity-js-local"))]
+#[cfg(all(not(feature = "activity-js-local"), not(feature = "embed-assets")))]
 pub(crate) const ACTIVITY_JS_LOCATION: &str =
     include_str!("../../assets/activity-js-runtime-version.txt");
-#[cfg(not(feature = "workflow-js-local"))]
+#[cfg(all(not(feature = "workflow-js-local"), not(feature = "embed-assets")))]
 pub(crate) const WORKFLOW_JS_LOCATION: &str =
     include_str!("../../assets/workflow-js-runtime-version.txt");
-#[cfg(not(feature = "webhook-js-local"))]
+#[cfg(all(not(feature = "webhook-js-local"), not(feature = "embed-assets")))]
 pub(crate) const WEBHOOK_JS_LOCATION: &str =
     include_str!("../../assets/webhook-js-runtime-version.txt");
 
@@ -3577,9 +3579,7 @@ impl DeploymentVerified {
                 .push(webhook::WebhookWasmComponentConfigResolved {
                     common: ComponentCommon {
                         name: ConfigName::new(StrVariant::Static(COMPONENT_NAME_WEBUI)).unwrap(),
-                        location: WEBUI_LOCATION
-                            .parse()
-                            .expect("hard-coded webui reference must be parsed"),
+                        location: webui_location(&wasm_cache_dir).await?,
                     },
                     content_digest: None,
                     http_server: ConfigName::new(HTTP_SERVER_NAME_WEBUI.into()).unwrap(),
@@ -4706,8 +4706,19 @@ async fn fetch_activity_js_runtime(
     ))
 }
 
+/// Resolve the activity-js runtime WASM from the bytes embedded at build time.
+#[cfg(all(not(feature = "activity-js-local"), feature = "embed-assets"))]
+async fn fetch_activity_js_runtime(
+    wasm_cache_dir: Arc<Path>,
+    _metadata_dir: Arc<Path>,
+) -> Result<PathBuf, anyhow::Error> {
+    write_embedded_runtime(embedded_assets::ACTIVITY_JS_RUNTIME_WASM, &wasm_cache_dir)
+        .await
+        .context("cannot materialize embedded activity-js runtime")
+}
+
 /// Fetch the activity-js runtime WASM from OCI.
-#[cfg(not(feature = "activity-js-local"))]
+#[cfg(all(not(feature = "activity-js-local"), not(feature = "embed-assets")))]
 async fn fetch_activity_js_runtime(
     wasm_cache_dir: Arc<Path>,
     metadata_dir: Arc<Path>,
@@ -4733,8 +4744,19 @@ async fn fetch_workflow_js_runtime(
     ))
 }
 
+/// Resolve the workflow-js runtime WASM from the bytes embedded at build time.
+#[cfg(all(not(feature = "workflow-js-local"), feature = "embed-assets"))]
+async fn fetch_workflow_js_runtime(
+    wasm_cache_dir: Arc<Path>,
+    _metadata_dir: Arc<Path>,
+) -> Result<PathBuf, anyhow::Error> {
+    write_embedded_runtime(embedded_assets::WORKFLOW_JS_RUNTIME_WASM, &wasm_cache_dir)
+        .await
+        .context("cannot materialize embedded workflow-js runtime")
+}
+
 /// Fetch the workflow-js runtime WASM from OCI.
-#[cfg(not(feature = "workflow-js-local"))]
+#[cfg(all(not(feature = "workflow-js-local"), not(feature = "embed-assets")))]
 async fn fetch_workflow_js_runtime(
     wasm_cache_dir: Arc<Path>,
     metadata_dir: Arc<Path>,
@@ -4760,8 +4782,19 @@ async fn fetch_webhook_js_runtime(
     ))
 }
 
+/// Resolve the webhook-js runtime WASM from the bytes embedded at build time.
+#[cfg(all(not(feature = "webhook-js-local"), feature = "embed-assets"))]
+async fn fetch_webhook_js_runtime(
+    wasm_cache_dir: Arc<Path>,
+    _metadata_dir: Arc<Path>,
+) -> Result<PathBuf, anyhow::Error> {
+    write_embedded_runtime(embedded_assets::WEBHOOK_JS_RUNTIME_WASM, &wasm_cache_dir)
+        .await
+        .context("cannot materialize embedded webhook-js runtime")
+}
+
 /// Fetch the webhook-js runtime WASM from OCI.
-#[cfg(not(feature = "webhook-js-local"))]
+#[cfg(all(not(feature = "webhook-js-local"), not(feature = "embed-assets")))]
 #[instrument(skip_all)]
 async fn fetch_webhook_js_runtime(
     wasm_cache_dir: Arc<Path>,
@@ -4775,6 +4808,51 @@ async fn fetch_webhook_js_runtime(
         .await
         .context("cannot fetch webhook-js runtime")?;
     Ok(wasm_path)
+}
+
+/// Write an embedded WASM asset to the wasm cache under its content-digest filename
+/// (idempotent) and return its path. Shared by the `embed-assets` fetch/webui paths.
+#[cfg(feature = "embed-assets")]
+async fn write_embedded_runtime(
+    bytes: &[u8],
+    wasm_cache_dir: &Path,
+) -> Result<PathBuf, anyhow::Error> {
+    use concepts::component_id::{ContentDigest, Digest};
+    use sha2::Digest as _;
+    let digest = ContentDigest(Digest(sha2::Sha256::digest(bytes).into()));
+    let path = crate::config::content_digest_to_wasm_file(wasm_cache_dir, &digest);
+    if crate::oci::verify_cached_file(&path, &digest).await.is_ok() {
+        return Ok(path);
+    }
+    let parent = path
+        .parent()
+        .context("wasm cache path must have a parent")?;
+    let _ = tokio::fs::create_dir_all(parent).await;
+    let tmp = tempfile::NamedTempFile::new_in(parent)?;
+    std::fs::write(tmp.path(), bytes)?;
+    // Atomic rename within the cache dir; a racing writer producing identical bytes is fine.
+    tmp.persist(&path)
+        .map_err(|err| err.error)
+        .context("persisting embedded runtime to wasm cache")?;
+    Ok(path)
+}
+
+#[cfg(not(feature = "embed-assets"))]
+#[expect(clippy::unused_async)]
+async fn webui_location(_wasm_cache_dir: &Path) -> Result<ComponentLocationToml, anyhow::Error> {
+    WEBUI_LOCATION
+        .parse()
+        .context("hard-coded webui reference must be parsed")
+}
+
+#[cfg(feature = "embed-assets")]
+async fn webui_location(wasm_cache_dir: &Path) -> Result<ComponentLocationToml, anyhow::Error> {
+    let path = write_embedded_runtime(embedded_assets::WEBUI_WASM, wasm_cache_dir)
+        .await
+        .context("cannot materialize embedded web UI")?;
+    Ok(ComponentLocationToml::Path(
+        path.to_string_lossy().into_owned(),
+    ))
 }
 
 #[instrument(level = "debug", skip_all, fields(

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -128,7 +128,10 @@ fn digest_to_metadata_file(metadata_dir: &Path, metadata_file: &Digest) -> PathB
     metadata_dir.join(format!("{}.txt", metadata_file.with_infix("_")))
 }
 
-async fn verify_cached_file(path: &Path, content_digest: &ContentDigest) -> Result<(), ()> {
+pub(crate) async fn verify_cached_file(
+    path: &Path,
+    content_digest: &ContentDigest,
+) -> Result<(), ()> {
     match calculate_sha256_file(&path).await {
         Ok(actual_digest) if actual_digest == *content_digest => Ok(()),
         Ok(wrong_digest) => {


### PR DESCRIPTION
Embed the pinned JavaScript runtimes and Web UI at build time,
then verify and materialize them in the WASM cache at startup.
Publish embedded Linux and macOS variants in GitHub releases.
