### PR TITLE
refactor(sqlite): Use quick_check instead of integrity_check at startup

### DIFF
--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -95,7 +95,7 @@ const PRAGMA: [[&str; 2]; 10] = [
     ["page_size", "8192"], // 8 KB
     ["mmap_size", "134217728"],
     ["journal_size_limit", "67108864"],
-    ["integrity_check", ""],
+    ["quick_check", ""],
 ];
 
 mod embedded {


### PR DESCRIPTION
The full integrity_check reads every page and cross-checks every index
against its table, a single-threaded full scan that runs on every startup
before the pool is usable. On large execution-history databases this added
several seconds to boot. quick_check performs the same page-level structural
verification but skips the expensive index/table cross-checks, cutting the
cost to roughly a fifth in a synthetic benchmark.
