### PR TITLE
refactor(config): Carry backtrace source digests in component_files

### DIFF
--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -965,37 +965,13 @@
           "description": "Maps a frame-symbol key to a backtrace source file path. On-disk format only;\nresolved to `ComponentBacktraceConfigResolved` before transmission and hash\ncomputation. A relative path is deployment-dir-relative (a leading\n`${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/BacktraceSourceToml"
+            "type": "string"
           }
         }
       },
       "additionalProperties": false,
       "required": [
         "sources"
-      ]
-    },
-    "BacktraceSourceToml": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "path": {
-              "type": "string"
-            },
-            "content_digest": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "path"
-          ]
-        }
       ]
     },
     "WorkflowJsComponentConfigToml": {

--- a/deployment-help.toml
+++ b/deployment-help.toml
@@ -417,9 +417,9 @@
 ##   - A relative path (e.g. "components/a.wasm", "scripts/x.js") is relative to the directory
 ##     containing this deployment.toml. It must stay within that directory ("../" escapes are rejected).
 ##   - An absolute path (e.g. "/opt/wasm/a.wasm") is rejected.
-## For JS/exec components, deployment-relative sources are read and inlined at deploy time so the deployment is
-## self-contained. `obelisk deployment get` recreates the deployment-relative files (mirroring subfolders) but
-## cannot recreate WASM bytes.
+## JS/exec components and backtrace sources are attached as deployment files at deploy time and referenced by the
+## processed manifest's generated `component_files` map. `obelisk deployment get` recreates these files (mirroring
+## subfolders), along with deployment-owned WASM components, from the content-addressed store.
 ##
 ## For backwards compatibility a relative path may be prefixed with `${DEPLOYMENT_DIR}/`; this is
 ## equivalent to a bare relative path (the directory containing this deployment.toml) and is no longer needed.

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -159,14 +159,12 @@ fn strip_generated_deployment_metadata_from_doc(doc: &mut DocumentMut) -> anyhow
         }
     }
 
