### PR TITLE
refactor: Unify deployment pipeline with a single CAS path

### DIFF
--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -101,7 +101,7 @@
             },
             {
               "name": "--skip-db",
-              "help": "Skip opening the sqlite database and validating its schema"
+              "help": "Skip opening the sqlite database and validating its schema. Requires `--deployment`, since with no database there is no active deployment to fall back to"
             },
             {
               "name": "--fix",

--- a/assets/schemas/toml/deployment.json
+++ b/assets/schemas/toml/deployment.json
@@ -601,7 +601,7 @@
           "description": "Location of the JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).",
           "anyOf": [
             {
-              "$ref": "#/$defs/JsLocationToml"
+              "$ref": "#/$defs/ScriptLocationPathOrOci"
             },
             {
               "type": "null"
@@ -702,7 +702,7 @@
         }
       ]
     },
-    "JsLocationToml": {
+    "ScriptLocationPathOrOci": {
       "description": "Location of a JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).\nOn-disk format only; replaced by [`ScriptLocationResolved`] before hash computation.",
       "type": "string"
     },
@@ -725,7 +725,7 @@
           "description": "Location of the exec script.\nSupports local file paths and OCI registry references (`oci://...`).",
           "anyOf": [
             {
-              "$ref": "#/$defs/JsLocationToml"
+              "$ref": "#/$defs/ScriptLocationPathOrOci"
             },
             {
               "type": "null"
@@ -993,7 +993,7 @@
           "description": "Location of the JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).",
           "anyOf": [
             {
-              "$ref": "#/$defs/JsLocationToml"
+              "$ref": "#/$defs/ScriptLocationPathOrOci"
             },
             {
               "type": "null"
@@ -1191,7 +1191,7 @@
           "description": "Location of the JavaScript source file.\nSupports local file paths and OCI registry references (`oci://...`).",
           "anyOf": [
             {
-              "$ref": "#/$defs/JsLocationToml"
+              "$ref": "#/$defs/ScriptLocationPathOrOci"
             },
             {
               "type": "null"

--- a/crates/concepts/src/cas.rs
+++ b/crates/concepts/src/cas.rs
@@ -1,5 +1,15 @@
 use crate::ContentDigest;
+use crate::component_id::Digest;
 use async_trait::async_trait;
+use sha2::{Digest as _, Sha256};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Content digest of `content`, the address every `Cas` keys blobs by.
+#[must_use]
+pub fn content_digest(content: &[u8]) -> ContentDigest {
+    ContentDigest(Digest(Sha256::digest(content).into()))
+}
 
 /// Content-addressed blob store for deployment files (scripts, WASM, backtrace
 /// sources), addressed purely by content digest.
@@ -18,6 +28,34 @@ pub trait Cas: Send + Sync {
 
     /// Whether a blob is present, without fetching its bytes.
     async fn contains_blob(&self, digest: &ContentDigest) -> Result<bool, CasError>;
+}
+
+/// A `Cas` that keeps blobs in a `HashMap`, for offline deployment verification
+/// and tests. Follows the same content-addressed contract as the persistent
+/// implementations: `write_blob` computes and returns the digest of the content.
+#[derive(Default)]
+pub struct InMemoryCas {
+    blobs: Mutex<HashMap<ContentDigest, Vec<u8>>>,
+}
+
+#[async_trait]
+impl Cas for InMemoryCas {
+    async fn read_blob(&self, digest: &ContentDigest) -> Result<Option<Vec<u8>>, CasError> {
+        Ok(self.blobs.lock().unwrap().get(digest).cloned())
+    }
+
+    async fn write_blob(&self, content: &[u8]) -> Result<ContentDigest, CasError> {
+        let digest = content_digest(content);
+        self.blobs
+            .lock()
+            .unwrap()
+            .insert(digest.clone(), content.to_vec());
+        Ok(digest)
+    }
+
+    async fn contains_blob(&self, digest: &ContentDigest) -> Result<bool, CasError> {
+        Ok(self.blobs.lock().unwrap().contains_key(digest))
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -468,8 +468,9 @@ pub(crate) struct VerifyArgs {
     /// Do not fail when a component's imports/exports fail type checking against the deployment.
     #[arg(long)]
     pub(crate) suppress_type_checking_errors: bool,
-    /// Skip opening the sqlite database and validating its schema.
-    #[arg(long)]
+    /// Skip opening the sqlite database and validating its schema. Requires `--deployment`,
+    /// since with no database there is no active deployment to fall back to.
+    #[arg(long, requires = "deployment")]
     pub(crate) skip_db: bool,
     /// Clean generated deployment metadata and, when `--server-config` is passed, fix its exec allowlist and add missing secret scaffolds.
     #[arg(long, requires = "deployment")]

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -11,7 +11,7 @@ use crate::config::toml::ConfigName;
 use crate::config::toml::DeploymentTomlValidated;
 use crate::config::toml::DurationConfig;
 use crate::config::toml::FunctionInterfaceToml;
-use crate::config::toml::JsLocationToml;
+use crate::config::toml::ScriptLocationPathOrOci;
 use crate::config::toml::OCI_SCHEMA_PREFIX;
 use crate::config::wasm_cache_metadata_dir;
 use crate::oci;
@@ -164,9 +164,9 @@ fn find_component_for_push(
                 .expect("name is in map so it must be in the list");
             let source = match (&cfg.location, &cfg.content) {
                 (None, Some(content)) => content.clone(),
-                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                (Some(ScriptLocationPathOrOci::Path(path)), None) => std::fs::read_to_string(path)
                     .with_context(|| format!("cannot read JS file {path:?}"))?,
-                (Some(JsLocationToml::Oci(_)), None) => {
+                (Some(ScriptLocationPathOrOci::Oci(_)), None) => {
                     bail!(
                         "component '{name}' uses OCI source, only local sources are supported for push"
                     );
@@ -196,9 +196,9 @@ fn find_component_for_push(
                 .expect("name is in map so it must be in the list");
             let source = match (&cfg.location, &cfg.content) {
                 (None, Some(content)) => content.clone(),
-                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                (Some(ScriptLocationPathOrOci::Path(path)), None) => std::fs::read_to_string(path)
                     .with_context(|| format!("cannot read JS file {path:?}"))?,
-                (Some(JsLocationToml::Oci(_)), None) => {
+                (Some(ScriptLocationPathOrOci::Oci(_)), None) => {
                     bail!(
                         "component '{name}' uses OCI source, only local sources are supported for push"
                     );
@@ -226,9 +226,9 @@ fn find_component_for_push(
                 .expect("name is in map so it must be in the list");
             let source = match (&cfg.location, &cfg.content) {
                 (None, Some(content)) => content.clone(),
-                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                (Some(ScriptLocationPathOrOci::Path(path)), None) => std::fs::read_to_string(path)
                     .with_context(|| format!("cannot read JS file {path:?}"))?,
-                (Some(JsLocationToml::Oci(_)), None) => {
+                (Some(ScriptLocationPathOrOci::Oci(_)), None) => {
                     bail!(
                         "component '{name}' uses OCI source, only local sources are supported for push"
                     );
@@ -253,9 +253,9 @@ fn find_component_for_push(
                 .expect("name is in map so it must be in the list");
             let script = match (&cfg.location, &cfg.content) {
                 (None, Some(content)) => content.clone(),
-                (Some(JsLocationToml::Path(path)), None) => std::fs::read_to_string(path)
+                (Some(ScriptLocationPathOrOci::Path(path)), None) => std::fs::read_to_string(path)
                     .with_context(|| format!("cannot read exec file {path:?}"))?,
-                (Some(JsLocationToml::Oci(_)), None) => {
+                (Some(ScriptLocationPathOrOci::Oci(_)), None) => {
                     bail!(
                         "component '{name}' uses OCI source, only local sources are supported for push"
                     );
@@ -998,7 +998,7 @@ mod tests {
             act.name.as_ref().expect("name set").to_string(),
             "my_exec_activity"
         );
-        assert!(matches!(act.location, Some(JsLocationToml::Oci(_))));
+        assert!(matches!(act.location, Some(ScriptLocationPathOrOci::Oci(_))));
         assert!(act.content.is_none());
         assert_eq!(act.content_digest, Some(content_digest));
         assert_eq!(act.ffqn.to_string(), "my-pkg:my-iface/my-ifc.my-fn");

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -11,8 +11,8 @@ use crate::config::toml::ConfigName;
 use crate::config::toml::DeploymentTomlValidated;
 use crate::config::toml::DurationConfig;
 use crate::config::toml::FunctionInterfaceToml;
-use crate::config::toml::ScriptLocationPathOrOci;
 use crate::config::toml::OCI_SCHEMA_PREFIX;
+use crate::config::toml::ScriptLocationPathOrOci;
 use crate::config::wasm_cache_metadata_dir;
 use crate::oci;
 use crate::oci::ComponentMetadataAnnotation;
@@ -998,7 +998,10 @@ mod tests {
             act.name.as_ref().expect("name set").to_string(),
             "my_exec_activity"
         );
-        assert!(matches!(act.location, Some(ScriptLocationPathOrOci::Oci(_))));
+        assert!(matches!(
+            act.location,
+            Some(ScriptLocationPathOrOci::Oci(_))
+        ));
         assert!(act.content.is_none());
         assert_eq!(act.content_digest, Some(content_digest));
         assert_eq!(act.ffqn.to_string(), "my-pkg:my-iface/my-ifc.my-fn");

--- a/src/command/generate.rs
+++ b/src/command/generate.rs
@@ -6,16 +6,15 @@ use crate::command::server::{
 };
 use crate::command::termination_notifier::termination_notifier;
 use crate::config::config_holder::{
-    ConfigHolder, OBELISK_HELP_DEPLOYMENT_TOML, load_deployment_validated, server_config_template,
+    ConfigHolder, OBELISK_HELP_DEPLOYMENT_TOML, server_config_template,
 };
+use crate::config::manifest::{prepare_deployment_manifest, resolve_manifest};
 use crate::config::secret_registry::SecretRegistry;
-use crate::config::toml::{
-    ActivityExternalComponentConfigToml, ActivityStubComponentConfigToml, ComponentLocationToml,
-    DeploymentTomlValidated, JsLocationToml, ServerConfigToml,
-};
+use crate::config::toml::{OCI_SCHEMA_PREFIX, ServerConfigToml};
 use crate::init::{self};
 use crate::project_dirs;
-use anyhow::Context;
+use anyhow::{Context, ensure};
+use concepts::cas::{Cas, InMemoryCas};
 use concepts::{ComponentType, ExecutionId, PackageIfcFns, PkgFqn, prefixed_ulid::DeploymentId};
 use directories::{BaseDirs, ProjectDirs};
 use hashbrown::{HashMap, HashSet};
@@ -24,6 +23,7 @@ use std::{borrow::Cow, path::PathBuf, sync::Arc};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt as _;
 use tokio::sync::watch;
+use toml_edit::{DocumentMut, Item};
 use utils::{wasm_tools::WasmComponent, wit};
 use wasm_workers::registry::WitOrigin;
 
@@ -644,15 +644,40 @@ async fn generate_wit_deps(
     options: GenerateWitDepsOptions,
     secret_registry: Arc<SecretRegistry>,
 ) -> Result<Vec<GeneratedPathStatus>, anyhow::Error> {
-    let deployment = filter_wit_deps_deployment(
-        load_deployment_validated(&deployment_toml).await?,
-        options.skip_local,
-    );
+    let raw = tokio::fs::read_to_string(&deployment_toml)
+        .await
+        .with_context(|| format!("cannot read deployment manifest {deployment_toml:?}"))?;
+    let filtered = filter_wit_deps_toml(&raw, options.skip_local)
+        .with_context(|| format!("cannot filter {deployment_toml:?}"))?;
+    let deployment_dir = deployment_toml
+        .canonicalize()
+        .with_context(|| format!("cannot canonicalize {deployment_toml:?}"))?
+        .parent()
+        .with_context(|| format!("cannot resolve parent of {deployment_toml:?}"))?
+        .to_path_buf();
     let mut server_config = ServerConfigToml::default();
     server_config.webui.enabled = false;
     let _guard = init::init(&server_config)?; // Configure logging
-    let deployment = deployment
-        .resolve()
+
+    // Route through the shared CAS-based pipeline: prepare the filtered manifest into an
+    // ephemeral in-memory CAS, then resolve it by digest exactly like a server would.
+    let prepared = prepare_deployment_manifest(&filtered, &deployment_dir)
+        .await
+        .with_context(|| format!("cannot prepare {deployment_toml:?}"))?;
+    let cas = Arc::new(InMemoryCas::default());
+    for file in &prepared.files {
+        let stored = cas
+            .write_blob(&file.bytes)
+            .await
+            .with_context(|| format!("cannot store deployment file `{}`", file.path))?;
+        ensure!(
+            stored == file.digest,
+            "prepared blob digest mismatch for `{}`",
+            file.path
+        );
+    }
+    let cas: Arc<dyn Cas> = cas;
+    let deployment = resolve_manifest(&prepared.deployment_toml, cas.as_ref())
         .await
         .with_context(|| format!("cannot resolve {deployment_toml:?}"))?;
     let (termination_sender, mut termination_watcher) = watch::channel(());
@@ -679,12 +704,11 @@ async fn generate_wit_deps(
 
     // WIT extraction resolves no secrets; the caller passes a no-secrets registry.
     let server_verified = Box::pin(server_verify(server_config, engines, secret_registry)).await?;
-    // Disk-authored resolved form: only absolute paths, so it resolves without a CAS.
     let deployment_verified = deployment_verify_config(
         &server_verified,
         &prepared_dirs,
         deployment,
-        None,
+        cas,
         verify_params.clone(),
         &mut termination_watcher,
     )
@@ -772,90 +796,56 @@ async fn generate_wit_deps(
     write_wit_deps(&pkg_to_wit, &output_directory, options.force, options.prune).await
 }
 
-fn filter_wit_deps_deployment(
-    mut deployment: DeploymentTomlValidated,
-    skip_local: bool,
-) -> DeploymentTomlValidated {
-    if skip_local {
-        deployment
-            .activities_wasm
-            .retain(|c| matches!(c.common.location, ComponentLocationToml::Oci(_)));
-        deployment.activities_stub.retain(|(c, _)| match c {
-            ActivityStubComponentConfigToml::File(f) => {
-                matches!(f.common.location, ComponentLocationToml::Oci(_))
-            }
-            ActivityStubComponentConfigToml::Inline(_) => true,
-        });
-        deployment.activities_external.retain(|(c, _)| match c {
-            ActivityExternalComponentConfigToml::File(f) => {
-                matches!(f.common.location, ComponentLocationToml::Oci(_))
-            }
-            ActivityExternalComponentConfigToml::Inline(_) => true,
-        });
-        deployment.activities_js.retain(|(c, _)| {
-            c.content.is_none() && !matches!(c.location, Some(JsLocationToml::Path(_)))
-        });
-        deployment.activities_exec.retain(|(c, _)| {
-            c.content.is_none() && !matches!(c.location, Some(JsLocationToml::Path(_)))
-        });
-        deployment
-            .workflows_wasm
-            .retain(|c| matches!(c.common.location, ComponentLocationToml::Oci(_)));
-        deployment.workflows_js.retain(|(c, _)| {
-            c.content.is_none() && !matches!(c.location, Some(JsLocationToml::Path(_)))
-        });
+/// Prune a deployment manifest for WIT-deps extraction: webhooks and crons never contribute WITs,
+/// and `--skip-local` drops every deployment-owned (non-OCI) component so only OCI dependencies
+/// remain. Operating on the manifest text keeps a single resolution path: the pruned manifest is
+/// prepared and resolved through the CAS like any other.
+fn filter_wit_deps_toml(deployment_toml: &str, skip_local: bool) -> anyhow::Result<String> {
+    /// Whether a component table's `location` is an OCI reference.
+    fn table_is_oci_location(table: &toml_edit::Table) -> bool {
+        table
+            .get("location")
+            .and_then(Item::as_str)
+            .is_some_and(|location| location.starts_with(OCI_SCHEMA_PREFIX))
     }
 
-    deployment.webhooks_wasm.clear();
-    deployment.webhooks_js.clear();
-    deployment.crons.clear();
+    fn retain_tables(
+        doc: &mut DocumentMut,
+        section: &str,
+        keep: impl Fn(&toml_edit::Table) -> bool,
+    ) {
+        if let Some(tables) = doc.get_mut(section).and_then(Item::as_array_of_tables_mut) {
+            tables.retain(keep);
+        }
+    }
 
-    let remaining_names: HashSet<String> = deployment
-        .activities_wasm
-        .iter()
-        .map(|c| c.common.name.to_string())
-        .chain(
-            deployment
-                .activities_stub
-                .iter()
-                .map(|(_, name)| name.to_string()),
-        )
-        .chain(
-            deployment
-                .activities_external
-                .iter()
-                .map(|(_, name)| name.to_string()),
-        )
-        .chain(
-            deployment
-                .activities_js
-                .iter()
-                .map(|(_, name)| name.to_string()),
-        )
-        .chain(
-            deployment
-                .activities_exec
-                .iter()
-                .map(|(_, name)| name.to_string()),
-        )
-        .chain(
-            deployment
-                .workflows_wasm
-                .iter()
-                .map(|c| c.common.name.to_string()),
-        )
-        .chain(
-            deployment
-                .workflows_js
-                .iter()
-                .map(|(_, name)| name.to_string()),
-        )
-        .collect();
-    deployment
-        .component_names_to_types
-        .retain(|name, _| remaining_names.contains(name));
+    let mut doc = deployment_toml
+        .parse::<DocumentMut>()
+        .context("cannot parse deployment manifest as TOML")?;
 
-    deployment
+    for section in ["webhook_endpoint_wasm", "webhook_endpoint_js", "cron"] {
+        doc.remove(section);
+    }
+
+    if skip_local {
+        for section in ["activity_wasm", "workflow_wasm"] {
+            retain_tables(&mut doc, section, table_is_oci_location);
+        }
+        // Stub/external File entries carry a `location`; Inline entries (no `location`) are kept.
+        for section in ["activity_stub", "activity_external"] {
+            retain_tables(&mut doc, section, |table| {
+                table.get("location").is_none() || table_is_oci_location(table)
+            });
+        }
+        // Script components are local when they carry inline `content` or a non-OCI `location`.
+        for section in ["activity_js", "workflow_js", "activity_exec"] {
+            retain_tables(&mut doc, section, |table| {
+                table.get("content").is_none() && table_is_oci_location(table)
+            });
+        }
+    }
+
+    Ok(doc.to_string())
 }
 
 async fn write_wit_deps(

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1646,73 +1646,90 @@ pub(crate) async fn run_internal(
         }
     };
     let span = Span::current();
-    let (active_deployment_id, deployment_resolved, new_deployment_record) =
-        if let Some(deployment) = deployment {
-            // --deployment or `--deployment-empty` provided: prepare, insert+activate after compile.
+    // What to persist once the deployment has compiled and verified. Deferring activation past
+    // verification keeps a broken deployment from being marked active.
+    enum DeploymentPersist {
+        AlreadyActive,
+        ActivateEnqueued,
+        Insert {
+            record: Box<DeploymentRecord>,
+            component_files: Vec<DeploymentComponentFileRecord>,
+        },
+    }
+    let (active_deployment_id, deployment_resolved, persist) = if let Some(deployment) = deployment
+    {
+        // --deployment or `--deployment-empty` provided: prepare, insert+activate after verify.
+        let new_deployment_id = DeploymentId::generate();
+        span.record("deployment_id", tracing::field::display(&new_deployment_id));
+        let (record, component_files) = write_to_cas_prepare_deployment_record(
+            &*db_pool,
+            new_deployment_id,
+            deployment.processed_deployment_toml,
+            deployment.files,
+            description,
+        )
+        .await?;
+        // Same as if `DeploymentRecord` was in DB already.
+        let resolved =
+            deployment_resolved_from_manifest(&*db_pool, &record.deployment_toml).await?;
+        (
+            new_deployment_id,
+            resolved,
+            DeploymentPersist::Insert {
+                record: Box::new(record),
+                component_files,
+            },
+        )
+    } else {
+        // No --deployment: pick up from the DB. An Enqueued deployment (queued for this
+        // restart) is activated only after it verifies; see the post-verify block below.
+        let conn = db_pool
+            .external_api_conn()
+            .await
+            .context("cannot get db connection for deployment lookup")?;
+        if let Some(record) = conn
+            .get_current_deployment()
+            .await
+            .context("cannot query current deployment")?
+        {
+            let resolved =
+                deployment_resolved_from_manifest(&*db_pool, &record.deployment_toml).await?;
+            span.record(
+                "deployment_id",
+                tracing::field::display(&record.deployment_id),
+            );
+            let persist = if record.status == DeploymentStatus::Enqueued {
+                info!("Verifying enqueued deployment before activation");
+                DeploymentPersist::ActivateEnqueued
+            } else {
+                info!("Using the currently active deployment");
+                DeploymentPersist::AlreadyActive
+            };
+            (record.deployment_id, resolved, persist)
+        } else {
+            // empty db
             let new_deployment_id = DeploymentId::generate();
             span.record("deployment_id", tracing::field::display(&new_deployment_id));
-            let record = write_to_cas_prepare_deployment_record(
+            info!("No deployment found in DB; starting with empty deployment");
+            let (record, component_files) = write_to_cas_prepare_deployment_record(
                 &*db_pool,
                 new_deployment_id,
-                deployment.processed_deployment_toml,
-                deployment.files,
-                description,
+                String::new(),
+                Vec::new(),
+                None,
             )
             .await?;
-            // Same as if `DeploymentRecord` was in DB already.
-            let resolved =
-                deployment_resolved_from_manifest(&*db_pool, &record.0.deployment_toml).await?;
-            (new_deployment_id, resolved, Some(record))
-        } else {
-            // No --deployment: pick up from the DB.
-            // Activate any Enqueued deployment (queued for this restart), then use active.
-            let conn = db_pool
-                .external_api_conn()
-                .await
-                .context("cannot get db connection for deployment lookup")?;
-            if let Some(record) = conn
-                .get_current_deployment()
-                .await
-                .context("cannot query current deployment")?
-            {
-                if record.status == concepts::storage::DeploymentStatus::Enqueued {
-                    conn.activate_deployment(record.deployment_id, chrono::Utc::now())
-                        .await
-                        .context("cannot activate enqueued deployment")?;
-                }
-                let resolved =
-                    deployment_resolved_from_manifest(&*db_pool, &record.deployment_toml).await?;
-                span.record(
-                    "deployment_id",
-                    tracing::field::display(&record.deployment_id),
-                );
-                if record.status == concepts::storage::DeploymentStatus::Enqueued {
-                    info!("Activated enqueued deployment");
-                } else {
-                    info!("Using the currently active deployment");
-                }
-                (record.deployment_id, resolved, None)
-            } else {
-                // empty db
-                let new_deployment_id = DeploymentId::generate();
-                span.record("deployment_id", tracing::field::display(&new_deployment_id));
-                info!("No deployment found in DB; starting with empty deployment");
-                let record = write_to_cas_prepare_deployment_record(
-                    &*db_pool,
-                    new_deployment_id,
-                    String::new(),
-                    Vec::new(),
-                    None,
-                )
-                .await?;
 
-                (
-                    new_deployment_id,
-                    DeploymentResolved::default(),
-                    Some(record),
-                )
-            }
-        };
+            (
+                new_deployment_id,
+                DeploymentResolved::default(),
+                DeploymentPersist::Insert {
+                    record: Box::new(record),
+                    component_files,
+                },
+            )
+        }
+    };
     let engines = create_engines(&config, &prepared_dirs)?;
     let server_verified = server_verify(config, engines, secret_registry).await?;
     config_prepass::preflight(
@@ -1740,30 +1757,47 @@ pub(crate) async fn run_internal(
     ))
     .instrument(span.clone())
     .await?;
-    // Persist a freshly created deployment only now that it has compiled and verified, matching the submit path.
-    if let Some((record, component_files)) = new_deployment_record {
-        let api_conn = db_pool
-            .external_api_conn()
-            .await
-            .context("cannot get db connection for deployment insertion")?;
-        let (component_metadata, deployment_components) = build_component_metadata_records(
-            active_deployment_id,
-            &compiled_and_linked.component_registry_ro,
-        );
-        api_conn
-            .insert_deployment_with_components(
-                record,
-                component_metadata,
-                deployment_components,
-                component_files,
-            )
-            .await
-            .context("cannot insert deployment")?;
-        api_conn
-            .activate_deployment(active_deployment_id, chrono::Utc::now())
-            .await
-            .context("cannot activate deployment")?;
-        info!("Activated new deployment");
+    // Persist only now that the deployment has compiled and verified, matching the submit path.
+    match persist {
+        DeploymentPersist::AlreadyActive => {}
+        DeploymentPersist::ActivateEnqueued => {
+            let api_conn = db_pool
+                .external_api_conn()
+                .await
+                .context("cannot get db connection for deployment activation")?;
+            api_conn
+                .activate_deployment(active_deployment_id, chrono::Utc::now())
+                .await
+                .context("cannot activate enqueued deployment")?;
+            info!("Activated enqueued deployment");
+        }
+        DeploymentPersist::Insert {
+            record,
+            component_files,
+        } => {
+            let api_conn = db_pool
+                .external_api_conn()
+                .await
+                .context("cannot get db connection for deployment insertion")?;
+            let (component_metadata, deployment_components) = build_component_metadata_records(
+                active_deployment_id,
+                &compiled_and_linked.component_registry_ro,
+            );
+            api_conn
+                .insert_deployment_with_components(
+                    *record,
+                    component_metadata,
+                    deployment_components,
+                    component_files,
+                )
+                .await
+                .context("cannot insert deployment")?;
+            api_conn
+                .activate_deployment(active_deployment_id, chrono::Utc::now())
+                .await
+                .context("cannot activate deployment")?;
+            info!("Activated new deployment");
+        }
     }
 
     let cancel_registry = CancelRegistry::new();

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -5,13 +5,13 @@ use crate::args::shadow::PKG_VERSION;
 use crate::command::termination_notifier::termination_notifier;
 use crate::config::config_holder::ConfigHolder;
 use crate::config::config_holder::PathPrefixes;
-use crate::config::config_holder::load_deployment_resolved;
 use crate::config::content_digest_to_wasm_file;
 use crate::config::env_var::EnvVarConfig;
-use crate::config::file_provider::CasFileProvider;
 use crate::config::manifest::DeploymentManifest;
 use crate::config::manifest::DeploymentManifestFile;
+use crate::config::manifest::prepare_deployment_manifest_from_disk;
 use crate::config::manifest::reconcile_deployment_digests;
+use crate::config::manifest::resolve_manifest;
 use crate::config::secret_registry::EnvVarCleanupStrategy;
 use crate::config::secret_registry::SecretRegistry;
 use crate::config::toml::ActivityExecComponentConfigResolvedExt as _;
@@ -69,6 +69,7 @@ use crate::server::web_api_server::WebApiState;
 use crate::server::web_api_server::app_router;
 use anyhow::Context;
 use anyhow::bail;
+use anyhow::ensure;
 use chrono::Utc;
 use concepts::ComponentId;
 use concepts::ComponentType;
@@ -84,6 +85,8 @@ use concepts::Params;
 use concepts::ReturnTypeExtendable;
 use concepts::SUFFIX_FN_SCHEDULE;
 use concepts::StrVariant;
+use concepts::cas::Cas;
+use concepts::cas::InMemoryCas;
 use concepts::component_id::ComponentDigest;
 use concepts::component_id::Digest;
 use concepts::prefixed_ulid::DeploymentId;
@@ -655,15 +658,20 @@ pub(crate) struct VerifyParams {
     pub(crate) suppress_linking_errors: bool,
 }
 
+/// Called from `server verify [-d deployment.toml]` or `deployment verify -d deployment.toml`
 pub(crate) async fn verify(
     config_holder: ConfigHolder,
     config: ServerConfigToml,
-    deployment: Option<PathBuf>,
+    deployment: Option<PathBuf>, // None if `server verify` contains no explicit `deployment.toml` - verify current active deployment.
     verify_params: VerifyParams,
     skip_db: bool,
     fix: bool,
     secret_registry: Arc<SecretRegistry>,
 ) -> Result<(), anyhow::Error> {
+    ensure!(
+        !skip_db || deployment.is_some(),
+        "cannot skip database when deployment TOML file is not specified"
+    );
     let _guard: Guard = init::init(&config)?;
     let deployment_opt = if let Some(deployment_path) = deployment {
         let broken = reconcile_deployment_digests(&deployment_path, fix).await?;
@@ -699,10 +707,17 @@ pub(crate) async fn verify(
                 );
             }
         }
-        Some(load_deployment_resolved(&deployment_path).await?)
+        // Create a in-memory CAS with the deployment referenced files.
+        Some(resolve_deployment_offline(&deployment_path).await?)
     } else {
         None
     };
+    // Split the offline result into the resolved deployment and its ephemeral in-memory CAS.
+    let (deployment_opt, offline_cas): (Option<DeploymentResolved>, Option<Arc<dyn Cas>>) =
+        match deployment_opt {
+            Some((resolved, cas)) => (Some(resolved), Some(cas)),
+            None => (None, None),
+        };
 
     let (config_holder, config, secret_registry) = if fix
         && let Some(server_config_path) = config_holder.config_source.as_deref()
@@ -800,10 +815,16 @@ pub(crate) async fn verify(
         Some(&deployment),
         verify_params.runtime_config_availability,
     )?;
-    let cas: Option<Arc<dyn concepts::cas::Cas>> = if let Some((pool, _)) = db_pool.as_ref() {
-        Some(pool.cas_conn().await?.into())
+    // The offline `-d` path resolved into an in-memory CAS; the DB path reads blobs from the
+    // pool's CAS. Resolution and WASM materialization always have a CAS.
+    let cas: Arc<dyn Cas> = if let Some(cas) = offline_cas {
+        cas
+    } else if let Some((pool, _)) = db_pool.as_ref() {
+        pool.cas_conn().await?.into()
     } else {
-        None
+        unreachable!(
+            "skip_db == true && deployment.is_none() is disallowed at the start of this function"
+        );
     };
     deployment_verify_config_compile_link(
         server_verified,
@@ -973,7 +994,7 @@ pub(crate) async fn deployment_verify_config_compile_link(
     server_verified: ServerVerified,
     prepared_dirs: &PreparedDirs,
     deployment: DeploymentResolved,
-    cas: Option<Arc<dyn concepts::cas::Cas>>,
+    cas: Arc<dyn Cas>,
     deployment_id: DeploymentId,
     params: VerifyParams,
     termination_watcher: &mut watch::Receiver<()>,
@@ -1028,7 +1049,7 @@ pub(crate) async fn deployment_verify_config(
     server_verified: &ServerVerified,
     prepared_dirs: &PreparedDirs,
     deployment: DeploymentResolved,
-    cas: Option<Arc<dyn concepts::cas::Cas>>,
+    cas: Arc<dyn Cas>,
     params: VerifyParams,
     termination_watcher: &mut watch::Receiver<()>,
 ) -> Result<DeploymentVerified, anyhow::Error> {
@@ -1098,7 +1119,7 @@ pub(crate) async fn deployment_verify_config(
     }
     // Materialize deployment-owned WASM blobs from the CAS onto disk before compiling.
     let deployment =
-        DeploymentRunnable::resolve(deployment, cas.as_deref(), &prepared_dirs.wasm_cache_dir)
+        DeploymentRunnable::resolve(deployment, cas.as_ref(), &prepared_dirs.wasm_cache_dir)
             .await?;
     let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(
         deployment,
@@ -1288,166 +1309,81 @@ async fn get_deployment_resolved_from_db(
 }
 
 /// A deployment authored locally and passed via `server run -d <toml>` / `--empty`.
-///
-/// Carries the verbatim manifest (stored as the source of truth), its referenced file
-/// blobs (uploaded to the CAS so later restarts can resolve from it), and the
-/// already-resolved form used to compile/link this run.
 pub(crate) struct LocalDeployment {
-    deployment_toml: String,
-    resolved: DeploymentResolved,
+    processed_deployment_toml: String,
     files: Vec<DeploymentManifestFile>,
 }
 
 impl LocalDeployment {
     pub(crate) async fn from_path(deployment_path: &Path) -> anyhow::Result<Self> {
-        let resolved = load_deployment_resolved(deployment_path).await?;
-        let prepared =
-            crate::config::manifest::prepare_deployment_manifest_from_disk(deployment_path).await?;
+        let prepared = prepare_deployment_manifest_from_disk(deployment_path).await?;
         Ok(Self {
-            deployment_toml: prepared.deployment_toml,
-            resolved,
+            processed_deployment_toml: prepared.deployment_toml,
             files: prepared.files,
         })
     }
 
     pub(crate) fn empty() -> Self {
         Self {
-            deployment_toml: String::new(),
-            resolved: DeploymentResolved::default(),
+            processed_deployment_toml: String::new(),
             files: Vec::new(),
         }
     }
 }
 
-/// Root for resolving a stored manifest against the CAS.
+/// Root for parsing a stored manifest for resolution against the CAS.
 ///
-/// Empty on purpose: a stored manifest has no submitter host to anchor relative paths to.
-/// Deployment-owned references are addressed by content digest in the CAS, so joining a
-/// `${DEPLOYMENT_DIR}` / relative path against an empty root leaves it relative. That keeps
-/// deployment-owned WASM locations relative in the resulting `DeploymentResolved` (no
-/// fabricated host paths); they become concrete on-disk paths only later, in
+/// Empty on purpose: a stored (processed) manifest has no submitter host to anchor relative paths
+/// to. Deployment-owned references are addressed by content digest in the CAS, so a relative /
+/// `${DEPLOYMENT_DIR}` path validated against an empty root stays relative: a logical filename,
+/// never a storage address. Those become concrete on-disk paths only later, in
 /// [`DeploymentRunnable::resolve`], which materializes their blobs from the CAS.
-fn cas_deployment_dir() -> std::path::PathBuf {
+pub(crate) fn cas_deployment_dir() -> std::path::PathBuf {
     std::path::PathBuf::new()
 }
 
-/// A [`FileProvider`] that reads from the CAS and records the `(path, digest)` of every blob
-/// it serves, so the caller learns exactly which files the manifest references.
-struct RecordingCasProvider {
-    inner: crate::config::file_provider::CasFileProvider,
-    seen: std::sync::Mutex<Vec<concepts::storage::DeploymentFileRecord>>,
+/// Offline resolution for `deployment verify`: prepare the manifest from disk,
+/// then insert all of its files into an in-memory CAS.
+async fn resolve_deployment_offline(
+    deployment_path: &Path,
+) -> anyhow::Result<(DeploymentResolved, Arc<dyn Cas>)> {
+    let prepared = prepare_deployment_manifest_from_disk(deployment_path).await?;
+    let cas = Arc::new(InMemoryCas::default());
+    for file in &prepared.files {
+        let stored = cas
+            .write_blob(&file.bytes)
+            .await
+            .with_context(|| format!("cannot store deployment file `{}`", file.path))?;
+        ensure!(
+            stored == file.digest,
+            "prepared blob digest mismatch for `{}`: expected {}, got {stored}",
+            file.path,
+            file.digest
+        );
+    }
+    let cas: Arc<dyn Cas> = cas;
+    let mut resolved = resolve_manifest(&prepared.deployment_toml, cas.as_ref())
+        .await
+        .with_context(|| format!("cannot resolve deployment {deployment_path:?}"))?;
+    resolved.source_path = Some(deployment_path.to_path_buf());
+    Ok((resolved, cas))
 }
 
-#[async_trait::async_trait]
-impl crate::config::file_provider::FileProvider for RecordingCasProvider {
-    async fn read(&self, path: &str, digest: Option<&ContentDigest>) -> anyhow::Result<Vec<u8>> {
-        let bytes = self.inner.read(path, digest).await?;
-        if let Some(digest) = digest {
-            self.seen
-                .lock()
-                .expect("RecordingCasProvider mutex poisoned")
-                .push(concepts::storage::DeploymentFileRecord {
-                    path: path.to_string(),
-                    digest: digest.clone(),
-                    size: u64::try_from(bytes.len()).expect("file length fits u64"),
-                });
-        }
-        Ok(bytes)
-    }
-
-    async fn parse_js_graph(
-        &self,
-        entry_path: &str,
-        known_files: &std::collections::BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>> {
-        let files = self.inner.parse_js_graph(entry_path, known_files).await?;
-        let mut seen = self
-            .seen
-            .lock()
-            .expect("RecordingCasProvider mutex poisoned");
-        for (path, source) in &files {
-            let digest = known_files
-                .get(path)
-                .expect("CAS JS graph walker only reads files present in known_files");
-            seen.push(concepts::storage::DeploymentFileRecord {
-                path: path.clone(),
-                digest: digest.clone(),
-                size: u64::try_from(source.len()).expect("file length fits u64"),
-            });
-        }
-        drop(seen);
-        Ok(files)
-    }
-
-    async fn parse_wit_files(
-        &self,
-        root: &str,
-        known_files: &std::collections::BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<crate::config::file_provider::ParsedWitFiles> {
-        let parsed = self.inner.parse_wit_files(root, known_files).await?;
-        let mut seen = self
-            .seen
-            .lock()
-            .expect("RecordingCasProvider mutex poisoned");
-        for (path, source) in &parsed.files {
-            let digest = known_files
-                .get(path)
-                .expect("CAS WIT reader only returns known files");
-            seen.push(concepts::storage::DeploymentFileRecord {
-                path: path.clone(),
-                digest: digest.clone(),
-                size: u64::try_from(source.len()).expect("file length fits u64"),
-            });
-        }
-        drop(seen);
-        Ok(parsed)
-    }
-}
-
-/// Resolve a stored verbatim TOML manifest by reading its referenced blobs from the CAS,
-/// returning the resolved form and the `(path, digest)` of every file it referenced.
+/// Resolve a stored processed manifest by reading its referenced blobs from the CAS.
 ///
 /// `${...}` env vars and secrets resolve here, in the server's environment.
-async fn deployment_resolved_and_files_from_manifest(
-    db_pool: &dyn concepts::storage::DbPool,
-    deployment_toml: &str,
-) -> anyhow::Result<(
-    DeploymentResolved,
-    Vec<concepts::storage::DeploymentFileRecord>,
-)> {
-    let cas: Arc<dyn concepts::cas::Cas> = db_pool
-        .cas_conn()
-        .await
-        .context("cannot get CAS connection for deployment resolution")?
-        .into();
-    let provider = RecordingCasProvider {
-        inner: CasFileProvider { cas },
-        seen: std::sync::Mutex::new(Vec::new()),
-    };
-    let resolved = crate::config::manifest::manifest_to_resolved(
-        deployment_toml,
-        &cas_deployment_dir(),
-        &provider,
-    )
-    .await
-    .context("cannot resolve deployment manifest from the content-addressed store")?;
-    let files = provider
-        .seen
-        .into_inner()
-        .expect("RecordingCasProvider mutex poisoned");
-    Ok((resolved, files))
-}
-
-/// Resolve a stored verbatim manifest by reading its referenced blobs from the CAS.
 async fn deployment_resolved_from_manifest(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_toml: &str,
 ) -> anyhow::Result<DeploymentResolved> {
-    Ok(
-        deployment_resolved_and_files_from_manifest(db_pool, deployment_toml)
-            .await?
-            .0,
-    )
+    let cas: Arc<dyn Cas> = db_pool
+        .cas_conn()
+        .await
+        .context("cannot get CAS connection for deployment resolution")?
+        .into();
+    resolve_manifest(deployment_toml, cas.as_ref())
+        .await
+        .context("cannot resolve deployment manifest from the content-addressed store")
 }
 
 /// Transient server state whose every WASM component location is a concrete, runnable
@@ -1457,9 +1393,7 @@ async fn deployment_resolved_from_manifest(
 /// addressed by content digest in the CAS (a stored manifest carries no submitter host).
 /// Compiling/linking needs real files, so [`Self::resolve`] materializes each deployment-owned
 /// blob from the CAS into the wasm cache and rewrites its location to that path. OCI
-/// references already are concrete and pass through unchanged. The current disk-authored
-/// local-run resolved form expands valid relative WASM paths to absolute internal paths, so it
-/// resolves to itself.
+/// references already are concrete and pass through unchanged.
 ///
 /// The inner value is private so the only way to obtain one is `resolve`; that makes it
 /// impossible to feed an unresolved (relative-path) `DeploymentResolved` into compilation.
@@ -1469,14 +1403,9 @@ pub(crate) struct DeploymentRunnable {
 
 impl DeploymentRunnable {
     /// Resolve every deployment-owned WASM location against the CAS.
-    ///
-    /// `cas` may be `None` for disk/offline flows (e.g. `obelisk deployment verify`), whose
-    /// current resolved form holds internal absolute paths and OCI refs;
-    /// encountering a deployment-owned (relative) WASM there is an error because there is no
-    /// store to read it.
     pub(crate) async fn resolve(
         mut deployment: DeploymentResolved,
-        cas: Option<&dyn concepts::cas::Cas>,
+        cas: &dyn Cas,
         wasm_cache_dir: &Path,
     ) -> anyhow::Result<Self> {
         for c in &mut deployment.activities_wasm {
@@ -1545,20 +1474,17 @@ impl DeploymentRunnable {
 async fn materialize_wasm_location(
     location: &mut ComponentLocationToml,
     content_digest: Option<&ContentDigest>,
-    cas: Option<&dyn concepts::cas::Cas>,
+    cas: &dyn Cas,
     wasm_cache_dir: &Path,
 ) -> anyhow::Result<()> {
     let ComponentLocationToml::Path(path) = location else {
         return Ok(()); // OCI reference: pulled later, during fetch.
     };
     if Path::new(path).is_absolute() {
-        return Ok(()); // External / disk-authored file, read from disk at runtime.
+        return Ok(()); // External file, read from disk at runtime.
     }
     let digest = content_digest.with_context(|| {
         format!("deployment-owned WASM component `{path}` is missing a content digest")
-    })?;
-    let cas = cas.with_context(|| {
-        format!("cannot resolve deployment-owned WASM component `{path}` without a content-addressed store")
     })?;
     let target = content_digest_to_wasm_file(wasm_cache_dir, digest);
     if !target.exists() {
@@ -1577,7 +1503,7 @@ async fn materialize_wasm_location(
 /// without inserting it. Deferring the insert until after a successful
 /// compile with [`DbExternalApi::insert_deployment_with_components`]
 /// means startup, like submit, never persists a deployment that failed verification.
-async fn prepare_new_deployment_record(
+async fn write_to_cas_prepare_deployment_record(
     db_pool: &dyn concepts::storage::DbPool,
     deployment_id: DeploymentId,
     deployment_toml: String,
@@ -1725,15 +1651,18 @@ pub(crate) async fn run_internal(
             // --deployment or `--deployment-empty` provided: prepare, insert+activate after compile.
             let new_deployment_id = DeploymentId::generate();
             span.record("deployment_id", tracing::field::display(&new_deployment_id));
-            let record = prepare_new_deployment_record(
+            let record = write_to_cas_prepare_deployment_record(
                 &*db_pool,
                 new_deployment_id,
-                deployment.deployment_toml,
+                deployment.processed_deployment_toml,
                 deployment.files,
                 description,
             )
             .await?;
-            (new_deployment_id, deployment.resolved, Some(record))
+            // Same as if `DeploymentRecord` was in DB already.
+            let resolved =
+                deployment_resolved_from_manifest(&*db_pool, &record.0.deployment_toml).await?;
+            (new_deployment_id, resolved, Some(record))
         } else {
             // No --deployment: pick up from the DB.
             // Activate any Enqueued deployment (queued for this restart), then use active.
@@ -1762,13 +1691,13 @@ pub(crate) async fn run_internal(
                 } else {
                     info!("Using the currently active deployment");
                 }
-
                 (record.deployment_id, resolved, None)
             } else {
+                // empty db
                 let new_deployment_id = DeploymentId::generate();
                 span.record("deployment_id", tracing::field::display(&new_deployment_id));
                 info!("No deployment found in DB; starting with empty deployment");
-                let record = prepare_new_deployment_record(
+                let record = write_to_cas_prepare_deployment_record(
                     &*db_pool,
                     new_deployment_id,
                     String::new(),
@@ -1791,12 +1720,12 @@ pub(crate) async fn run_internal(
         Some(&deployment_resolved),
         RuntimeConfigAvailability::Strict,
     )?;
-    let cas: Arc<dyn concepts::cas::Cas> = db_pool.cas_conn().await?.into();
+    let cas: Arc<dyn Cas> = db_pool.cas_conn().await?.into();
     let compiled_and_linked = Box::pin(deployment_verify_config_compile_link(
         server_verified.clone(),
         &prepared_dirs,
         deployment_resolved,
-        Some(cas),
+        cas,
         active_deployment_id,
         VerifyParams {
             dir_params: PrepareDirsParams {
@@ -2693,7 +2622,7 @@ pub(crate) async fn submit_deployment(
                 deployment_resolved_from_manifest(db_pool_ref, deployment_toml)
                     .await
                     .map_err(SubmitDeploymentError::Other)?;
-            let cas_arc: Arc<dyn concepts::cas::Cas> = db_pool_ref
+            let cas_arc: Arc<dyn Cas> = db_pool_ref
                 .cas_conn()
                 .await
                 .map_err(anyhow::Error::from)?
@@ -2708,7 +2637,7 @@ pub(crate) async fn submit_deployment(
                 server_verified,
                 prepared_dirs,
                 deployment_resolved,
-                Some(cas_arc),
+                cas_arc,
                 deployment_id,
                 VerifyParams {
                     dir_params: PrepareDirsParams {
@@ -2989,7 +2918,7 @@ async fn prepare_switch_deployment(
     .await
     .map_err(SwitchError::Other)?;
 
-    let cas: Arc<dyn concepts::cas::Cas> = deployment_switch_manager
+    let cas: Arc<dyn Cas> = deployment_switch_manager
         .inner
         .db_pool
         .cas_conn()
@@ -3019,7 +2948,7 @@ async fn prepare_switch_deployment(
         deployment_switch_manager.inner.server_verified.clone(),
         &deployment_switch_manager.inner.prepared_dirs,
         target_deployment,
-        Some(cas),
+        cas,
         deployment_id,
         verify_params,
         termination_watcher,
@@ -5450,10 +5379,10 @@ mod tests {
                 report_missing_outbound_http_secret_replacements,
             },
             create_engines, deployment_verify_config, fix_server_exec_digests, prepare_dirs,
-            webhook_global_http_allowlist,
+            resolve_deployment_offline, webhook_global_http_allowlist,
         },
         config::{
-            config_holder::{ConfigHolder, load_deployment_resolved},
+            config_holder::ConfigHolder,
             secret_registry::SecretRegistry,
             toml::{
                 AllowExecActivities, AllowedHostToml, MethodsInput, MethodsInputStar, ReplaceIn,
@@ -5805,7 +5734,7 @@ mod tests {
             deployment_toml,
         )
         .await?;
-        let deployment = load_deployment_resolved(fixture.path()).await?;
+        let (deployment, cas) = resolve_deployment_offline(fixture.path()).await?;
 
         let prepared_dirs = prepare_dirs(
             &config,
@@ -5833,10 +5762,10 @@ mod tests {
         };
         let webui_enabled = None;
 
-        // Verify deployment. The current disk-authored resolved form holds internal absolute
-        // paths, so it resolves to itself without a CAS.
+        // Materialize deployment-owned WASM from the ephemeral CAS before compiling.
         let deployment =
-            DeploymentRunnable::resolve(deployment, None, &prepared_dirs.wasm_cache_dir).await?;
+            DeploymentRunnable::resolve(deployment, cas.as_ref(), &prepared_dirs.wasm_cache_dir)
+                .await?;
         let deployment_verified = Box::pin(DeploymentVerified::fetch_and_verify_all(
             deployment,
             server_verified.http_servers,
@@ -5888,7 +5817,7 @@ mod tests {
             "deployment-testing-wasm-local.toml",
         )
         .await?;
-        let mut deployment = load_deployment_resolved(fixture.path()).await?;
+        let (mut deployment, cas) = resolve_deployment_offline(fixture.path()).await?;
         let shared_digest: ComponentDigest =
             "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 .parse()
@@ -5915,7 +5844,7 @@ mod tests {
             &server_verified,
             &prepared_dirs,
             deployment,
-            None,
+            cas,
             VerifyParams {
                 dir_params: PrepareDirsParams {
                     clean_cache: false,
@@ -5950,8 +5879,8 @@ mod tests {
         )?;
         let config = config_holder.load_config()?;
         assert_eq!(config.allow_exec_activities, AllowExecActivities::Deny);
-        let deployment =
-            load_deployment_resolved(&workspace.join("deployment-testing-exec.toml")).await?;
+        let (deployment, cas) =
+            resolve_deployment_offline(&workspace.join("deployment-testing-exec.toml")).await?;
         let prepared_dirs = prepare_dirs(
             &config,
             &PrepareDirsParams {
@@ -5971,7 +5900,7 @@ mod tests {
             &server_verified,
             &prepared_dirs,
             deployment.clone(),
-            None,
+            cas.clone(),
             VerifyParams {
                 dir_params: PrepareDirsParams {
                     clean_cache: false,
@@ -5995,7 +5924,7 @@ mod tests {
             &server_verified,
             &prepared_dirs,
             deployment,
-            None,
+            cas,
             VerifyParams {
                 dir_params: PrepareDirsParams {
                     clean_cache: false,
@@ -6023,8 +5952,8 @@ mod tests {
         test_utils::set_up();
 
         let workspace = get_workspace_dir();
-        let deployment =
-            load_deployment_resolved(&workspace.join("deployment-testing-exec.toml")).await?;
+        let (deployment, _cas) =
+            resolve_deployment_offline(&workspace.join("deployment-testing-exec.toml")).await?;
         let dir = tempfile::tempdir()?;
         let server_config_path = dir.path().join("server.toml");
         let wrong = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
@@ -6077,8 +6006,8 @@ mod tests {
             Some(workspace.join("server-sqlite.toml")),
         )?;
         let mut config = config_holder.load_config()?;
-        let deployment =
-            load_deployment_resolved(&workspace.join("deployment-testing-exec.toml")).await?;
+        let (deployment, cas) =
+            resolve_deployment_offline(&workspace.join("deployment-testing-exec.toml")).await?;
         let digests = deployment
             .activities_exec
             .iter()
@@ -6137,7 +6066,7 @@ mod tests {
             &server_verified,
             &prepared_dirs,
             deployment.clone(),
-            None,
+            cas.clone(),
             verify_params.clone(),
             &mut termination_watcher,
         )
@@ -6165,7 +6094,7 @@ mod tests {
             &server_verified,
             &prepared_dirs,
             deployment,
-            None,
+            cas,
             verify_params,
             &mut termination_watcher,
         )

--- a/src/config/config_holder.rs
+++ b/src/config/config_holder.rs
@@ -1,7 +1,6 @@
 use super::env_var::interpolate_path_template;
 use super::secret_registry::SecretRegistry;
 use super::toml::{DeploymentToml, ServerConfigToml};
-use crate::config::toml::DeploymentResolved;
 use crate::config::toml::DeploymentTomlValidated;
 use anyhow::{Context as _, bail};
 use config::{Config, ConfigBuilder, Environment, File, FileFormat, builder::AsyncState};
@@ -195,18 +194,6 @@ pub(crate) async fn load_deployment_validated(
     deployment
         .validate(&deployment_dir)
         .with_context(|| format!("cannot validate {deployment_toml:?}"))
-}
-
-pub(crate) async fn load_deployment_resolved(
-    deployment_toml: &Path,
-) -> Result<DeploymentResolved, anyhow::Error> {
-    let mut deployment = load_deployment_validated(deployment_toml)
-        .await?
-        .resolve()
-        .await
-        .with_context(|| format!("cannot resolve {deployment_toml:?}"))?;
-    deployment.source_path = Some(deployment_toml.to_path_buf());
-    Ok(deployment)
 }
 
 fn canonicalize_parent(path: &Path) -> Result<PathBuf, anyhow::Error> {

--- a/src/config/file_provider.rs
+++ b/src/config/file_provider.rs
@@ -3,8 +3,6 @@ use concepts::ContentDigest;
 use concepts::cas::Cas;
 use concepts::component_id::Digest;
 use sha2::{Digest as _, Sha256};
-use std::path::PathBuf;
-use std::sync::Arc;
 use std::{collections::BTreeMap, path::Path};
 
 #[derive(Debug)]
@@ -14,47 +12,126 @@ pub(crate) struct ParsedWitFiles {
     pub(crate) main_pkg_id: wit_parser::PackageId,
 }
 
-/// Source of deployment-owned file bytes during deployment resolution.
+/// Read a deployment-owned blob from the CAS by digest.
 ///
-/// Resolution inlines every deployment-owned script/source into the
-/// `DeploymentResolved`; where the bytes come from depends on context.
-/// OCI refs are not deployment-owned and are not read through a provider.
+/// `what` is a human-readable label (a deployment-relative path) used only for error context.
+/// Every deployment-owned reference in a processed manifest carries a digest, so resolution
+/// addresses content purely by digest and never touches the submitter's disk.
+pub(crate) async fn read_package_blob(
+    cas: &dyn Cas,
+    digest: &ContentDigest,
+    what: &str,
+) -> anyhow::Result<Vec<u8>> {
+    cas.read_blob(digest)
+        .await?
+        .with_context(|| format!("blob {digest} for `{what}` not present in the CAS"))
+}
+
+/// Reads JS module sources from the CAS, resolving each deployment-relative path
+/// against the manifest's declared `component_files`. An import with no declared
+/// digest is rejected: it was never uploaded, so the graph is open.
+struct CasModuleReader<'a> {
+    cas: &'a dyn Cas,
+    known_files: &'a BTreeMap<String, ContentDigest>,
+}
+
 #[async_trait::async_trait]
-pub(crate) trait FileProvider: Send + Sync {
-    /// Read the bytes of a deployment-owned file.
-    ///
-    /// `path` is its deployment-relative path; `digest`, when present, is the
-    /// expected content hash. Implementations must ensure returned bytes hash
-    /// to `digest` when one is supplied.
-    async fn read(&self, path: &str, digest: Option<&ContentDigest>) -> anyhow::Result<Vec<u8>>;
+impl crate::javascript::graph::ModuleSourceReader for CasModuleReader<'_> {
+    async fn read_source(&self, dep_path: &str) -> anyhow::Result<String> {
+        let digest = self.known_files.get(dep_path).with_context(|| {
+            format!(
+                "JS module `{dep_path}` is imported but not part of the deployment package \
+                 (no matching `component_files` entry)"
+            )
+        })?;
+        let bytes = read_package_blob(self.cas, digest, dep_path).await?;
+        String::from_utf8(bytes)
+            .with_context(|| format!("JS module `{dep_path}` is not valid UTF-8"))
+    }
+}
 
-    /// Parse the JS module at `entry_path` and return its closed import graph: the
-    /// entry plus every transitively-imported relative module, as `(deployment-relative
-    /// path, source)`. Every relative import must resolve to a module the provider can
-    /// supply, so a manifest that under-declares its graph is rejected here rather than
-    /// failing at runtime. `known_files` is the manifest's declared `path -> digest` map;
-    /// CAS-backed resolution reads each module through it, the disk provider walks the
-    /// filesystem and ignores it. Non-JS scripts never call this.
-    async fn parse_js_graph(
-        &self,
-        entry_path: &str,
-        known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>>;
+/// Parse the JS module at `entry_path` and return its closed import graph: the entry plus every
+/// transitively-imported relative module, as `(deployment-relative path, source)`. Every
+/// relative import must resolve to a module declared in `known_files` and present in the CAS, so
+/// a manifest that under-declares its graph is rejected here rather than failing at runtime.
+pub(crate) async fn parse_js_graph_from_cas(
+    cas: &dyn Cas,
+    entry_path: &str,
+    known_files: &BTreeMap<String, ContentDigest>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let reader = CasModuleReader { cas, known_files };
+    let graph = crate::javascript::graph::collect_graph_with(&reader, entry_path).await?;
+    Ok(graph.files.into_iter().collect())
+}
 
-    /// Parse the WIT package rooted at `root`, retaining the resolve, main package ID, and
-    /// exactly the `.wit` sources selected as `(deployment-relative path, source)`. The parser
-    /// decides the file set, so malformed WIT is rejected and stray declarations cannot smuggle
-    /// in unused sources. `known_files` is the manifest's declared `path -> digest` map;
-    /// CAS-backed resolution materializes those blobs, while the disk provider ignores it.
-    async fn parse_wit_files(
-        &self,
-        root: &str,
-        known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<ParsedWitFiles>;
+/// Parse the WIT package rooted at `root`, retaining the resolve, main package ID, and exactly
+/// the `.wit` sources selected as `(deployment-relative path, source)`.
+///
+/// Every declared blob under `root` is materialized from the CAS into a temp dir, then
+/// `wit-parser` decides the file set. Trusting the declared prefix instead would let a broken
+/// client smuggle garbage or unused `.wit` files past submit, so malformed WIT is rejected and a
+/// declared source the parser does not select is refused.
+pub(crate) async fn parse_wit_files_from_cas(
+    cas: &dyn Cas,
+    root: &str,
+    known_files: &BTreeMap<String, ContentDigest>,
+) -> anyhow::Result<ParsedWitFiles> {
+    let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
+    let prefix = format!("{root}/");
+    let declared: Vec<(String, &ContentDigest)> = known_files
+        .iter()
+        .filter(|(path, _)| path.starts_with(&prefix))
+        .map(|(path, digest)| (path.clone(), digest))
+        .collect();
+    ensure!(
+        !declared.is_empty(),
+        "CAS-backed resolution has no declared WIT files for `{root}`"
+    );
+    let temp_dir = tempfile::tempdir().context("cannot create temp dir to parse WIT")?;
+    for (path, digest) in &declared {
+        let path = crate::config::toml::sanitize_deployment_relative_path(path)?;
+        ensure!(
+            Path::new(&path).extension().and_then(|ext| ext.to_str()) == Some("wit"),
+            "declared WIT source is not a .wit file: `{path}`"
+        );
+        let full = temp_dir.path().join(&path);
+        if let Some(parent) = full.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("cannot stage WIT file `{path}`"))?;
+        }
+        let bytes = read_package_blob(cas, digest, &path).await?;
+        tokio::fs::write(&full, &bytes)
+            .await
+            .with_context(|| format!("cannot stage WIT file `{path}`"))?;
+    }
+
+    let parsed = parse_wit_dir(temp_dir.path(), &root).await?;
+
+    // Reject stray declarations: a declared `.wit` file `wit-parser` did not select is
+    // dead weight the deployment -> digest mapping would pin, so refuse it here.
+    let selected: std::collections::BTreeSet<&str> =
+        parsed.files.iter().map(|(path, _)| path.as_str()).collect();
+    let stray: Vec<&str> = declared
+        .iter()
+        .map(|(path, _)| path.as_str())
+        .filter(|path| !selected.contains(path))
+        .collect();
+    ensure!(
+        stray.is_empty(),
+        "WIT directory `{root}` declares {stray:?} that `wit-parser` does not select"
+    );
+    Ok(parsed)
 }
 
 /// Parse the WIT package under `deployment_dir/root` and retain its resolve and selected sources.
-async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<ParsedWitFiles> {
+///
+/// Used by prepare on the submitter's disk, and by CAS resolution on a temp dir of materialized
+/// blobs.
+pub(crate) async fn parse_wit_dir(
+    deployment_dir: &Path,
+    root: &str,
+) -> anyhow::Result<ParsedWitFiles> {
     let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
     let deployment_dir = deployment_dir
         .canonicalize()
@@ -114,157 +191,6 @@ async fn parse_wit_dir(deployment_dir: &Path, root: &str) -> anyhow::Result<Pars
     })
 }
 
-/// Reads from the submitter's disk, under the deployment directory.
-pub(crate) struct DiskProvider {
-    pub(crate) deployment_dir: PathBuf,
-}
-
-#[async_trait::async_trait]
-impl FileProvider for DiskProvider {
-    async fn read(&self, path: &str, digest: Option<&ContentDigest>) -> anyhow::Result<Vec<u8>> {
-        let full = self.deployment_dir.join(path);
-        let bytes = tokio::fs::read(&full)
-            .await
-            .with_context(|| format!("cannot read file {full:?}"))?;
-        verify_content_digest(&bytes, digest, path)?;
-        Ok(bytes)
-    }
-
-    async fn parse_js_graph(
-        &self,
-        entry_path: &str,
-        _known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>> {
-        let graph =
-            crate::javascript::graph::collect_graph(&self.deployment_dir, entry_path).await?;
-        Ok(graph.files.into_iter().collect())
-    }
-
-    async fn parse_wit_files(
-        &self,
-        root: &str,
-        _known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<ParsedWitFiles> {
-        parse_wit_dir(&self.deployment_dir, root).await
-    }
-}
-
-/// Reads blobs from the content-addressed store by digest.
-///
-/// A digest is required; later manifest work makes digests mandatory on every
-/// relative ref before this provider is used for resolution.
-pub(crate) struct CasFileProvider {
-    pub(crate) cas: Arc<dyn Cas>,
-}
-
-/// Reads JS module sources from the CAS, resolving each deployment-relative path
-/// against the manifest's declared `component_files`. An import with no declared
-/// digest is rejected: it was never uploaded, so the graph is open.
-struct CasModuleReader<'a> {
-    cas: &'a Arc<dyn Cas>,
-    known_files: &'a BTreeMap<String, ContentDigest>,
-}
-
-#[async_trait::async_trait]
-impl crate::javascript::graph::ModuleSourceReader for CasModuleReader<'_> {
-    async fn read_source(&self, dep_path: &str) -> anyhow::Result<String> {
-        let digest = self.known_files.get(dep_path).with_context(|| {
-            format!(
-                "JS module `{dep_path}` is imported but not part of the deployment package \
-                 (no matching `component_files` entry)"
-            )
-        })?;
-        let bytes =
-            self.cas.read_blob(digest).await?.with_context(|| {
-                format!("blob {digest} for JS module `{dep_path}` not in the CAS")
-            })?;
-        String::from_utf8(bytes)
-            .with_context(|| format!("JS module `{dep_path}` is not valid UTF-8"))
-    }
-}
-
-#[async_trait::async_trait]
-impl FileProvider for CasFileProvider {
-    async fn read(&self, path: &str, digest: Option<&ContentDigest>) -> anyhow::Result<Vec<u8>> {
-        let digest = digest.with_context(|| {
-            format!("CAS-backed resolution requires a content digest for `{path}`")
-        })?;
-        self.cas
-            .read_blob(digest)
-            .await?
-            .with_context(|| format!("blob {digest} for `{path}` not present in the CAS"))
-    }
-
-    async fn parse_js_graph(
-        &self,
-        entry_path: &str,
-        known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<Vec<(String, String)>> {
-        let reader = CasModuleReader {
-            cas: &self.cas,
-            known_files,
-        };
-        let graph = crate::javascript::graph::collect_graph_with(&reader, entry_path).await?;
-        Ok(graph.files.into_iter().collect())
-    }
-
-    async fn parse_wit_files(
-        &self,
-        root: &str,
-        known_files: &BTreeMap<String, ContentDigest>,
-    ) -> anyhow::Result<ParsedWitFiles> {
-        let root = crate::config::toml::sanitize_deployment_relative_path(root)?;
-        let prefix = format!("{root}/");
-        // Materialize every declared blob under `root` into a temp dir, then let
-        // `wit-parser` decide the file set. Trusting the declared prefix instead would
-        // let a broken client smuggle garbage or unused `.wit` files past submit.
-        let declared: Vec<(String, &ContentDigest)> = known_files
-            .iter()
-            .filter(|(path, _)| path.starts_with(&prefix))
-            .map(|(path, digest)| (path.clone(), digest))
-            .collect();
-        ensure!(
-            !declared.is_empty(),
-            "CAS-backed resolution has no declared WIT files for `{root}`"
-        );
-        let temp_dir = tempfile::tempdir().context("cannot create temp dir to parse WIT")?;
-        for (path, digest) in &declared {
-            let path = crate::config::toml::sanitize_deployment_relative_path(path)?;
-            ensure!(
-                Path::new(&path).extension().and_then(|ext| ext.to_str()) == Some("wit"),
-                "declared WIT source is not a .wit file: `{path}`"
-            );
-            let full = temp_dir.path().join(&path);
-            if let Some(parent) = full.parent() {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .with_context(|| format!("cannot stage WIT file `{path}`"))?;
-            }
-            let bytes = self.read(&path, Some(digest)).await?;
-            tokio::fs::write(&full, &bytes)
-                .await
-                .with_context(|| format!("cannot stage WIT file `{path}`"))?;
-        }
-
-        let parsed = parse_wit_dir(temp_dir.path(), &root).await?;
-
-        // Reject stray declarations: a declared `.wit` file `wit-parser` did not select is
-        // dead weight the deployment -> digest mapping would pin, so refuse it here.
-        let selected: std::collections::BTreeSet<&str> =
-            parsed.files.iter().map(|(path, _)| path.as_str()).collect();
-        let stray: Vec<&str> = declared
-            .iter()
-            .map(|(path, _)| path.as_str())
-            .filter(|path| !selected.contains(path))
-            .collect();
-        ensure!(
-            stray.is_empty(),
-            "WIT directory `{root}` declares {stray:?} that `wit-parser` does not select"
-        );
-        Ok(parsed)
-    }
-}
-
 fn path_to_deployment_string(path: &Path) -> anyhow::Result<String> {
     let mut parts = Vec::new();
     for component in path.components() {
@@ -300,49 +226,21 @@ pub(crate) fn verify_content_digest(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use concepts::cas::CasError;
-    use std::collections::HashMap;
-    use std::sync::Mutex;
+    use concepts::cas::InMemoryCas;
 
-    fn digest_of(bytes: &[u8]) -> ContentDigest {
-        ContentDigest(Digest(Sha256::digest(bytes).into()))
-    }
-
-    #[derive(Default)]
-    struct MemCas {
-        blobs: Mutex<HashMap<ContentDigest, Vec<u8>>>,
-    }
-    impl MemCas {
-        fn insert(&self, bytes: &[u8]) -> ContentDigest {
-            let digest = digest_of(bytes);
-            self.blobs
-                .lock()
-                .unwrap()
-                .insert(digest.clone(), bytes.to_vec());
-            digest
-        }
-    }
-    #[async_trait::async_trait]
-    impl Cas for MemCas {
-        async fn read_blob(&self, digest: &ContentDigest) -> Result<Option<Vec<u8>>, CasError> {
-            Ok(self.blobs.lock().unwrap().get(digest).cloned())
-        }
-        async fn write_blob(&self, content: &[u8]) -> Result<ContentDigest, CasError> {
-            Ok(self.insert(content))
-        }
-        async fn contains_blob(&self, digest: &ContentDigest) -> Result<bool, CasError> {
-            Ok(self.blobs.lock().unwrap().contains_key(digest))
-        }
+    async fn insert(cas: &InMemoryCas, bytes: &[u8]) -> ContentDigest {
+        cas.write_blob(bytes).await.unwrap()
     }
 
     #[tokio::test]
     async fn cas_parse_wit_files_parses_a_valid_package() {
-        let cas = Arc::new(MemCas::default());
+        let cas = InMemoryCas::default();
         let src = "package any:any;\n\nworld any {}\n";
-        let digest = cas.insert(src.as_bytes());
-        let provider = CasFileProvider { cas };
+        let digest = insert(&cas, src.as_bytes()).await;
         let known = BTreeMap::from([("a/wit/impl.wit".to_string(), digest)]);
-        let parsed = provider.parse_wit_files("a/wit", &known).await.unwrap();
+        let parsed = parse_wit_files_from_cas(&cas, "a/wit", &known)
+            .await
+            .unwrap();
         assert_eq!(
             parsed.files,
             vec![("a/wit/impl.wit".to_string(), src.to_string())]
@@ -352,12 +250,10 @@ mod tests {
     #[tokio::test]
     async fn cas_parse_wit_files_rejects_malformed_wit() {
         // Before parsing on the CAS path, a client could push arbitrary bytes as `.wit`.
-        let cas = Arc::new(MemCas::default());
-        let digest = cas.insert(b"this is not valid wit @@@");
-        let provider = CasFileProvider { cas };
+        let cas = InMemoryCas::default();
+        let digest = insert(&cas, b"this is not valid wit @@@").await;
         let known = BTreeMap::from([("a/wit/impl.wit".to_string(), digest)]);
-        let err = provider
-            .parse_wit_files("a/wit", &known)
+        let err = parse_wit_files_from_cas(&cas, "a/wit", &known)
             .await
             .unwrap_err()
             .to_string();
@@ -371,17 +267,15 @@ mod tests {
     async fn cas_parse_wit_files_rejects_stray_declared_wit() {
         // A declared `.wit` `wit-parser` does not select (here, one buried in a non-`deps`
         // subdirectory) must be refused rather than silently persisted.
-        let cas = Arc::new(MemCas::default());
+        let cas = InMemoryCas::default();
         let impl_src = "package any:any;\n\nworld any {}\n";
-        let impl_digest = cas.insert(impl_src.as_bytes());
-        let stray_digest = cas.insert(b"package other:other;\n");
-        let provider = CasFileProvider { cas };
+        let impl_digest = insert(&cas, impl_src.as_bytes()).await;
+        let stray_digest = insert(&cas, b"package other:other;\n").await;
         let known = BTreeMap::from([
             ("a/wit/impl.wit".to_string(), impl_digest),
             ("a/wit/notes/scratch.wit".to_string(), stray_digest),
         ]);
-        let err = provider
-            .parse_wit_files("a/wit", &known)
+        let err = parse_wit_files_from_cas(&cas, "a/wit", &known)
             .await
             .unwrap_err()
             .to_string();

--- a/src/config/manifest.rs
+++ b/src/config/manifest.rs
@@ -1,10 +1,12 @@
-use crate::config::file_provider::{DiskProvider, FileProvider};
+use crate::command::server::cas_deployment_dir;
+use crate::config::file_provider::parse_wit_dir;
 use crate::config::toml::{
     DeploymentResolved, DeploymentToml, OCI_SCHEMA_PREFIX, sanitize_deployment_relative_path,
     strip_deployment_dir_prefix,
 };
 use anyhow::{Context, bail, ensure};
 use concepts::ContentDigest;
+use concepts::cas::Cas;
 use concepts::component_id::Digest;
 use concepts::storage::{ComponentFileRole, DeploymentComponentFileRecord, DeploymentFileRecord};
 use hashbrown::{HashMap, HashSet};
@@ -38,17 +40,21 @@ impl PreparedDeploymentManifest {
     }
 }
 
-/// Parse a verbatim manifest and resolve it using the supplied file provider.
+/// Resolve a processed deployment manifest against `cas`, reading every deployment-owned
+/// reference from the content-addressed store by digest.
 ///
-/// `deployment_dir` remains explicit until later slices move all `${DEPLOYMENT_DIR}` and
-/// WASM path resolution to the runtime environment.
-pub(crate) async fn manifest_to_resolved(
+/// This is the single resolution entry point shared by RPC submit, activation,
+/// `server run (-d)`, and offline `deployment verify`. The manifest is addressed by content:
+/// deployment-relative paths stay logical filenames (for imports, diagnostics, and exported
+/// sources) and are never storage addresses, so resolution never touches the submitter's disk.
+pub(crate) async fn resolve_manifest(
     deployment_toml: &str,
-    deployment_dir: &Path,
-    provider: &dyn FileProvider,
+    cas: &dyn Cas,
 ) -> anyhow::Result<DeploymentResolved> {
-    parse_manifest(deployment_toml, deployment_dir)?
-        .resolve_with_provider(provider)
+    // A processed manifest carries no submitter host, so relative WASM/script paths stay
+    // relative (addressed by digest in the CAS) after validation against an empty root.
+    parse_manifest(deployment_toml, &cas_deployment_dir())?
+        .resolve(cas)
         .await
 }
 
@@ -975,17 +981,12 @@ async fn collect_wit_refs(
     let Some(components) = doc.get_mut(section).and_then(Item::as_array_of_tables_mut) else {
         return Ok(());
     };
-    let provider = DiskProvider {
-        deployment_dir: deployment_dir.to_path_buf(),
-    };
     for table in components.iter_mut() {
         let Some(raw_root) = table.get("wit").and_then(Item::as_str) else {
             continue;
         };
         let root = sanitize_deployment_relative_path(raw_root)?;
-        let parsed = provider
-            .parse_wit_files(&root, &std::collections::BTreeMap::new()) // disk provider does not need a path -> digest map
-            .await?;
+        let parsed = parse_wit_dir(deployment_dir, &root).await?;
 
         let mut refs = InlineTable::new();
         if let Some(existing) = table.get("component_files").and_then(Item::as_table_like) {
@@ -1326,7 +1327,20 @@ async fn reconcile_backtrace_section(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::file_provider::DiskProvider;
+    use concepts::cas::InMemoryCas;
+
+    /// Upload a prepared manifest's blobs to an in-memory CAS (checking each digest), then
+    /// resolve the processed TOML through the shared CAS-based path.
+    async fn resolve_prepared(prepared: &PreparedDeploymentManifest) -> DeploymentResolved {
+        let cas = InMemoryCas::default();
+        for file in &prepared.files {
+            let stored = cas.write_blob(&file.bytes).await.unwrap();
+            assert_eq!(stored, file.digest, "prepared blob digest mismatch");
+        }
+        resolve_manifest(&prepared.deployment_toml, &cas)
+            .await
+            .unwrap()
+    }
 
     #[tokio::test]
     async fn prepare_fills_relative_script_digest_and_collects_blob() {
@@ -1555,12 +1569,7 @@ ffqn = "ns:pkg/ifc.fn"
             ComponentFileRole::JsModule
         );
 
-        let provider = DiskProvider {
-            deployment_dir: dir.path().to_path_buf(),
-        };
-        let resolved = manifest_to_resolved(&prepared.deployment_toml, dir.path(), &provider)
-            .await
-            .unwrap();
+        let resolved = resolve_prepared(&prepared).await;
         assert_matches::assert_matches!(
             &resolved.activities_js[0].location,
             crate::config::toml::ScriptLocationResolved::Graph { entry_path, files }
@@ -1698,12 +1707,7 @@ location = "components/w.wasm"
             ComponentFileRole::BacktraceSource
         );
 
-        let provider = DiskProvider {
-            deployment_dir: dir.path().to_path_buf(),
-        };
-        let resolved = manifest_to_resolved(&prepared.deployment_toml, dir.path(), &provider)
-            .await
-            .unwrap();
+        let resolved = resolve_prepared(&prepared).await;
         assert_eq!(
             resolved.workflows_wasm[0].backtrace.frame_files_to_sources[".../src/lib.rs"]
                 .content_digest,
@@ -1911,7 +1915,7 @@ location = "components/a.wasm"
     }
 
     #[tokio::test]
-    async fn manifest_to_resolved_uses_supplied_provider() {
+    async fn resolve_manifest_reads_blobs_from_cas() {
         let dir = tempfile::tempdir().unwrap();
         tokio::fs::write(dir.path().join("a.js"), "export const x = 1;")
             .await
@@ -1922,13 +1926,11 @@ name = "a"
 location = "a.js"
 ffqn = "ns:pkg/ifc.fn"
 "#;
-        let provider = DiskProvider {
-            deployment_dir: dir.path().to_path_buf(),
-        };
-
-        let resolved = manifest_to_resolved(manifest, dir.path(), &provider)
+        let prepared = prepare_deployment_manifest(manifest, dir.path())
             .await
             .unwrap();
+
+        let resolved = resolve_prepared(&prepared).await;
 
         assert_eq!(resolved.activities_js.len(), 1);
     }

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -1101,29 +1101,29 @@ impl HasOptionalNameAndFfqn for ActivityStubExtInlineConfigToml {
 /// On-disk format only; replaced by [`ScriptLocationResolved`] before hash computation.
 #[derive(Debug, Clone, Hash, JsonSchema, SerializeDisplay, DeserializeFromStr)]
 #[schemars(with = "String")]
-pub(crate) enum JsLocationToml {
+pub(crate) enum ScriptLocationPathOrOci {
     Path(String),
     Oci(oci_client::Reference),
 }
-impl Display for JsLocationToml {
+impl Display for ScriptLocationPathOrOci {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            JsLocationToml::Path(p) => write!(f, "{p}"),
-            JsLocationToml::Oci(r) => write!(f, "{OCI_SCHEMA_PREFIX}{r}"),
+            ScriptLocationPathOrOci::Path(p) => write!(f, "{p}"),
+            ScriptLocationPathOrOci::Oci(r) => write!(f, "{OCI_SCHEMA_PREFIX}{r}"),
         }
     }
 }
-impl FromStr for JsLocationToml {
+impl FromStr for ScriptLocationPathOrOci {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(location) = s.strip_prefix(OCI_SCHEMA_PREFIX) {
-            Ok(JsLocationToml::Oci(
+            Ok(ScriptLocationPathOrOci::Oci(
                 oci_client::Reference::from_str(location)
                     .map_err(|e| anyhow::anyhow!("invalid OCI reference: {e}"))?,
             ))
         } else {
-            Ok(JsLocationToml::Path(s.to_string()))
+            Ok(ScriptLocationPathOrOci::Path(s.to_string()))
         }
     }
 }
@@ -1700,7 +1700,7 @@ pub(crate) struct ActivityJsComponentConfigToml {
     /// Location of the JavaScript source file.
     /// Supports local file paths and OCI registry references (`oci://...`).
     #[serde(default)]
-    pub(crate) location: Option<JsLocationToml>,
+    pub(crate) location: Option<ScriptLocationPathOrOci>,
     /// Inline JavaScript source embedded in the TOML.
     /// Exactly one of `location` or `content` must be set.
     #[serde(default)]
@@ -1782,7 +1782,7 @@ pub(crate) struct ActivityExecComponentConfigToml {
     /// Location of the exec script.
     /// Supports local file paths and OCI registry references (`oci://...`).
     #[serde(default)]
-    pub(crate) location: Option<JsLocationToml>,
+    pub(crate) location: Option<ScriptLocationPathOrOci>,
     /// Inline script content embedded in the TOML.
     /// Exactly one of `location` or `content` must be set.
     #[serde(default)]
@@ -2046,7 +2046,7 @@ pub(crate) struct WorkflowJsComponentConfigToml {
     /// Location of the JavaScript source file.
     /// Supports local file paths and OCI registry references (`oci://...`).
     #[serde(default)]
-    pub(crate) location: Option<JsLocationToml>,
+    pub(crate) location: Option<ScriptLocationPathOrOci>,
     /// Inline JavaScript source embedded in the TOML.
     /// Exactly one of `location` or `content` must be set.
     #[serde(default)]
@@ -3036,12 +3036,12 @@ pub(crate) fn sanitize_deployment_relative_path(rel: &str) -> anyhow::Result<Str
 
 enum ScriptToml {
     JavaScript {
-        location: Option<JsLocationToml>,
+        location: Option<ScriptLocationPathOrOci>,
         content: Option<String>,
         component_files: BTreeMap<String, ContentDigest>,
     },
     Exec {
-        location: Option<JsLocationToml>,
+        location: Option<ScriptLocationPathOrOci>,
         content: Option<String>,
     },
 }
@@ -3095,7 +3095,7 @@ async fn resolve_script_toml(
                 file_name: default_file_name,
             })
         }
-        (Some(JsLocationToml::Path(path)), None) => {
+        (Some(ScriptLocationPathOrOci::Path(path)), None) => {
             if std::path::Path::new(&path).is_absolute() {
                 bail!("absolute local paths are not allowed in deployment manifests: `{path}`")
             }
@@ -3161,7 +3161,7 @@ async fn resolve_script_toml(
                 file_name: path,
             })
         }
-        (Some(JsLocationToml::Oci(reference)), None) => {
+        (Some(ScriptLocationPathOrOci::Oci(reference)), None) => {
             if let ModuleGraphResolution::JavaScript(component_files) = module_graph {
                 ensure!(
                     component_files.is_empty(),
@@ -3491,7 +3491,7 @@ pub(crate) mod webhook {
     use super::{
         AllowedHostToml, ComponentBacktraceConfig, ComponentCommon, ComponentCommonFetchExt,
         ComponentStdOutputToml, ComponentStdOutputTomlExt, ConfigName, JsContent,
-        JsLocationResolvedExt, JsLocationToml, LogLevelTomlExt, SecretResolver, hash_js_graph,
+        JsLocationResolvedExt, ScriptLocationPathOrOci, LogLevelTomlExt, SecretResolver, hash_js_graph,
         resolve_allowed_hosts, resolve_env_vars_plaintext, restricted_secret_registry,
         validate_no_env_collision,
     };
@@ -3621,7 +3621,7 @@ pub(crate) mod webhook {
         /// Location of the JavaScript source file.
         /// Supports local file paths and OCI registry references (`oci://...`).
         #[serde(default)]
-        pub(crate) location: Option<JsLocationToml>,
+        pub(crate) location: Option<ScriptLocationPathOrOci>,
         /// Inline JavaScript source embedded in the TOML.
         /// Exactly one of `location` or `content` must be set.
         #[serde(default)]
@@ -4881,7 +4881,7 @@ name = "my_stub"
         use concepts::cas::InMemoryCas;
 
         fn javascript(
-            location: Option<JsLocationToml>,
+            location: Option<ScriptLocationPathOrOci>,
             content: Option<String>,
             component_files: BTreeMap<String, ContentDigest>,
         ) -> ScriptToml {
@@ -4923,7 +4923,7 @@ name = "my_stub"
             // Bare relative path (implicit `${DEPLOYMENT_DIR}` prefix).
             let location = resolve_script_toml(
                 javascript(
-                    Some(JsLocationToml::Path("scripts/a.js".to_string())),
+                    Some(ScriptLocationPathOrOci::Path("scripts/a.js".to_string())),
                     None,
                     BTreeMap::new(),
                 ),
@@ -4950,7 +4950,7 @@ name = "my_stub"
 
             let location = resolve_script_toml(
                 javascript(
-                    Some(JsLocationToml::Path(
+                    Some(ScriptLocationPathOrOci::Path(
                         "${DEPLOYMENT_DIR}/scripts/a.js".to_string(),
                     )),
                     None,
@@ -4974,7 +4974,7 @@ name = "my_stub"
             let abs = "/tmp/outside.js".to_string();
             let err = resolve_script_toml(
                 javascript(
-                    Some(JsLocationToml::Path(abs.clone())),
+                    Some(ScriptLocationPathOrOci::Path(abs.clone())),
                     None,
                     BTreeMap::new(),
                 ),
@@ -4997,7 +4997,7 @@ name = "my_stub"
             for raw in ["../escape.js", "${DEPLOYMENT_DIR}/../escape.js"] {
                 let err = resolve_script_toml(
                     javascript(
-                        Some(JsLocationToml::Path(raw.to_string())),
+                        Some(ScriptLocationPathOrOci::Path(raw.to_string())),
                         None,
                         BTreeMap::new(),
                     ),
@@ -5018,7 +5018,7 @@ name = "my_stub"
             let reference =
                 oci_client::Reference::from_str("docker.io/library/example:latest").unwrap();
             let location = resolve_script_toml(
-                javascript(Some(JsLocationToml::Oci(reference)), None, BTreeMap::new()),
+                javascript(Some(ScriptLocationPathOrOci::Oci(reference)), None, BTreeMap::new()),
                 "ignored.js".to_string(),
                 &cas,
                 None,
@@ -5072,7 +5072,7 @@ name = "my_stub"
             let missing = digest_of(b"nope");
             let err = resolve_script_toml(
                 javascript(
-                    Some(JsLocationToml::Path("script.js".to_string())),
+                    Some(ScriptLocationPathOrOci::Path("script.js".to_string())),
                     None,
                     BTreeMap::new(),
                 ),

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -5,7 +5,9 @@ use crate::config::config_holder::{CACHE_DIR_PREFIX, DATA_DIR_PREFIX};
 use crate::config::env_var::{
     EnvVarError, EnvVarsMissing, interpolate_env_vars_plaintext, interpolate_env_vars_secret,
 };
-use crate::config::file_provider::{DiskProvider, FileProvider, verify_content_digest};
+use crate::config::file_provider::{
+    parse_js_graph_from_cas, parse_wit_files_from_cas, read_package_blob, verify_content_digest,
+};
 use crate::config::secret_registry::{
     RestrictedSecretRegistry, SecretRegistry, SecretViolation, SecretsToml,
 };
@@ -16,6 +18,7 @@ use anyhow::{Context, ensure};
 use anyhow::{anyhow, bail};
 use concepts::ContentDigest;
 use concepts::ReturnType;
+use concepts::cas::Cas;
 use concepts::component_id::Digest;
 use concepts::{
     ComponentId, ComponentRetryConfig, ComponentType, FunctionFqn, StrVariant,
@@ -149,24 +152,14 @@ pub(crate) struct DeploymentTomlValidated {
     pub(crate) crons: Vec<CronComponentConfigToml>,
 
     pub(crate) component_names_to_types: hashbrown::HashMap<String, crate::args::TomlComponentType>,
-
-    /// Canonicalized deployment directory, used to decide whether a script path is
-    /// owned by the deployment (under this dir) or an external reference.
-    pub(crate) deployment_dir: PathBuf,
 }
 impl DeploymentTomlValidated {
-    pub(crate) async fn resolve(self) -> Result<DeploymentResolved, anyhow::Error> {
-        let provider = DiskProvider {
-            deployment_dir: self.deployment_dir.clone(),
-        };
-        self.resolve_with_provider(&provider).await
-    }
-
-    pub(crate) async fn resolve_with_provider(
-        self,
-        provider: &dyn FileProvider,
-    ) -> Result<DeploymentResolved, anyhow::Error> {
-        resolve_local_refs(self, provider).await
+    /// Resolve every deployment-owned reference by reading its blob from `cas` by digest.
+    ///
+    /// The manifest must be processed (every deployment-owned reference carries a digest in
+    /// `content_digest` / `component_files`); resolution never touches the submitter's disk.
+    pub(crate) async fn resolve(self, cas: &dyn Cas) -> Result<DeploymentResolved, anyhow::Error> {
+        resolve_local_refs(self, cas).await
     }
 }
 
@@ -285,7 +278,6 @@ impl DeploymentToml {
             crons: self.crons,
 
             component_names_to_types,
-            deployment_dir: deployment_dir.to_path_buf(),
         })
     }
 
@@ -2676,12 +2668,12 @@ impl WorkflowJsComponentConfigResolvedExt for WorkflowJsComponentConfigResolved 
 /// source files.
 async fn resolve_local_refs(
     deployment: DeploymentTomlValidated,
-    provider: &dyn FileProvider,
+    cas: &dyn Cas,
 ) -> anyhow::Result<DeploymentResolved> {
     let mut activities_js = Vec::with_capacity(deployment.activities_js.len());
     for (mut a, name) in deployment.activities_js {
         let interface =
-            resolve_function_interface(a.interface, &mut a.component_files, provider).await?;
+            resolve_function_interface(a.interface, &mut a.component_files, cas).await?;
         activities_js.push(ActivityJsComponentConfigResolved {
             location: resolve_script_toml(
                 ScriptToml::JavaScript {
@@ -2690,7 +2682,7 @@ async fn resolve_local_refs(
                     component_files: a.component_files,
                 },
                 format!("{name}.js"),
-                provider,
+                cas,
                 a.content_digest.as_ref(),
             )
             .await?,
@@ -2719,7 +2711,7 @@ async fn resolve_local_refs(
             exec: w.exec,
             retry_exp_backoff: w.retry_exp_backoff,
             blocking_strategy: w.blocking_strategy,
-            backtrace: resolve_backtrace(&w.backtrace, &w.component_files, provider).await?,
+            backtrace: resolve_backtrace(&w.backtrace, &w.component_files)?,
             stub_wasi: w.stub_wasi,
             lock_extension: w.lock_extension,
             lock_extension_leeway: w.lock_extension_leeway,
@@ -2730,7 +2722,7 @@ async fn resolve_local_refs(
     let mut workflows_js = Vec::with_capacity(deployment.workflows_js.len());
     for (mut w, name) in deployment.workflows_js {
         let interface =
-            resolve_function_interface(w.interface, &mut w.component_files, provider).await?;
+            resolve_function_interface(w.interface, &mut w.component_files, cas).await?;
         workflows_js.push(WorkflowJsComponentConfigResolved {
             location: resolve_script_toml(
                 ScriptToml::JavaScript {
@@ -2739,7 +2731,7 @@ async fn resolve_local_refs(
                     component_files: w.component_files,
                 },
                 format!("{name}.js"),
-                provider,
+                cas,
                 w.content_digest.as_ref(),
             )
             .await?,
@@ -2767,7 +2759,7 @@ async fn resolve_local_refs(
             forward_stdout: w.forward_stdout,
             forward_stderr: w.forward_stderr,
             env_vars: w.env_vars,
-            backtrace: resolve_backtrace(&w.backtrace, &w.component_files, provider).await?,
+            backtrace: resolve_backtrace(&w.backtrace, &w.component_files)?,
             backtrace_persist: w.backtrace_persist,
             logs_store_min_level: w.logs_store_min_level,
             allowed_hosts: w.allowed_hosts,
@@ -2785,7 +2777,7 @@ async fn resolve_local_refs(
                     component_files: w.component_files,
                 },
                 format!("{}.js", w.name),
-                provider,
+                cas,
                 w.content_digest.as_ref(),
             )
             .await?,
@@ -2805,7 +2797,7 @@ async fn resolve_local_refs(
     let mut activities_exec = Vec::with_capacity(deployment.activities_exec.len());
     for (mut a, name) in deployment.activities_exec {
         let interface =
-            resolve_function_interface(a.interface, &mut a.component_files, provider).await?;
+            resolve_function_interface(a.interface, &mut a.component_files, cas).await?;
         ensure!(
             a.component_files.is_empty(),
             "activity_exec component_files contains files not selected by its WIT"
@@ -2816,7 +2808,7 @@ async fn resolve_local_refs(
                 content: a.content,
             },
             name.to_string(),
-            provider,
+            cas,
             a.content_digest.as_ref(),
         )
         .await?;
@@ -2849,8 +2841,7 @@ async fn resolve_local_refs(
             }
             ActivityStubComponentConfigToml::Inline(mut i) => {
                 let interface =
-                    resolve_function_interface(i.interface, &mut i.component_files, provider)
-                        .await?;
+                    resolve_function_interface(i.interface, &mut i.component_files, cas).await?;
                 ensure!(
                     i.component_files.is_empty(),
                     "activity_stub component_files contains files not selected by its WIT"
@@ -2871,8 +2862,7 @@ async fn resolve_local_refs(
             }
             ActivityExternalComponentConfigToml::Inline(mut i) => {
                 let interface =
-                    resolve_function_interface(i.interface, &mut i.component_files, provider)
-                        .await?;
+                    resolve_function_interface(i.interface, &mut i.component_files, cas).await?;
                 ensure!(
                     i.component_files.is_empty(),
                     "activity_external component_files contains files not selected by its WIT"
@@ -2908,7 +2898,7 @@ async fn resolve_local_refs(
 async fn resolve_function_interface(
     interface: FunctionInterfaceToml,
     component_files: &mut BTreeMap<String, ContentDigest>,
-    provider: &dyn FileProvider,
+    cas: &dyn Cas,
 ) -> anyhow::Result<FunctionInterfaceResolved> {
     let root = match interface {
         FunctionInterfaceToml::Authored(AuthoredFunctionInterfaceToml { wit }) => wit,
@@ -2926,7 +2916,7 @@ async fn resolve_function_interface(
     };
     let root = sanitize_deployment_relative_path(&root)?;
     // TODO: Cache parsed WIT packages by root during deployment resolution.
-    let parsed = provider.parse_wit_files(&root, component_files).await?;
+    let parsed = parse_wit_files_from_cas(cas, &root, component_files).await?;
     let prefix = format!("{root}/");
     for (path, _) in &parsed.files {
         ensure!(
@@ -3074,7 +3064,7 @@ enum ModuleGraphResolution {
 async fn resolve_script_toml(
     script: ScriptToml,
     default_file_name: String,
-    provider: &dyn FileProvider,
+    cas: &dyn Cas,
     content_digest: Option<&ContentDigest>,
 ) -> anyhow::Result<ScriptLocationResolved> {
     let (location, content, module_graph) = match script {
@@ -3129,7 +3119,7 @@ async fn resolve_script_toml(
                     }
                     _ => {}
                 }
-                let files = provider.parse_js_graph(&path, &known).await?;
+                let files = parse_js_graph_from_cas(cas, &path, &known).await?;
                 let entry_source = files
                     .iter()
                     .find_map(|(module_path, source)| (module_path == &path).then_some(source))
@@ -3158,7 +3148,12 @@ async fn resolve_script_toml(
                     });
                 }
             }
-            let content = provider.read(&path, content_digest).await?;
+            let digest = content_digest.with_context(|| {
+                // TODO: resolved deployment must have content_digest set, this can only happen on a corrupted deployment record.
+                // This should be fixed by having a separate schema for DB deployment.
+                format!("deployment-owned script `{path}` is missing a content digest")
+            })?;
+            let content = read_package_blob(cas, digest, &path).await?;
             let content = String::from_utf8(content)
                 .with_context(|| format!("script file {path:?} is not valid UTF-8"))?;
             Ok(ScriptLocationResolved::Content {
@@ -3181,10 +3176,9 @@ async fn resolve_script_toml(
     }
 }
 
-async fn resolve_backtrace(
+fn resolve_backtrace(
     backtrace: &ComponentBacktraceConfig,
     component_files: &BTreeMap<String, ContentDigest>,
-    provider: &dyn FileProvider,
 ) -> anyhow::Result<ComponentBacktraceConfigResolved> {
     let mut frame_files_to_sources = HashMap::new();
     for (key, source) in &backtrace.frame_files_to_sources {
@@ -3198,29 +3192,17 @@ async fn resolve_backtrace(
         } else {
             sanitize_deployment_relative_path(path)?
         };
-        // backcompat: 0.41 processed manifests stored the digest beside each source path.
-        // Remove `source.content_digest()` in 0.42 as clients must supply the content_digest in `component_files`.
-        // The bytes are uploaded to the CAS with the deployment files, so a known digest is a
-        // complete reference. An authored manifest with no pinned digest (disk resolution)
-        // falls back to reading the file once to hash it.
-        let content_digest = if let Some(digest) = component_files
+        // The processed manifest carries every deployment-owned backtrace source's digest in
+        // `component_files`; the bytes are in the CAS, so the digest is a complete reference.
+        // backcompat: 0.41 processed manifests stored the digest beside each source path
+        // (`source.content_digest()`); remove that fallback in 0.42.
+        let content_digest = component_files
             .get(&file_name)
             .or_else(|| source.content_digest())
-        {
-            digest.clone()
-        } else {
-            // Reached only on the `server run -d` raw-resolution path, where `provider` is a
-            // `DiskProvider`: this is a disk read, never a CAS read (the RPC/DB path always
-            // has a populated `component_files`). Removed once both paths resolve the
-            // processed manifest from the CAS: see meta/designs/cas-first-deployment-pipeline.md.
-            match provider.read(&file_name, None).await {
-                Ok(bytes) => ContentDigest(Digest(Sha256::digest(&bytes).into())),
-                Err(err) => {
-                    warn!("Cannot read backtrace source {file_name:?} - {err:?}");
-                    continue;
-                }
-            }
-        };
+            .with_context(|| {
+                format!("backtrace source `{file_name}` has no digest in `component_files`")
+            })?
+            .clone();
         frame_files_to_sources.insert(
             key.clone(),
             BacktraceSourceResolved {
@@ -4290,6 +4272,13 @@ pub(crate) mod cron {
 
 #[cfg(test)]
 mod tests {
+    use concepts::{ContentDigest, component_id::Digest};
+    use sha2::{Digest as _, Sha256};
+
+    fn digest_of(bytes: &[u8]) -> ContentDigest {
+        ContentDigest(Digest(Sha256::digest(bytes).into()))
+    }
+
     mod outbound_http {
         use super::super::*;
 
@@ -4635,12 +4624,9 @@ strategy = { kind = "await", non_blocking_event_batching = 25, extra_stuff = "he
     }
 
     mod activity_stub {
-        use super::super::*;
+        use crate::config::toml::tests::digest_of;
 
-        fn digest_of(bytes: &[u8]) -> ContentDigest {
-            let hash: [u8; 32] = Sha256::digest(bytes).into();
-            ContentDigest(Digest(hash))
-        }
+        use super::super::*;
 
         #[test]
         fn deserialize_file_mode() {
@@ -4711,6 +4697,8 @@ name = "my_stub"
     mod activity_exec {
         use secrecy::{ExposeSecret as _, SecretString};
 
+        use crate::config::toml::tests::digest_of;
+
         use super::super::*;
 
         /// A config that references the registered secret name `MY_SECRET`.
@@ -4768,14 +4756,10 @@ name = "my_stub"
             }
         }
 
-        fn content_digest_of(bytes: &[u8]) -> ContentDigest {
-            ContentDigest(Digest(Sha256::digest(bytes).into()))
-        }
-
         fn inline_program() -> ResolvedExecProgram {
             ResolvedExecProgram {
                 program: PathBuf::from("/tmp/fake-exec-script.sh"),
-                content_digest: content_digest_of(b"#!/usr/bin/env bash\necho null\n"),
+                content_digest: digest_of(b"#!/usr/bin/env bash\necho null\n"),
             }
         }
 
@@ -4843,7 +4827,7 @@ name = "my_stub"
                 .fetch_and_verify(
                     ResolvedExecProgram {
                         program: PathBuf::from("/tmp/fake-exec-script.sh"),
-                        content_digest: content_digest_of(&source),
+                        content_digest: digest_of(&source),
                     },
                     true,
                     &std::sync::Arc::new(SecretRegistry::empty()),
@@ -4854,7 +4838,7 @@ name = "my_stub"
                 .fetch_and_verify(
                     ResolvedExecProgram {
                         program: PathBuf::from("/tmp/fake-exec-script.sh"),
-                        content_digest: content_digest_of(&source),
+                        content_digest: digest_of(&source),
                     },
                     true,
                     &std::sync::Arc::new(SecretRegistry::empty()),
@@ -4891,7 +4875,10 @@ name = "my_stub"
     }
 
     mod script_location {
+        use crate::config::toml::tests::digest_of;
+
         use super::super::*;
+        use concepts::cas::InMemoryCas;
 
         fn javascript(
             location: Option<JsLocationToml>,
@@ -4905,21 +4892,9 @@ name = "my_stub"
             }
         }
 
-        fn digest_of(bytes: &[u8]) -> ContentDigest {
-            let hash: [u8; 32] = Sha256::digest(bytes).into();
-            ContentDigest(Digest(hash))
-        }
-
-        fn disk_provider(dir: &Path) -> DiskProvider {
-            DiskProvider {
-                deployment_dir: dir.to_path_buf(),
-            }
-        }
-
         #[tokio::test]
         async fn inline_content_becomes_owned() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
+            let cas = InMemoryCas::default();
             let location = resolve_script_toml(
                 javascript(
                     None,
@@ -4927,7 +4902,7 @@ name = "my_stub"
                     BTreeMap::new(),
                 ),
                 "foo.js".to_string(),
-                &provider,
+                &cas,
                 None,
             )
             .await
@@ -4941,11 +4916,9 @@ name = "my_stub"
 
         #[tokio::test]
         async fn relative_file_is_owned_and_mirrors_subpath() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
-            let sub = dir.path().join("scripts");
-            std::fs::create_dir_all(&sub).unwrap();
-            std::fs::write(sub.join("a.js"), "export default 'owned content';").unwrap();
+            let cas = InMemoryCas::default();
+            let source = "export default 'owned content';";
+            let digest = cas.write_blob(source.as_bytes()).await.unwrap();
 
             // Bare relative path (implicit `${DEPLOYMENT_DIR}` prefix).
             let location = resolve_script_toml(
@@ -4955,25 +4928,25 @@ name = "my_stub"
                     BTreeMap::new(),
                 ),
                 "ignored.js".to_string(),
-                &provider,
-                None,
+                &cas,
+                Some(&digest),
             )
             .await
             .unwrap();
             assert_matches::assert_matches!(
                 location,
                 ScriptLocationResolved::Content { content, file_name }
-                    if content == "export default 'owned content';" && file_name == "scripts/a.js"
+                    if content == source && file_name == "scripts/a.js"
             );
         }
 
         #[tokio::test]
         async fn explicit_deployment_dir_prefix_is_owned() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
-            let sub = dir.path().join("scripts");
-            std::fs::create_dir_all(&sub).unwrap();
-            std::fs::write(sub.join("a.js"), "export default 'owned content';").unwrap();
+            let cas = InMemoryCas::default();
+            let digest = cas
+                .write_blob(b"export default 'owned content';")
+                .await
+                .unwrap();
 
             let location = resolve_script_toml(
                 javascript(
@@ -4984,8 +4957,8 @@ name = "my_stub"
                     BTreeMap::new(),
                 ),
                 "ignored.js".to_string(),
-                &provider,
-                None,
+                &cas,
+                Some(&digest),
             )
             .await
             .unwrap();
@@ -4997,12 +4970,8 @@ name = "my_stub"
 
         #[tokio::test]
         async fn absolute_path_is_rejected() {
-            let root = tempfile::tempdir().unwrap();
-            let provider = disk_provider(root.path());
-            let outside = root.path().join("outside.js");
-            std::fs::write(&outside, "external content").unwrap();
-            let abs = outside.to_string_lossy().into_owned();
-
+            let cas = InMemoryCas::default();
+            let abs = "/tmp/outside.js".to_string();
             let err = resolve_script_toml(
                 javascript(
                     Some(JsLocationToml::Path(abs.clone())),
@@ -5010,7 +4979,7 @@ name = "my_stub"
                     BTreeMap::new(),
                 ),
                 "ignored.js".to_string(),
-                &provider,
+                &cas,
                 None,
             )
             .await
@@ -5024,8 +4993,7 @@ name = "my_stub"
 
         #[tokio::test]
         async fn parent_dir_escape_is_rejected() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
+            let cas = InMemoryCas::default();
             for raw in ["../escape.js", "${DEPLOYMENT_DIR}/../escape.js"] {
                 let err = resolve_script_toml(
                     javascript(
@@ -5034,7 +5002,7 @@ name = "my_stub"
                         BTreeMap::new(),
                     ),
                     "ignored.js".to_string(),
-                    &provider,
+                    &cas,
                     None,
                 )
                 .await
@@ -5046,14 +5014,13 @@ name = "my_stub"
 
         #[tokio::test]
         async fn oci_becomes_oci() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
+            let cas = InMemoryCas::default();
             let reference =
                 oci_client::Reference::from_str("docker.io/library/example:latest").unwrap();
             let location = resolve_script_toml(
                 javascript(Some(JsLocationToml::Oci(reference)), None, BTreeMap::new()),
                 "ignored.js".to_string(),
-                &provider,
+                &cas,
                 None,
             )
             .await
@@ -5067,26 +5034,25 @@ name = "my_stub"
 
         #[tokio::test]
         async fn content_digest_verified_at_submit() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
+            let cas = InMemoryCas::default();
             let content = "export const x = 1;";
 
             // Matching digest succeeds.
             resolve_script_toml(
                 javascript(None, Some(content.to_string()), BTreeMap::new()),
                 "foo.js".to_string(),
-                &provider,
+                &cas,
                 Some(&digest_of(content.as_bytes())),
             )
             .await
             .expect("matching digest should pass");
 
-            // Mismatching digest fails.
+            // Mismatching digest on inline content fails.
             let wrong = digest_of(b"different");
             let err = resolve_script_toml(
                 javascript(None, Some(content.to_string()), BTreeMap::new()),
                 "foo.js".to_string(),
-                &provider,
+                &cas,
                 Some(&wrong),
             )
             .await
@@ -5099,16 +5065,11 @@ name = "my_stub"
         }
 
         #[tokio::test]
-        async fn relative_file_content_digest_verified_at_submit() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = disk_provider(dir.path());
-            std::fs::write(
-                dir.path().join("script.js"),
-                "export default 'owned content';",
-            )
-            .unwrap();
-
-            let wrong = digest_of(b"nope");
+        async fn relative_file_missing_blob_is_rejected() {
+            // A relative script whose pinned digest is not in the CAS cannot be resolved: in the
+            // content-addressed model a wrong digest is a missing blob, not a hash mismatch.
+            let cas = InMemoryCas::default();
+            let missing = digest_of(b"nope");
             let err = resolve_script_toml(
                 javascript(
                     Some(JsLocationToml::Path("script.js".to_string())),
@@ -5116,14 +5077,14 @@ name = "my_stub"
                     BTreeMap::new(),
                 ),
                 "ignored.js".to_string(),
-                &provider,
-                Some(&wrong),
+                &cas,
+                Some(&missing),
             )
             .await
-            .unwrap_err()
-            .to_string();
+            .unwrap_err();
+            let err = format!("{err:#}");
             assert!(
-                err.contains("content digest mismatch"),
+                err.contains("not present in the CAS"),
                 "unexpected error: {err}"
             );
         }
@@ -5203,6 +5164,8 @@ name = "my_stub"
     }
 
     mod backtrace {
+        use crate::config::toml::tests::digest_of;
+
         use super::super::*;
 
         #[test]
@@ -5244,72 +5207,50 @@ name = "my_stub"
             );
         }
 
-        #[tokio::test]
-        async fn resolved_retains_relative_subpath() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = DiskProvider {
-                deployment_dir: dir.path().to_path_buf(),
-            };
-            let sub = dir.path().join("crates/foo/src");
-            std::fs::create_dir_all(&sub).unwrap();
-            std::fs::write(sub.join("lib.rs"), "SRC").unwrap();
+        #[test]
+        fn resolved_retains_relative_subpath() {
+            let digest = digest_of(b"SRC");
+            let component_files =
+                BTreeMap::from([("crates/foo/src/lib.rs".to_string(), digest.clone())]);
 
             let mut bt = ComponentBacktraceConfig::default();
             bt.frame_files_to_sources.insert(
                 ".../src/lib.rs".to_string(),
                 "${DEPLOYMENT_DIR}/crates/foo/src/lib.rs".to_string().into(),
             );
-            let resolved = resolve_backtrace(&bt, &BTreeMap::new(), &provider)
-                .await
-                .unwrap();
+            let resolved = resolve_backtrace(&bt, &component_files).unwrap();
             let src = resolved
                 .frame_files_to_sources
                 .get(".../src/lib.rs")
                 .unwrap();
-            assert_eq!(
-                src.content_digest,
-                ContentDigest(Digest(Sha256::digest(b"SRC").into()))
-            );
+            assert_eq!(src.content_digest, digest);
             assert_eq!(src.file_name, "crates/foo/src/lib.rs");
         }
 
-        #[tokio::test]
-        async fn bare_relative_source_is_deployment_dir_relative() {
-            // A bare relative backtrace source (no `${DEPLOYMENT_DIR}` prefix) is resolved
-            // against the deployment dir, same as the explicit-prefix form.
-            let dir = tempfile::tempdir().unwrap();
-            let provider = DiskProvider {
-                deployment_dir: dir.path().to_path_buf(),
-            };
-            let sub = dir.path().join("crates/foo/src");
-            std::fs::create_dir_all(&sub).unwrap();
-            std::fs::write(sub.join("lib.rs"), "SRC").unwrap();
+        #[test]
+        fn bare_relative_source_is_deployment_dir_relative() {
+            // A bare relative backtrace source (no `${DEPLOYMENT_DIR}` prefix) resolves to the
+            // same deployment-relative file name as the explicit-prefix form.
+            let digest = digest_of(b"SRC");
+            let component_files =
+                BTreeMap::from([("crates/foo/src/lib.rs".to_string(), digest.clone())]);
 
             let mut bt = ComponentBacktraceConfig::default();
             bt.frame_files_to_sources.insert(
                 ".../src/lib.rs".to_string(),
                 "crates/foo/src/lib.rs".to_string().into(),
             );
-            let resolved = resolve_backtrace(&bt, &BTreeMap::new(), &provider)
-                .await
-                .unwrap();
+            let resolved = resolve_backtrace(&bt, &component_files).unwrap();
             let src = resolved
                 .frame_files_to_sources
                 .get(".../src/lib.rs")
                 .unwrap();
-            assert_eq!(
-                src.content_digest,
-                ContentDigest(Digest(Sha256::digest(b"SRC").into()))
-            );
+            assert_eq!(src.content_digest, digest);
             assert_eq!(src.file_name, "crates/foo/src/lib.rs");
         }
 
-        #[tokio::test]
-        async fn source_parent_dir_escape_is_rejected() {
-            let dir = tempfile::tempdir().unwrap();
-            let provider = DiskProvider {
-                deployment_dir: dir.path().to_path_buf(),
-            };
+        #[test]
+        fn source_parent_dir_escape_is_rejected() {
             let mut bt = ComponentBacktraceConfig::default();
             bt.frame_files_to_sources.insert(
                 "frame".to_string(),
@@ -5317,31 +5258,19 @@ name = "my_stub"
             );
             let err = format!(
                 "{:#}",
-                resolve_backtrace(&bt, &BTreeMap::new(), &provider)
-                    .await
-                    .unwrap_err()
+                resolve_backtrace(&bt, &BTreeMap::new()).unwrap_err()
             );
             assert!(err.contains("`..`"), "unexpected error: {err}");
         }
 
-        #[tokio::test]
-        async fn absolute_source_is_rejected() {
-            let dir = tempfile::tempdir().unwrap();
-            let abs = dir.path().join("nested/lib.rs");
-            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
-            std::fs::write(&abs, "SRC").unwrap();
-
+        #[test]
+        fn absolute_source_is_rejected() {
             let mut bt = ComponentBacktraceConfig::default();
             bt.frame_files_to_sources.insert(
                 ".../src/lib.rs".to_string(),
-                abs.to_string_lossy().into_owned().into(),
+                "/nested/lib.rs".to_string().into(),
             );
-            let other_dir = tempfile::tempdir().unwrap();
-            let provider = DiskProvider {
-                deployment_dir: other_dir.path().to_path_buf(),
-            };
-            let err = resolve_backtrace(&bt, &BTreeMap::new(), &provider)
-                .await
+            let err = resolve_backtrace(&bt, &BTreeMap::new())
                 .unwrap_err()
                 .to_string();
             assert!(

--- a/src/config/toml.rs
+++ b/src/config/toml.rs
@@ -3491,9 +3491,9 @@ pub(crate) mod webhook {
     use super::{
         AllowedHostToml, ComponentBacktraceConfig, ComponentCommon, ComponentCommonFetchExt,
         ComponentStdOutputToml, ComponentStdOutputTomlExt, ConfigName, JsContent,
-        JsLocationResolvedExt, ScriptLocationPathOrOci, LogLevelTomlExt, SecretResolver, hash_js_graph,
-        resolve_allowed_hosts, resolve_env_vars_plaintext, restricted_secret_registry,
-        validate_no_env_collision,
+        JsLocationResolvedExt, LogLevelTomlExt, ScriptLocationPathOrOci, SecretResolver,
+        hash_js_graph, resolve_allowed_hosts, resolve_env_vars_plaintext,
+        restricted_secret_registry, validate_no_env_collision,
     };
     use crate::command::server::{FrameFilesToSource, FrameSource};
     use crate::config::secret_registry::SecretRegistry;
@@ -5018,7 +5018,11 @@ name = "my_stub"
             let reference =
                 oci_client::Reference::from_str("docker.io/library/example:latest").unwrap();
             let location = resolve_script_toml(
-                javascript(Some(ScriptLocationPathOrOci::Oci(reference)), None, BTreeMap::new()),
+                javascript(
+                    Some(ScriptLocationPathOrOci::Oci(reference)),
+                    None,
+                    BTreeMap::new(),
+                ),
                 "ignored.js".to_string(),
                 &cas,
                 None,


### PR DESCRIPTION
- **refactor(deployment): resolve manifests through a single CAS path**
- **refactor(config): rename JsLocationToml to ScriptLocationPathOrOci**
- **refactor(cli): require --deployment when --skip-db is set**
- **refactor(deployment): activate enqueued deployment only after verification**
- **style: Formatting**
