### PR TITLE
fix(deployment): Reject unparseable JS, WITs from deployment submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,6 +3230,8 @@ dependencies = [
  "const_format",
  "derive_more",
  "hashbrown 0.16.1",
+ "oci-client",
+ "reqwest",
  "rusqlite",
  "schemars 1.2.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,6 +3240,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio-postgres",
  "tracing",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -703,7 +703,7 @@
       ]
     },
     "JsLocationToml": {
-      "description": "Location of a JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).\nOn-disk format only; replaced by [`ScriptLocationResolved`] before transmission and hash computation.",
+      "description": "Location of a JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).\nOn-disk format only; replaced by [`ScriptLocationResolved`] before hash computation.",
       "type": "string"
     },
     "ActivityExecComponentConfigToml": {
@@ -962,7 +962,7 @@
       "type": "object",
       "properties": {
         "sources": {
-          "description": "Maps a frame-symbol key to a backtrace source file path. On-disk format only;\nresolved to `ComponentBacktraceConfigResolved` before transmission and hash\ncomputation. A relative path is deployment-dir-relative (a leading\n`${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.",
+          "description": "Maps a frame-symbol key to a backtrace source file path. On-disk format only;\nresolved to `ComponentBacktraceConfigResolved` before hash\ncomputation. A relative path is deployment-dir-relative (a leading\n`${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.",
           "type": "object",
           "additionalProperties": {
             "type": "string"

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1563,14 +1563,10 @@ pub trait DbExternalApi: DbConnection {
         execution_counts: DeploymentExecutionCounts,
     ) -> Result<Vec<DeploymentState>, DbErrorRead>;
 
-    /// Insert a new deployment. The record must have `status == Inactive` and
-    /// `last_active_at == None`; activation is a separate step via [`Self::activate_deployment`].
-    async fn insert_deployment(&self, record: DeploymentRecord) -> Result<(), DbErrorWrite>;
-
-    /// [`Self::insert_deployment`] + [`Self::upsert_component_metadata`] +
-    /// [`Self::insert_deployment_components`] in a single transaction, so the deployment row
-    /// and its component rows commit together or not at all. Same preconditions as
-    /// [`Self::insert_deployment`].
+    /// Insert a new deployment row together with its component metadata and component rows in a
+    /// single transaction, so the deployment row and its component rows commit together or not at
+    /// all. The record must have `status == Inactive` and `last_active_at == None`; activation is
+    /// a separate step via [`Self::activate_deployment`].
     async fn insert_deployment_with_components(
         &self,
         record: DeploymentRecord,

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -5220,15 +5220,6 @@ impl DbExternalApi for PostgresConnection {
         Ok(deployments)
     }
 
-    #[instrument(skip(self))]
-    async fn insert_deployment(&self, record: DeploymentRecord) -> Result<(), DbErrorWrite> {
-        let mut client_guard = self.client.lock().await;
-        let tx = client_guard.transaction().await?;
-        insert_deployment_tx(&tx, &record).await?;
-        tx.commit().await?;
-        Ok(())
-    }
-
     async fn insert_deployment_with_components(
         &self,
         record: DeploymentRecord,

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -5102,16 +5102,6 @@ impl DbExternalApi for SqlitePool {
         .await
     }
 
-    #[instrument(skip(self))]
-    async fn insert_deployment(&self, record: DeploymentRecord) -> Result<(), DbErrorWrite> {
-        self.transaction(
-            move |tx| Self::insert_deployment_tx(tx, &record),
-            TxType::MultipleWrites,
-            "insert_deployment",
-        )
-        .await
-    }
-
     async fn insert_deployment_with_components(
         &self,
         record: DeploymentRecord,

--- a/crates/deployment-config/Cargo.toml
+++ b/crates/deployment-config/Cargo.toml
@@ -24,6 +24,7 @@ strum.workspace = true
 thiserror.workspace = true
 tokio-postgres = { workspace = true, optional = true }
 tracing.workspace = true
+wit-parser.workspace = true
 
 [features]
 test = ["dep:arbitrary"]

--- a/crates/deployment-config/Cargo.toml
+++ b/crates/deployment-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "obeli-sk-deployment-config"
-description = "Shared deployment configuration schema and core naming types of obelisk. Compiles to wasm32-unknown-unknown for the webui."
+description = "Deployment configuration schema, transient resolution types, and core naming types of Obelisk."
 
 authors.workspace = true
 edition.workspace = true
@@ -14,6 +14,8 @@ arbitrary = { workspace = true, optional = true }
 const_format.workspace = true
 derive_more.workspace = true
 hashbrown.workspace = true
+oci-client.workspace = true
+reqwest.workspace = true
 rusqlite = { workspace = true, optional = true }
 schemars.workspace = true
 serde.workspace = true

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -498,6 +498,7 @@ pub enum ScriptLocationResolved {
     },
     /// OCI-sourced script. No `oci://` prefix.
     Oci {
+        // String, not `oci_client::Reference`: this crate compiles to wasm32 for the webui and cannot depend on `oci_client`. Always built from a valid reference; callers re-parse it.
         image: String,
     },
 }

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -1,9 +1,9 @@
-//! Deployment configuration data model shared between the obelisk server and the webui.
+//! Deployment configuration data model.
 //!
-//! Contains the resolved deployment configuration ([`DeploymentResolved`]), the stored
-//! manifest representation used for deployment submission and DB storage, plus the data
-//! types it is composed of. Some of these types double as the TOML representation
-//! (their original `*Toml` names are kept).
+//! Contains the stored manifest representation used for deployment submission and DB storage,
+//! plus transient resolved configuration ([`DeploymentResolved`]) used by the local server and
+//! `obelisk deployment verify`. Some types double as the TOML representation (their original
+//! `*Toml` names are kept).
 //!
 //! Behavior that requires the server runtime (OCI fetching, executor configuration,
 //! env var resolution) lives in the obelisk binary as extension traits.
@@ -498,8 +498,7 @@ pub enum ScriptLocationResolved {
     },
     /// OCI-sourced script. No `oci://` prefix.
     Oci {
-        // String, not `oci_client::Reference`: this crate compiles to wasm32 for the webui and cannot depend on `oci_client`. Always built from a valid reference; callers re-parse it.
-        image: String,
+        image: oci_client::Reference,
     },
 }
 
@@ -740,10 +739,10 @@ pub mod cron {
 
 /// Resolved deployment configuration after resolving deployment-owned text sources.
 ///
-/// This is a runtime/verification shape derived from the stored manifest plus a file
-/// provider. It is not the stored deployment source of truth, and is an in-memory value
-/// only (never serialized): it is rebuilt on each server from the stored manifest and the
-/// CAS. Deployment-owned scripts and backtrace sources are inlined as content;
+/// This is a transient runtime/verification shape used by the local server and
+/// `obelisk deployment verify`. It is derived from the stored manifest plus a file provider,
+/// never serialized, and rebuilt on each server from the stored manifest and the CAS.
+/// Deployment-owned scripts and backtrace sources are inlined as content;
 /// deployment-owned WASM locations remain relative path + content digest until
 /// `DeploymentRunnable` materializes them from the CAS into a runnable cache path. OCI
 /// references remain external references.

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -426,13 +426,12 @@ pub struct ActivityStubExtInlineConfigResolved {
     pub interface: FunctionInterfaceResolved,
 }
 
-/// Authored WIT files belonging to a deployment component.
+/// Parsed authored WIT belonging to a deployment component.
 #[derive(Debug, Clone)]
 pub struct WitSourceResolved {
-    /// Deployment-relative root supplied by the author.
     pub root: String,
-    /// Parser-selected deployment-relative WIT paths and their contents.
-    pub files: Vec<(String, String)>,
+    pub resolve: wit_parser::Resolve,
+    pub main_pkg_id: wit_parser::PackageId,
 }
 
 #[derive(Debug, Clone)]
@@ -443,7 +442,7 @@ pub struct InlineFunctionInterfaceResolved {
 
 #[derive(Debug, Clone)]
 pub enum FunctionInterfaceResolved {
-    Authored { wit: WitSourceResolved },
+    Authored { wit: Box<WitSourceResolved> },
     Inline(InlineFunctionInterfaceResolved),
 }
 

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -419,18 +419,15 @@ pub struct ActivityExternalFileConfigToml {
     pub component_digest: Option<ComponentDigest>,
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Clone)]
 pub struct ActivityStubExtInlineConfigResolved {
     pub name: ConfigName,
-    #[schemars(with = "String")]
     pub ffqn: FunctionFqn,
-    #[serde(flatten)]
     pub interface: FunctionInterfaceResolved,
 }
 
 /// Authored WIT files belonging to a deployment component.
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct WitSourceResolved {
     /// Deployment-relative root supplied by the author.
     pub root: String,
@@ -438,24 +435,19 @@ pub struct WitSourceResolved {
     pub files: Vec<(String, String)>,
 }
 
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct InlineFunctionInterfaceResolved {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<Vec<JsParamToml>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub return_type: Option<String>,
 }
 
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum FunctionInterfaceResolved {
     Authored { wit: WitSourceResolved },
     Inline(InlineFunctionInterfaceResolved),
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum ActivityStubComponentConfigResolved {
     File(ActivityStubFileConfigToml),
     Inline(ActivityStubExtInlineConfigResolved),
@@ -471,8 +463,7 @@ impl ActivityStubComponentConfigResolved {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum ActivityExternalComponentConfigResolved {
     File(ActivityExternalFileConfigToml),
     Inline(ActivityStubExtInlineConfigResolved),
@@ -495,33 +486,27 @@ impl ActivityExternalComponentConfigResolved {
 ///   deployment-relative path (which may include subfolders), used for source names and
 ///   backtraces.
 /// - `Oci` is an external registry reference.
-#[derive(Debug, Clone, Hash, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Hash)]
 pub enum ScriptLocationResolved {
-    #[schemars(with = "String")]
     Content { content: String, file_name: String },
-    // backcompat: 0.41 deployments keep using `Content`; graphs use the new explicit shape.
     Graph {
         entry_path: String,
         files: Vec<(String, String)>,
     },
     /// OCI-sourced script. No `oci://` prefix.
-    #[schemars(with = "String")]
     Oci { image: String },
 }
 
 /// Resolved backtrace source: the inlined source `content` plus the deployment-relative
 /// `file_name` it was read from (used to recreate the file, mirroring subfolders, on export).
-#[derive(JsonSchema, Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct BacktraceSourceResolved {
     pub content: String,
     pub file_name: String,
 }
 
-#[derive(JsonSchema, Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone)]
 pub struct ComponentBacktraceConfigResolved {
-    #[schemars(with = "std::collections::HashMap<String, BacktraceSourceResolved>")]
     pub frame_files_to_sources: HashMap<String, BacktraceSourceResolved>,
 }
 
@@ -538,14 +523,13 @@ impl ComponentBacktraceConfigResolved {
 }
 
 /// Resolved form of `ActivityJsComponentConfigToml`.
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct ActivityJsComponentConfigResolved {
     pub name: ConfigName,
     pub location: ScriptLocationResolved,
     pub content_digest: Option<ContentDigest>,
     pub component_digest: Option<ComponentDigest>,
     pub ffqn: FunctionFqn,
-    #[serde(flatten)]
     pub interface: FunctionInterfaceResolved,
     pub exec: ExecConfigToml,
     pub max_retries: u32,
@@ -558,13 +542,12 @@ pub struct ActivityJsComponentConfigResolved {
 }
 
 /// Resolved form of `ActivityExecComponentConfigToml`.
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct ActivityExecComponentConfigResolved {
     pub name: ConfigName,
     pub location: ScriptLocationResolved,
     pub content_digest: Option<ContentDigest>,
     pub ffqn: FunctionFqn,
-    #[serde(flatten)]
     pub interface: FunctionInterfaceResolved,
     pub component_digest: Option<ComponentDigest>,
     pub exec: ExecConfigToml,
@@ -577,9 +560,7 @@ pub struct ActivityExecComponentConfigResolved {
     pub max_output_bytes: u64,
     /// Registered secret names (from the operator-owned `server.toml` `[secrets]`
     /// table) to expose to the script in the stdin JSON `secrets` object.
-    #[serde(default)]
     pub secrets: Vec<String>,
-    #[serde(default)]
     pub params_via_stdin: bool,
 }
 
@@ -618,11 +599,9 @@ pub enum BlockingStrategyConfigSimple {
 }
 
 /// Resolved form of `WorkflowWasmComponentConfigToml`.
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct WorkflowWasmComponentConfigResolved {
     pub common: ComponentCommon,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_digest: Option<ContentDigest>,
     pub component_digest: Option<ComponentDigest>,
     pub exec: ExecConfigToml,
@@ -631,27 +610,24 @@ pub struct WorkflowWasmComponentConfigResolved {
     pub backtrace: ComponentBacktraceConfigResolved,
     pub stub_wasi: bool,
     pub lock_extension: bool,
-    #[serde(default = "default_lock_extension_leeway")]
     pub lock_extension_leeway: DurationConfig,
     pub logs_store_min_level: LogLevelToml,
 }
 
 /// Resolved form of `WorkflowJsComponentConfigToml`.
-#[derive(JsonSchema, Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Clone)]
 pub struct WorkflowJsComponentConfigResolved {
     pub name: ConfigName,
     pub location: ScriptLocationResolved,
     pub content_digest: Option<ContentDigest>,
     pub component_digest: Option<ComponentDigest>,
     pub ffqn: FunctionFqn,
-    #[serde(flatten)]
     pub interface: FunctionInterfaceResolved,
     pub exec: ExecConfigToml,
     pub retry_exp_backoff: DurationConfig,
     pub blocking_strategy: BlockingStrategyConfigToml,
     pub logs_store_min_level: LogLevelToml,
     pub lock_extension: bool,
-    #[serde(default = "default_lock_extension_leeway")]
     pub lock_extension_leeway: DurationConfig,
 }
 
@@ -694,56 +670,35 @@ pub mod webhook {
     }
 
     /// Resolved form of `WebhookWasmComponentConfigToml`.
-    #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
-    #[serde(deny_unknown_fields)]
+    #[derive(Debug, Clone)]
     pub struct WebhookWasmComponentConfigResolved {
-        #[serde(flatten)]
         pub common: ComponentCommon,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         pub content_digest: Option<ContentDigest>,
-        #[serde(default = "default_external_server_name")]
         pub http_server: ConfigName,
         pub routes: Vec<WebhookRoute>,
-        #[serde(default)]
         pub forward_stdout: ComponentStdOutputToml,
-        #[serde(default)]
         pub forward_stderr: ComponentStdOutputToml,
-        #[serde(default)]
         pub env_vars: Vec<EnvVarConfig>,
-        #[serde(default)]
         pub backtrace: ComponentBacktraceConfigResolved,
-        #[serde(default)]
         pub backtrace_persist: bool,
-        #[serde(default)]
         pub logs_store_min_level: LogLevelToml,
-        #[serde(default, rename = "allowed_host")]
         pub allowed_hosts: Vec<AllowedHostToml>,
-        #[serde(skip)]
         pub is_webui: bool,
     }
 
     /// Resolved form of `WebhookJsComponentConfigToml`.
-    #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
-    #[serde(deny_unknown_fields)]
+    #[derive(Debug, Clone)]
     pub struct WebhookJsComponentConfigResolved {
         pub name: ConfigName,
         pub location: ScriptLocationResolved,
-        #[serde(default)]
         pub content_digest: Option<ContentDigest>,
-        #[serde(default = "default_external_server_name")]
         pub http_server: ConfigName,
         pub routes: Vec<WebhookRoute>,
-        #[serde(default)]
         pub forward_stdout: ComponentStdOutputToml,
-        #[serde(default)]
         pub forward_stderr: ComponentStdOutputToml,
-        #[serde(default)]
         pub logs_store_min_level: LogLevelToml,
-        #[serde(default)]
         pub env_vars: Vec<EnvVarConfig>,
-        #[serde(default)]
         pub backtrace_persist: bool,
-        #[serde(default, rename = "allowed_host")]
         pub allowed_hosts: Vec<AllowedHostToml>,
     }
 }
@@ -779,10 +734,12 @@ pub mod cron {
 /// Resolved deployment configuration after resolving deployment-owned text sources.
 ///
 /// This is a runtime/verification shape derived from the stored manifest plus a file
-/// provider. It is not the stored deployment source of truth. Deployment-owned scripts
-/// and backtrace sources are inlined as content; deployment-owned WASM locations remain
-/// relative path + content digest until `DeploymentRunnable` materializes them from the
-/// CAS into a runnable cache path. OCI references remain external references.
+/// provider. It is not the stored deployment source of truth, and is an in-memory value
+/// only (never serialized): it is rebuilt on each server from the stored manifest and the
+/// CAS. Deployment-owned scripts and backtrace sources are inlined as content;
+/// deployment-owned WASM locations remain relative path + content digest until
+/// `DeploymentRunnable` materializes them from the CAS into a runnable cache path. OCI
+/// references remain external references.
 #[derive(Debug, Default, Clone)]
 pub struct DeploymentResolved {
     /// Path of the deployment manifest this configuration was loaded from, when available.

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -502,11 +502,12 @@ pub enum ScriptLocationResolved {
     },
 }
 
-/// Resolved backtrace source: the inlined source `content` plus the deployment-relative
-/// `file_name` it was read from (used to recreate the file, mirroring subfolders, on export).
+/// Resolved backtrace source: a CAS reference (`content_digest`) to the source bytes,
+/// which are uploaded to the CAS with the deployment files, plus the deployment-relative
+/// `file_name` it was read from (used to detect owned-source name collisions).
 #[derive(Debug, Clone)]
 pub struct BacktraceSourceResolved {
-    pub content: String,
+    pub content_digest: ContentDigest,
     pub file_name: String,
 }
 
@@ -516,13 +517,13 @@ pub struct ComponentBacktraceConfigResolved {
 }
 
 impl ComponentBacktraceConfigResolved {
-    /// Map each frame-symbol key to its source content (dropping the recreate path),
-    /// as needed by the runtime backtrace lookup.
+    /// Map each frame-symbol key to the CAS digest of its source (dropping the recreate
+    /// path), as needed to persist the runtime backtrace-source lookup.
     #[must_use]
-    pub fn into_frame_files(self) -> HashMap<String, String> {
+    pub fn into_frame_files(self) -> HashMap<String, ContentDigest> {
         self.frame_files_to_sources
             .into_iter()
-            .map(|(k, v)| (k, v.content))
+            .map(|(k, v)| (k, v.content_digest))
             .collect()
     }
 }

--- a/crates/deployment-config/src/config.rs
+++ b/crates/deployment-config/src/config.rs
@@ -488,13 +488,18 @@ impl ActivityExternalComponentConfigResolved {
 /// - `Oci` is an external registry reference.
 #[derive(Debug, Clone, Hash)]
 pub enum ScriptLocationResolved {
-    Content { content: String, file_name: String },
+    Content {
+        content: String,
+        file_name: String,
+    },
     Graph {
         entry_path: String,
         files: Vec<(String, String)>,
     },
     /// OCI-sourced script. No `oci://` prefix.
-    Oci { image: String },
+    Oci {
+        image: String,
+    },
 }
 
 /// Resolved backtrace source: the inlined source `content` plus the deployment-relative

--- a/crates/deployment-config/src/lib.rs
+++ b/crates/deployment-config/src/lib.rs
@@ -1,10 +1,9 @@
-//! Shared deployment configuration schema and core naming types.
+//! Deployment configuration schema, transient resolution types, and core naming types.
 //!
-//! This crate holds the data model that is shared between the obelisk server
-//! (TOML parsing, resolution, DB storage) and the webui. It must keep
-//! compiling for `wasm32-unknown-unknown`, so it contains plain data types only;
-//! all behavior that needs the server runtime (OCI fetching, executor
-//! configuration, env var resolution) lives in the obelisk binary.
+//! This crate holds the manifest data model used for TOML parsing and DB storage, plus
+//! transient resolved forms used by the local server and `obelisk deployment verify`.
+//! Behavior that needs the server runtime (OCI fetching, executor configuration, env var
+//! resolution) lives in the obelisk binary.
 
 pub mod component_id;
 pub mod config;

--- a/crates/testing/db-tests/tests/deployment_components.rs
+++ b/crates/testing/db-tests/tests/deployment_components.rs
@@ -49,7 +49,12 @@ async fn insert_deployment(
     now: chrono::DateTime<chrono::Utc>,
 ) {
     api_conn
-        .insert_deployment(mk_deployment_record(deployment_id, now))
+        .insert_deployment_with_components(
+            mk_deployment_record(deployment_id, now),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
         .await
         .unwrap();
 }

--- a/crates/testing/db-tests/tests/deployment_pagination.rs
+++ b/crates/testing/db-tests/tests/deployment_pagination.rs
@@ -37,18 +37,23 @@ async fn create_deployment_with_execution(
         .is_none()
     {
         db_connection
-            .insert_deployment(DeploymentRecord {
-                deployment_id,
-                description: None,
-                digest: DeploymentRecord::compute_digest("{}"),
-                created_at: now,
-                last_active_at: None,
-                status: DeploymentStatus::Inactive,
-                deployment_toml: "{}".to_string(),
-                obelisk_version: "0.0.0-test".to_string(),
-                created_by: None,
-                files: Vec::new(),
-            })
+            .insert_deployment_with_components(
+                DeploymentRecord {
+                    deployment_id,
+                    description: None,
+                    digest: DeploymentRecord::compute_digest("{}"),
+                    created_at: now,
+                    last_active_at: None,
+                    status: DeploymentStatus::Inactive,
+                    deployment_toml: "{}".to_string(),
+                    obelisk_version: "0.0.0-test".to_string(),
+                    created_by: None,
+                    files: Vec::new(),
+                },
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            )
             .await
             .unwrap();
     }

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -4989,7 +4989,10 @@ async fn deployment_insert_and_get(database: Database) {
         created_by: Some("test".to_string()),
         files: Vec::new(),
     };
-    api_conn.insert_deployment(record).await.unwrap();
+    api_conn
+        .insert_deployment_with_components(record, Vec::new(), Vec::new(), Vec::new())
+        .await
+        .unwrap();
 
     let fetched = api_conn
         .get_deployment(deployment_id)
@@ -5029,18 +5032,23 @@ async fn deployment_files_roundtrip_and_missing_digests(database: Database) {
         size: 0,
     };
     api_conn
-        .insert_deployment(DeploymentRecord {
-            deployment_id,
-            description: None,
-            digest: DeploymentRecord::compute_digest("{}"),
-            created_at: now,
-            last_active_at: None,
-            status: DeploymentStatus::Inactive,
-            deployment_toml: "{}".to_string(),
-            obelisk_version: "0.0.0-test".to_string(),
-            created_by: None,
-            files: vec![file.clone()],
-        })
+        .insert_deployment_with_components(
+            DeploymentRecord {
+                deployment_id,
+                description: None,
+                digest: DeploymentRecord::compute_digest("{}"),
+                created_at: now,
+                last_active_at: None,
+                status: DeploymentStatus::Inactive,
+                deployment_toml: "{}".to_string(),
+                obelisk_version: "0.0.0-test".to_string(),
+                created_by: None,
+                files: vec![file.clone()],
+            },
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
         .await
         .unwrap();
 
@@ -5112,18 +5120,23 @@ async fn deployment_activate(database: Database) {
     let deployment_id = concepts::prefixed_ulid::DeploymentId::generate();
     let now = sim_clock.now();
     api_conn
-        .insert_deployment(DeploymentRecord {
-            deployment_id,
-            description: None,
-            digest: DeploymentRecord::compute_digest("{}"),
-            created_at: now,
-            last_active_at: None,
-            status: DeploymentStatus::Inactive,
-            deployment_toml: "{}".to_string(),
-            obelisk_version: "0.0.0-test".to_string(),
-            created_by: None,
-            files: Vec::new(),
-        })
+        .insert_deployment_with_components(
+            DeploymentRecord {
+                deployment_id,
+                description: None,
+                digest: DeploymentRecord::compute_digest("{}"),
+                created_at: now,
+                last_active_at: None,
+                status: DeploymentStatus::Inactive,
+                deployment_toml: "{}".to_string(),
+                obelisk_version: "0.0.0-test".to_string(),
+                created_by: None,
+                files: Vec::new(),
+            },
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
         .await
         .unwrap();
 
@@ -5154,18 +5167,23 @@ async fn deployment_only_one_active_allowed(database: Database) {
     let now = sim_clock.now();
     let id1 = concepts::prefixed_ulid::DeploymentId::generate();
     api_conn
-        .insert_deployment(DeploymentRecord {
-            deployment_id: id1,
-            description: None,
-            digest: DeploymentRecord::compute_digest("{}"),
-            created_at: now,
-            last_active_at: None,
-            status: DeploymentStatus::Inactive,
-            deployment_toml: "{}".to_string(),
-            obelisk_version: "0.0.0-test".to_string(),
-            created_by: None,
-            files: Vec::new(),
-        })
+        .insert_deployment_with_components(
+            DeploymentRecord {
+                deployment_id: id1,
+                description: None,
+                digest: DeploymentRecord::compute_digest("{}"),
+                created_at: now,
+                last_active_at: None,
+                status: DeploymentStatus::Inactive,
+                deployment_toml: "{}".to_string(),
+                obelisk_version: "0.0.0-test".to_string(),
+                created_by: None,
+                files: Vec::new(),
+            },
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
         .await
         .unwrap();
     api_conn.activate_deployment(id1, now).await.unwrap();
@@ -5173,18 +5191,23 @@ async fn deployment_only_one_active_allowed(database: Database) {
     // Activating a second deployment must deactivate the first.
     let id2 = concepts::prefixed_ulid::DeploymentId::generate();
     api_conn
-        .insert_deployment(DeploymentRecord {
-            deployment_id: id2,
-            description: None,
-            digest: DeploymentRecord::compute_digest("{}"),
-            created_at: now,
-            last_active_at: None,
-            status: DeploymentStatus::Inactive,
-            deployment_toml: "{}".to_string(),
-            obelisk_version: "0.0.0-test".to_string(),
-            created_by: None,
-            files: Vec::new(),
-        })
+        .insert_deployment_with_components(
+            DeploymentRecord {
+                deployment_id: id2,
+                description: None,
+                digest: DeploymentRecord::compute_digest("{}"),
+                created_at: now,
+                last_active_at: None,
+                status: DeploymentStatus::Inactive,
+                deployment_toml: "{}".to_string(),
+                obelisk_version: "0.0.0-test".to_string(),
+                created_by: None,
+                files: Vec::new(),
+            },
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
         .await
         .unwrap();
     api_conn.activate_deployment(id2, now).await.unwrap();
@@ -5215,18 +5238,23 @@ async fn deployment_enqueue_active_clears_pending(database: Database) {
     let pending_id = concepts::prefixed_ulid::DeploymentId::generate();
     for id in [active_id, pending_id] {
         api_conn
-            .insert_deployment(DeploymentRecord {
-                deployment_id: id,
-                description: None,
-                digest: DeploymentRecord::compute_digest("{}"),
-                created_at: now,
-                last_active_at: None,
-                status: DeploymentStatus::Inactive,
-                deployment_toml: "{}".to_string(),
-                obelisk_version: "0.0.0-test".to_string(),
-                created_by: None,
-                files: Vec::new(),
-            })
+            .insert_deployment_with_components(
+                DeploymentRecord {
+                    deployment_id: id,
+                    description: None,
+                    digest: DeploymentRecord::compute_digest("{}"),
+                    created_at: now,
+                    last_active_at: None,
+                    status: DeploymentStatus::Inactive,
+                    deployment_toml: "{}".to_string(),
+                    obelisk_version: "0.0.0-test".to_string(),
+                    created_by: None,
+                    files: Vec::new(),
+                },
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            )
             .await
             .unwrap();
     }
@@ -5283,18 +5311,23 @@ async fn deployment_list(database: Database) {
     let id2 = concepts::prefixed_ulid::DeploymentId::generate();
     for id in [id1, id2] {
         api_conn
-            .insert_deployment(DeploymentRecord {
-                deployment_id: id,
-                description: None,
-                digest: DeploymentRecord::compute_digest("{}"),
-                created_at: now,
-                last_active_at: None,
-                status: DeploymentStatus::Inactive,
-                deployment_toml: "{}".to_string(),
-                obelisk_version: "0.0.0-test".to_string(),
-                created_by: None,
-                files: Vec::new(),
-            })
+            .insert_deployment_with_components(
+                DeploymentRecord {
+                    deployment_id: id,
+                    description: None,
+                    digest: DeploymentRecord::compute_digest("{}"),
+                    created_at: now,
+                    last_active_at: None,
+                    status: DeploymentStatus::Inactive,
+                    deployment_toml: "{}".to_string(),
+                    obelisk_version: "0.0.0-test".to_string(),
+                    created_by: None,
+                    files: Vec::new(),
+                },
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            )
             .await
             .unwrap();
     }

--- a/crates/utils/src/wasm_tools.rs
+++ b/crates/utils/src/wasm_tools.rs
@@ -285,11 +285,21 @@ impl WasmComponent {
                 source,
             )
         })?;
+        Self::new_from_wit_resolve_for_ffqn(resolve, main_pkg_id, component_type, ffqn)
+    }
+
+    /// Build an authored WIT component from an already-parsed package.
+    pub fn new_from_wit_resolve_for_ffqn(
+        resolve: Resolve,
+        main_pkg_id: PackageId,
+        component_type: ComponentType,
+        ffqn: &FunctionFqn,
+    ) -> Result<Self, DecodeError> {
         let world_id = resolve
             .select_world(&[main_pkg_id], None)
             .map_err(|source| {
                 DecodeError::new_with_source(
-                    format!("cannot select the default world of {path:?}"),
+                    "cannot select the default world of authored WIT",
                     source,
                 )
             })?;
@@ -314,33 +324,21 @@ impl WasmComponent {
             .retain(|interface| !interface.fns.is_empty());
         if exim_lite.exports.len() != 1 || exim_lite.exports[0].fns.len() != 1 {
             return Err(DecodeError::new_without_source(format!(
-                "WIT directory {path:?} does not export selected function `{ffqn}`"
+                "authored WIT does not export selected function `{ffqn}`"
             )));
         }
         let full_exim = ExIm::decode(full_exim_lite, component_type)?;
         let (authored_resolve, authored_main_pkg_id) =
             crate::wit::rebuild_resolve(&full_exim, resolve.clone(), main_pkg_id).map_err(
-                |err| {
-                    DecodeError::new_with_source(
-                        format!("cannot rebuild full authored resolve from {path:?}"),
-                        err,
-                    )
-                },
+                |err| DecodeError::new_with_source("cannot rebuild full authored resolve", err),
             )?;
         let authored_wit =
             authored_wit_without_extension_world_exports(&authored_resolve, authored_main_pkg_id)
-                .map_err(|err| {
-                DecodeError::new_with_source(
-                    format!("cannot print authored WIT from {path:?}"),
-                    err,
-                )
-            })?;
+                .map_err(|err| DecodeError::new_with_source("cannot print authored WIT", err))?;
 
         let exim = ExIm::decode(exim_lite, component_type)?;
         let (resolve, main_pkg_id) = crate::wit::rebuild_resolve(&exim, resolve, main_pkg_id)
-            .map_err(|err| {
-                DecodeError::new_with_source(format!("cannot rebuild resolve from {path:?}"), err)
-            })?;
+            .map_err(|err| DecodeError::new_with_source("cannot rebuild resolve", err))?;
         Ok(Self {
             exim,
             resolve,

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2429,6 +2429,83 @@ ffqn = "testing:integration/deferred.run"
     server.shutdown().await;
 }
 
+/// A deployment whose JS imports an interface that no component exports fails to
+/// compile+link on the server. This is a structural error that no runtime config can
+/// resolve, so it must be rejected regardless of `RuntimeConfigCheck` and persist
+/// nothing. The manifest is submitted verbatim over gRPC (inline content, no attached
+/// files) so verification does not lean on any client-side import checking.
+#[tokio::test]
+async fn submit_broken_js_import_fails_regardless_of_runtime_config_check_grpc() {
+    let server = TestServer::start(test_addr!(92)).await;
+
+    // Inline webhook importing an interface no component exports. Inline content needs
+    // no attached file blobs, so the whole package travels in the manifest.
+    let deployment_toml = r#"
+[[webhook_endpoint_js]]
+name = "broken_import"
+content = """
+import { add } from 'testing:integration/nonexistent';
+export default function handle(request) {
+    return Response.json({ result: add(5, 7) });
+}
+"""
+routes = [{ methods = ["GET"], route = "/broken-import" }]
+"#;
+
+    let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap()
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+
+    let submit = |check: RuntimeConfigCheck, id: GrpcDeploymentId| {
+        let mut client = grpc_client.clone();
+        async move {
+            client
+                .submit_deployment(SubmitDeploymentRequest {
+                    deployment_toml: deployment_toml.to_string(),
+                    created_by: Some("test".to_string()),
+                    runtime_config_check: check as i32,
+                    description: None,
+                    deployment_id: Some(id),
+                    files: Vec::new(),
+                })
+                .await
+        }
+    };
+
+    // Both a strict and an allow-unavailable submit must be rejected: the missing import
+    // is a link failure, not a missing env var / secret / exec allowlist entry, so no
+    // runtime config tolerance can make it verify.
+    for check in [
+        RuntimeConfigCheck::Strict,
+        RuntimeConfigCheck::AllowUnavailable,
+    ] {
+        let deployment_id = DeploymentId::generate();
+        let grpc_id = GrpcDeploymentId {
+            id: deployment_id.to_string(),
+        };
+        let status = submit(check, grpc_id.clone())
+            .await
+            .expect_err(&format!("{check:?} submit of a broken import must fail"));
+        assert!(
+            status.message().contains("testing:integration/nonexistent"),
+            "{check:?} error must name the unresolved import, got: {}",
+            status.message()
+        );
+        grpc_client
+            .clone()
+            .get_deployment(GetDeploymentRequest {
+                deployment_id: Some(grpc_id),
+                include_generated_metadata: None,
+            })
+            .await
+            .expect_err("a broken deployment must not be persisted");
+    }
+
+    server.shutdown().await;
+}
+
 /// Phase 5: `RuntimeConfigCheck` governs whether missing env vars / secrets fail
 /// verification. Submit is strict by default and tolerant under `ALLOW_UNAVAILABLE`; a
 /// hot redeploy is always strict and rejects `ALLOW_UNAVAILABLE` outright.

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2506,6 +2506,127 @@ routes = [{ methods = ["GET"], route = "/broken-import" }]
     server.shutdown().await;
 }
 
+/// A webhook whose entry JS imports a relative module that is not part of the submitted
+/// package must be rejected server-side. This mirrors a broken client (e.g. the
+/// workflow-agent) that declares/uploads only the entry file: the manifest carries the
+/// entry's `content_digest` but no `component_files`, so the server must walk the import
+/// graph from the CAS and refuse the open graph rather than persisting a webhook that
+/// only traps at request time. Like the missing-interface case, no runtime config can
+/// resolve it, so both `Strict` and `ALLOW_UNAVAILABLE` must fail and persist nothing.
+#[tokio::test]
+async fn submit_webhook_missing_js_import_file_is_rejected_grpc() {
+    let server = TestServer::start(test_addr!(93)).await;
+
+    // A valid two-file graph on disk, so `prepare` computes the entry digest for us.
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::create_dir_all(dir.path().join("webhook/lib"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        dir.path().join("webhook/ui-api.js"),
+        "import { util } from './lib/util.js';\n\
+         export default function handle(request) { return new Response(util()); }\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        dir.path().join("webhook/lib/util.js"),
+        "export function util() { return 'ok'; }\n",
+    )
+    .await
+    .unwrap();
+    let deployment_toml_path = dir.path().join("deployment.toml");
+    tokio::fs::write(
+        &deployment_toml_path,
+        r#"
+[[webhook_endpoint_js]]
+name = "broken_import"
+location = "webhook/ui-api.js"
+routes = [{ methods = ["GET"], route = "/" }]
+"#,
+    )
+    .await
+    .unwrap();
+    let prepared =
+        crate::config::manifest::prepare_deployment_manifest_from_disk(&deployment_toml_path)
+            .await
+            .unwrap();
+
+    // Simulate the broken client: drop `component_files` so only the entry is declared,
+    // and attach only the entry blob. The manifest still carries the entry's content_digest.
+    let mut doc = prepared.deployment_toml.parse::<DocumentMut>().unwrap();
+    if let Some(tables) = doc
+        .get_mut("webhook_endpoint_js")
+        .and_then(toml_edit::Item::as_array_of_tables_mut)
+    {
+        for table in tables.iter_mut() {
+            table.remove("component_files");
+        }
+    }
+    let broken_toml = doc.to_string();
+    let entry = prepared
+        .files
+        .iter()
+        .find(|file| file.path.ends_with("ui-api.js"))
+        .expect("prepared package contains the entry file");
+
+    let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap()
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+
+    let submit = |check: RuntimeConfigCheck, id: GrpcDeploymentId| {
+        let mut client = grpc_client.clone();
+        let toml = broken_toml.clone();
+        let files = vec![grpc::grpc_gen::DeploymentFileContent {
+            path: entry.path.clone(),
+            digest: Some(entry.digest.to_string()),
+            content: entry.bytes.clone(),
+        }];
+        async move {
+            client
+                .submit_deployment(SubmitDeploymentRequest {
+                    deployment_toml: toml,
+                    created_by: Some("test".to_string()),
+                    runtime_config_check: check as i32,
+                    description: None,
+                    deployment_id: Some(id),
+                    files,
+                })
+                .await
+        }
+    };
+
+    for check in [
+        RuntimeConfigCheck::Strict,
+        RuntimeConfigCheck::AllowUnavailable,
+    ] {
+        let deployment_id = DeploymentId::generate();
+        let grpc_id = GrpcDeploymentId {
+            id: deployment_id.to_string(),
+        };
+        let status = submit(check, grpc_id.clone())
+            .await
+            .expect_err(&format!("{check:?} submit of an open JS graph must fail"));
+        assert!(
+            status.message().contains("webhook/lib/util.js"),
+            "{check:?} error must name the missing module, got: {}",
+            status.message()
+        );
+        grpc_client
+            .clone()
+            .get_deployment(GetDeploymentRequest {
+                deployment_id: Some(grpc_id),
+                include_generated_metadata: None,
+            })
+            .await
+            .expect_err("a webhook with an unresolved import must not be persisted");
+    }
+
+    server.shutdown().await;
+}
+
 /// Phase 5: `RuntimeConfigCheck` governs whether missing env vars / secrets fail
 /// verification. Submit is strict by default and tolerant under `ALLOW_UNAVAILABLE`; a
 /// hot redeploy is always strict and rejects `ALLOW_UNAVAILABLE` outright.

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2742,6 +2742,88 @@ routes = [{ methods = ["GET"], route = "/" }]
     server.shutdown().await;
 }
 
+/// Submit writes referenced blobs to the CAS before validating (persist-then-validate). A
+/// submit rejected after that write must reclaim its blobs, or they leak as orphans until a
+/// manual GC. Here a webhook file blob is written, then compile+link fails on a missing
+/// interface; the follow-up GC must find nothing left to delete.
+#[tokio::test]
+async fn rejected_submit_reclaims_orphan_blobs_grpc() {
+    let server = TestServer::start(test_addr!(95)).await;
+
+    // A single-file webhook (its only import is a WIT interface, so no `component_files`)
+    // whose interface no component exports: resolution succeeds and writes the blob, then
+    // compile+link fails.
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join("webhook.js"),
+        "import { nope } from 'testing:integration/nonexistent';\n\
+         export default function handle(request) { return new Response(nope()); }\n",
+    )
+    .await
+    .unwrap();
+    let deployment_toml_path = dir.path().join("deployment.toml");
+    tokio::fs::write(
+        &deployment_toml_path,
+        r#"
+[[webhook_endpoint_js]]
+name = "orphan_probe"
+location = "webhook.js"
+routes = [{ methods = ["GET"], route = "/" }]
+"#,
+    )
+    .await
+    .unwrap();
+    let prepared =
+        crate::config::manifest::prepare_deployment_manifest_from_disk(&deployment_toml_path)
+            .await
+            .unwrap();
+    assert_eq!(prepared.files.len(), 1, "webhook must contribute one blob");
+    let files: Vec<grpc::grpc_gen::DeploymentFileContent> = prepared
+        .files
+        .iter()
+        .map(|file| grpc::grpc_gen::DeploymentFileContent {
+            path: file.path.clone(),
+            digest: Some(file.digest.to_string()),
+            content: file.bytes.clone(),
+        })
+        .collect();
+
+    let mut grpc_client =
+        DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+            .await
+            .unwrap()
+            .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+    grpc_client
+        .submit_deployment(SubmitDeploymentRequest {
+            deployment_toml: prepared.deployment_toml.clone(),
+            created_by: Some("test".to_string()),
+            runtime_config_check: RuntimeConfigCheck::Strict as i32,
+            description: None,
+            deployment_id: Some(GrpcDeploymentId {
+                id: DeploymentId::generate().to_string(),
+            }),
+            files,
+        })
+        .await
+        .expect_err("compile+link must reject the missing interface");
+
+    // Fresh server: the only blob that could be orphaned is the one this rejected submit
+    // wrote. The submit's own best-effort sweep must already have reclaimed it.
+    let deleted = grpc_client
+        .gc_orphan_files(grpc::grpc_gen::GcOrphanFilesRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .deleted_count;
+    assert_eq!(
+        deleted, 0,
+        "a rejected submit must not leak orphan blobs, found {deleted}"
+    );
+
+    server.shutdown().await;
+}
+
 /// Phase 5: `RuntimeConfigCheck` governs whether missing env vars / secrets fail
 /// verification. Submit is strict by default and tolerant under `ALLOW_UNAVAILABLE`; a
 /// hot redeploy is always strict and rejects `ALLOW_UNAVAILABLE` outright.
@@ -2976,9 +3058,10 @@ ffqn = "testing:integration/pkg.run"
     server.shutdown().await;
 }
 
-/// Phase 8: a submit that writes file blobs and then fails verification leaves orphan
-/// blobs in the CAS. `GcOrphanFiles` deletes blobs not referenced by any stored
-/// deployment while keeping those a valid deployment still references.
+/// `GcOrphanFiles` deletes CAS blobs not referenced by any stored deployment while keeping
+/// those a valid deployment still references. A rejected submit now reclaims its own blobs
+/// (see `rejected_submit_reclaims_orphan_blobs_grpc`), so the orphan here is seeded straight
+/// into the CAS to give GC something to reclaim.
 #[tokio::test]
 async fn gc_orphan_files_grpc() {
     let server = TestServer::start(test_addr!(81)).await;
@@ -2989,43 +3072,34 @@ async fn gc_orphan_files_grpc() {
         .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
         .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
 
-    // Prepare a deployment-owned JS file (digest-enriched) from disk. `section` selects
-    // `activity_js` or `workflow_js` (a JS workflow validates its source at link time, so
-    // a syntax error there fails submit verification).
-    async fn prepare(
-        section: &str,
-        source: &str,
-    ) -> (
-        tempfile::TempDir,
-        crate::config::manifest::PreparedDeploymentManifest,
-    ) {
-        let dir = tempfile::tempdir().unwrap();
-        tokio::fs::write(dir.path().join("a.js"), source)
-            .await
-            .unwrap();
-        let toml_path = dir.path().join("deployment.toml");
-        tokio::fs::write(
-            &toml_path,
-            format!(
-                r#"
-[[{section}]]
+    // A valid deployment: its blob is referenced and must survive GC.
+    let good_dir = tempfile::tempdir().unwrap();
+    tokio::fs::write(
+        good_dir.path().join("a.js"),
+        "export function run() { return 'ok'; }",
+    )
+    .await
+    .unwrap();
+    let toml_path = good_dir.path().join("deployment.toml");
+    tokio::fs::write(
+        &toml_path,
+        r#"
+[[activity_js]]
 name = "a"
 location = "a.js"
 ffqn = "testing:integration/a.run"
-"#
-            ),
-        )
+"#,
+    )
+    .await
+    .unwrap();
+    let good = crate::config::manifest::prepare_deployment_manifest_from_disk(&toml_path)
         .await
         .unwrap();
-        let prepared = crate::config::manifest::prepare_deployment_manifest_from_disk(&toml_path)
-            .await
-            .unwrap();
-        (dir, prepared)
-    }
-
-    let submit_request =
-        |prepared: &crate::config::manifest::PreparedDeploymentManifest| SubmitDeploymentRequest {
-            deployment_toml: prepared.deployment_toml.clone(),
+    let good_digest = good.files[0].digest.to_string();
+    grpc_client
+        .clone()
+        .submit_deployment(SubmitDeploymentRequest {
+            deployment_toml: good.deployment_toml.clone(),
             created_by: Some("test".to_string()),
             runtime_config_check: RuntimeConfigCheck::Strict as i32,
             description: None,
@@ -3034,34 +3108,30 @@ ffqn = "testing:integration/a.run"
             }),
             files: vec![grpc::grpc_gen::DeploymentFileContent {
                 path: "a.js".to_string(),
-                digest: Some(prepared.files[0].digest.to_string()),
-                content: prepared.files[0].bytes.clone(),
+                digest: Some(good.files[0].digest.to_string()),
+                content: good.files[0].bytes.clone(),
             }],
-        };
-
-    // A valid deployment: its blob is referenced and must survive GC.
-    let (_good_dir, good) = prepare("activity_js", "export function run() { return 'ok'; }").await;
-    let good_digest = good.files[0].digest.to_string();
-    grpc_client
-        .clone()
-        .submit_deployment(submit_request(&good))
+        })
         .await
         .expect("valid deployment must persist");
 
-    // An invalid deployment: the blob is written, then verification fails, so no
-    // deployment row references it. The source parses during graph collection, but its
-    // unknown host import fails during workflow linking.
-    let (_bad_dir, bad) = prepare(
-        "workflow_js",
-        "import { missing } from 'testing:integration/activity'; export default () => missing();",
-    )
-    .await;
-    let bad_digest = bad.files[0].digest.to_string();
-    grpc_client
-        .clone()
-        .submit_deployment(submit_request(&bad))
-        .await
-        .expect_err("invalid deployment must fail verification");
+    // Seed an orphan blob directly in the CAS: no deployment references it. A rejected submit
+    // sweeps its own blobs before returning, so a genuine orphan cannot be produced through
+    // the submit path anymore.
+    let orphan_digest = {
+        let pool = SqlitePool::new(&server.sqlite_file, SqliteConfig::default())
+            .await
+            .unwrap();
+        let digest = pool
+            .cas_conn()
+            .await
+            .unwrap()
+            .write_blob(b"orphan blob referenced by no deployment")
+            .await
+            .unwrap();
+        pool.close().await;
+        digest.to_string()
+    };
 
     // Before GC: both blobs are present in the CAS.
     grpc_client
@@ -3074,7 +3144,7 @@ ffqn = "testing:integration/a.run"
     grpc_client
         .clone()
         .get_file(GetFileRequest {
-            digest: bad_digest.clone(),
+            digest: orphan_digest.clone(),
         })
         .await
         .expect("orphan blob present before gc");
@@ -3099,7 +3169,9 @@ ffqn = "testing:integration/a.run"
         .expect("referenced blob must survive gc");
     let status = grpc_client
         .clone()
-        .get_file(GetFileRequest { digest: bad_digest })
+        .get_file(GetFileRequest {
+            digest: orphan_digest,
+        })
         .await
         .expect_err("orphan blob must be gone after gc");
     assert_eq!(status.code(), tonic::Code::NotFound);

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -2627,6 +2627,121 @@ routes = [{ methods = ["GET"], route = "/" }]
     server.shutdown().await;
 }
 
+/// A manifest that declares a `component_files` entry its module graph never imports is
+/// rejected at submit. Otherwise the stray blob is persisted and the deployment -> digest
+/// mapping the orphan GC consults would pin a dead file forever. Built by preparing a
+/// valid graph, then hand-adding an unreferenced module + its blob (a broken client).
+#[tokio::test]
+async fn submit_rejects_stray_declared_component_file_grpc() {
+    let server = TestServer::start(test_addr!(94)).await;
+
+    let dir = tempfile::tempdir().unwrap();
+    tokio::fs::create_dir_all(dir.path().join("webhook"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        dir.path().join("webhook/ui-api.js"),
+        "import { util } from './util.js';\n\
+         export default function handle(request) { return new Response(util()); }\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        dir.path().join("webhook/util.js"),
+        "export function util() { return 'ok'; }\n",
+    )
+    .await
+    .unwrap();
+    let deployment_toml_path = dir.path().join("deployment.toml");
+    tokio::fs::write(
+        &deployment_toml_path,
+        r#"
+[[webhook_endpoint_js]]
+name = "stray"
+location = "webhook/ui-api.js"
+routes = [{ methods = ["GET"], route = "/" }]
+"#,
+    )
+    .await
+    .unwrap();
+    let prepared =
+        crate::config::manifest::prepare_deployment_manifest_from_disk(&deployment_toml_path)
+            .await
+            .unwrap();
+
+    // Hand-add an extra module nothing imports, plus its blob: a broken client declaring
+    // more than the graph needs.
+    let stray_source = "export const unused = 1;\n";
+    let stray_hash: [u8; 32] = <Sha256 as sha2::Digest>::digest(stray_source.as_bytes()).into();
+    let stray_digest =
+        concepts::ContentDigest(concepts::component_id::Digest(stray_hash)).to_string();
+    let mut doc = prepared.deployment_toml.parse::<DocumentMut>().unwrap();
+    let tables = doc
+        .get_mut("webhook_endpoint_js")
+        .and_then(toml_edit::Item::as_array_of_tables_mut)
+        .expect("webhook section");
+    for table in tables.iter_mut() {
+        let component_files = table
+            .get_mut("component_files")
+            .and_then(toml_edit::Item::as_table_like_mut)
+            .expect("prepare generated component_files for a multi-file component");
+        component_files.insert("webhook/unused.js", toml_edit::value(stray_digest.clone()));
+    }
+    let broken_toml = doc.to_string();
+
+    let mut files: Vec<grpc::grpc_gen::DeploymentFileContent> = prepared
+        .files
+        .iter()
+        .map(|file| grpc::grpc_gen::DeploymentFileContent {
+            path: file.path.clone(),
+            digest: Some(file.digest.to_string()),
+            content: file.bytes.clone(),
+        })
+        .collect();
+    files.push(grpc::grpc_gen::DeploymentFileContent {
+        path: "webhook/unused.js".to_string(),
+        digest: Some(stray_digest),
+        content: stray_source.as_bytes().to_vec(),
+    });
+
+    let deployment_id = DeploymentId::generate();
+    let grpc_id = GrpcDeploymentId {
+        id: deployment_id.to_string(),
+    };
+    let status = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap()
+        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .submit_deployment(SubmitDeploymentRequest {
+            deployment_toml: broken_toml,
+            created_by: Some("test".to_string()),
+            runtime_config_check: RuntimeConfigCheck::Strict as i32,
+            description: None,
+            deployment_id: Some(grpc_id.clone()),
+            files,
+        })
+        .await
+        .expect_err("a stray declared component file must be rejected");
+    assert!(
+        status.message().contains("webhook/unused.js"),
+        "error must name the stray file, got: {}",
+        status.message()
+    );
+
+    DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
+        .await
+        .unwrap()
+        .get_deployment(GetDeploymentRequest {
+            deployment_id: Some(grpc_id),
+            include_generated_metadata: None,
+        })
+        .await
+        .expect_err("a deployment with a stray declared file must not be persisted");
+
+    server.shutdown().await;
+}
+
 /// Phase 5: `RuntimeConfigCheck` governs whether missing env vars / secrets fail
 /// verification. Submit is strict by default and tolerant under `ALLOW_UNAVAILABLE`; a
 /// hot redeploy is always strict and rejects `ALLOW_UNAVAILABLE` outright.

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1379,12 +1379,12 @@ impl crate::config::file_provider::FileProvider for RecordingCasProvider {
         Ok(files)
     }
 
-    async fn read_wit_files(
+    async fn parse_wit_files(
         &self,
         root: &str,
         known_files: &std::collections::BTreeMap<String, ContentDigest>,
     ) -> anyhow::Result<Vec<(String, String)>> {
-        let files = self.inner.read_wit_files(root, known_files).await?;
+        let files = self.inner.parse_wit_files(root, known_files).await?;
         let mut seen = self
             .seen
             .lock()

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1855,19 +1855,7 @@ pub(crate) async fn run_internal(
     )
     .instrument(span)
     .await?;
-    let mut server_init = server_init;
-    let deployment_switch_manager = DeploymentSwitchManagerHandle::new(
-        server_init.server_verified.clone(),
-        server_init.prepared_dirs.clone(),
-        server_init.db_pool.clone(),
-        termination_watcher.clone(),
-        server_init.deployment_ctx.clone(),
-        server_init.webhook_registry.clone(),
-        cancel_registry.clone(),
-        server_init.log_forwarder_sender.clone(),
-        DEFAULT_SUBMIT_CONCURRENCY,
-    );
-    server_init.deployment_switch_manager = Some(deployment_switch_manager.clone());
+    let deployment_switch_manager = server_init.deployment_switch_manager.clone();
     switch_deployment(
         deployment_switch_manager.clone(),
         active_deployment_id,
@@ -2603,14 +2591,10 @@ pub(crate) async fn submit_deployment(
     supplied_files: Vec<SuppliedFile>,
     db_pool: Arc<dyn DbPool>,
     termination_watcher: &mut watch::Receiver<()>,
-    deployment_switch_manager: Option<DeploymentSwitchManagerHandle>,
+    deployment_switch_manager: DeploymentSwitchManagerHandle,
 ) -> Result<DeploymentId, SubmitDeploymentError> {
     info!("Submitting deployment");
-    let _submit_permit = if let Some(manager) = &deployment_switch_manager {
-        Some(manager.try_acquire_submit_permit()?)
-    } else {
-        None
-    };
+    let _submit_permit = deployment_switch_manager.try_acquire_submit_permit()?;
     // The deployment digest is the hash of the verbatim manifest; it transitively covers
     // every referenced file because the manifest embeds each file's content digest. It is
     // used only for idempotency, not returned (the client already has the manifest).
@@ -2785,10 +2769,8 @@ pub(crate) async fn submit_deployment(
     // Only cache strict-verified artifacts. A hot redeploy is always strict, so an
     // artifact compiled while tolerating unavailable runtime config must not be
     // reused to satisfy a later strict switch; a strict artifact satisfies any consumer.
-    if let Some(manager) = deployment_switch_manager
-        && runtime_config_availability == RuntimeConfigAvailability::Strict
-    {
-        manager
+    if runtime_config_availability == RuntimeConfigAvailability::Strict {
+        deployment_switch_manager
             .store_latest_prepared(PreparedDeploymentSwitch {
                 deployment_id,
                 digest,
@@ -3272,6 +3254,18 @@ async fn spawn_tasks_and_threads(
             cancel_registry,
             &log_forwarder_sender,
         )));
+    let webhook_registry = Arc::new(webhook_registry);
+    let deployment_switch_manager = DeploymentSwitchManagerHandle::new(
+        server_verified.clone(),
+        prepared_dirs.clone(),
+        db_pool.clone(),
+        termination_watcher.clone(),
+        deployment_ctx.clone(),
+        webhook_registry.clone(),
+        cancel_registry.clone(),
+        log_forwarder_sender.clone(),
+        DEFAULT_SUBMIT_CONCURRENCY,
+    );
     let server_init = ServerInit {
         server_verified,
         deployment_ctx,
@@ -3287,9 +3281,9 @@ async fn spawn_tasks_and_threads(
         log_db_forarder,
         engines: server_compiled_linked.engines,
         log_forwarder_sender,
-        webhook_registry: Arc::new(webhook_registry),
+        webhook_registry,
         prepared_dirs,
-        deployment_switch_manager: None,
+        deployment_switch_manager,
     };
     Ok(server_init)
 }
@@ -3309,7 +3303,7 @@ struct ServerInit {
     log_forwarder_sender: mpsc::Sender<LogInfoAppendRow>,
     webhook_registry: Arc<WebhookRegistry>,
     prepared_dirs: PreparedDirs,
-    deployment_switch_manager: Option<DeploymentSwitchManagerHandle>,
+    deployment_switch_manager: DeploymentSwitchManagerHandle,
 }
 impl ServerInit {
     async fn close(self) {
@@ -3333,9 +3327,7 @@ impl ServerInit {
             deployment_switch_manager,
         } = self;
 
-        if let Some(deployment_switch_manager) = deployment_switch_manager {
-            deployment_switch_manager.close().await;
-        }
+        deployment_switch_manager.close().await;
 
         debug!("Closing executors");
         let executors = {

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1355,6 +1355,30 @@ impl crate::config::file_provider::FileProvider for RecordingCasProvider {
         Ok(bytes)
     }
 
+    async fn parse_js_graph(
+        &self,
+        entry_path: &str,
+        known_files: &std::collections::BTreeMap<String, ContentDigest>,
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        let files = self.inner.parse_js_graph(entry_path, known_files).await?;
+        let mut seen = self
+            .seen
+            .lock()
+            .expect("RecordingCasProvider mutex poisoned");
+        for (path, source) in &files {
+            let digest = known_files
+                .get(path)
+                .expect("CAS JS graph walker only reads files present in known_files");
+            seen.push(concepts::storage::DeploymentFileRecord {
+                path: path.clone(),
+                digest: digest.clone(),
+                size: u64::try_from(source.len()).expect("file length fits u64"),
+            });
+        }
+        drop(seen);
+        Ok(files)
+    }
+
     async fn read_wit_files(
         &self,
         root: &str,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1450,7 +1450,7 @@ async fn deployment_resolved_from_manifest(
     )
 }
 
-/// A [`DeploymentResolved`] whose every WASM component location is a concrete, runnable
+/// Transient server state whose every WASM component location is a concrete, runnable
 /// reference: an absolute on-disk path or an OCI image.
 ///
 /// `DeploymentResolved` is host-independent: a deployment-owned WASM is a *relative* path

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2680,75 +2680,102 @@ pub(crate) async fn submit_deployment(
         }
     }
 
-    // Fully validate the deployment before persisting it, so a stored deployment is
-    // already known-good: resolve from the CAS (resolving env vars/secrets),
-    // parse JS, validate WIT/WASM, and compile + link every component. Activation no
-    // longer performs first-time package validation. Blobs already written to the CAS
-    // when verification fails are acceptable GC input; no deployment row is inserted.
-    let deployment_resolved = deployment_resolved_from_manifest(&*db_pool, deployment_toml)
-        .await
-        .map_err(SubmitDeploymentError::Other)?;
-    let cas_arc: Arc<dyn concepts::cas::Cas> = db_pool
-        .cas_conn()
-        .await
-        .map_err(anyhow::Error::from)?
-        .into();
+    // Fully validate the deployment before persisting it, so a stored deployment is already
+    // known-good: resolve from the CAS (resolving env vars/secrets), parse JS, validate
+    // WIT/WASM, and compile + link every component. Activation no longer performs first-time
+    // package validation. Any failure from here through the insert leaves the blobs just
+    // written to the CAS as orphans, reclaimed by the best-effort sweep below; no deployment
+    // row is inserted on failure.
     let deployment_id = requested_deployment_id.unwrap_or_else(DeploymentId::generate);
-    config_prepass::preflight(
-        &server_verified,
-        Some(&deployment_resolved),
-        runtime_config_availability,
-    )
-    .map_err(SubmitDeploymentError::Other)?;
-    let compiled_linked = deployment_verify_config_compile_link(
-        server_verified,
-        prepared_dirs,
-        deployment_resolved,
-        Some(cas_arc),
-        deployment_id,
-        VerifyParams {
-            dir_params: PrepareDirsParams {
-                clean_cache: false,
-                clean_codegen_cache: false,
-            },
-            runtime_config_availability,
-            suppress_type_checking_errors: false,
-            suppress_linking_errors: false,
-        },
-        termination_watcher,
-    )
-    .await
-    .map_err(SubmitDeploymentError::Other)?;
+    let validate_and_persist = {
+        let db_pool_ref: &dyn DbPool = &*db_pool;
+        let conn_ref = conn.as_ref();
+        let manifest_ref = &manifest;
+        let digest_ref = &digest;
+        async move {
+            let deployment_resolved =
+                deployment_resolved_from_manifest(db_pool_ref, deployment_toml)
+                    .await
+                    .map_err(SubmitDeploymentError::Other)?;
+            let cas_arc: Arc<dyn concepts::cas::Cas> = db_pool_ref
+                .cas_conn()
+                .await
+                .map_err(anyhow::Error::from)?
+                .into();
+            config_prepass::preflight(
+                &server_verified,
+                Some(&deployment_resolved),
+                runtime_config_availability,
+            )
+            .map_err(SubmitDeploymentError::Other)?;
+            let compiled_linked = deployment_verify_config_compile_link(
+                server_verified,
+                prepared_dirs,
+                deployment_resolved,
+                Some(cas_arc),
+                deployment_id,
+                VerifyParams {
+                    dir_params: PrepareDirsParams {
+                        clean_cache: false,
+                        clean_codegen_cache: false,
+                    },
+                    runtime_config_availability,
+                    suppress_type_checking_errors: false,
+                    suppress_linking_errors: false,
+                },
+                termination_watcher,
+            )
+            .await
+            .map_err(SubmitDeploymentError::Other)?;
 
-    let now = chrono::Utc::now();
+            let now = chrono::Utc::now();
 
-    // Persist the deployment row together with its verified component metadata in a single
-    // transaction so the DB-backed ListComponents / GetWit see this deployment without waiting
-    // for a server restart, and so the submit is cancel-safe: this future runs inline in the
-    // request handler and is dropped if the client disconnects, so the row that makes a
-    // deployment queryable and its component rows must commit together or not at all.
-    // Verification above already compiled and linked every component.
-    let (component_metadata, deployment_components) =
-        build_component_metadata_records(deployment_id, &compiled_linked.component_registry_ro);
-    conn.insert_deployment_with_components(
-        DeploymentRecord {
-            deployment_id,
-            description,
-            digest: digest.clone(),
-            created_at: now,
-            last_active_at: None,
-            status: DeploymentStatus::Inactive,
-            obelisk_version: crate::args::shadow::PKG_VERSION.to_string(),
-            created_by,
-            deployment_toml: deployment_toml.to_string(),
-            files: manifest.file_records(),
-        },
-        component_metadata,
-        deployment_components,
-        manifest.component_file_records(),
-    )
-    .await
-    .map_err(anyhow::Error::from)?;
+            // Persist the deployment row together with its verified component metadata in a
+            // single transaction so the DB-backed ListComponents / GetWit see this deployment
+            // without waiting for a server restart, and so the submit is cancel-safe: this
+            // future runs inline in the request handler and is dropped if the client
+            // disconnects, so the row that makes a deployment queryable and its component rows
+            // must commit together or not at all. Verification above already compiled and
+            // linked every component.
+            let (component_metadata, deployment_components) = build_component_metadata_records(
+                deployment_id,
+                &compiled_linked.component_registry_ro,
+            );
+            conn_ref
+                .insert_deployment_with_components(
+                    DeploymentRecord {
+                        deployment_id,
+                        description,
+                        digest: digest_ref.clone(),
+                        created_at: now,
+                        last_active_at: None,
+                        status: DeploymentStatus::Inactive,
+                        obelisk_version: crate::args::shadow::PKG_VERSION.to_string(),
+                        created_by,
+                        deployment_toml: deployment_toml.to_string(),
+                        files: manifest_ref.file_records(),
+                    },
+                    component_metadata,
+                    deployment_components,
+                    manifest_ref.component_file_records(),
+                )
+                .await
+                .map_err(anyhow::Error::from)?;
+            Ok::<_, SubmitDeploymentError>(compiled_linked)
+        }
+    };
+    let compiled_linked = match validate_and_persist.await {
+        Ok(compiled_linked) => compiled_linked,
+        Err(err) => {
+            // Best-effort: reclaim the blobs this submit wrote. Submits are serialized by the
+            // submit lane, so the only unreferenced blobs are this rejected submit's. Keep the
+            // original rejection reason regardless of the sweep's outcome.
+            if let Err(gc_err) = conn.gc_orphan_files().await {
+                warn!(%deployment_id, "orphan blob GC after a rejected submit failed: {gc_err}");
+            }
+            return Err(err);
+        }
+    };
 
     // Backtrace sources are content-addressed and deployment-independent (keyed by component
     // digest), only consulted once a component runs and produces a backtrace, so they are

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2751,9 +2751,13 @@ pub(crate) async fn submit_deployment(
     let compiled_linked = match validate_and_persist.await {
         Ok(compiled_linked) => compiled_linked,
         Err(err) => {
-            // Best-effort: reclaim the blobs this submit wrote. Submits are serialized by the
-            // submit lane, so the only unreferenced blobs are this rejected submit's. Keep the
-            // original rejection reason regardless of the sweep's outcome.
+            // Best-effort: reclaim the blobs this submit wrote. This is a global sweep of every
+            // unreferenced blob, safe only because the submit lane serializes submits: with one
+            // submit in flight, the only unreferenced blobs are this rejected submit's. If
+            // `DEFAULT_SUBMIT_CONCURRENCY` is ever raised, a concurrent submit's not-yet-referenced
+            // blobs would be swept too; delete exactly this submit's `to_write` digests instead.
+            // Keep the original rejection reason regardless of the sweep's outcome.
+            const { assert!(DEFAULT_SUBMIT_CONCURRENCY == 1) };
             if let Err(gc_err) = conn.gc_orphan_files().await {
                 warn!(%deployment_id, "orphan blob GC after a rejected submit failed: {gc_err}");
             }

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2142,9 +2142,18 @@ impl ServerVerified {
     }
 }
 
-pub(crate) type FrameFilesToSourceContent = HashMap<
+/// A backtrace source to persist for `GetBacktraceSource`, addressed either by inlined
+/// `Content` (JS/exec sources, materialized into the CAS at startup) or by a CAS `Digest`
+/// (WASM backtrace sources, already uploaded with the deployment files).
+#[derive(Debug)]
+pub(crate) enum FrameSource {
+    Content(String),
+    Digest(ContentDigest),
+}
+
+pub(crate) type FrameFilesToSource = HashMap<
     String, // file name, can contain `.../` prefix
-    String, //content
+    FrameSource,
 >;
 
 pub(crate) type HttpServersToWebhooksAndState = Vec<(
@@ -2159,7 +2168,7 @@ pub(crate) struct ServerCompiledLinked {
     pub(crate) workers_linked: Vec<WorkerLinked>,
     pub(crate) http_servers_to_webhooks_and_state: HttpServersToWebhooksAndState,
     supressed_errors: Option<String>,
-    frame_files: Vec<(ComponentDigest, FrameFilesToSourceContent)>,
+    frame_files: Vec<(ComponentDigest, FrameFilesToSource)>,
 }
 
 impl ServerCompiledLinked {
@@ -2298,9 +2307,9 @@ pub(crate) async fn upsert_backtrace_sources(
     cas: &dyn concepts::cas::Cas,
     server_compiled_linked: &ServerCompiledLinked,
 ) {
-    // Persist source files so GetBacktraceSource can serve them without filesystem access.
-    // The bytes go to the content-addressed store (shared with deployment files); only the
-    // (component, frame_key) -> digest mapping lives in the DB.
+    // Persist the (component, frame_key) -> digest mapping so GetBacktraceSource can serve
+    // sources without filesystem access. WASM backtrace sources are already CAS blobs (a
+    // digest reference); inlined JS/exec sources are written to the CAS here.
     for (component_digest, frame_files) in &server_compiled_linked.frame_files {
         for (config_key, source) in frame_files {
             // Keys starting with ".../" become suffix keys (strip "...", prepend "/").
@@ -2309,12 +2318,15 @@ pub(crate) async fn upsert_backtrace_sources(
             } else {
                 (config_key.clone(), false)
             };
-            let digest = match cas.write_blob(source.as_bytes()).await {
-                Ok(digest) => digest,
-                Err(err) => {
-                    warn!("Cannot store backtrace source {config_key:?} in CAS: {err:?}");
-                    continue;
-                }
+            let digest = match source {
+                FrameSource::Digest(digest) => digest.clone(),
+                FrameSource::Content(content) => match cas.write_blob(content.as_bytes()).await {
+                    Ok(digest) => digest,
+                    Err(err) => {
+                        warn!("Cannot store backtrace source {config_key:?} in CAS: {err:?}");
+                        continue;
+                    }
+                },
             };
             if let Err(err) = conn
                 .upsert_source_mapping(component_digest, &frame_key, is_suffix, &digest)
@@ -3979,7 +3991,7 @@ struct Linked {
     webhooks_wasm_by_names: IndexMap<ConfigName, WebhookInstancesAndRoutes>,
     component_registry_ro: ComponentConfigRegistryRO,
     supressed_errors: Option<String>,
-    all_frame_files: Vec<(ComponentDigest, FrameFilesToSourceContent)>,
+    all_frame_files: Vec<(ComponentDigest, FrameFilesToSource)>,
 }
 
 #[expect(clippy::large_enum_variant)]
@@ -3987,13 +3999,13 @@ enum CompiledComponent {
     ActivityOrWorkflow {
         worker: WorkerCompiled,
         component_config: ComponentConfig,
-        frame_files: FrameFilesToSourceContent,
+        frame_files: FrameFilesToSource,
     },
     Webhook {
         webhook_name: ConfigName,
         webhook_compiled: WebhookEndpointCompiled,
         routes: Vec<WebhookRouteVerified>,
-        frame_files: FrameFilesToSourceContent,
+        frame_files: FrameFilesToSource,
     },
     ActivityStubOrExternal {
         component_config: ComponentConfig,
@@ -4140,7 +4152,7 @@ async fn compile_and_link(
                         CompiledComponent::ActivityOrWorkflow {
                             worker,
                             component_config,
-                            frame_files: FrameFilesToSourceContent::default(),
+                            frame_files: FrameFilesToSource::default(),
                         }
                     })
                 })
@@ -4355,7 +4367,7 @@ async fn compile_and_link(
     let mut component_registry = ComponentConfigRegistry::default();
     let mut workers_compiled = Vec::with_capacity(results_of_results.len());
     let mut webhooks_compiled_by_names = hashbrown::HashMap::new();
-    let mut all_frame_files: Vec<(ComponentDigest, FrameFilesToSourceContent)> = Vec::new();
+    let mut all_frame_files: Vec<(ComponentDigest, FrameFilesToSource)> = Vec::new();
     for handle in results_of_results {
         match handle?? {
             CompiledComponent::ActivityOrWorkflow {
@@ -4605,7 +4617,7 @@ fn prespawn_activity_wasm(
             Ok(CompiledComponent::ActivityOrWorkflow {
                 worker,
                 component_config,
-                frame_files: FrameFilesToSourceContent::new(),
+                frame_files: FrameFilesToSource::new(),
             })
         }
         Err(err) if suppress_linking_errors => {
@@ -4633,7 +4645,7 @@ fn prespawn_activity_js(
     activity_js: ActivityJsConfigVerified,
     engines: &Engines,
     runnable_component: RunnableComponent,
-) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSourceContent), anyhow::Error> {
+) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSource), anyhow::Error> {
     let component_id = activity_js.component_id().clone();
     assert!(component_id.component_type == ComponentType::Activity);
     let frame_files = activity_js.as_frame_sources();
@@ -4909,7 +4921,7 @@ fn prespawn_workflow_wasm(
     engines: &Engines,
     workflows_lock_extension_leeway: Duration,
     max_replay_captured_writes: usize,
-) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSourceContent), anyhow::Error> {
+) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSource), anyhow::Error> {
     let component_id = workflow.component_id().clone();
     assert!(component_id.component_type == ComponentType::Workflow);
     debug!("Instantiating workflow");
@@ -4941,7 +4953,7 @@ fn prespawn_workflow_js(
     runnable_component: RunnableComponent,
     workflows_lock_extension_leeway: Duration,
     max_replay_captured_writes: usize,
-) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSourceContent), anyhow::Error> {
+) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSource), anyhow::Error> {
     let component_id = workflow_js.component_id().clone();
     assert!(component_id.component_type == ComponentType::Workflow);
     let engine = engines.workflow_engine.clone();
@@ -5095,9 +5107,9 @@ impl WorkerCompiled {
         exec_config: ExecConfig,
         wit: String,
         logs_store_min_level: Option<LogLevel>,
-        frame_files: FrameFilesToSourceContent, // to be served by GetBacktraceSource
+        frame_files: FrameFilesToSource, // to be served by GetBacktraceSource
         wit_origin: WitOrigin,
-    ) -> (WorkerCompiled, ComponentConfig, FrameFilesToSourceContent) {
+    ) -> (WorkerCompiled, ComponentConfig, FrameFilesToSource) {
         let component = ComponentConfig {
             component_id: exec_config.component_id.clone(),
             workflow_or_activity_config: Some(ComponentConfigImportable {
@@ -5153,10 +5165,8 @@ impl WorkerCompiled {
         wit: String,
         workflows_lock_extension_leeway: Duration,
         max_replay_captured_writes: usize,
-    ) -> Result<
-        (WorkerCompiled, ComponentConfig, FrameFilesToSourceContent),
-        utils::wasm_tools::DecodeError,
-    > {
+    ) -> Result<(WorkerCompiled, ComponentConfig, FrameFilesToSource), utils::wasm_tools::DecodeError>
+    {
         let replay_compiled = WorkflowWorkerCompiled::new_with_config(
             runnable_component.clone(),
             replay_workflow_config(&workflow.workflow_config, max_replay_captured_writes),
@@ -5206,7 +5216,7 @@ impl WorkerCompiled {
         wit: String,
         js_files: std::collections::BTreeMap<String, String>,
         wit_origin: WitOrigin,
-    ) -> (WorkerCompiled, ComponentConfig, FrameFilesToSourceContent) {
+    ) -> (WorkerCompiled, ComponentConfig, FrameFilesToSource) {
         let frame_files = WorkflowJsConfigVerified::frame_sources(js_files);
         let component = ComponentConfig {
             component_id: exec_config.component_id.clone(),

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1383,13 +1383,13 @@ impl crate::config::file_provider::FileProvider for RecordingCasProvider {
         &self,
         root: &str,
         known_files: &std::collections::BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>> {
-        let files = self.inner.parse_wit_files(root, known_files).await?;
+    ) -> anyhow::Result<crate::config::file_provider::ParsedWitFiles> {
+        let parsed = self.inner.parse_wit_files(root, known_files).await?;
         let mut seen = self
             .seen
             .lock()
             .expect("RecordingCasProvider mutex poisoned");
-        for (path, source) in &files {
+        for (path, source) in &parsed.files {
             let digest = known_files
                 .get(path)
                 .expect("CAS WIT reader only returns known files");
@@ -1400,7 +1400,7 @@ impl crate::config::file_provider::FileProvider for RecordingCasProvider {
             });
         }
         drop(seen);
-        Ok(files)
+        Ok(parsed)
     }
 }
 

--- a/src/config/file_provider.rs
+++ b/src/config/file_provider.rs
@@ -7,6 +7,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{collections::BTreeMap, path::Path};
 
+#[derive(Debug)]
+pub(crate) struct ParsedWitFiles {
+    pub(crate) files: Vec<(String, String)>,
+    pub(crate) resolve: wit_parser::Resolve,
+    pub(crate) main_pkg_id: wit_parser::PackageId,
+}
+
 /// Source of deployment-owned file bytes during deployment resolution.
 ///
 /// Resolution inlines every deployment-owned script/source into the
@@ -34,23 +41,20 @@ pub(crate) trait FileProvider: Send + Sync {
         known_files: &BTreeMap<String, ContentDigest>,
     ) -> anyhow::Result<Vec<(String, String)>>;
 
-    /// Parse the WIT package rooted at `root` and return exactly the `.wit` sources
-    /// `wit-parser` selects, as `(deployment-relative path, source)`. The parser (not the
-    /// client) decides the file set, so malformed WIT is rejected and stray declarations
-    /// cannot smuggle in unused sources. `known_files` is the manifest's declared `path ->
-    /// digest` map; CAS-backed resolution materializes those blobs to parse them, the disk
-    /// provider parses the folder in place and ignores it.
+    /// Parse the WIT package rooted at `root`, retaining the resolve, main package ID, and
+    /// exactly the `.wit` sources selected as `(deployment-relative path, source)`. The parser
+    /// decides the file set, so malformed WIT is rejected and stray declarations cannot smuggle
+    /// in unused sources. `known_files` is the manifest's declared `path -> digest` map;
+    /// CAS-backed resolution materializes those blobs, while the disk provider ignores it.
     async fn parse_wit_files(
         &self,
         root: &str,
         known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>>;
+    ) -> anyhow::Result<ParsedWitFiles>;
 }
 
-/// Parse the WIT package under `deployment_dir/root` and return the `.wit` sources
-/// `wit-parser` selects, keyed by deployment-relative path. Shared by the disk provider
-/// and the CAS provider (which first materializes the declared blobs into a temp dir).
-async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<Vec<(String, String)>> {
+/// Parse the WIT package under `deployment_dir/root` and retain its resolve and selected sources.
+async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<ParsedWitFiles> {
     let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
     let deployment_dir = deployment_dir
         .canonicalize()
@@ -68,7 +72,7 @@ async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<Vec<
     ensure!(wit_root.is_dir(), "WIT path `{root}` is not a directory");
 
     let mut resolve = wit_parser::Resolve::default();
-    let (_, parsed_sources) = resolve
+    let (main_pkg_id, parsed_sources) = resolve
         .push_dir(&wit_root)
         .with_context(|| format!("cannot parse WIT directory `{root}`"))?;
     let parsed_paths: Vec<_> = parsed_sources.paths().map(Path::to_path_buf).collect();
@@ -103,7 +107,11 @@ async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<Vec<
     }
     files.sort_by(|a, b| a.0.cmp(&b.0));
     files.dedup_by(|a, b| a.0 == b.0);
-    Ok(files)
+    Ok(ParsedWitFiles {
+        files,
+        resolve,
+        main_pkg_id,
+    })
 }
 
 /// Reads from the submitter's disk, under the deployment directory.
@@ -136,7 +144,7 @@ impl FileProvider for DiskProvider {
         &self,
         root: &str,
         _known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>> {
+    ) -> anyhow::Result<ParsedWitFiles> {
         parse_wit_dir(&self.deployment_dir, root).await
     }
 }
@@ -204,7 +212,7 @@ impl FileProvider for CasFileProvider {
         &self,
         root: &str,
         known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>> {
+    ) -> anyhow::Result<ParsedWitFiles> {
         let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
         let prefix = format!("{root}/");
         // Materialize every declared blob under `root` into a temp dir, then let
@@ -238,12 +246,12 @@ impl FileProvider for CasFileProvider {
                 .with_context(|| format!("cannot stage WIT file `{path}`"))?;
         }
 
-        let files = parse_wit_dir(temp_dir.path(), &root).await?;
+        let parsed = parse_wit_dir(temp_dir.path(), &root).await?;
 
         // Reject stray declarations: a declared `.wit` file `wit-parser` did not select is
         // dead weight the deployment -> digest mapping would pin, so refuse it here.
         let selected: std::collections::BTreeSet<&str> =
-            files.iter().map(|(path, _)| path.as_str()).collect();
+            parsed.files.iter().map(|(path, _)| path.as_str()).collect();
         let stray: Vec<&str> = declared
             .iter()
             .map(|(path, _)| path.as_str())
@@ -253,7 +261,7 @@ impl FileProvider for CasFileProvider {
             stray.is_empty(),
             "WIT directory `{root}` declares {stray:?} that `wit-parser` does not select"
         );
-        Ok(files)
+        Ok(parsed)
     }
 }
 
@@ -334,8 +342,11 @@ mod tests {
         let digest = cas.insert(src.as_bytes());
         let provider = CasFileProvider { cas };
         let known = BTreeMap::from([("a/wit/impl.wit".to_string(), digest)]);
-        let files = provider.parse_wit_files("a/wit", &known).await.unwrap();
-        assert_eq!(files, vec![("a/wit/impl.wit".to_string(), src.to_string())]);
+        let parsed = provider.parse_wit_files("a/wit", &known).await.unwrap();
+        assert_eq!(
+            parsed.files,
+            vec![("a/wit/impl.wit".to_string(), src.to_string())]
+        );
     }
 
     #[tokio::test]

--- a/src/config/file_provider.rs
+++ b/src/config/file_provider.rs
@@ -21,12 +21,18 @@ pub(crate) trait FileProvider: Send + Sync {
     /// to `digest` when one is supplied.
     async fn read(&self, path: &str, digest: Option<&ContentDigest>) -> anyhow::Result<Vec<u8>>;
 
-    async fn read_js_graph(
+    /// Parse the JS module at `entry_path` and return its closed import graph: the
+    /// entry plus every transitively-imported relative module, as `(deployment-relative
+    /// path, source)`. Every relative import must resolve to a module the provider can
+    /// supply, so a manifest that under-declares its graph is rejected here rather than
+    /// failing at runtime. `known_files` is the manifest's declared `path -> digest` map;
+    /// CAS-backed resolution reads each module through it, the disk provider walks the
+    /// filesystem and ignores it. Non-JS scripts never call this.
+    async fn parse_js_graph(
         &self,
-        _entry_path: &str,
-    ) -> anyhow::Result<Option<(String, Vec<(String, String)>)>> {
-        Ok(None)
-    }
+        entry_path: &str,
+        known_files: &BTreeMap<String, ContentDigest>,
+    ) -> anyhow::Result<Vec<(String, String)>>;
 
     /// Read exactly the WIT source files selected by `wit-parser` for `root`.
     async fn read_wit_files(
@@ -52,13 +58,14 @@ impl FileProvider for DiskProvider {
         Ok(bytes)
     }
 
-    async fn read_js_graph(
+    async fn parse_js_graph(
         &self,
         entry_path: &str,
-    ) -> anyhow::Result<Option<(String, Vec<(String, String)>)>> {
+        _known_files: &BTreeMap<String, ContentDigest>,
+    ) -> anyhow::Result<Vec<(String, String)>> {
         let graph =
             crate::javascript::graph::collect_graph(&self.deployment_dir, entry_path).await?;
-        Ok(Some((graph.entry_path, graph.files.into_iter().collect())))
+        Ok(graph.files.into_iter().collect())
     }
 
     async fn read_wit_files(
@@ -133,6 +140,32 @@ pub(crate) struct CasFileProvider {
     pub(crate) cas: Arc<dyn Cas>,
 }
 
+/// Reads JS module sources from the CAS, resolving each deployment-relative path
+/// against the manifest's declared `component_files`. An import with no declared
+/// digest is rejected: it was never uploaded, so the graph is open.
+struct CasModuleReader<'a> {
+    cas: &'a Arc<dyn Cas>,
+    known_files: &'a BTreeMap<String, ContentDigest>,
+}
+
+#[async_trait::async_trait]
+impl crate::javascript::graph::ModuleSourceReader for CasModuleReader<'_> {
+    async fn read_source(&self, dep_path: &str) -> anyhow::Result<String> {
+        let digest = self.known_files.get(dep_path).with_context(|| {
+            format!(
+                "JS module `{dep_path}` is imported but not part of the deployment package \
+                 (no matching `component_files` entry)"
+            )
+        })?;
+        let bytes =
+            self.cas.read_blob(digest).await?.with_context(|| {
+                format!("blob {digest} for JS module `{dep_path}` not in the CAS")
+            })?;
+        String::from_utf8(bytes)
+            .with_context(|| format!("JS module `{dep_path}` is not valid UTF-8"))
+    }
+}
+
 #[async_trait::async_trait]
 impl FileProvider for CasFileProvider {
     async fn read(&self, path: &str, digest: Option<&ContentDigest>) -> anyhow::Result<Vec<u8>> {
@@ -143,6 +176,19 @@ impl FileProvider for CasFileProvider {
             .read_blob(digest)
             .await?
             .with_context(|| format!("blob {digest} for `{path}` not present in the CAS"))
+    }
+
+    async fn parse_js_graph(
+        &self,
+        entry_path: &str,
+        known_files: &BTreeMap<String, ContentDigest>,
+    ) -> anyhow::Result<Vec<(String, String)>> {
+        let reader = CasModuleReader {
+            cas: &self.cas,
+            known_files,
+        };
+        let graph = crate::javascript::graph::collect_graph_with(&reader, entry_path).await?;
+        Ok(graph.files.into_iter().collect())
     }
 
     async fn read_wit_files(

--- a/src/config/file_provider.rs
+++ b/src/config/file_provider.rs
@@ -34,12 +34,76 @@ pub(crate) trait FileProvider: Send + Sync {
         known_files: &BTreeMap<String, ContentDigest>,
     ) -> anyhow::Result<Vec<(String, String)>>;
 
-    /// Read exactly the WIT source files selected by `wit-parser` for `root`.
-    async fn read_wit_files(
+    /// Parse the WIT package rooted at `root` and return exactly the `.wit` sources
+    /// `wit-parser` selects, as `(deployment-relative path, source)`. The parser (not the
+    /// client) decides the file set, so malformed WIT is rejected and stray declarations
+    /// cannot smuggle in unused sources. `known_files` is the manifest's declared `path ->
+    /// digest` map; CAS-backed resolution materializes those blobs to parse them, the disk
+    /// provider parses the folder in place and ignores it.
+    async fn parse_wit_files(
         &self,
         root: &str,
         known_files: &BTreeMap<String, ContentDigest>,
     ) -> anyhow::Result<Vec<(String, String)>>;
+}
+
+/// Parse the WIT package under `deployment_dir/root` and return the `.wit` sources
+/// `wit-parser` selects, keyed by deployment-relative path. Shared by the disk provider
+/// and the CAS provider (which first materializes the declared blobs into a temp dir).
+async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<Vec<(String, String)>> {
+    let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
+    let deployment_dir = deployment_dir
+        .canonicalize()
+        .with_context(|| format!("cannot canonicalize deployment directory {deployment_dir:?}"))?;
+    let wit_root = deployment_dir.join(&root).canonicalize().with_context(|| {
+        format!(
+            "cannot canonicalize WIT directory {:?}",
+            deployment_dir.join(&root)
+        )
+    })?;
+    ensure!(
+        wit_root.starts_with(&deployment_dir),
+        "WIT directory `{root}` resolves outside the deployment directory"
+    );
+    ensure!(wit_root.is_dir(), "WIT path `{root}` is not a directory");
+
+    let mut resolve = wit_parser::Resolve::default();
+    let (_, parsed_sources) = resolve
+        .push_dir(&wit_root)
+        .with_context(|| format!("cannot parse WIT directory `{root}`"))?;
+    let parsed_paths: Vec<_> = parsed_sources.paths().map(Path::to_path_buf).collect();
+    ensure!(
+        !parsed_paths.is_empty(),
+        "WIT directory `{root}` contains no parsed files"
+    );
+
+    let mut files = Vec::with_capacity(parsed_paths.len());
+    for parsed_path in parsed_paths {
+        let canonical = parsed_path
+            .canonicalize()
+            .with_context(|| format!("cannot canonicalize parsed WIT file {parsed_path:?}"))?;
+        ensure!(
+            canonical.starts_with(&deployment_dir),
+            "parsed WIT file {parsed_path:?} resolves outside the deployment directory"
+        );
+        ensure!(
+            canonical.extension().and_then(|ext| ext.to_str()) == Some("wit"),
+            "parsed WIT source is not a .wit file: {parsed_path:?}"
+        );
+        let relative = canonical
+            .strip_prefix(&deployment_dir)
+            .expect("checked prefix");
+        let relative = path_to_deployment_string(relative)?;
+        let bytes = tokio::fs::read(&canonical)
+            .await
+            .with_context(|| format!("cannot read parsed WIT file {canonical:?}"))?;
+        let source = String::from_utf8(bytes)
+            .with_context(|| format!("WIT file {canonical:?} is not valid UTF-8"))?;
+        files.push((relative, source));
+    }
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files.dedup_by(|a, b| a.0 == b.0);
+    Ok(files)
 }
 
 /// Reads from the submitter's disk, under the deployment directory.
@@ -68,67 +132,12 @@ impl FileProvider for DiskProvider {
         Ok(graph.files.into_iter().collect())
     }
 
-    async fn read_wit_files(
+    async fn parse_wit_files(
         &self,
         root: &str,
         _known_files: &BTreeMap<String, ContentDigest>,
     ) -> anyhow::Result<Vec<(String, String)>> {
-        let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
-        let deployment_dir = self.deployment_dir.canonicalize().with_context(|| {
-            format!(
-                "cannot canonicalize deployment directory {:?}",
-                self.deployment_dir
-            )
-        })?;
-        let wit_root = deployment_dir.join(&root).canonicalize().with_context(|| {
-            format!(
-                "cannot canonicalize WIT directory {:?}",
-                deployment_dir.join(&root)
-            )
-        })?;
-        ensure!(
-            wit_root.starts_with(&deployment_dir),
-            "WIT directory `{root}` resolves outside the deployment directory"
-        );
-        ensure!(wit_root.is_dir(), "WIT path `{root}` is not a directory");
-
-        let mut resolve = wit_parser::Resolve::default();
-        let (_, parsed_sources) = resolve
-            .push_dir(&wit_root)
-            .with_context(|| format!("cannot parse WIT directory `{root}`"))?;
-        let parsed_paths: Vec<_> = parsed_sources.paths().map(Path::to_path_buf).collect();
-        ensure!(
-            !parsed_paths.is_empty(),
-            "WIT directory `{root}` contains no parsed files"
-        );
-
-        let mut files = Vec::with_capacity(parsed_paths.len());
-        for parsed_path in parsed_paths {
-            let canonical = parsed_path
-                .canonicalize()
-                .with_context(|| format!("cannot canonicalize parsed WIT file {parsed_path:?}"))?;
-            ensure!(
-                canonical.starts_with(&deployment_dir),
-                "parsed WIT file {parsed_path:?} resolves outside the deployment directory"
-            );
-            ensure!(
-                canonical.extension().and_then(|ext| ext.to_str()) == Some("wit"),
-                "parsed WIT source is not a .wit file: {parsed_path:?}"
-            );
-            let relative = canonical
-                .strip_prefix(&deployment_dir)
-                .expect("checked prefix");
-            let relative = path_to_deployment_string(relative)?;
-            let bytes = tokio::fs::read(&canonical)
-                .await
-                .with_context(|| format!("cannot read parsed WIT file {canonical:?}"))?;
-            let source = String::from_utf8(bytes)
-                .with_context(|| format!("WIT file {canonical:?} is not valid UTF-8"))?;
-            files.push((relative, source));
-        }
-        files.sort_by(|a, b| a.0.cmp(&b.0));
-        files.dedup_by(|a, b| a.0 == b.0);
-        Ok(files)
+        parse_wit_dir(&self.deployment_dir, root).await
     }
 }
 
@@ -191,33 +200,59 @@ impl FileProvider for CasFileProvider {
         Ok(graph.files.into_iter().collect())
     }
 
-    async fn read_wit_files(
+    async fn parse_wit_files(
         &self,
         root: &str,
         known_files: &BTreeMap<String, ContentDigest>,
     ) -> anyhow::Result<Vec<(String, String)>> {
         let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
         let prefix = format!("{root}/");
-        let selected: Vec<_> = known_files
+        // Materialize every declared blob under `root` into a temp dir, then let
+        // `wit-parser` decide the file set. Trusting the declared prefix instead would
+        // let a broken client smuggle garbage or unused `.wit` files past submit.
+        let declared: Vec<(String, &ContentDigest)> = known_files
             .iter()
             .filter(|(path, _)| path.starts_with(&prefix))
+            .map(|(path, digest)| (path.clone(), digest))
             .collect();
         ensure!(
-            !selected.is_empty(),
-            "CAS-backed resolution has no parser-selected WIT files for `{root}`"
+            !declared.is_empty(),
+            "CAS-backed resolution has no declared WIT files for `{root}`"
         );
-        let mut files = Vec::with_capacity(selected.len());
-        for (path, digest) in selected {
+        let temp_dir = tempfile::tempdir().context("cannot create temp dir to parse WIT")?;
+        for (path, digest) in &declared {
             let path = crate::config::toml::sanitize_deployment_relative_path(path)?;
             ensure!(
                 Path::new(&path).extension().and_then(|ext| ext.to_str()) == Some("wit"),
-                "WIT source is not a .wit file: `{path}`"
+                "declared WIT source is not a .wit file: `{path}`"
             );
+            let full = temp_dir.path().join(&path);
+            if let Some(parent) = full.parent() {
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .with_context(|| format!("cannot stage WIT file `{path}`"))?;
+            }
             let bytes = self.read(&path, Some(digest)).await?;
-            let source = String::from_utf8(bytes)
-                .with_context(|| format!("WIT file `{path}` is not valid UTF-8"))?;
-            files.push((path, source));
+            tokio::fs::write(&full, &bytes)
+                .await
+                .with_context(|| format!("cannot stage WIT file `{path}`"))?;
         }
+
+        let files = parse_wit_dir(temp_dir.path(), &root).await?;
+
+        // Reject stray declarations: a declared `.wit` file `wit-parser` did not select is
+        // dead weight the deployment -> digest mapping would pin, so refuse it here.
+        let selected: std::collections::BTreeSet<&str> =
+            files.iter().map(|(path, _)| path.as_str()).collect();
+        let stray: Vec<&str> = declared
+            .iter()
+            .map(|(path, _)| path.as_str())
+            .filter(|path| !selected.contains(path))
+            .collect();
+        ensure!(
+            stray.is_empty(),
+            "WIT directory `{root}` declares {stray:?} that `wit-parser` does not select"
+        );
         Ok(files)
     }
 }
@@ -252,4 +287,96 @@ pub(crate) fn verify_content_digest(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use concepts::cas::CasError;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn digest_of(bytes: &[u8]) -> ContentDigest {
+        ContentDigest(Digest(Sha256::digest(bytes).into()))
+    }
+
+    #[derive(Default)]
+    struct MemCas {
+        blobs: Mutex<HashMap<ContentDigest, Vec<u8>>>,
+    }
+    impl MemCas {
+        fn insert(&self, bytes: &[u8]) -> ContentDigest {
+            let digest = digest_of(bytes);
+            self.blobs
+                .lock()
+                .unwrap()
+                .insert(digest.clone(), bytes.to_vec());
+            digest
+        }
+    }
+    #[async_trait::async_trait]
+    impl Cas for MemCas {
+        async fn read_blob(&self, digest: &ContentDigest) -> Result<Option<Vec<u8>>, CasError> {
+            Ok(self.blobs.lock().unwrap().get(digest).cloned())
+        }
+        async fn write_blob(&self, content: &[u8]) -> Result<ContentDigest, CasError> {
+            Ok(self.insert(content))
+        }
+        async fn contains_blob(&self, digest: &ContentDigest) -> Result<bool, CasError> {
+            Ok(self.blobs.lock().unwrap().contains_key(digest))
+        }
+    }
+
+    #[tokio::test]
+    async fn cas_parse_wit_files_parses_a_valid_package() {
+        let cas = Arc::new(MemCas::default());
+        let src = "package any:any;\n\nworld any {}\n";
+        let digest = cas.insert(src.as_bytes());
+        let provider = CasFileProvider { cas };
+        let known = BTreeMap::from([("a/wit/impl.wit".to_string(), digest)]);
+        let files = provider.parse_wit_files("a/wit", &known).await.unwrap();
+        assert_eq!(files, vec![("a/wit/impl.wit".to_string(), src.to_string())]);
+    }
+
+    #[tokio::test]
+    async fn cas_parse_wit_files_rejects_malformed_wit() {
+        // Before parsing on the CAS path, a client could push arbitrary bytes as `.wit`.
+        let cas = Arc::new(MemCas::default());
+        let digest = cas.insert(b"this is not valid wit @@@");
+        let provider = CasFileProvider { cas };
+        let known = BTreeMap::from([("a/wit/impl.wit".to_string(), digest)]);
+        let err = provider
+            .parse_wit_files("a/wit", &known)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("cannot parse WIT directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cas_parse_wit_files_rejects_stray_declared_wit() {
+        // A declared `.wit` `wit-parser` does not select (here, one buried in a non-`deps`
+        // subdirectory) must be refused rather than silently persisted.
+        let cas = Arc::new(MemCas::default());
+        let impl_src = "package any:any;\n\nworld any {}\n";
+        let impl_digest = cas.insert(impl_src.as_bytes());
+        let stray_digest = cas.insert(b"package other:other;\n");
+        let provider = CasFileProvider { cas };
+        let known = BTreeMap::from([
+            ("a/wit/impl.wit".to_string(), impl_digest),
+            ("a/wit/notes/scratch.wit".to_string(), stray_digest),
+        ]);
+        let err = provider
+            .parse_wit_files("a/wit", &known)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("scratch.wit") && err.contains("does not select"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -1705,8 +1705,9 @@ location = "components/w.wasm"
             .await
             .unwrap();
         assert_eq!(
-            resolved.workflows_wasm[0].backtrace.frame_files_to_sources[".../src/lib.rs"].content,
-            "fn workflow() {}"
+            resolved.workflows_wasm[0].backtrace.frame_files_to_sources[".../src/lib.rs"]
+                .content_digest,
+            content_digest(b"fn workflow() {}")
         );
     }
 

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -983,7 +983,7 @@ async fn collect_wit_refs(
             continue;
         };
         let root = sanitize_deployment_relative_path(raw_root)?;
-        let parsed_files = provider
+        let parsed = provider
             .parse_wit_files(&root, &std::collections::BTreeMap::new()) // disk provider does not need a path -> digest map
             .await?;
 
@@ -1000,7 +1000,7 @@ async fn collect_wit_refs(
                 );
             }
         }
-        for (path, source) in parsed_files {
+        for (path, source) in parsed.files {
             let bytes = source.into_bytes();
             let digest = content_digest(&bytes);
             if let Some(previous) = refs.get(&path).and_then(Value::as_str) {

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -984,7 +984,7 @@ async fn collect_wit_refs(
         };
         let root = sanitize_deployment_relative_path(raw_root)?;
         let parsed_files = provider
-            .read_wit_files(&root, &std::collections::BTreeMap::new())
+            .parse_wit_files(&root, &std::collections::BTreeMap::new()) // disk provider does not need a path -> digest map
             .await?;
 
         let mut refs = InlineTable::new();

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1,6 +1,6 @@
 use super::{config_holder::PathPrefixes, env_var::EnvVarConfig};
 use crate::args::TomlComponentType;
-use crate::command::server::FrameFilesToSourceContent;
+use crate::command::server::{FrameFilesToSource, FrameSource};
 use crate::config::config_holder::{CACHE_DIR_PREFIX, DATA_DIR_PREFIX};
 use crate::config::env_var::{
     EnvVarError, EnvVarsMissing, interpolate_env_vars_plaintext, interpolate_env_vars_secret,
@@ -1777,8 +1777,12 @@ impl ActivityJsConfigVerified {
         &self.activity_config.component_id
     }
 
-    pub(crate) fn as_frame_sources(&self) -> FrameFilesToSourceContent {
-        self.js_files.clone().into_iter().collect()
+    pub(crate) fn as_frame_sources(&self) -> FrameFilesToSource {
+        self.js_files
+            .clone()
+            .into_iter()
+            .map(|(name, content)| (name, FrameSource::Content(content)))
+            .collect()
     }
 }
 
@@ -2120,8 +2124,11 @@ impl WorkflowJsConfigVerified {
         &self.workflow_config.component_id
     }
 
-    pub(crate) fn frame_sources(js_files: BTreeMap<String, String>) -> FrameFilesToSourceContent {
-        js_files.into_iter().collect()
+    pub(crate) fn frame_sources(js_files: BTreeMap<String, String>) -> FrameFilesToSource {
+        js_files
+            .into_iter()
+            .map(|(name, content)| (name, FrameSource::Content(content)))
+            .collect()
     }
 }
 
@@ -2356,7 +2363,7 @@ pub(crate) struct WorkflowConfigVerified {
     pub(crate) wasm_path: PathBuf,
     pub(crate) workflow_config: WorkflowConfig,
     pub(crate) exec_config: executor::executor::ExecConfig,
-    pub(crate) frame_files_to_sources: FrameFilesToSourceContent,
+    pub(crate) frame_files_to_sources: FrameFilesToSource,
     pub(crate) logs_store_min_level: Option<LogLevel>,
     pub(crate) lock_extension_leeway: Duration,
 }
@@ -2548,7 +2555,12 @@ impl WorkflowWasmComponentConfigResolvedExt for WorkflowWasmComponentConfigResol
                 response_refresh_interval,
             },
         };
-        let frame_files_to_sources = self.backtrace.into_frame_files();
+        let frame_files_to_sources: FrameFilesToSource = self
+            .backtrace
+            .into_frame_files()
+            .into_iter()
+            .map(|(name, digest)| (name, FrameSource::Digest(digest)))
+            .collect();
         let retry_config = ComponentRetryConfig {
             max_retries: None,
             retry_exp_backoff,
@@ -2945,14 +2957,20 @@ async fn resolve_function_interface(
 /// `file_name` and refuses to clobber. Identical re-uses of a name are allowed (they dedupe
 /// to a single file). This surfaces the failure at submit time rather than on a later round-trip.
 fn validate_owned_source_file_names(resolved: &DeploymentResolved) -> anyhow::Result<()> {
+    // Compare by content digest: scripts carry inline content (hashed here), backtrace
+    // sources already carry their CAS digest. Differing digests at the same `file_name` are
+    // the collision `deployment get` cannot round-trip.
+    fn digest_of(content: &str) -> ContentDigest {
+        ContentDigest(Digest(Sha256::digest(content.as_bytes()).into()))
+    }
     fn register<'a>(
-        seen: &mut HashMap<&'a str, &'a str>,
+        seen: &mut HashMap<&'a str, ContentDigest>,
         file_name: &'a str,
-        content: &'a str,
+        digest: &ContentDigest,
     ) -> anyhow::Result<()> {
-        if let Some(existing) = seen.insert(file_name, content) {
+        if let Some(existing) = seen.insert(file_name, digest.clone()) {
             ensure!(
-                existing == content,
+                existing == *digest,
                 "two deployment-owned source files would be written to `{file_name}`; rename \
                  one of the colliding scripts or backtrace sources so the deployment can be \
                  retrieved with `deployment get`"
@@ -2961,7 +2979,7 @@ fn validate_owned_source_file_names(resolved: &DeploymentResolved) -> anyhow::Re
         Ok(())
     }
 
-    let mut seen: HashMap<&str, &str> = HashMap::new();
+    let mut seen: HashMap<&str, ContentDigest> = HashMap::new();
 
     let script_locations = resolved
         .activities_js
@@ -2973,11 +2991,11 @@ fn validate_owned_source_file_names(resolved: &DeploymentResolved) -> anyhow::Re
     for loc in script_locations {
         match loc {
             ScriptLocationResolved::Content { content, file_name } => {
-                register(&mut seen, file_name, content)?;
+                register(&mut seen, file_name, &digest_of(content))?;
             }
             ScriptLocationResolved::Graph { files, .. } => {
                 for (file_name, content) in files {
-                    register(&mut seen, file_name, content)?;
+                    register(&mut seen, file_name, &digest_of(content))?;
                 }
             }
             ScriptLocationResolved::Oci { .. } => {}
@@ -2991,7 +3009,7 @@ fn validate_owned_source_file_names(resolved: &DeploymentResolved) -> anyhow::Re
         .chain(resolved.webhooks_wasm.iter().map(|c| &c.backtrace));
     for bt in backtraces {
         for source in bt.frame_files_to_sources.values() {
-            register(&mut seen, &source.file_name, &source.content)?;
+            register(&mut seen, &source.file_name, &source.content_digest)?;
         }
     }
     Ok(())
@@ -3190,25 +3208,34 @@ async fn resolve_backtrace(
         };
         // backcompat: 0.41 processed manifests stored the digest beside each source path.
         // Remove `source.content_digest()` in 0.42 as clients must supply the content_digest in `component_files`.
-        let content_digest = component_files
+        // The bytes are uploaded to the CAS with the deployment files, so a known digest is a
+        // complete reference. An authored manifest with no pinned digest (disk resolution)
+        // falls back to reading the file once to hash it.
+        let content_digest = if let Some(digest) = component_files
             .get(&file_name)
-            .or_else(|| source.content_digest());
-        let content = provider
-            .read(&file_name, content_digest)
-            .await
-            .and_then(|bytes| {
-                String::from_utf8(bytes)
-                    .with_context(|| format!("backtrace source {file_name:?} is not valid UTF-8"))
-            });
-        match content {
-            Ok(content) => {
-                frame_files_to_sources
-                    .insert(key.clone(), BacktraceSourceResolved { content, file_name });
+            .or_else(|| source.content_digest())
+        {
+            digest.clone()
+        } else {
+            // Reached only on the `server run -d` raw-resolution path, where `provider` is a
+            // `DiskProvider`: this is a disk read, never a CAS read (the RPC/DB path always
+            // has a populated `component_files`). Removed once both paths resolve the
+            // processed manifest from the CAS: see meta/designs/cas-first-deployment-pipeline.md.
+            match provider.read(&file_name, None).await {
+                Ok(bytes) => ContentDigest(Digest(Sha256::digest(&bytes).into())),
+                Err(err) => {
+                    warn!("Cannot read backtrace source {file_name:?} - {err:?}");
+                    continue;
+                }
             }
-            Err(err) => {
-                warn!("Cannot read backtrace source {file_name:?} - {err:?}");
-            }
-        }
+        };
+        frame_files_to_sources.insert(
+            key.clone(),
+            BacktraceSourceResolved {
+                content_digest,
+                file_name,
+            },
+        );
     }
     Ok(ComponentBacktraceConfigResolved {
         frame_files_to_sources,
@@ -3494,7 +3521,7 @@ pub(crate) mod webhook {
         resolve_allowed_hosts, resolve_env_vars_plaintext, restricted_secret_registry,
         validate_no_env_collision,
     };
-    use crate::command::server::FrameFilesToSourceContent;
+    use crate::command::server::{FrameFilesToSource, FrameSource};
     use crate::config::secret_registry::SecretRegistry;
     use crate::config::{env_var::EnvVarConfig, toml::LogLevelToml};
     use anyhow::Context;
@@ -3572,7 +3599,7 @@ pub(crate) mod webhook {
         pub(crate) forward_stdout: Option<StdOutputConfig>,
         pub(crate) forward_stderr: Option<StdOutputConfig>,
         pub(crate) env_vars: Arc<[EnvVar]>,
-        pub(crate) frame_files_to_sources: FrameFilesToSourceContent,
+        pub(crate) frame_files_to_sources: FrameFilesToSource,
         pub(crate) backtrace_persist: bool,
         pub(crate) subscription_interruption: Option<Duration>,
         pub(crate) logs_store_min_level: Option<LogLevel>,
@@ -3674,8 +3701,12 @@ pub(crate) mod webhook {
     }
 
     impl WebhookJsConfigVerified {
-        pub(crate) fn as_frame_sources(&self) -> FrameFilesToSourceContent {
-            self.js_files.clone().into_iter().collect()
+        pub(crate) fn as_frame_sources(&self) -> FrameFilesToSource {
+            self.js_files
+                .clone()
+                .into_iter()
+                .map(|(name, content)| (name, FrameSource::Content(content)))
+                .collect()
         }
     }
 
@@ -3708,7 +3739,12 @@ pub(crate) mod webhook {
                 expected_content_digest.as_ref(),
                 &common.location.to_string(),
             )?;
-            let frame_files_to_sources = self.backtrace.into_frame_files();
+            let frame_files_to_sources: FrameFilesToSource = self
+                .backtrace
+                .into_frame_files()
+                .into_iter()
+                .map(|(name, digest)| (name, FrameSource::Digest(digest)))
+                .collect();
             let component_id = ComponentId::new(
                 ComponentType::WebhookEndpoint,
                 StrVariant::from(common.name.clone()),
@@ -5238,7 +5274,10 @@ name = "my_stub"
                 .frame_files_to_sources
                 .get(".../src/lib.rs")
                 .unwrap();
-            assert_eq!(src.content, "SRC");
+            assert_eq!(
+                src.content_digest,
+                ContentDigest(Digest(Sha256::digest(b"SRC").into()))
+            );
             assert_eq!(src.file_name, "crates/foo/src/lib.rs");
         }
 
@@ -5266,7 +5305,10 @@ name = "my_stub"
                 .frame_files_to_sources
                 .get(".../src/lib.rs")
                 .unwrap();
-            assert_eq!(src.content, "SRC");
+            assert_eq!(
+                src.content_digest,
+                ContentDigest(Digest(Sha256::digest(b"SRC").into()))
+            );
             assert_eq!(src.file_name, "crates/foo/src/lib.rs");
         }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -3104,6 +3104,8 @@ async fn resolve_script_toml(
                 // Ensure the entry is in it (an entry-only manifest declares none), then walk
                 // the import graph and require it be fully contained: an import missing from
                 // the package is rejected here rather than trapping at runtime.
+                let declared: std::collections::BTreeSet<String> =
+                    component_files.keys().cloned().collect();
                 let mut known = component_files;
                 match (known.get(&path), content_digest) {
                     (Some(entry_digest), Some(expected)) => ensure!(
@@ -3121,6 +3123,22 @@ async fn resolve_script_toml(
                     .find_map(|(module_path, source)| (module_path == &path).then_some(source))
                     .context("parsed JS graph does not contain its entry")?;
                 verify_content_digest(entry_source.as_bytes(), content_digest, &path)?;
+                // Reject stray declared files: every `component_files` entry must be reachable
+                // from the entry's imports, so the stored file set is exactly what runs and the
+                // deployment -> digest mapping the orphan GC relies on carries no dead blobs.
+                let reached: std::collections::BTreeSet<&str> = files
+                    .iter()
+                    .map(|(module_path, _)| module_path.as_str())
+                    .collect();
+                let stray: Vec<&str> = declared
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|declared_path| !reached.contains(declared_path))
+                    .collect();
+                ensure!(
+                    stray.is_empty(),
+                    "component_files for `{path}` declares {stray:?} that its module graph does not import"
+                );
                 if files.len() > 1 {
                     return Ok(ScriptLocationResolved::Graph {
                         entry_path: path,

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -3100,41 +3100,32 @@ async fn resolve_script_toml(
             let path = strip_deployment_dir_prefix(&path).unwrap_or(&path);
             let path = sanitize_deployment_relative_path(path)?;
             if let ModuleGraphResolution::JavaScript(component_files) = module_graph {
-                if !component_files.is_empty() {
-                    let entry_digest = component_files.get(&path).with_context(|| {
-                        format!("component_files for `{path}` does not contain the entry path")
-                    })?;
-                    if let Some(expected) = content_digest {
-                        ensure!(
-                            expected == entry_digest,
-                            "content_digest for `{path}` does not match its component_files digest"
-                        );
+                // `component_files` is the manifest's declared closure (`path -> digest`).
+                // Ensure the entry is in it (an entry-only manifest declares none), then walk
+                // the import graph and require it be fully contained: an import missing from
+                // the package is rejected here rather than trapping at runtime.
+                let mut known = component_files;
+                match (known.get(&path), content_digest) {
+                    (Some(entry_digest), Some(expected)) => ensure!(
+                        expected == entry_digest,
+                        "content_digest for `{path}` does not match its component_files digest"
+                    ),
+                    (None, Some(cd)) => {
+                        known.insert(path.clone(), cd.clone());
                     }
-                    let mut files = Vec::with_capacity(component_files.len());
-                    for (module_path, digest) in component_files {
-                        let module_path = sanitize_deployment_relative_path(&module_path)?;
-                        let bytes = provider.read(&module_path, Some(&digest)).await?;
-                        let source = String::from_utf8(bytes).with_context(|| {
-                            format!("script file {module_path:?} is not valid UTF-8")
-                        })?;
-                        files.push((module_path, source));
-                    }
+                    _ => {}
+                }
+                let files = provider.parse_js_graph(&path, &known).await?;
+                let entry_source = files
+                    .iter()
+                    .find_map(|(module_path, source)| (module_path == &path).then_some(source))
+                    .context("parsed JS graph does not contain its entry")?;
+                verify_content_digest(entry_source.as_bytes(), content_digest, &path)?;
+                if files.len() > 1 {
                     return Ok(ScriptLocationResolved::Graph {
                         entry_path: path,
                         files,
                     });
-                }
-                if let Some((entry_path, files)) = provider.read_js_graph(&path).await? {
-                    let entry_source = files
-                        .iter()
-                        .find_map(|(module_path, source)| {
-                            (module_path == &entry_path).then_some(source)
-                        })
-                        .context("collected JS graph does not contain its entry")?;
-                    verify_content_digest(entry_source.as_bytes(), content_digest, &entry_path)?;
-                    if files.len() > 1 {
-                        return Ok(ScriptLocationResolved::Graph { entry_path, files });
-                    }
                 }
             }
             let content = provider.read(&path, content_digest).await?;

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1378,20 +1378,14 @@ fn verify_function_interface(
             })
         }
         FunctionInterfaceResolved::Authored { wit } => {
-            let temporary = tempfile::tempdir().context("cannot create temporary WIT directory")?;
-            for (path, source) in &wit.files {
-                let path = sanitize_deployment_relative_path(path)?;
-                let destination = temporary.path().join(path);
-                let parent = destination.parent().expect("WIT path has a parent");
-                std::fs::create_dir_all(parent)?;
-                std::fs::write(&destination, source)?;
-            }
-            let root = sanitize_deployment_relative_path(&wit.root)?;
-            let component = WasmComponent::new_from_wit_folder_for_ffqn(
-                temporary.path().join(root),
+            let root = wit.root;
+            let component = WasmComponent::new_from_wit_resolve_for_ffqn(
+                wit.resolve,
+                wit.main_pkg_id,
                 component_type,
                 ffqn,
-            )?;
+            )
+            .with_context(|| format!("cannot verify authored WIT directory `{root}`"))?;
             let exports = component.exported_functions(false);
             ensure!(
                 exports.len() == 1 && exports[0].ffqn == *ffqn,
@@ -2931,9 +2925,10 @@ async fn resolve_function_interface(
         }
     };
     let root = sanitize_deployment_relative_path(&root)?;
-    let files = provider.parse_wit_files(&root, component_files).await?;
+    // TODO: Cache parsed WIT packages by root during deployment resolution.
+    let parsed = provider.parse_wit_files(&root, component_files).await?;
     let prefix = format!("{root}/");
-    for (path, _) in &files {
+    for (path, _) in &parsed.files {
         ensure!(
             path.starts_with(&prefix),
             "parsed WIT file `{path}` is outside configured WIT directory `{root}`"
@@ -2941,7 +2936,11 @@ async fn resolve_function_interface(
         component_files.remove(path);
     }
     Ok(FunctionInterfaceResolved::Authored {
-        wit: WitSourceResolved { root, files },
+        wit: Box::new(WitSourceResolved {
+            root,
+            resolve: parsed.resolve,
+            main_pkg_id: parsed.main_pkg_id,
+        }),
     })
 }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1927,13 +1927,10 @@ impl ActivityExecComponentConfigResolvedExt for ActivityExecComponentConfigResol
                 bail!("activity_exec does not support module graphs")
             }
             ScriptLocationResolved::Oci { image } => {
-                let oci_ref = oci_client::Reference::from_str(image)
-                    .map_err(|e| anyhow!("invalid OCI reference `{image}`: {e}"))?;
                 tokio::fs::create_dir_all(&exec_cache_dir).await?;
                 let metadata_dir = wasm_cache_metadata_dir(wasm_cache_dir);
                 let result =
-                    crate::oci::pull_exec_to_cache(&oci_ref, &exec_cache_dir, &metadata_dir)
-                        .await?;
+                    crate::oci::pull_exec_to_cache(image, &exec_cache_dir, &metadata_dir).await?;
                 if let Some(expected) = self.content_digest.as_ref() {
                     let actual = utils::sha256sum::calculate_sha256_file(&result.exec_path).await?;
                     ensure!(
@@ -2316,8 +2313,6 @@ impl JsLocationResolvedExt for ScriptLocationResolved {
                 files: files.iter().cloned().collect(),
             }),
             ScriptLocationResolved::Oci { image } => {
-                let oci_ref = oci_client::Reference::from_str(image)
-                    .map_err(|e| anyhow::anyhow!("invalid OCI reference in resolved form: {e}"))?;
                 let js_cache_dir = wasm_cache_dir.join("js");
                 tokio::fs::create_dir_all(&js_cache_dir)
                     .await
@@ -2331,7 +2326,7 @@ impl JsLocationResolvedExt for ScriptLocationResolved {
                         format!("cannot create metadata directory {metadata_dir:?}")
                     })?;
                 let crate::oci::JsCacheResult { js_path, .. } =
-                    crate::oci::pull_js_to_cache(&oci_ref, &js_cache_dir, &metadata_dir)
+                    crate::oci::pull_js_to_cache(image, &js_cache_dir, &metadata_dir)
                         .await
                         .with_context(|| format!("cannot pull JS from OCI: {image}"))?;
                 if let Some(expected) = expected_digest {
@@ -3179,9 +3174,7 @@ async fn resolve_script_toml(
                     "OCI scripts cannot set `component_files`"
                 );
             }
-            Ok(ScriptLocationResolved::Oci {
-                image: reference.to_string(),
-            })
+            Ok(ScriptLocationResolved::Oci { image: reference })
         }
         (None, None) | (Some(_), Some(_)) => {
             bail!("exactly one of `location` or `content` must be set for script components")
@@ -4842,7 +4835,7 @@ name = "my_stub"
             );
             let oci = exec_config_with_source(
                 ScriptLocationResolved::Oci {
-                    image: "registry.example.com/ns/exec:latest".into(),
+                    image: "registry.example.com/ns/exec:latest".parse().unwrap(),
                 },
                 None,
             );
@@ -5069,7 +5062,7 @@ name = "my_stub"
             assert_matches::assert_matches!(
                 location,
                 ScriptLocationResolved::Oci { image }
-                    if image == "docker.io/library/example:latest"
+                    if image.to_string() == "docker.io/library/example:latest"
             );
         }
 

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1106,7 +1106,7 @@ impl HasOptionalNameAndFfqn for ActivityStubExtInlineConfigToml {
 
 /// Location of a JavaScript source file.
 /// Supports local file paths and OCI registry references (`oci://...`).
-/// On-disk format only; replaced by [`ScriptLocationResolved`] before transmission and hash computation.
+/// On-disk format only; replaced by [`ScriptLocationResolved`] before hash computation.
 #[derive(Debug, Clone, Hash, JsonSchema, SerializeDisplay, DeserializeFromStr)]
 #[schemars(with = "String")]
 pub(crate) enum JsLocationToml {
@@ -2203,7 +2203,7 @@ impl BlockingStrategyConfigTomlExt for BlockingStrategyConfigToml {
 #[serde(deny_unknown_fields)]
 pub(crate) struct ComponentBacktraceConfig {
     /// Maps a frame-symbol key to a backtrace source file path. On-disk format only;
-    /// resolved to `ComponentBacktraceConfigResolved` before transmission and hash
+    /// resolved to `ComponentBacktraceConfigResolved` before hash
     /// computation. A relative path is deployment-dir-relative (a leading
     /// `${DEPLOYMENT_DIR}/` is accepted for backcompat); absolute paths are rejected.
     #[serde(rename = "sources")]

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -2924,7 +2924,7 @@ async fn resolve_function_interface(
         }
     };
     let root = sanitize_deployment_relative_path(&root)?;
-    let files = provider.read_wit_files(&root, component_files).await?;
+    let files = provider.parse_wit_files(&root, component_files).await?;
     let prefix = format!("{root}/");
     for (path, _) in &files {
         ensure!(

--- a/src/javascript/graph.rs
+++ b/src/javascript/graph.rs
@@ -13,6 +13,31 @@ use boa_engine::Source;
 use std::collections::{BTreeMap, VecDeque};
 use std::path::{Component, Path, PathBuf};
 
+/// Reads a JS module's source by its deployment-relative path (forward slashes).
+///
+/// Lets the graph walker be driven from either the submitter's disk
+/// ([`DiskModuleReader`]) or the content-addressed store (a CAS-backed reader),
+/// so the same closure check runs client-side and server-side.
+#[async_trait::async_trait]
+pub(crate) trait ModuleSourceReader: Send + Sync {
+    async fn read_source(&self, dep_path: &str) -> anyhow::Result<String>;
+}
+
+/// Reads module sources from the submitter's disk, under `deployment_dir`.
+struct DiskModuleReader<'a> {
+    deployment_dir: &'a Path,
+}
+
+#[async_trait::async_trait]
+impl ModuleSourceReader for DiskModuleReader<'_> {
+    async fn read_source(&self, dep_path: &str) -> anyhow::Result<String> {
+        let path = self.deployment_dir.join(dep_path);
+        tokio::fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("cannot read JS file {path:?}"))
+    }
+}
+
 /// A closed multi-file JS module graph.
 ///
 /// `entry_path` is one of the keys in `files`. Every relative `import` in the
@@ -38,6 +63,15 @@ pub(crate) async fn collect_graph(
     deployment_dir: &Path,
     entry_rel: &str,
 ) -> anyhow::Result<JsGraph> {
+    collect_graph_with(&DiskModuleReader { deployment_dir }, entry_rel).await
+}
+
+/// Walk the module graph starting from `entry_rel`, reading each reachable file
+/// through `reader`. See [`collect_graph`]; this is the provider-agnostic core.
+pub(crate) async fn collect_graph_with(
+    reader: &dyn ModuleSourceReader,
+    entry_rel: &str,
+) -> anyhow::Result<JsGraph> {
     let entry_key = sanitize_deployment_relative_path(entry_rel)?;
     reject_typescript(&entry_key)?;
 
@@ -50,13 +84,13 @@ pub(crate) async fn collect_graph(
             // Cycle: an earlier walk path already pulled this file in.
             continue;
         }
-        let path = deployment_dir.join(&key);
-        let source = tokio::fs::read_to_string(&path)
+        let source = reader
+            .read_source(&key)
             .await
-            .with_context(|| format!("cannot read JS file {path:?}"))?;
+            .with_context(|| format!("cannot read JS module `{key}`"))?;
 
         let specifiers = extract_module_specifiers(&source)
-            .with_context(|| format!("parse error in {path:?}"))?;
+            .with_context(|| format!("parse error in `{key}`"))?;
 
         let importer_dir = Path::new(&key).parent().map(Path::to_path_buf);
 

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -1865,7 +1865,7 @@ impl grpc_gen::deployment_repository_server::DeploymentRepository for GrpcServer
             supplied_files,
             self.db_pool.clone(),
             &mut termination_watcher,
-            Some(self.deployment_switch_manager.clone()),
+            self.deployment_switch_manager.clone(),
         ))
         .await;
         let deployment_id = match result {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -3846,7 +3846,7 @@ mod deployment {
             inputs.files,
             state.db_pool.clone(),
             &mut termination_watcher,
-            Some(state.deployment_switch_manager.clone()),
+            state.deployment_switch_manager.clone(),
         ))
         .await;
 


### PR DESCRIPTION
- **test: Reject deployments if JS contains invalid FFQN**
- **fix(deployment): reject JS components importing files missing from the package**
- **fix(deployment): reject stray declared component_files a graph never imports**
- **fix(deployment): parse WIT on the CAS submit path instead of trusting the client**
- **fix(deployment): reclaim orphan blobs when a submit is rejected**
- **refactor: Remove init-only optional `DeploymentSwitchManagerHandle`**
- **refactor(deployment): guard the orphan sweep on serialized submits**
- **refactor: Remove stray `Serialize` and comments around `DeploymentResolved`**
- **style: Formatting**
- **refactor(deployment): carry backtrace sources as CAS digests**
- **refactor(db): drop redundant insert_deployment DB API**
- **docs(deployment-config): explain why resolved OCI image stays a String**
- **refactor(deployment): retain parsed OCI script references**
- **refactor(deployment): retain parsed WIT resolves**