-    for section in [
-        "activity_js",
-        "workflow_js",
-        "webhook_endpoint_js",
-        "activity_exec",
-        "activity_stub",
-        "activity_external",
-    ] {
+    // Every section a `collect_*_refs` writer can attach a generated `component_files` map to.
+    for section in SCRIPT_SECTIONS
+        .iter()
+        .chain(WIT_SECTIONS)
+        .chain(BACKTRACE_SECTIONS)
+    {
         let Some(components) = doc.get_mut(section).and_then(Item::as_array_of_tables_mut) else {
             continue;
         };
@@ -808,12 +806,20 @@ fn collect_backtrace_section(
             let Some(path) = deployment_owned_path(&raw_path)? else {
                 continue;
             };
-            let digest = required_content_digest(
-                source
-                    .as_table_like()
-                    .and_then(|table| table.get("content_digest")),
-                &path,
-            )?;
+            let generated_digest = table
+                .get("component_files")
+                .and_then(Item::as_table_like)
+                .and_then(|files| files.get(&path));
+            // backcompat: 0.41 processed manifests stored the digest beside the source path.
+            let legacy_digest = source
+                .as_table_like()
+                .and_then(|source| source.get("content_digest"));
+            let digest = required_content_digest(generated_digest.or(legacy_digest), &path)
+                .with_context(|| {
+                    format!(
+                        "{section}[name={name}].backtrace.sources[{key}]: component_files must contain `{path}`"
+                    )
+                })?;
             files.push(DeploymentFileRef {
                 path: path.clone(),
                 digest,
@@ -1070,6 +1076,19 @@ async fn collect_backtrace_refs(
     };
 
     for table in components.iter_mut() {
+        let mut refs = table
+            .get("component_files")
+            .and_then(Item::as_table_like)
+            .map(|files| {
+                let mut refs = InlineTable::new();
+                for (path, digest) in files.iter() {
+                    if let Some(digest) = digest.as_value() {
+                        refs.insert(path, digest.clone());
+                    }
+                }
+                refs
+            })
+            .unwrap_or_default();
         let Some(sources) = table
             .get_mut("backtrace")
             .and_then(Item::as_table_like_mut)
@@ -1078,7 +1097,6 @@ async fn collect_backtrace_refs(
         else {
             continue;
         };
-
         for (_, source) in sources.iter_mut() {
             let Some(raw_path) = backtrace_source_path(source) else {
                 continue;
@@ -1087,12 +1105,16 @@ async fn collect_backtrace_refs(
                 continue;
             };
             let (digest, bytes) = read_deployment_file(deployment_dir, &path).await?;
-            write_backtrace_source_digest(source, raw_path, &digest);
+            refs.insert(&path, Value::from(digest.to_string()));
+            *source = value(raw_path);
             files.push(DeploymentManifestFile {
                 path,
                 digest,
                 bytes,
             });
+        }
+        if !refs.is_empty() {
+            table["component_files"] = Item::Value(Value::InlineTable(refs));
         }
     }
 
@@ -1107,18 +1129,6 @@ fn backtrace_source_path(source: &Item) -> Option<String> {
             .and_then(Item::as_str)
             .map(str::to_string)
     })
-}
-
-fn write_backtrace_source_digest(source: &mut Item, path: String, digest: &ContentDigest) {
-    if let Some(table) = source.as_table_like_mut() {
-        table.insert("content_digest", value(digest.to_string()));
-        return;
-    }
-
-    let mut inline = InlineTable::new();
-    inline.insert("path", Value::from(path));
-    inline.insert("content_digest", Value::from(digest.to_string()));
-    *source = Item::Value(Value::InlineTable(inline));
 }
 
 fn deployment_owned_path(raw: &str) -> anyhow::Result<Option<String>> {
@@ -1628,7 +1638,7 @@ location = "components/a.wasm"
     }
 
     #[tokio::test]
-    async fn prepare_fills_relative_backtrace_digest_and_collects_blob() {
+    async fn prepare_puts_relative_backtrace_digest_in_component_files() {
         let dir = tempfile::tempdir().unwrap();
         tokio::fs::create_dir_all(dir.path().join("components"))
             .await
@@ -1663,15 +1673,45 @@ location = "components/w.wasm"
                 .any(|file| file.path == "components/w.wasm")
         );
         assert!(prepared.files.iter().any(|file| file.path == "src/lib.rs"));
+        let doc = prepared.deployment_toml.parse::<DocumentMut>().unwrap();
+        let workflow = doc["workflow_wasm"]
+            .as_array_of_tables()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert_eq!(
+            workflow["backtrace"]["sources"][".../src/lib.rs"].as_str(),
+            Some("src/lib.rs")
+        );
         assert!(
-            prepared.deployment_toml.contains(
-                "\".../src/lib.rs\" = { path = \"src/lib.rs\", content_digest = \"sha256:"
-            )
+            workflow["component_files"]["src/lib.rs"]
+                .as_str()
+                .unwrap()
+                .starts_with("sha256:")
+        );
+        let classified =
+            DeploymentManifest::try_from_toml(&prepared.deployment_toml, Path::new("")).unwrap();
+        assert_eq!(classified.files.len(), 2);
+        assert_eq!(classified.component_files.len(), 2);
+        assert_eq!(
+            classified.component_files[1].role,
+            ComponentFileRole::BacktraceSource
+        );
+
+        let provider = DiskProvider {
+            deployment_dir: dir.path().to_path_buf(),
+        };
+        let resolved = manifest_to_resolved(&prepared.deployment_toml, dir.path(), &provider)
+            .await
+            .unwrap();
+        assert_eq!(
+            resolved.workflows_wasm[0].backtrace.frame_files_to_sources[".../src/lib.rs"].content,
+            "fn workflow() {}"
         );
     }
 
     #[tokio::test]
-    async fn prepare_preserves_detailed_backtrace_source_shape() {
+    async fn prepare_normalizes_detailed_backtrace_source_shape() {
         let dir = tempfile::tempdir().unwrap();
         tokio::fs::create_dir_all(dir.path().join("components"))
             .await
@@ -1699,11 +1739,21 @@ location = "components/w.wasm"
             .unwrap();
 
         assert!(prepared.files.iter().any(|file| file.path == "src/lib.rs"));
-        assert!(prepared.deployment_toml.contains("path = \"src/lib.rs\""));
+        let doc = prepared.deployment_toml.parse::<DocumentMut>().unwrap();
+        let workflow = doc["workflow_wasm"]
+            .as_array_of_tables()
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert_eq!(
+            workflow["backtrace"]["sources"][".../src/lib.rs"].as_str(),
+            Some("src/lib.rs")
+        );
         assert!(
-            prepared
-                .deployment_toml
-                .contains("content_digest = \"sha256:")
+            workflow["component_files"]["src/lib.rs"]
+                .as_str()
+                .unwrap()
+                .starts_with("sha256:")
         );
     }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -171,6 +171,7 @@ impl DeploymentTomlValidated {
 }
 
 impl DeploymentToml {
+    // backcompat: Delete ${DEPLOYMENT_DIR} in 0.42
     /// Expand `${DEPLOYMENT_DIR}/` prefixes in WASM component paths,
     /// verify that every component name is unique, and return a `DeploymentTomlValidated`
     /// that also carries the name→type index and the deployment directory.
@@ -2133,6 +2134,10 @@ pub(crate) struct WorkflowWasmComponentConfigToml {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(with = "Option<String>")]
     pub(crate) content_digest: Option<ContentDigest>,
+    /// Generated CAS references for backtrace source files.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[schemars(skip)]
+    pub(crate) component_files: BTreeMap<String, ContentDigest>,
     /// Deprecated override of the auto-computed component digest used for locking.
     /// This option will be removed in 0.42.
     #[serde(default)]
@@ -2202,7 +2207,7 @@ pub(crate) struct ComponentBacktraceConfig {
     /// computation. A relative path is deployment-dir-relative (a leading
     /// `${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.
     #[serde(rename = "sources")]
-    #[schemars(with = "std::collections::HashMap<String, BacktraceSourceToml>")]
+    #[schemars(with = "std::collections::HashMap<String, String>")]
     pub(crate) frame_files_to_sources: HashMap<String, BacktraceSourceToml>,
 }
 
@@ -2210,6 +2215,7 @@ pub(crate) struct ComponentBacktraceConfig {
 #[serde(untagged)]
 pub(crate) enum BacktraceSourceToml {
     Path(String),
+    // backcompat: Remove in 0.42
     Detailed {
         path: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2712,7 +2718,7 @@ async fn resolve_local_refs(
             exec: w.exec,
             retry_exp_backoff: w.retry_exp_backoff,
             blocking_strategy: w.blocking_strategy,
-            backtrace: resolve_backtrace(&w.backtrace, provider).await?,
+            backtrace: resolve_backtrace(&w.backtrace, &w.component_files, provider).await?,
             stub_wasi: w.stub_wasi,
             lock_extension: w.lock_extension,
             lock_extension_leeway: w.lock_extension_leeway,
@@ -2760,7 +2766,7 @@ async fn resolve_local_refs(
             forward_stdout: w.forward_stdout,
             forward_stderr: w.forward_stderr,
             env_vars: w.env_vars,
-            backtrace: resolve_backtrace(&w.backtrace, provider).await?,
+            backtrace: resolve_backtrace(&w.backtrace, &w.component_files, provider).await?,
             backtrace_persist: w.backtrace_persist,
             logs_store_min_level: w.logs_store_min_level,
             allowed_hosts: w.allowed_hosts,
@@ -3158,12 +3164,12 @@ async fn resolve_script_toml(
 
 async fn resolve_backtrace(
     backtrace: &ComponentBacktraceConfig,
+    component_files: &BTreeMap<String, ContentDigest>,
     provider: &dyn FileProvider,
 ) -> anyhow::Result<ComponentBacktraceConfigResolved> {
     let mut frame_files_to_sources = HashMap::new();
     for (key, source) in &backtrace.frame_files_to_sources {
         let path = source.path();
-        let content_digest = source.content_digest();
         // Classify the source path like a script: a relative path (bare or
         // `${DEPLOYMENT_DIR}/…`) is deployment-relative and its subpath is mirrored on export.
         let file_name = if let Some(rest) = strip_deployment_dir_prefix(path) {
@@ -3173,6 +3179,11 @@ async fn resolve_backtrace(
         } else {
             sanitize_deployment_relative_path(path)?
         };
+        // backcompat: 0.41 processed manifests stored the digest beside each source path.
+        // Remove `source.content_digest()` in 0.42 as clients must supply the content_digest in `component_files`.
+        let content_digest = component_files
+            .get(&file_name)
+            .or_else(|| source.content_digest());
         let content = provider
             .read(&file_name, content_digest)
             .await
@@ -3519,6 +3530,10 @@ pub(crate) mod webhook {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[schemars(with = "Option<String>")]
         pub(crate) content_digest: Option<ContentDigest>,
+        /// Generated CAS references for backtrace source files.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        #[schemars(skip)]
+        pub(crate) component_files: BTreeMap<String, ContentDigest>,
         #[serde(default = "default_external_server_name")]
         pub(crate) http_server: ConfigName,
         pub(crate) routes: Vec<WebhookRoute>,
@@ -5207,7 +5222,9 @@ name = "my_stub"
                 ".../src/lib.rs".to_string(),
                 "${DEPLOYMENT_DIR}/crates/foo/src/lib.rs".to_string().into(),
             );
-            let resolved = resolve_backtrace(&bt, &provider).await.unwrap();
+            let resolved = resolve_backtrace(&bt, &BTreeMap::new(), &provider)
+                .await
+                .unwrap();
             let src = resolved
                 .frame_files_to_sources
                 .get(".../src/lib.rs")
@@ -5233,7 +5250,9 @@ name = "my_stub"
                 ".../src/lib.rs".to_string(),
                 "crates/foo/src/lib.rs".to_string().into(),
             );
-            let resolved = resolve_backtrace(&bt, &provider).await.unwrap();
+            let resolved = resolve_backtrace(&bt, &BTreeMap::new(), &provider)
+                .await
+                .unwrap();
             let src = resolved
                 .frame_files_to_sources
                 .get(".../src/lib.rs")
@@ -5253,7 +5272,12 @@ name = "my_stub"
                 "frame".to_string(),
                 "${DEPLOYMENT_DIR}/../escape.rs".to_string().into(),
             );
-            let err = format!("{:#}", resolve_backtrace(&bt, &provider).await.unwrap_err());
+            let err = format!(
+                "{:#}",
+                resolve_backtrace(&bt, &BTreeMap::new(), &provider)
+                    .await
+                    .unwrap_err()
+            );
             assert!(err.contains("`..`"), "unexpected error: {err}");
         }
 
@@ -5273,7 +5297,7 @@ name = "my_stub"
             let provider = DiskProvider {
                 deployment_dir: other_dir.path().to_path_buf(),
             };
-            let err = resolve_backtrace(&bt, &provider)
+            let err = resolve_backtrace(&bt, &BTreeMap::new(), &provider)
                 .await
                 .unwrap_err()
                 .to_string();


### PR DESCRIPTION
Backtrace source digests were injected inline into each source entry
(BacktraceSourceToml::Detailed) during pre-submit processing. Now the
processed manifest normalizes every deployment-owned source to a bare
path and records its digest in the component's generated component_files
map, matching how JS modules and WIT sources are already tracked. Stored
manifests therefore only ever contain BacktraceSourceToml::Path.

BacktraceSourceToml::Detailed and the source-side content_digest fallback
are retained parse-only for backcompat with 0.41 manifests; both are
slated for removal in 0.42.
