### PR TITLE
refactor(cli): use REST transport and simplify connection configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(api)* `OBELISK_API_TOKEN` is now the canonical CLI token environment variable. The legacy
+  `OBELISK__API__TOKEN` remains supported with a deprecation warning, and plaintext `api.token`
+  has been removed from server configuration. Configure persistent server tokens with
+  `api.token_hashes`.
+
 ## [0.41.4](https://github.com/obeli-sk/obelisk/compare/v0.41.3...v0.41.4)
 
 This patch release fixes a Wasmtime 48.0.0 bug which causes not sending `Host` header in outgoing requests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,7 @@ bytes = "1.12.1"
 cargo_metadata = "0.23"
 cfg-if = "1.0.4"
 chrono = { version = "0.4.45", features = ["arbitrary", "serde"] }
-clap = { version = "4.6.6", features = ["derive"] }
+clap = { version = "4.6.6", features = ["derive", "env"] }
 config = { version = "0.15.25", default-features = false, features = [
     "toml",
     "preserve_order",

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -58,7 +58,7 @@
               "help": "Do not fail startup when a component's imports/exports fail type checking against the current deployment"
             },
             {
-              "name": "--allow-unauthenticated-api",
+              "name": "--no-auth",
               "help": "Accept unauthenticated requests on the API port. Dev/recovery override"
             }
           ]
@@ -117,7 +117,7 @@
       "options": [
         {
           "name": "--api-token",
-          "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`, then `$OBELISK__API__TOKEN`"
+          "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated"
         }
       ],
       "subcommands": [
@@ -576,7 +576,7 @@
       "options": [
         {
           "name": "--api-token",
-          "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`, then `$OBELISK__API__TOKEN`"
+          "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated"
         }
       ],
       "subcommands": [
@@ -667,7 +667,7 @@
       "options": [
         {
           "name": "--api-token",
-          "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`, then `$OBELISK__API__TOKEN`"
+          "help": "API token presented to the server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated"
         }
       ],
       "subcommands": [

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -1488,6 +1488,27 @@
         }
       }
     },
+    "/v1/files/orphans": {
+      "delete": {
+        "tags": [
+          "deployments"
+        ],
+        "summary": "Delete file blobs that are not referenced by a deployment.",
+        "operationId": "gc_orphan_files",
+        "responses": {
+          "200": {
+            "description": "Orphan files deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GcOrphanFilesResponseSer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/files/{digest}": {
       "get": {
         "tags": [
@@ -2703,6 +2724,19 @@
           "ffqn": {
             "type": "string",
             "description": "Fully qualified function name"
+          }
+        }
+      },
+      "GcOrphanFilesResponseSer": {
+        "type": "object",
+        "required": [
+          "deleted_count"
+        ],
+        "properties": {
+          "deleted_count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           }
         }
       },

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -227,13 +227,6 @@
             "type": "string"
           },
           "default": []
-        },
-        "token": {
-          "description": "Plaintext accepted token, intended for env injection only\n(`OBELISK__API__TOKEN`); do not write it into the config file.",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "additionalProperties": false

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -290,12 +290,15 @@ pub struct ExecutionEvent {
     Eq,
     derive_more::Display,
     derive_more::Into,
-    Serialize, /* webapi */
+    Serialize,
+    /* webapi */ Deserialize,
     schemars::JsonSchema,
 )]
 pub struct ResponseCursor(pub u32);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize /* webapi */, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize /* webapi */, Deserialize, schemars::JsonSchema,
+)]
 pub struct ResponseWithCursor {
     pub event: JoinSetResponseEventOuter,
     pub cursor: ResponseCursor,
@@ -314,7 +317,9 @@ pub struct ListResponsesResponse {
     pub scan_cursor: ResponseCursor,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize /* webapi */, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize /* webapi */, Deserialize, schemars::JsonSchema,
+)]
 pub struct JoinSetResponseEventOuter {
     pub created_at: DateTime<Utc>,
     pub event: JoinSetResponseEvent,
@@ -2590,7 +2595,9 @@ pub struct ExpiredDelay {
     pub delay_id: DelayId,
 }
 
-#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum PendingState {
     /// Caused by [`ExecutionRequest::Locked`].
@@ -2690,14 +2697,18 @@ impl From<PendingState> for PendingStateMerged {
     }
 }
 
-#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[display("Locked(`{lock_expires_at}`, {}, {})", locked_by.executor_id, locked_by.run_id)]
 pub struct PendingStateLocked {
     pub locked_by: LockedBy,
     pub lock_expires_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[display("`{scheduled_at}`, last_lock={last_lock:?}")]
 pub struct PendingStatePendingAt {
     pub scheduled_at: DateTime<Utc>,
@@ -2705,7 +2716,9 @@ pub struct PendingStatePendingAt {
     pub last_lock: Option<LockedBy>,
 }
 
-#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[display("{join_set_id}, `{lock_expires_at}`, closing={closing}")]
 pub struct PendingStateBlockedByJoinSet {
     pub join_set_id: JoinSetId,
@@ -2719,7 +2732,9 @@ pub struct PendingStateBlockedByJoinSet {
 ///
 /// A paused activity is always `PendingAt`. Pausing a locked workflow must first
 /// append `Unlocked`, so `Locked` is never wrapped here.
-#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub enum PendingStatePaused {
     #[display("PendingAt({_0})")]
     PendingAt(PendingStatePendingAt),
@@ -2733,7 +2748,9 @@ pub enum PendingStatePaused {
 /// teardown is pronounced finished once the `Locked` lease expires. The other
 /// variants are a frozen snapshot from when cancellation was requested (incoming
 /// responses do not unblock a cancelling execution), kept for observability.
-#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, derive_more::Display, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 pub enum PendingStateCancelling {
     #[display("Locked({_0})")]
     Locked(PendingStateLocked),
@@ -2757,8 +2774,7 @@ impl From<&Locked> for LockedBy {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, schemars::JsonSchema)]
-#[cfg_attr(any(test, feature = "test"), derive(Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PendingStateFinished {
     pub version: VersionType, // not Version since it must be Copy
     pub finished_at: DateTime<Utc>,

--- a/server-help.toml
+++ b/server-help.toml
@@ -18,9 +18,6 @@
 #   "sha256:...",   # agent
 #   "sha256:...",   # laptop
 # ]
-## Plaintext accepted token, intended for env injection only (`OBELISK__API__TOKEN`);
-## do not write it into this file.
-# api.token = "..."
 
 ## Semver version requirement for the Obelisk binary.
 ## If set, the server will fail to start if the binary version doesn't match.

--- a/src/args.rs
+++ b/src/args.rs
@@ -162,7 +162,12 @@ pub(crate) enum Deployment {
         #[arg(long)]
         deployment_id: Option<DeploymentId>,
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// Submit (if a file is given) and enqueue for next server restart.
@@ -192,7 +197,12 @@ pub(crate) enum Deployment {
         #[arg(long)]
         deployment_id: Option<DeploymentId>,
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// Submit (if a file is given) and apply immediately. Fails if not possible.
@@ -218,13 +228,23 @@ pub(crate) enum Deployment {
         #[arg(long)]
         deployment_id: Option<DeploymentId>,
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// List recent deployments.
     List {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// Delete content-addressed file blobs not referenced by any stored deployment.
@@ -233,7 +253,12 @@ pub(crate) enum Deployment {
     /// fails verification before persisting the deployment.
     Gc {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// Print the ID of the currently active deployment.
@@ -242,7 +267,12 @@ pub(crate) enum Deployment {
         #[arg(long)]
         json: bool,
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
 
@@ -262,7 +292,12 @@ pub(crate) enum Deployment {
         #[arg(long)]
         json: bool,
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// Retrieve a deployment as editable TOML without generated metadata, plus its source files.
@@ -281,7 +316,12 @@ pub(crate) enum Deployment {
         #[arg(long)]
         include_generated_metadata: bool,
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
     },
     /// Verify a local deployment without accessing the server database.
@@ -508,7 +548,12 @@ pub(crate) enum Component {
     /// List components.
     List {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Show component imports
         #[arg(short, long)]
@@ -610,7 +655,12 @@ pub(crate) enum Execution {
     /// List recent executions.
     List {
         /// Address of the obelisk server.
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Filter by function FFQN prefix.
         /// Accepts any prefix of a fully-qualified function name, e.g.: `namespace:`.
@@ -638,7 +688,12 @@ pub(crate) enum Execution {
     /// Fetch structured logs for an execution.
     Logs {
         /// Address of the obelisk server.
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID to fetch logs for.
         #[arg(value_name = "EXECUTION_ID")]
@@ -674,7 +729,12 @@ pub(crate) enum Execution {
     /// Show the execution event log (history).
     Events {
         /// Address of the obelisk server.
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID.
         #[arg(value_name = "EXECUTION_ID")]
@@ -692,7 +752,12 @@ pub(crate) enum Execution {
     /// Show join-set responses for an execution (child results, delay completions).
     Responses {
         /// Address of the obelisk server.
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID.
         #[arg(value_name = "EXECUTION_ID")]
@@ -710,7 +775,12 @@ pub(crate) enum Execution {
     /// Submit a new execution and optionally follow its status stream until it finishes.
     Submit {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Use this explicit execution ID instead of having the server assign one. Useful for idempotency. See `obelisk generate execution-id`.
         #[arg(short, long)]
@@ -750,7 +820,12 @@ pub(crate) enum Execution {
     #[command(alias = "get")]
     Status {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Follow the status stream until the execution finishes.
         #[arg(short, long)]
@@ -767,7 +842,12 @@ pub(crate) enum Execution {
     /// Get the final result of an execution.
     Result {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Follow until the execution finishes and the final result is available.
         #[arg(short, long)]
@@ -786,7 +866,12 @@ pub(crate) enum Execution {
     /// Pause a workflow execution or a pending delay.
     Pause {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID (`E_01`...) or delay ID (`Delay_01`...) to pause.
         #[arg(value_name = "ID")]
@@ -795,7 +880,12 @@ pub(crate) enum Execution {
     /// Resume a previously paused workflow execution or delay.
     Unpause {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID (`E_01`...) or delay ID (`Delay_01`...) to unpause.
         #[arg(value_name = "ID")]
@@ -804,7 +894,12 @@ pub(crate) enum Execution {
     /// Replay a workflow execution from its execution log, checking for non-determinism.
     Replay {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID to replay.
         execution_id: ExecutionId,
@@ -815,7 +910,12 @@ pub(crate) enum Execution {
     /// Replay a workflow and persist its call-site backtraces.
     PersistBacktraces {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID whose backtraces should be persisted.
         execution_id: ExecutionId,
@@ -823,7 +923,12 @@ pub(crate) enum Execution {
     /// Advance a paused workflow execution by replaying it and applying the next captured writes.
     Advance {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID to advance.
         execution_id: ExecutionId,
@@ -852,7 +957,12 @@ pub(crate) enum Execution {
     /// deployment, and upgrades the execution from its current component digest to the new one.
     Upgrade {
         /// Address of the obelisk server
-        #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+        #[arg(
+            short,
+            long,
+            env = "OBELISK_API_URL",
+            default_value = "http://127.0.0.1:5005"
+        )]
         api_url: String,
         /// Execution ID to upgrade.
         execution_id: ExecutionId,
@@ -944,7 +1054,12 @@ pub(crate) mod params {
 #[command()]
 pub(crate) struct Stub {
     /// Address of the obelisk server
-    #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+    #[arg(
+        short,
+        long,
+        env = "OBELISK_API_URL",
+        default_value = "http://127.0.0.1:5005"
+    )]
     pub(crate) api_url: String,
     /// Execution ID of the stub execution waiting for its return value.
     #[arg(value_name = "EXECUTION_ID")]
@@ -983,7 +1098,12 @@ impl std::str::FromStr for ExecutionIdOrDelayId {
 #[expect(clippy::doc_markdown)]
 pub(crate) struct CancelCommand {
     /// Address of the obelisk server
-    #[arg(short, long, default_value = "http://127.0.0.1:5005")]
+    #[arg(
+        short,
+        long,
+        env = "OBELISK_API_URL",
+        default_value = "http://127.0.0.1:5005"
+    )]
     pub(crate) api_url: String,
     /// Execution id of an activity (E_01...) or a delay request (Delay_01...)
     #[arg(value_name = "ID")]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,4 @@
+use crate::config::secret_registry::API_TOKEN_CLIENT;
 use clap::Parser;
 use concepts::{
     ComponentType, ExecutionId, FunctionFqn, FunctionFqnParseError,
@@ -83,10 +84,12 @@ pub(crate) struct Args {
 #[derive(Debug, clap::Args)]
 pub(crate) struct ClientToken {
     /// API token presented to the server as `Authorization: Bearer <token>`.
-    /// Falls back to `$OBELISK_API_TOKEN`, then `$OBELISK__API__TOKEN`.
+    /// Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated.
     #[arg(
         long,
         global = true,
+        env = API_TOKEN_CLIENT,
+        hide_env_values = true,
         value_name = "TOKEN",
         value_parser = parse_secret_string
     )]
@@ -421,8 +424,8 @@ pub(crate) enum Generate {
     },
     /// Generate a random API token and print it to stdout.
     ///
-    /// Stdout carries only the token, so it composes with env injection:
-    /// `OBELISK__API__TOKEN=$(obelisk generate token)`. When run interactively,
+    /// Stdout carries only the token, so it composes with client env injection:
+    /// `OBELISK_API_TOKEN=$(obelisk generate token)`. When run interactively,
     /// the token's `api.token_hashes` entry is also printed to stderr.
     /// The plaintext token is printed once and never stored; revoke it by
     /// deleting its `api.token_hashes` entry and restarting the server.

--- a/src/args.rs
+++ b/src/args.rs
@@ -479,8 +479,9 @@ pub(crate) enum Server {
         #[arg(long)]
         suppress_type_checking_errors: bool,
         /// Accept unauthenticated requests on the API port. Dev/recovery override.
-        #[arg(long)]
-        allow_unauthenticated_api: bool,
+        // backcompat: remove the `allow-unauthenticated-api` alias after 0.43.
+        #[arg(long, visible_alias = "allow-unauthenticated-api")]
+        no_auth: bool,
     },
     /// Read the configuration, compile the components, verify their imports and exit without starting the server.
     Verify(VerifyArgs),

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,13 +1,46 @@
 use crate::config::secret_registry::{API_TOKEN_CLIENT, API_TOKEN_SERVER};
-use grpc::{grpc_gen, injector::TracingInjector};
 use secrecy::{ExposeSecret as _, SecretString};
-use tonic::{codec::CompressionEncoding, transport::Channel};
+use serde::de::DeserializeOwned;
 
 /// Holds the API token (resolved from `--api-token` > `OBELISK_API_TOKEN` >
-/// `OBELISK__API__TOKEN`) and builds gRPC and web-API clients that inject it.
+/// `OBELISK__API__TOKEN`) and builds web-API clients that inject it.
 #[derive(Clone, Default)]
 pub(crate) struct ClientStartup {
     api_token: Option<SecretString>,
+}
+
+pub(crate) async fn send_json<T: DeserializeOwned>(
+    request: reqwest::RequestBuilder,
+) -> Result<T, anyhow::Error> {
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {body}");
+    }
+    Ok(response.json().await?)
+}
+
+pub(crate) async fn send_empty(request: reqwest::RequestBuilder) -> Result<(), anyhow::Error> {
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {body}");
+    }
+    Ok(())
+}
+
+pub(crate) async fn send_bytes(
+    request: reqwest::RequestBuilder,
+) -> Result<bytes::Bytes, anyhow::Error> {
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {body}");
+    }
+    Ok(response.bytes().await?)
 }
 
 impl ClientStartup {
@@ -18,10 +51,6 @@ impl ClientStartup {
             .filter(|token| !token.expose_secret().is_empty());
 
         Self { api_token }
-    }
-
-    fn interceptor(&self) -> Result<ClientInterceptor, anyhow::Error> {
-        ClientInterceptor::new(self.api_token.as_ref())
     }
 
     /// HTTP client for web-API calls, presenting the API token as a default header.
@@ -42,101 +71,4 @@ impl ClientStartup {
         }
         Ok(reqwest::Client::builder().default_headers(headers))
     }
-
-    pub(crate) fn execution_repository_client(
-        &self,
-        channel: Channel,
-    ) -> Result<ExecutionRepositoryClient, anyhow::Error> {
-        Ok(
-            grpc_gen::execution_repository_client::ExecutionRepositoryClient::with_interceptor(
-                channel,
-                self.interceptor()?,
-            )
-            .send_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Gzip),
-        )
-    }
-
-    pub(crate) fn deployment_repository_client(
-        &self,
-        channel: Channel,
-    ) -> Result<DeploymentRepositoryClient, anyhow::Error> {
-        Ok(
-            grpc_gen::deployment_repository_client::DeploymentRepositoryClient::with_interceptor(
-                channel,
-                self.interceptor()?,
-            )
-            .send_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Gzip)
-            .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-            .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE),
-        )
-    }
-
-    pub(crate) fn fn_repository_client(
-        &self,
-        channel: Channel,
-    ) -> Result<FunctionRepositoryClient, anyhow::Error> {
-        Ok(
-            grpc_gen::function_repository_client::FunctionRepositoryClient::with_interceptor(
-                channel,
-                self.interceptor()?,
-            )
-            .send_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Zstd)
-            .accept_compressed(CompressionEncoding::Gzip),
-        )
-    }
 }
-
-/// Client interceptor for all gRPC calls: injects tracing metadata and, if a
-/// token is configured, the `authorization` header.
-#[derive(Clone)]
-pub(crate) struct ClientInterceptor {
-    authorization: Option<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>,
-}
-
-impl ClientInterceptor {
-    fn new(token: Option<&SecretString>) -> Result<Self, anyhow::Error> {
-        let authorization = if let Some(token) = token {
-            let mut authorization: tonic::metadata::MetadataValue<tonic::metadata::Ascii> =
-                format!("Bearer {}", token.expose_secret())
-                    .parse()
-                    .map_err(|_| anyhow::anyhow!("API token contains invalid header characters"))?;
-            authorization.set_sensitive(true);
-            Some(authorization)
-        } else {
-            None
-        };
-        Ok(Self { authorization })
-    }
-}
-
-impl tonic::service::Interceptor for ClientInterceptor {
-    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
-        let mut request = tonic::service::Interceptor::call(&mut TracingInjector, request)?;
-        if let Some(authorization) = &self.authorization {
-            request
-                .metadata_mut()
-                .insert("authorization", authorization.clone());
-        }
-        Ok(request)
-    }
-}
-
-pub(crate) type ExecutionRepositoryClient =
-    grpc_gen::execution_repository_client::ExecutionRepositoryClient<
-        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
-    >;
-
-type DeploymentRepositoryClient =
-    grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
-        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
-    >;
-
-pub(crate) type FunctionRepositoryClient =
-    grpc_gen::function_repository_client::FunctionRepositoryClient<
-        tonic::service::interceptor::InterceptedService<Channel, ClientInterceptor>,
-    >;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,8 @@
-use crate::config::secret_registry::{API_TOKEN_CLIENT, API_TOKEN_SERVER};
+use crate::config::secret_registry::API_TOKEN_LEGACY;
 use secrecy::{ExposeSecret as _, SecretString};
 use serde::de::DeserializeOwned;
 
-/// Holds the API token (resolved from `--api-token` > `OBELISK_API_TOKEN` >
-/// `OBELISK__API__TOKEN`) and builds web-API clients that inject it.
+/// Holds the API token and builds web-API clients that inject it.
 #[derive(Clone, Default)]
 pub(crate) struct ClientStartup {
     api_token: Option<SecretString>,
@@ -45,9 +44,19 @@ pub(crate) async fn send_bytes(
 
 impl ClientStartup {
     pub(crate) fn new(flag: Option<SecretString>) -> Self {
+        // backcompat: remove the OBELISK__API__TOKEN fallback after 0.43.
+        let legacy_token = (flag.is_none())
+            .then(|| std::env::var(API_TOKEN_LEGACY).ok())
+            .flatten()
+            .filter(|token| !token.is_empty())
+            .map(|token| {
+                eprintln!(
+                    "warning: {API_TOKEN_LEGACY} is deprecated; use OBELISK_API_TOKEN instead"
+                );
+                SecretString::from(token)
+            });
         let api_token = flag
-            .or_else(|| std::env::var(API_TOKEN_CLIENT).ok().map(SecretString::from))
-            .or_else(|| std::env::var(API_TOKEN_SERVER).ok().map(SecretString::from))
+            .or(legacy_token)
             .filter(|token| !token.expose_secret().is_empty());
 
         Self { api_token }

--- a/src/command/component.rs
+++ b/src/command/component.rs
@@ -1,8 +1,7 @@
 use crate::FunctionMetadataVerbosity;
 use crate::args;
 use crate::args::TomlComponentType;
-use crate::client::ClientStartup;
-use crate::client::FunctionRepositoryClient;
+use crate::client::{ClientStartup, send_json};
 use crate::config::config_holder::{ConfigHolder, OBELISK_HELP_DEPLOYMENT_TOML};
 use crate::config::deployment::ComponentLocationToml;
 use crate::config::deployment::ConfigName;
@@ -17,13 +16,11 @@ use crate::config::wasm_cache_metadata_dir;
 use crate::oci;
 use crate::oci::ComponentMetadataAnnotation;
 use crate::project_dirs;
+use crate::server::web_api_server::components::{ComponentConfig, FunctionMetadataLite};
 use anyhow::Context;
 use anyhow::bail;
-use concepts::ComponentType;
-use concepts::FunctionFqn;
 use directories::BaseDirs;
-use grpc::grpc_gen;
-use grpc::to_channel;
+use http::header::ACCEPT;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs::OpenOptions;
@@ -42,10 +39,9 @@ impl args::Component {
                 imports,
                 extensions,
             } => {
-                let channel = to_channel(&api_url).await?;
-                let client = client_startup.fn_repository_client(channel)?;
                 list_components(
-                    client,
+                    &client_startup,
+                    &api_url,
                     if imports {
                         FunctionMetadataVerbosity::ExportsAndImports
                     } else {
@@ -731,75 +727,53 @@ fn serialize_methods_input(methods: &crate::config::deployment::MethodsInput) ->
 }
 
 pub(crate) async fn list_components(
-    mut client: FunctionRepositoryClient,
+    client_startup: &ClientStartup,
+    api_url: &str,
     verbosity: FunctionMetadataVerbosity,
     extensions: bool,
 ) -> anyhow::Result<()> {
-    let components = client
-        .list_components(tonic::Request::new(grpc_gen::ListComponentsRequest {
-            function_name: None,
-            component_digest: None,
-            extensions,
-            deployment_id: None,
-        }))
-        .await?
-        .into_inner()
-        .components;
+    let client = client_startup.web_api_client()?;
+    let components: Vec<ComponentConfig> = send_json(
+        client
+            .get(format!("{api_url}/v1/components"))
+            .header(ACCEPT, "application/json")
+            .query(&[
+                ("exports", "true"),
+                (
+                    "imports",
+                    if verbosity > FunctionMetadataVerbosity::ExportsOnly {
+                        "true"
+                    } else {
+                        "false"
+                    },
+                ),
+                ("extensions", if extensions { "true" } else { "false" }),
+            ]),
+    )
+    .await?;
     for component in components {
-        let component_id = component.component_id.expect("`component_id` is sent");
+        let component_id = component.component_id;
         println!(
             "{name}\t{ty}\t{sha}",
             name = component_id.name,
-            ty = grpc_gen::ComponentType::try_from(component_id.component_type)
-                .map_err(|_| ())
-                .and_then(|ty| ComponentType::try_from(ty).map_err(|_| ()))
-                .map(|ct| ct.to_string())
-                .unwrap_or_else(|()| "unknown type".to_string()),
-            sha = component_id.digest.map(|d| d.digest).unwrap_or_default()
+            ty = component_id.component_type,
+            sha = component_id.component_digest,
         );
         println!("Exports:");
-        print_fn_details(component.exports)?;
+        print_fn_details(component.exports.unwrap_or_default());
         if verbosity > FunctionMetadataVerbosity::ExportsOnly {
             println!("Imports:");
-            print_fn_details(component.imports)?;
+            print_fn_details(component.imports.unwrap_or_default());
         }
         println!();
     }
     Ok(())
 }
 
-fn print_fn_details(vec: Vec<grpc_gen::FunctionDetail>) -> Result<(), anyhow::Error> {
-    for fn_detail in vec {
-        let func = fn_detail.function_name.context("function must exist")?;
-        let func = if let Ok(func) = FunctionFqn::try_from(func.clone())
-            .with_context(|| format!("ffqn sent by the server must be valid - {func:?}"))
-        {
-            func.to_string()
-        } else {
-            // FIXME: here because of functions like: interface_name: "wasi:io/poll@0.2.3", function_name: "[method]pollable.block"
-            format!("{} . {}", func.interface_name, func.function_name)
-        };
-        print!("\t{func} : func(");
-        let mut params = fn_detail.params.into_iter().peekable();
-        while let Some(param) = params.next() {
-            print!("{}: ", param.name);
-            print_wit_type(&param.r#type.context("field `params.type` must exist")?);
-            if params.peek().is_some() {
-                print!(", ");
-            }
-        }
-        print!(")");
-        if let Some(return_type) = fn_detail.return_type {
-            print!(" -> ");
-            print_wit_type(&return_type);
-        }
-        println!();
+fn print_fn_details(functions: Vec<FunctionMetadataLite>) {
+    for function in functions {
+        println!("\t{function}");
     }
-    Ok(())
-}
-
-fn print_wit_type(wit_type: &grpc_gen::WitType) {
-    print!("{}", wit_type.wit_type);
 }
 
 #[cfg(test)]

--- a/src/command/deployment.rs
+++ b/src/command/deployment.rs
@@ -1,26 +1,19 @@
 use crate::args::{self, DeploymentSource};
-use crate::client::ClientStartup;
+use crate::client::{ClientStartup, send_bytes, send_json};
 use crate::config::deployment::sanitize_deployment_relative_path;
 use crate::config::deployment::{
     PreparedDeploymentManifest, prepare_deployment_manifest_from_disk,
 };
+use crate::server::web_api_server::deployment::{
+    DeploymentRecordSer, DeploymentStateSer, DeploymentStatusSer, DeploymentSubmitPayload,
+    DeploymentSubmitResponse, DeploymentSwitchPayload, GcOrphanFilesResponseSer,
+    SubmitPackageErrorBody,
+};
 use anyhow::{Context as _, bail};
-use chrono::DateTime;
 use concepts::prefixed_ulid::DeploymentId;
-use grpc::grpc_gen;
-use grpc::grpc_gen::switch_deployment_response::Outcome;
-use grpc::to_channel;
+use http::header::ACCEPT;
+use serde::Deserialize;
 use std::path::PathBuf;
-use tonic::transport::Channel;
-
-/// Map the CLI `--allow-unavailable-runtime-config` flag to the wire enum.
-fn runtime_config_check_from_bool(allow_unavailable: bool) -> grpc_gen::RuntimeConfigCheck {
-    if allow_unavailable {
-        grpc_gen::RuntimeConfigCheck::AllowUnavailable
-    } else {
-        grpc_gen::RuntimeConfigCheck::Strict
-    }
-}
 
 impl args::Deployment {
     pub(crate) async fn run(self, client_startup: ClientStartup) -> Result<(), anyhow::Error> {
@@ -34,12 +27,11 @@ impl args::Deployment {
                 api_url,
             } => {
                 let prepared = prepare_manifest_from_file_or_empty(file, empty).await?;
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
                 let id = upload_and_submit_manifest(
-                    &mut client,
+                    &client_startup,
+                    &api_url,
                     prepared,
-                    runtime_config_check_from_bool(allow_unavailable_runtime_config),
+                    allow_unavailable_runtime_config,
                     description,
                     deployment_id,
                 )
@@ -56,23 +48,21 @@ impl args::Deployment {
                 deployment_id,
                 api_url,
             } => {
-                let runtime_config_check =
-                    runtime_config_check_from_bool(allow_unavailable_runtime_config);
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
                 let id = submit_deployment(
-                    &mut client,
+                    &client_startup,
+                    &api_url,
                     source,
                     empty,
-                    runtime_config_check,
+                    allow_unavailable_runtime_config,
                     description,
                     deployment_id,
                 )
                 .await?;
                 switch_deployment(
-                    &mut client,
+                    &client_startup,
+                    &api_url,
                     id,
-                    runtime_config_check,
+                    allow_unavailable_runtime_config,
                     SwitchCommand::Enqueue,
                 )
                 .await
@@ -85,37 +75,29 @@ impl args::Deployment {
                 deployment_id,
                 api_url,
             } => {
-                // A hot redeploy always requires runtime config to be available.
-                let runtime_config_check = grpc_gen::RuntimeConfigCheck::Strict;
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
                 let id = submit_deployment(
-                    &mut client,
+                    &client_startup,
+                    &api_url,
                     source,
                     empty,
-                    runtime_config_check,
+                    false,
                     description,
                     deployment_id,
                 )
                 .await?;
-                switch_deployment(&mut client, id, runtime_config_check, SwitchCommand::Apply).await
+                switch_deployment(&client_startup, &api_url, id, false, SwitchCommand::Apply).await
             }
 
             args::Deployment::List { api_url } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
-                let resp = client
-                    .list_deployments(grpc_gen::ListDeploymentsRequest {
-                        pagination: None,
-                        include_deployment_toml: false,
-                        include_execution_counts: false,
-                        include_component_summary: false,
-                        include_derived: false,
-                    })
-                    .await?
-                    .into_inner();
+                let client = client_startup.web_api_client()?;
+                let deployments: Vec<DeploymentStateSer> = send_json(
+                    client
+                        .get(format!("{api_url}/v1/deployments"))
+                        .header(ACCEPT, "application/json"),
+                )
+                .await?;
 
-                if resp.deployments.is_empty() {
+                if deployments.is_empty() {
                     println!("No deployments found.");
                     return Ok(());
                 }
@@ -124,23 +106,13 @@ impl args::Deployment {
                     "{:<32}  {:<12}  {:<19}  {:<19}  DESCRIPTION",
                     "ID", "STATUS", "CREATED_AT", "LAST_ACTIVE_AT"
                 );
-                for summary in resp.deployments {
-                    let dep = summary.deployment.context("missing deployment")?;
-                    let id = dep
-                        .deployment_id
-                        .as_ref()
-                        .map(|d| d.id.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let status = format_status(dep.status());
-                    let created: DateTime<_> = dep.created_at.expect("created_at is sent").into();
-                    let created = created.format("%Y-%m-%d %H:%M:%S");
+                for dep in deployments {
+                    let id = dep.deployment_id;
+                    let status = format_status(&dep.status);
+                    let created = dep.created_at.format("%Y-%m-%d %H:%M:%S");
                     let last_active = dep
                         .last_active_at
-                        .map(|t| {
-                            let dt: DateTime<_> = t.into();
-                            dt.format("%Y-%m-%d %H:%M:%S").to_string()
-                        })
+                        .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
                         .unwrap_or_default();
                     println!(
                         "{id:<32}  {status:<12}  {created:<19}  {last_active:<19}  {}",
@@ -151,24 +123,25 @@ impl args::Deployment {
             }
 
             args::Deployment::Gc { api_url } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
-                let resp = client
-                    .gc_orphan_files(grpc_gen::GcOrphanFilesRequest {})
-                    .await?
-                    .into_inner();
+                let client = client_startup.web_api_client()?;
+                let resp: GcOrphanFilesResponseSer = send_json(
+                    client
+                        .delete(format!("{api_url}/v1/files/orphans"))
+                        .header(ACCEPT, "application/json"),
+                )
+                .await?;
                 println!("Deleted {} orphan file blob(s).", resp.deleted_count);
                 Ok(())
             }
 
             args::Deployment::Active { api_url, json } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
-                let resp = client
-                    .get_current_deployment_id(grpc_gen::GetCurrentDeploymentIdRequest {})
-                    .await?
-                    .into_inner();
-                let id = resp.deployment_id.context("missing deployment_id")?.id;
+                let client = client_startup.web_api_client()?;
+                let id: DeploymentId = send_json(
+                    client
+                        .get(format!("{api_url}/v1/deployment-id"))
+                        .header(ACCEPT, "application/json"),
+                )
+                .await?;
                 if json {
                     println!("\"{id}\"");
                 } else {
@@ -183,19 +156,15 @@ impl args::Deployment {
                 json,
                 api_url,
             } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
-                let resp = client
-                    .get_deployment(grpc_gen::GetDeploymentRequest {
-                        deployment_id: Some(grpc_gen::DeploymentId { id: id.to_string() }),
-                        include_generated_metadata: Some(true),
-                    })
-                    .await?
-                    .into_inner();
-                let dep = resp.deployment.context("deployment not found")?;
-                let deployment_toml = dep
-                    .deployment_toml
-                    .context("deployment_toml not available")?;
+                let client = client_startup.web_api_client()?;
+                let dep: DeploymentRecordSer = send_json(
+                    client
+                        .get(format!("{api_url}/v1/deployments/{id}"))
+                        .header(ACCEPT, "application/json")
+                        .query(&[("include_generated_metadata", "true")]),
+                )
+                .await?;
+                let deployment_toml = dep.deployment_toml;
 
                 if let Some(file) = file {
                     // Normalize the requested path the same way `get` writes it, so a
@@ -205,7 +174,7 @@ impl args::Deployment {
                     let file_ref = dep.files.iter().find(|f| f.path == rel).with_context(|| {
                         format!("deployment {id} has no deployment-owned source file `{rel}`")
                     })?;
-                    let bytes = fetch_file(&mut client, &file_ref.digest).await?;
+                    let bytes = fetch_file(&client, &api_url, &file_ref.digest).await?;
                     print!("{}", String::from_utf8_lossy(&bytes));
                     return Ok(());
                 }
@@ -229,19 +198,18 @@ impl args::Deployment {
                 include_generated_metadata,
                 api_url,
             } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.deployment_repository_client(channel)?;
-                let resp = client
-                    .get_deployment(grpc_gen::GetDeploymentRequest {
-                        deployment_id: Some(grpc_gen::DeploymentId { id: id.to_string() }),
-                        include_generated_metadata: Some(include_generated_metadata),
-                    })
-                    .await?
-                    .into_inner();
-                let dep = resp.deployment.context("deployment not found")?;
-                let deployment_toml = dep
-                    .deployment_toml
-                    .context("deployment_toml not available")?;
+                let client = client_startup.web_api_client()?;
+                let dep: DeploymentRecordSer = send_json(
+                    client
+                        .get(format!("{api_url}/v1/deployments/{id}"))
+                        .header(ACCEPT, "application/json")
+                        .query(&[(
+                            "include_generated_metadata",
+                            include_generated_metadata.to_string(),
+                        )]),
+                )
+                .await?;
+                let deployment_toml = dep.deployment_toml;
 
                 let output_dir = output.unwrap_or_else(|| PathBuf::from("."));
                 tokio::fs::create_dir_all(&output_dir)
@@ -264,7 +232,7 @@ impl args::Deployment {
                             format!("cannot create source directory {parent:?}")
                         })?;
                     }
-                    let bytes = fetch_file(&mut client, &file_ref.digest).await?;
+                    let bytes = fetch_file(&client, &api_url, &file_ref.digest).await?;
                     write_new_file(&path, &bytes, force).await?;
                 }
                 println!(
@@ -275,8 +243,7 @@ impl args::Deployment {
                 Ok(())
             }
 
-            // `deployment verify` is dispatched through the local verification path in `main`,
-            // so it never reaches the gRPC client here.
+            // `deployment verify` is dispatched through the local verification path in `main`.
             args::Deployment::Verify(_) => unreachable!("handled in main before ClientStartup"),
         }
     }
@@ -308,17 +275,14 @@ async fn write_new_file(
     Ok(())
 }
 
-type DeploymentClient = grpc::grpc_gen::deployment_repository_client::DeploymentRepositoryClient<
-    tonic::service::interceptor::InterceptedService<Channel, crate::client::ClientInterceptor>,
->;
-
 /// If the source is a file, submit it and return the new ID. If it's an ID, return it directly.
 /// If `empty`, submit an empty deployment and return the new ID.
 async fn submit_deployment(
-    client: &mut DeploymentClient,
+    client_startup: &ClientStartup,
+    api_url: &str,
     source: Option<DeploymentSource>,
     empty: bool,
-    runtime_config_check: grpc_gen::RuntimeConfigCheck,
+    allow_unavailable_runtime_config: bool,
     description: Option<String>,
     deployment_id: Option<DeploymentId>,
 ) -> anyhow::Result<DeploymentId> {
@@ -337,9 +301,10 @@ async fn submit_deployment(
         None => prepare_manifest_from_file_or_empty(None, empty).await?,
     };
     let id = upload_and_submit_manifest(
-        client,
+        client_startup,
+        api_url,
         prepared,
-        runtime_config_check,
+        allow_unavailable_runtime_config,
         description,
         deployment_id,
     )
@@ -352,20 +317,23 @@ async fn submit_deployment(
 /// blobs, and if the server reports missing files, retry the same submit with only
 /// those blobs attached. The requested TOML is identical on both attempts.
 async fn upload_and_submit_manifest(
-    client: &mut DeploymentClient,
+    client_startup: &ClientStartup,
+    api_url: &str,
     prepared: PreparedDeploymentManifest,
-    runtime_config_check: grpc_gen::RuntimeConfigCheck,
+    allow_unavailable_runtime_config: bool,
     description: Option<String>,
     deployment_id: Option<DeploymentId>,
 ) -> anyhow::Result<DeploymentId> {
+    let client = client_startup.web_api_client()?;
     // Preflight: no blobs, so digests already in the CAS are not re-uploaded.
     let missing = match submit_attempt(
-        client,
+        &client,
+        api_url,
         &prepared,
-        runtime_config_check,
+        allow_unavailable_runtime_config,
         description.as_deref(),
         deployment_id,
-        Vec::new(),
+        &[],
     )
     .await?
     {
@@ -374,23 +342,19 @@ async fn upload_and_submit_manifest(
     };
 
     // Retry with only the blobs the server is missing.
-    let files = prepared
+    let files: Vec<_> = prepared
         .files
         .iter()
         .filter(|file| missing.contains(&file.digest.to_string()))
-        .map(|file| grpc_gen::DeploymentFileContent {
-            path: file.path.clone(),
-            digest: Some(file.digest.to_string()),
-            content: file.bytes.clone(),
-        })
         .collect();
     match submit_attempt(
-        client,
+        &client,
+        api_url,
         &prepared,
-        runtime_config_check,
+        allow_unavailable_runtime_config,
         description.as_deref(),
         deployment_id,
-        files,
+        &files,
     )
     .await?
     {
@@ -409,71 +373,83 @@ enum SubmitAttempt {
     Missing(Vec<String>),
 }
 
-/// One submit request. A `FAILED_PRECONDITION` carrying only `missing_files`
-/// becomes `Missing`; any other structured issue or status is a hard error.
+/// One submit request. A conflict carrying only `missing_files` becomes `Missing`.
 async fn submit_attempt(
-    client: &mut DeploymentClient,
+    client: &reqwest::Client,
+    api_url: &str,
     prepared: &PreparedDeploymentManifest,
-    runtime_config_check: grpc_gen::RuntimeConfigCheck,
+    allow_unavailable_runtime_config: bool,
     description: Option<&str>,
     deployment_id: Option<DeploymentId>,
-    files: Vec<grpc_gen::DeploymentFileContent>,
+    files: &[&crate::config::deployment::DeploymentManifestFile],
 ) -> anyhow::Result<SubmitAttempt> {
-    let resp = client
-        .submit_deployment(grpc_gen::SubmitDeploymentRequest {
-            deployment_toml: prepared.deployment_toml.clone(),
-            created_by: Some("cli".to_string()),
-            runtime_config_check: runtime_config_check.into(),
-            description: description.map(str::to_string),
-            deployment_id: deployment_id.map(grpc_gen::DeploymentId::from),
-            files,
-        })
-        .await;
-    match resp {
-        Ok(resp) => {
-            let resp = resp.into_inner();
-            Ok(SubmitAttempt::Stored(DeploymentId::try_from(
-                resp.deployment_id.context("missing deployment_id")?,
-            )?))
+    let url = format!("{api_url}/v1/deployments");
+    let request = if files.is_empty() {
+        client
+            .post(url)
+            .header(ACCEPT, "application/json")
+            .json(&DeploymentSubmitPayload {
+                deployment_toml: prepared.deployment_toml.clone(),
+                description: description.map(str::to_string),
+                allow_unavailable_runtime_config,
+                deployment_id: deployment_id.map(|id| id.to_string()),
+            })
+    } else {
+        let mut form = reqwest::multipart::Form::new()
+            .text("deployment_toml", prepared.deployment_toml.clone())
+            .text(
+                "allow_unavailable_runtime_config",
+                allow_unavailable_runtime_config.to_string(),
+            );
+        if let Some(description) = description {
+            form = form.text("description", description.to_string());
         }
-        Err(status) => {
-            if let Some(detail) = decode_submit_error_detail(&status) {
-                let only_missing = detail.unexpected_files.is_empty()
-                    && detail.digest_mismatches.is_empty()
-                    && detail.oversized_files.is_empty()
-                    && detail.missing_digest_fields.is_empty()
-                    && !detail.missing_files.is_empty();
-                if only_missing {
-                    let digests = detail
-                        .missing_files
-                        .iter()
-                        .filter_map(|issue| issue.digest.clone())
-                        .collect();
-                    return Ok(SubmitAttempt::Missing(digests));
-                }
-                bail!(
-                    "deployment submit rejected: {}",
-                    format_submit_detail(&detail)
-                );
-            }
-            Err(status.into())
+        if let Some(deployment_id) = deployment_id {
+            form = form.text("deployment_id", deployment_id.to_string());
         }
+        for file in files {
+            form = form.part(
+                file.digest.to_string(),
+                reqwest::multipart::Part::bytes(file.bytes.clone()).file_name(file.path.clone()),
+            );
+        }
+        client
+            .post(url)
+            .header(ACCEPT, "application/json")
+            .multipart(form)
+    };
+    let response = request.send().await?;
+    let status = response.status();
+    if status.is_success() {
+        let response: DeploymentSubmitResponse = response.json().await?;
+        return Ok(SubmitAttempt::Stored(response.deployment_id.parse()?));
     }
+    if status == reqwest::StatusCode::CONFLICT {
+        let detail: SubmitPackageErrorBody = response.json().await?;
+        let only_missing = detail.unexpected_files.is_empty()
+            && detail.digest_mismatches.is_empty()
+            && detail.oversized_files.is_empty()
+            && detail.missing_digest_fields.is_empty()
+            && !detail.missing_files.is_empty();
+        if only_missing {
+            return Ok(SubmitAttempt::Missing(
+                detail
+                    .missing_files
+                    .iter()
+                    .filter_map(|issue| issue.digest.clone())
+                    .collect(),
+            ));
+        }
+        bail!(
+            "deployment submit rejected: {}",
+            format_submit_detail(&detail)
+        );
+    }
+    let body = response.text().await.unwrap_or_default();
+    bail!("server returned {status}: {body}")
 }
 
-/// Decode the `SubmitDeploymentErrorDetail` attached to a submit status, if present.
-fn decode_submit_error_detail(
-    status: &tonic::Status,
-) -> Option<grpc_gen::SubmitDeploymentErrorDetail> {
-    use prost::Message as _;
-    let details = status.details();
-    if details.is_empty() {
-        return None;
-    }
-    grpc_gen::SubmitDeploymentErrorDetail::decode(details).ok()
-}
-
-fn format_submit_detail(detail: &grpc_gen::SubmitDeploymentErrorDetail) -> String {
+fn format_submit_detail(detail: &SubmitPackageErrorBody) -> String {
     let mut lines = Vec::new();
     for issue in &detail.missing_digest_fields {
         lines.push(format!("missing content_digest at {}", issue.field_path));
@@ -490,9 +466,7 @@ fn format_submit_detail(detail: &grpc_gen::SubmitDeploymentErrorDetail) -> Strin
     for mismatch in &detail.digest_mismatches {
         lines.push(format!(
             "digest mismatch for {}: supplied {}, actual {}",
-            mismatch.file.as_ref().map_or("", |file| &file.field_path),
-            mismatch.supplied_digest,
-            mismatch.actual_digest
+            mismatch.file.field_path, mismatch.supplied_digest, mismatch.actual_digest
         ));
     }
     for issue in &detail.oversized_files {
@@ -502,48 +476,53 @@ fn format_submit_detail(detail: &grpc_gen::SubmitDeploymentErrorDetail) -> Strin
 }
 
 /// Fetch a deployment file blob from the server's content-addressed store.
-async fn fetch_file(client: &mut DeploymentClient, digest: &str) -> anyhow::Result<Vec<u8>> {
-    let resp = client
-        .get_file(grpc_gen::GetFileRequest {
-            digest: digest.to_string(),
-        })
+async fn fetch_file(
+    client: &reqwest::Client,
+    api_url: &str,
+    digest: &str,
+) -> anyhow::Result<bytes::Bytes> {
+    send_bytes(client.get(format!("{api_url}/v1/files/{digest}")))
         .await
-        .with_context(|| format!("cannot fetch deployment file `{digest}`"))?
-        .into_inner();
-    Ok(resp.content)
+        .with_context(|| format!("cannot fetch deployment file `{digest}`"))
 }
 
 async fn switch_deployment(
-    client: &mut DeploymentClient,
+    client_startup: &ClientStartup,
+    api_url: &str,
     id: DeploymentId,
-    runtime_config_check: grpc_gen::RuntimeConfigCheck,
+    allow_unavailable_runtime_config: bool,
     command: SwitchCommand,
 ) -> anyhow::Result<()> {
-    let resp = client
-        .switch_deployment(grpc_gen::SwitchDeploymentRequest {
-            deployment_id: Some(grpc_gen::DeploymentId::from(id)),
-            runtime_config_check: runtime_config_check.into(),
-            apply: command == SwitchCommand::Apply,
-        })
-        .await?
-        .into_inner();
+    #[derive(Deserialize)]
+    struct SwitchResponse {
+        ok: String,
+    }
+    let client = client_startup.web_api_client()?;
+    let response: SwitchResponse = send_json(
+        client
+            .put(format!("{api_url}/v1/deployments/{id}/switch"))
+            .header(ACCEPT, "application/json")
+            .json(&DeploymentSwitchPayload {
+                allow_unavailable_runtime_config,
+                apply: command == SwitchCommand::Apply,
+            }),
+    )
+    .await?;
 
-    match (command, resp.outcome()) {
-        (SwitchCommand::Apply, Outcome::SwitchOutcomeSwitched) => {
+    match (command, response.ok.as_str()) {
+        (SwitchCommand::Apply, "switched") => {
             println!("Applied successfully.");
         }
-        (SwitchCommand::Apply, Outcome::SwitchOutcomeRestartRequired) => {
+        (SwitchCommand::Apply, "restart_required") => {
             bail!("Could not apply immediately; deployment enqueued. Restart the server to apply.");
         }
-        (SwitchCommand::Enqueue, Outcome::SwitchOutcomeSwitched) => {
+        (SwitchCommand::Enqueue, "switched") => {
             println!("Deployment already active; it will remain active after restart.");
         }
-        (SwitchCommand::Enqueue, Outcome::SwitchOutcomeRestartRequired) => {
+        (SwitchCommand::Enqueue, "restart_required") => {
             println!("Deployment enqueued. Restart the server to apply.");
         }
-        (_, Outcome::SwitchOutcomeUnspecified) => {
-            bail!("Unexpected outcome from server.");
-        }
+        (_, outcome) => bail!("unexpected outcome from server: {outcome}"),
     }
     Ok(())
 }
@@ -566,11 +545,10 @@ async fn prepare_manifest_from_file_or_empty(
     }
 }
 
-fn format_status(status: grpc_gen::DeploymentStatus) -> &'static str {
+fn format_status(status: &DeploymentStatusSer) -> &'static str {
     match status {
-        grpc_gen::DeploymentStatus::Inactive => "Inactive",
-        grpc_gen::DeploymentStatus::Enqueued => "Enqueued",
-        grpc_gen::DeploymentStatus::Active => "Active",
-        grpc_gen::DeploymentStatus::Unspecified => "Unknown",
+        DeploymentStatusSer::Inactive => "Inactive",
+        DeploymentStatusSer::Enqueued => "Enqueued",
+        DeploymentStatusSer::Active => "Active",
     }
 }

--- a/src/command/execution.rs
+++ b/src/command/execution.rs
@@ -2,29 +2,21 @@ use crate::args;
 use crate::args::CancelCommand;
 use crate::args::FunctionFqnOrShort;
 use crate::args::params::parse_params;
-use crate::client::ClientStartup;
-use crate::client::ExecutionRepositoryClient;
-use crate::server::web_api_server::{AdvanceRequestSer, ExecutionSubmitPayload, ReplayResponseSer};
+use crate::client::{ClientStartup, send_empty, send_json};
+use crate::server::web_api_server::components::ComponentConfig;
+use crate::server::web_api_server::logs::{LogEntryRowSer, LogEntrySer};
+use crate::server::web_api_server::{
+    AdvanceRequestSer, ExecutionEventsResponse, ExecutionResponsesResponse, ExecutionSubmitPayload,
+    ExecutionUpgradePayload, ExecutionWithStateSer, PersistBacktracesResponseSer,
+    ReplayResponseSer, format_execution_status_text,
+};
 use anyhow::Context as _;
 use anyhow::bail;
 use base64::Engine as _;
-use chrono::DateTime;
-use concepts::ExecutionFailureKind;
-use concepts::JoinSetId;
-use concepts::JoinSetKind;
+use concepts::ExecutionId;
 use concepts::prefixed_ulid::ExecutionIdDerived;
-use concepts::{ExecutionId, FunctionFqn};
-use grpc::grpc_gen;
-use grpc::grpc_gen::CancelDelayRequest;
-use grpc::grpc_gen::CancelExecutionRequest;
-use grpc::grpc_gen::cancel_delay_response::CancelDelayOutcome;
-use grpc::grpc_gen::cancel_execution_response::CancelExecutionOutcome;
-use grpc::grpc_gen::execution_status::BlockedByJoinSet;
-use grpc::grpc_gen::execution_status::Finished;
-use grpc::to_channel;
-use grpc_gen::execution_status::Status;
 use http::header::ACCEPT;
-use itertools::Either;
+use serde::Deserialize;
 use std::fmt::Write as _;
 use std::time::Duration;
 use tracing::instrument;
@@ -130,11 +122,7 @@ impl args::Execution {
                 api_url,
                 execution_id,
                 return_value,
-            }) => {
-                let channel = to_channel(&api_url).await?;
-                let client = client_startup.execution_repository_client(channel)?;
-                stub(client, execution_id, return_value).await
-            }
+            }) => stub(&client_startup, &api_url, execution_id, return_value).await,
             args::Execution::Status {
                 api_url,
                 execution_id,
@@ -142,24 +130,15 @@ impl args::Execution {
                 no_reconnect,
                 json,
             } => {
-                if json {
-                    get_execution_status_json(
-                        &client_startup,
-                        &api_url,
-                        execution_id,
-                        follow,
-                        no_reconnect,
-                    )
-                    .await
-                } else {
-                    let channel = to_channel(&api_url).await?;
-                    let client = client_startup.execution_repository_client(channel)?;
-                    let opts = GetStatusOptions {
-                        follow,
-                        no_reconnect,
-                    };
-                    get_execution_status(client, execution_id, opts).await
-                }
+                get_execution_status_rest(
+                    &client_startup,
+                    &api_url,
+                    execution_id,
+                    follow,
+                    no_reconnect,
+                    json,
+                )
+                .await
             }
             args::Execution::Result {
                 api_url,
@@ -168,71 +147,26 @@ impl args::Execution {
                 no_reconnect,
                 json,
             } => {
-                if json {
-                    get_execution_result_json(
-                        &client_startup,
-                        &api_url,
-                        execution_id,
-                        follow,
-                        no_reconnect,
-                    )
-                    .await
-                } else {
-                    let channel = to_channel(&api_url).await?;
-                    let client = client_startup.execution_repository_client(channel)?;
-                    let opts = GetStatusOptions {
-                        follow,
-                        no_reconnect,
-                    };
-                    get_execution_result(client, execution_id, opts).await
-                }
+                get_execution_result_rest(
+                    &client_startup,
+                    &api_url,
+                    execution_id,
+                    follow,
+                    no_reconnect,
+                    json,
+                )
+                .await
             }
             args::Execution::Cancel(cancel_request) => {
                 cancel_request.execute(&client_startup).await
             }
             args::Execution::Pause { api_url, id } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.execution_repository_client(channel)?;
-                match id {
-                    args::ExecutionIdOrDelayId::Execution(execution_id) => {
-                        client
-                            .pause_execution(tonic::Request::new(grpc_gen::PauseExecutionRequest {
-                                execution_id: Some(grpc_gen::ExecutionId::from(execution_id)),
-                            }))
-                            .await?;
-                    }
-                    args::ExecutionIdOrDelayId::Delay(delay_id) => {
-                        client
-                            .pause_delay(tonic::Request::new(grpc_gen::PauseDelayRequest {
-                                delay_id: Some(grpc_gen::DelayId::from(delay_id)),
-                            }))
-                            .await?;
-                    }
-                }
+                execution_pause_change(&client_startup, &api_url, id, "pause").await?;
                 println!("Paused");
                 Ok(())
             }
             args::Execution::Unpause { api_url, id } => {
-                let channel = to_channel(&api_url).await?;
-                let mut client = client_startup.execution_repository_client(channel)?;
-                match id {
-                    args::ExecutionIdOrDelayId::Execution(execution_id) => {
-                        client
-                            .unpause_execution(tonic::Request::new(
-                                grpc_gen::UnpauseExecutionRequest {
-                                    execution_id: Some(grpc_gen::ExecutionId::from(execution_id)),
-                                },
-                            ))
-                            .await?;
-                    }
-                    args::ExecutionIdOrDelayId::Delay(delay_id) => {
-                        client
-                            .unpause_delay(tonic::Request::new(grpc_gen::UnpauseDelayRequest {
-                                delay_id: Some(grpc_gen::DelayId::from(delay_id)),
-                            }))
-                            .await?;
-                    }
-                }
+                execution_pause_change(&client_startup, &api_url, id, "unpause").await?;
                 println!("Unpaused");
                 Ok(())
             }
@@ -304,37 +238,29 @@ pub(crate) async fn submit(
     paused: bool,
     opts: SubmitOutputOpts,
 ) -> anyhow::Result<()> {
-    let channel = to_channel(api_url).await?;
-    let mut client = client_startup.execution_repository_client(channel.clone())?;
-    let mut component_client = client_startup.fn_repository_client(channel)?;
+    let client = client_startup.web_api_client()?;
     let ffqn = match ffqn {
         FunctionFqnOrShort::Short {
             ifc_name,
             function_name,
         } => {
             // Guess function
-            let components = component_client
-                .list_components(tonic::Request::new(grpc_gen::ListComponentsRequest {
-                    function_name: None,
-                    component_digest: None,
-                    extensions: false,
-                    deployment_id: None,
-                }))
-                .await?
-                .into_inner()
-                .components;
+            let components: Vec<ComponentConfig> = send_json(
+                client
+                    .get(format!("{api_url}/v1/components"))
+                    .header(ACCEPT, "application/json")
+                    .query(&[("exports", "true"), ("extensions", "false")]),
+            )
+            .await?;
             let mut matched = Vec::new();
             for export in components
                 .into_iter()
-                .flat_map(|component| component.exports)
-                .map(|detail| detail.function_name.expect("function_name is sent"))
+                .flat_map(|component| component.exports.unwrap_or_default())
             {
-                if export.function_name == function_name.as_ref() {
-                    let ffqn =
-                        FunctionFqn::try_from(export).expect("sent FunctionName must be parseable");
-                    if ffqn.ifc_fqn.ifc_name() == ifc_name {
-                        matched.push(ffqn);
-                    }
+                if export.ffqn.function_name.as_ref() == function_name
+                    && export.ffqn.ifc_fqn.ifc_name() == ifc_name
+                {
+                    matched.push(export.ffqn);
                 }
             }
             let ffqn = match matched.as_slice() {
@@ -350,431 +276,136 @@ pub(crate) async fn submit(
         FunctionFqnOrShort::Ffqn(ffqn) => ffqn,
     };
     let execution_id = execution_id.unwrap_or_else(ExecutionId::generate);
-    match opts {
+    let (follow, no_reconnect, json) = match opts {
         SubmitOutputOpts::Plain {
             follow,
             no_reconnect,
-        } => {
-            client
-                .submit(tonic::Request::new(grpc_gen::SubmitRequest {
-                    execution_id: Some(execution_id.clone().into()),
-                    params: Some(prost_wkt_types::Any {
-                        type_url: format!("urn:obelisk:json:params:{ffqn}"),
-                        value: serde_json::Value::Array(params).to_string().into_bytes(),
-                    }),
-                    function_name: Some(grpc_gen::FunctionName::from(ffqn)),
-                    paused,
-                }))
-                .await?;
-            println!("{execution_id}");
-            if follow {
-                let opts = GetStatusOptions {
-                    follow: true,
-                    no_reconnect,
-                };
-                get_execution_result(client, execution_id, opts).await?;
-            }
-        }
+        } => (follow, no_reconnect, false),
         SubmitOutputOpts::Json {
             follow,
             no_reconnect,
-        } => {
-            let client = client_startup
-                .web_api_client_builder()?
-                .build()
-                .context("failed to build HTTP client")?;
-
-            let url = format!("{api_url}/v1/executions/{execution_id}?follow={follow}");
-
-            loop {
-                let request = client.put(&url).header(ACCEPT, "application/json").json(
-                    &ExecutionSubmitPayload {
-                        ffqn: ffqn.clone(),
-                        params: params.clone(),
-                        paused,
-                    },
-                );
-                match request.send().await {
-                    Ok(resp) => {
-                        let status = resp.status();
-                        if status.is_success() {
-                            // Execution was submitted. If following, response will be streamed later.
-                            // Connection drop here means we can retry.
-                            match resp.json::<serde_json::Value>().await {
-                                Ok(resp_json) => {
-                                    let output = serde_json::to_string_pretty(&resp_json)
-                                        .context("failed to format JSON output")?;
-                                    println!("{output}");
-                                    break; // Success!
-                                }
-                                Err(e) => {
-                                    // If we can't read the body, the server probably died mid-response
-                                    if no_reconnect {
-                                        return Err(e).context("failed to parse JSON response");
-                                    }
-                                    eprintln!("failed to read response body: {e:#}. retrying...");
-                                    // Fall through to sleep & retry
-                                }
-                            }
-                        } else {
-                            // Handle 4xx/5xx errors. No retry here as 5xx might indicate a serious problem,
-                            // for example in database connection.
-                            // We try to read the error text, but that might also fail if connection dropped.
-                            match resp.text().await {
-                                Ok(error_body) => {
-                                    return Err(anyhow::anyhow!(
-                                        "server returned status {status}: {error_body}"
-                                    ));
-                                }
-                                Err(e) => {
-                                    return Err(e).context("failed to read error body");
-                                }
-                            }
+        } => (follow, no_reconnect, true),
+    };
+    let request_follow = follow && json;
+    let url = format!("{api_url}/v1/executions/{execution_id}?follow={request_follow}");
+    loop {
+        let response = client
+            .put(&url)
+            .header(ACCEPT, "application/json")
+            .json(&ExecutionSubmitPayload {
+                ffqn: ffqn.clone(),
+                params: params.clone(),
+                paused,
+            })
+            .send()
+            .await;
+        match response {
+            Ok(response) if response.status().is_success() => {
+                if request_follow {
+                    match response.json::<RetValWire>().await {
+                        Ok(result) => return print_retval(&result, json),
+                        Err(err) if !no_reconnect => {
+                            eprintln!("failed to read response body: {err:#}. retrying...");
                         }
+                        Err(err) => return Err(err).context("failed to parse execution result"),
                     }
-                    Err(e) => {
-                        // Handle connection refused / timeout
-                        if no_reconnect {
-                            return Err(e).context("failed to send execution request");
-                        }
-                        eprintln!("connection failed: {e:#}. retrying...");
+                } else {
+                    let response: ApiOk = response.json().await?;
+                    if json {
+                        print_json(&response)?;
+                    } else {
+                        println!("{}", response.ok);
                     }
+                    return if follow {
+                        get_execution_result_rest(
+                            client_startup,
+                            api_url,
+                            execution_id,
+                            true,
+                            no_reconnect,
+                            json,
+                        )
+                        .await
+                    } else {
+                        Ok(())
+                    };
                 }
-                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
+            Ok(response) => {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                bail!("server returned {status}: {body}");
+            }
+            Err(err) if !no_reconnect => {
+                eprintln!("connection failed: {err:#}. retrying...");
+            }
+            Err(err) => return Err(err).context("failed to send execution request"),
         }
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    Ok(())
+}
+
+#[derive(Debug, serde::Serialize, Deserialize)]
+struct ApiOk {
+    ok: String,
+}
+
+#[derive(Deserialize)]
+struct ApiError {
+    err: String,
+}
+
+#[derive(Debug, serde::Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RetValWire {
+    Ok(Option<serde_json::Value>),
+    Err(Option<serde_json::Value>),
+    ExecutionFailed(concepts::FinishedExecutionFailure),
 }
 
 pub(crate) async fn stub(
-    mut client: ExecutionRepositoryClient,
+    client_startup: &ClientStartup,
+    api_url: &str,
     execution_id: ExecutionIdDerived,
     return_value: String,
 ) -> anyhow::Result<()> {
-    let execution_id = ExecutionId::Derived(execution_id);
-
-    client
-        .stub(tonic::Request::new(grpc_gen::StubRequest {
-            execution_id: Some(execution_id.clone().into()),
-            return_value: Some(prost_wkt_types::Any {
-                type_url: "urn:obelisk:json:retval:TBD".to_string(),
-                value: return_value.into_bytes(),
-            }),
-        }))
-        .await?
-        .into_inner();
-    Ok(())
-}
-
-#[derive(Clone, Copy)]
-enum GetMode {
-    Status,
-    Result,
-}
-
-enum PollOutcome {
-    Pending,
-    Finished,
-}
-
-fn print_status(
-    response: grpc_gen::GetStatusResponse,
-    mode: GetMode,
-) -> Result<PollOutcome, AlreadyPrintedError> {
-    use grpc_gen::get_status_response::Message;
-    let message = response.message.expect("message expected");
-
-    let status_or_finished = match message {
-        Message::Summary(summary) => Either::Left(summary.current_status.expect("sent by server")),
-        Message::CurrentStatus(status) => Either::Left(status),
-        Message::FinishedStatus(finished) => match mode {
-            GetMode::Status => {
-                println!("Finished");
-                return Ok(PollOutcome::Finished);
-            }
-            GetMode::Result => Either::Right(finished),
-        },
-    };
-    match status_or_finished {
-        Either::Left(status) => {
-            let is_finished = matches!(
-                status
-                    .status
-                    .as_ref()
-                    .expect("status is sent by the server"),
-                Status::Finished(_)
-            );
-            println!("{}", format_pending_status(status));
-            match mode {
-                GetMode::Status if is_finished => Ok(PollOutcome::Finished),
-                GetMode::Status | GetMode::Result => Ok(PollOutcome::Pending),
-            }
-        }
-        Either::Right(finished) => {
-            print_finished_status(finished)?;
-            Ok(PollOutcome::Finished)
-        }
-    }
-}
-
-fn format_pending_status(pending_status: grpc_gen::ExecutionStatus) -> String {
-    let status = pending_status.status.expect("status is sent by the server");
-    match status {
-        Status::Locked(_) => "Locked".to_string(),
-        Status::PendingAt(grpc_gen::execution_status::PendingAt { scheduled_at }) => {
-            let scheduled_at = scheduled_at.expect("sent by the server");
-            format!("Pending at {scheduled_at}")
-        }
-        Status::BlockedByJoinSet(BlockedByJoinSet {
-            closing,
-            join_set_id: Some(grpc_gen::JoinSetId { name, kind }),
-            lock_expires_at: _,
-        }) => {
-            let kind = grpc_gen::join_set_id::JoinSetKind::try_from(kind)
-                .map_err(|_| ())
-                .and_then(JoinSetKind::try_from)
-                .expect("JoinSetKind must be valid");
-            let join_set_id =
-                JoinSetId::new(kind, name.into()).expect("server sends valid join sets");
-            format!(
-                "BlockedByJoinSet {join_set_id}{closing}",
-                closing = if closing { " (closing)" } else { "" }
-            )
-        }
-        Status::Finished(Finished { result_kind, .. }) => {
-            // The final result will be sent in the next message for `GetMode::Result`,
-            // but status mode still needs to distinguish success from failure.
-            format_finished_status(result_kind)
-        }
-        Status::Paused(grpc_gen::execution_status::Paused {}) => "Paused".to_string(),
-        Status::Cancelling(grpc_gen::execution_status::Cancelling {}) => "Cancelling".to_string(),
-        illegal @ Status::BlockedByJoinSet(_) => panic!("illegal state {illegal:?}"),
-    }
-}
-
-fn format_finished_status(result_kind: Option<grpc_gen::ResultKind>) -> String {
-    match result_kind.and_then(format_finished_result_kind) {
-        Some(result_kind) => format!("Finished: {result_kind}"),
-        None => "Finished".to_string(),
-    }
-}
-
-fn format_finished_result_kind(result_kind: grpc_gen::ResultKind) -> Option<String> {
-    use grpc_gen::result_kind::Value;
-
-    match result_kind.value {
-        Some(Value::Ok(_)) => Some("OK".to_string()),
-        Some(Value::Error(_)) => Some("Error".to_string()),
-        Some(Value::ExecutionFailureKind(kind)) => {
-            let kind = grpc_gen::ExecutionFailureKind::try_from(kind).ok()?;
-            let kind = ExecutionFailureKind::try_from(kind).ok()?;
-            Some(format!("Execution failure ({kind})"))
-        }
-        None => None,
-    }
-}
-
-fn print_finished_status(
-    finished_status: grpc_gen::FinishedStatus,
-) -> Result<(), AlreadyPrintedError> {
-    let created_at = DateTime::from(
-        finished_status
-            .created_at
-            .expect("`created_at` is sent by the server"),
-    );
-    let finished_at = DateTime::from(
-        finished_status
-            .finished_at
-            .expect("`finished_at` is sent by the server"),
-    );
-
-    let (new_pending_status, res) = match finished_status
-        .value
-        .expect("`result_detail` is sent by the server")
-        .value
-    {
-        Some(grpc_gen::supported_function_result::Value::Ok(
-            grpc_gen::supported_function_result::OkPayload {
-                return_value: Some(return_value),
-            },
-        )) => {
-            let return_value = String::from_utf8_lossy(&return_value.value);
-            (format!("OK: {return_value}"), Ok(()))
-        }
-        Some(grpc_gen::supported_function_result::Value::Ok(
-            grpc_gen::supported_function_result::OkPayload { return_value: None },
-        )) => ("OK: (no return value)".to_string(), Ok(())),
-        Some(grpc_gen::supported_function_result::Value::Error(
-            grpc_gen::supported_function_result::ErrorPayload {
-                return_value: Some(return_value),
-            },
-        )) => {
-            let return_value = String::from_utf8_lossy(&return_value.value);
-            (format!("Error: {return_value}"), Err(AlreadyPrintedError))
-        }
-        Some(grpc_gen::supported_function_result::Value::Error(
-            grpc_gen::supported_function_result::ErrorPayload { return_value: None },
-        )) => (
-            "Error: (no return value)".to_string(),
-            Err(AlreadyPrintedError),
-        ),
-        Some(grpc_gen::supported_function_result::Value::ExecutionFailure(
-            grpc_gen::supported_function_result::ExecutionFailure {
-                kind,
-                reason,
-                detail,
-            },
-        )) => {
-            let kind = grpc_gen::ExecutionFailureKind::try_from(kind)
-                .map_err(|_| ())
-                .and_then(ExecutionFailureKind::try_from)
-                .expect("ExecutionFailureKind must be in sync with the server");
-
-            let mut string = format!("Execution failure ({kind})");
-            if let Some(reason) = reason {
-                string.push_str(": `");
-                string.push_str(&reason);
-                string.push('`');
-            }
-            if let Some(detail) = detail {
-                string.push('\n');
-                string.push_str(&detail);
-            }
-            (string, Err(AlreadyPrintedError))
-        }
-        other => unreachable!("unexpected variant {other:?}"),
-    };
-
-    println!("Execution finished: {new_pending_status}");
-    println!(
-        "\nExecution took {since_created:?}.",
-        since_created = (finished_at - created_at)
-            .to_std()
-            .expect("must be non-negative")
-    );
-    res
+    let return_value: serde_json::Value =
+        serde_json::from_str(&return_value).context("return value must be valid JSON")?;
+    let client = client_startup.web_api_client()?;
+    send_empty(
+        client
+            .put(format!("{api_url}/v1/executions/{execution_id}/stub"))
+            .header(ACCEPT, "application/json")
+            .json(&return_value),
+    )
+    .await
 }
 
 #[derive(Debug, thiserror::Error)]
 #[error("")]
 struct AlreadyPrintedError;
 
-#[derive(Clone, Copy, Default)]
-pub(crate) struct GetStatusOptions {
-    pub(crate) follow: bool,
-    pub(crate) no_reconnect: bool,
-}
-
-pub(crate) async fn get_execution_result(
-    mut client: ExecutionRepositoryClient,
-    execution_id: ExecutionId,
-    opts: GetStatusOptions,
-) -> anyhow::Result<()> {
-    let reconnect = !opts.no_reconnect;
-    loop {
-        match poll_get_status_stream(&mut client, &execution_id, opts, GetMode::Result).await {
-            Ok(PollOutcome::Finished) => return Ok(()),
-            Ok(PollOutcome::Pending) => bail!("execution not finished yet"),
-            Err(err) => {
-                if reconnect {
-                    if err.downcast_ref::<tonic::Status>().is_some() {
-                        eprintln!("Got error while polling the status, reconnecting - {err}");
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                    } else if err.downcast_ref::<AlreadyPrintedError>().is_some() {
-                        // Already printed.
-                        return Err(err);
-                    } else {
-                        eprintln!("Encountered unrecoverable error, not reconnecting - {err:?}");
-                        return Err(err);
-                    }
-                } else {
-                    return Err(err);
-                }
-            }
-        }
-    }
-}
-
-pub(crate) async fn get_execution_status(
-    mut client: ExecutionRepositoryClient,
-    execution_id: ExecutionId,
-    opts: GetStatusOptions,
-) -> anyhow::Result<()> {
-    let reconnect = !opts.no_reconnect;
-    loop {
-        match poll_get_status_stream(&mut client, &execution_id, opts, GetMode::Status).await {
-            Ok(_) => return Ok(()),
-            Err(err) => {
-                if reconnect {
-                    if err.downcast_ref::<tonic::Status>().is_some() {
-                        eprintln!("Got error while polling the status, reconnecting - {err}");
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                    } else if err.downcast_ref::<AlreadyPrintedError>().is_some() {
-                        return Err(err);
-                    } else {
-                        eprintln!("Encountered unrecoverable error, not reconnecting - {err:?}");
-                        return Err(err);
-                    }
-                } else {
-                    return Err(err);
-                }
-            }
-        }
-    }
-}
-
-async fn poll_get_status_stream(
-    client: &mut ExecutionRepositoryClient,
-    execution_id: &ExecutionId,
-    opts: GetStatusOptions,
-    mode: GetMode,
-) -> anyhow::Result<PollOutcome> {
-    let mut stream = client
-        .get_status(tonic::Request::new(grpc_gen::GetStatusRequest {
-            execution_id: Some(grpc_gen::ExecutionId::from(execution_id.clone())),
-            follow: opts.follow,
-            send_finished_status: matches!(mode, GetMode::Result),
-        }))
-        .await?
-        .into_inner();
-    while let Some(status) = stream.message().await? {
-        let outcome = print_status(status, mode)?;
-        if matches!(outcome, PollOutcome::Finished) {
-            return Ok(outcome);
-        }
-    }
-    Ok(PollOutcome::Pending)
-}
-
 async fn fetch_execution_status_json(
     client: &reqwest::Client,
     api_url: &str,
     execution_id: &ExecutionId,
-) -> anyhow::Result<serde_json::Value> {
-    let response = client
-        .get(format!("{api_url}/v1/executions/{execution_id}/status"))
-        .header(ACCEPT, "application/json")
-        .send()
-        .await
-        .context("failed to get execution status")?;
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        bail!("server returned {status}: {body}");
-    }
-    let value: serde_json::Value = response
-        .json()
-        .await
-        .context("failed to parse execution status response")?;
-    Ok(value)
+) -> anyhow::Result<ExecutionWithStateSer> {
+    send_json(
+        client
+            .get(format!("{api_url}/v1/executions/{execution_id}/status"))
+            .header(ACCEPT, "application/json"),
+    )
+    .await
 }
 
-fn execution_status_json_is_finished(status: &serde_json::Value) -> bool {
-    status["pending_state"]["status"].as_str() == Some("finished")
+fn execution_status_is_finished(status: &ExecutionWithStateSer) -> bool {
+    matches!(
+        status.pending_state,
+        concepts::storage::PendingState::Finished(_)
+    )
 }
 
-fn print_json(value: &serde_json::Value) -> anyhow::Result<()> {
+fn print_json(value: &impl serde::Serialize) -> anyhow::Result<()> {
     println!(
         "{}",
         serde_json::to_string_pretty(value).context("failed to format JSON output")?
@@ -787,35 +418,27 @@ async fn fetch_execution_result_json(
     api_url: &str,
     execution_id: &ExecutionId,
     follow: bool,
-) -> anyhow::Result<serde_json::Value> {
-    let response = client
-        .get(format!("{api_url}/v1/executions/{execution_id}"))
-        .query(&[("follow", follow.to_string())])
-        .header(ACCEPT, "application/json")
-        .send()
-        .await
-        .context("failed to get execution result")?;
-    let status = response.status();
-    if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        bail!("server returned {status}: {body}");
-    }
-    response
-        .json()
-        .await
-        .context("failed to parse execution result response")
+) -> anyhow::Result<RetValWire> {
+    send_json(
+        client
+            .get(format!("{api_url}/v1/executions/{execution_id}"))
+            .query(&[("follow", follow.to_string())])
+            .header(ACCEPT, "application/json"),
+    )
+    .await
 }
 
-async fn get_execution_status_json(
+async fn get_execution_status_rest(
     client_startup: &ClientStartup,
     api_url: &str,
     execution_id: ExecutionId,
     follow: bool,
     no_reconnect: bool,
+    json: bool,
 ) -> anyhow::Result<()> {
     let client = client_startup.web_api_client()?;
     let reconnect = !no_reconnect;
-    let mut last_status: Option<serde_json::Value> = None;
+    let mut last_status = None;
 
     loop {
         let status = match fetch_execution_status_json(&client, api_url, &execution_id).await {
@@ -829,11 +452,16 @@ async fn get_execution_status_json(
                 return Err(err);
             }
         };
-        if last_status.as_ref() != Some(&status) {
-            print_json(&status)?;
+        let rendered = serde_json::to_string(&status)?;
+        if last_status.as_ref() != Some(&rendered) {
+            if json {
+                print_json(&status)?;
+            } else {
+                println!("{}", format_execution_status_text(&status.pending_state));
+            }
         }
 
-        if execution_status_json_is_finished(&status) {
+        if execution_status_is_finished(&status) {
             return Ok(());
         }
 
@@ -841,26 +469,38 @@ async fn get_execution_status_json(
             return Ok(());
         }
 
-        last_status = Some(status);
+        last_status = Some(rendered);
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 
-async fn get_execution_result_json(
+async fn get_execution_result_rest(
     client_startup: &ClientStartup,
     api_url: &str,
     execution_id: ExecutionId,
     follow: bool,
     no_reconnect: bool,
+    json: bool,
 ) -> anyhow::Result<()> {
+    if follow && !json {
+        get_execution_status_rest(
+            client_startup,
+            api_url,
+            execution_id.clone(),
+            true,
+            no_reconnect,
+            false,
+        )
+        .await?;
+    }
     let client = client_startup.web_api_client()?;
     let reconnect = follow && !no_reconnect;
+    let stream_result = follow && json;
 
     loop {
-        match fetch_execution_result_json(&client, api_url, &execution_id, follow).await {
+        match fetch_execution_result_json(&client, api_url, &execution_id, stream_result).await {
             Ok(result) => {
-                print_json(&result)?;
-                return Ok(());
+                return print_retval(&result, json);
             }
             Err(err) => {
                 if reconnect {
@@ -874,23 +514,42 @@ async fn get_execution_result_json(
     }
 }
 
-/// Send a GET request and forward the response body to stdout.
-async fn send_and_print(req: reqwest::RequestBuilder) -> anyhow::Result<()> {
-    let resp = req.send().await.context("failed to send request")?;
-    let status = resp.status();
-    if status.is_success() {
-        let body = resp.text().await.context("failed to read response body")?;
-        // Ensure output ends with a newline even when the server omits it (e.g. JSON).
-        if body.ends_with('\n') {
-            print!("{body}");
-        } else {
-            println!("{body}");
-        }
-        Ok(())
+fn print_retval(result: &RetValWire, json: bool) -> anyhow::Result<()> {
+    if json {
+        print_json(result)?;
     } else {
-        let body = resp.text().await.unwrap_or_default();
-        Err(anyhow::anyhow!("server returned {status}: {body}"))
+        match result {
+            RetValWire::Ok(value) => println!(
+                "Execution finished: OK: {}",
+                value.as_ref().map_or_else(
+                    || "(no return value)".to_string(),
+                    |value| serde_json::to_string(value).expect("return value is serializable"),
+                )
+            ),
+            RetValWire::Err(value) => {
+                println!(
+                    "Execution finished: Error: {}",
+                    value.as_ref().map_or_else(
+                        || "(no return value)".to_string(),
+                        |value| serde_json::to_string(value).expect("return value is serializable"),
+                    )
+                );
+                return Err(AlreadyPrintedError.into());
+            }
+            RetValWire::ExecutionFailed(failure) => {
+                let mut message = format!("Execution failure ({})", failure.kind);
+                if let Some(reason) = &failure.reason {
+                    write!(&mut message, ": `{reason}`").expect("writing to string");
+                }
+                if let Some(detail) = &failure.detail {
+                    write!(&mut message, "\n{detail}").expect("writing to string");
+                }
+                println!("Execution finished: {message}");
+                return Err(AlreadyPrintedError.into());
+            }
+        }
     }
+    Ok(())
 }
 
 async fn replay(
@@ -899,16 +558,29 @@ async fn replay(
     execution_id: ExecutionId,
     json: bool,
 ) -> anyhow::Result<()> {
-    let client = client_startup.web_api_client()?;
-    let accept = if json {
-        "application/json"
-    } else {
-        "text/plain"
-    };
-    let req = client
-        .put(format!("{api_url}/v1/executions/{execution_id}/replay"))
-        .header(ACCEPT, accept);
-    send_and_print(req).await
+    let response = replay_json(client_startup, api_url, &execution_id).await?;
+    if json {
+        return print_json(&response);
+    }
+    match response {
+        ReplayResponseSer::Advanceable { captured_writes } => {
+            println!("outcome: advanceable, {} writes", captured_writes.len());
+        }
+        ReplayResponseSer::Finished { retval } => {
+            println!("outcome: finished\nresult: {retval}");
+        }
+        ReplayResponseSer::Blocked => println!("outcome: blocked"),
+        ReplayResponseSer::ReplayFailed {
+            error,
+            captured_writes,
+        } => {
+            println!(
+                "outcome: replay_failed, error: {error}, {} writes",
+                captured_writes.len()
+            );
+        }
+    }
+    Ok(())
 }
 
 async fn persist_backtraces(
@@ -916,16 +588,15 @@ async fn persist_backtraces(
     api_url: &str,
     execution_id: ExecutionId,
 ) -> anyhow::Result<()> {
-    let channel = to_channel(api_url).await?;
-    let mut client = client_startup.execution_repository_client(channel)?;
-    let response = client
-        .persist_execution_backtraces(tonic::Request::new(
-            grpc_gen::PersistExecutionBacktracesRequest {
-                execution_id: Some(grpc_gen::ExecutionId::from(execution_id)),
-            },
-        ))
-        .await?
-        .into_inner();
+    let client = client_startup.web_api_client()?;
+    let response: PersistBacktracesResponseSer = send_json(
+        client
+            .put(format!(
+                "{api_url}/v1/executions/{execution_id}/backtrace/persist"
+            ))
+            .header(ACCEPT, "application/json"),
+    )
+    .await?;
     println!(
         "Persisted {} backtraces",
         response.persisted_backtrace_count
@@ -938,7 +609,7 @@ async fn replay_json(
     client_startup: &ClientStartup,
     api_url: &str,
     execution_id: &ExecutionId,
-) -> anyhow::Result<serde_json::Value> {
+) -> anyhow::Result<ReplayResponseSer> {
     let client = client_startup.web_api_client()?;
     let resp = client
         .put(format!("{api_url}/v1/executions/{execution_id}/replay"))
@@ -1013,11 +684,9 @@ fn trim_replay(advance_request: &mut AdvanceRequestSer, trim: usize) {
 }
 
 fn replay_to_advanceable_request(
-    replay: &serde_json::Value,
+    replay: ReplayResponseSer,
     force: bool,
 ) -> anyhow::Result<AdvanceRequestSer> {
-    let replay: ReplayResponseSer = serde_json::from_value(replay.clone())
-        .context("failed to decode replay response as ReplayResponseSer")?;
     match replay {
         ReplayResponseSer::Advanceable { captured_writes } => Ok(AdvanceRequestSer {
             captured_writes,
@@ -1068,7 +737,7 @@ async fn advance(
     opts: AdvanceOpts,
 ) -> anyhow::Result<()> {
     let replay = replay_json(client_startup, api_url, &execution_id).await?;
-    let mut advance_request = replay_to_advanceable_request(&replay, opts.force)?;
+    let mut advance_request = replay_to_advanceable_request(replay, opts.force)?;
     if let Some(trim) = opts.trim {
         trim_replay(&mut advance_request, trim);
     }
@@ -1079,89 +748,45 @@ async fn advance(
         pause_delays_in_replay(&mut advance_request);
     }
     let client = client_startup.web_api_client()?;
-    let accept = if opts.json {
-        "application/json"
+    #[derive(Debug, serde::Serialize, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum AdvanceResponseWire {
+        Finished {
+            value: RetValWire,
+        },
+        InProgress {
+            pending_state: concepts::storage::PendingState,
+        },
+    }
+    let response: AdvanceResponseWire = send_json(
+        client
+            .put(format!("{api_url}/v1/executions/{execution_id}/advance"))
+            .header(ACCEPT, "application/json")
+            .json(&advance_request),
+    )
+    .await?;
+    if opts.json {
+        print_json(&response)
     } else {
-        "text/plain"
-    };
-    let req = client
-        .put(format!("{api_url}/v1/executions/{execution_id}/advance"))
-        .header(ACCEPT, accept)
-        .json(&advance_request);
-    send_and_print(req).await
+        match response {
+            AdvanceResponseWire::Finished { value } => {
+                println!("success:\n{}", serde_json::to_string_pretty(&value)?);
+                Ok(())
+            }
+            AdvanceResponseWire::InProgress { pending_state } => {
+                println!("success, current state: {pending_state}");
+                Ok(())
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        execution_status_json_is_finished, format_finished_result_kind, format_finished_status,
-        pause_delays_in_replay, pause_submitted_in_replay,
-    };
+    use super::{pause_delays_in_replay, pause_submitted_in_replay};
     use crate::server::web_api_server::{AdvanceRequestSer, CapturedWriteSer};
     use chrono::{DateTime, Utc};
-    use grpc::grpc_gen;
     use serde_json::json;
-
-    #[test]
-    fn execution_status_json_finished_detection() {
-        assert!(execution_status_json_is_finished(&json!({
-            "pending_state": {
-                "status": "finished"
-            }
-        })));
-        assert!(!execution_status_json_is_finished(&json!({
-            "pending_state": {
-                "status": "locked"
-            }
-        })));
-    }
-
-    #[test]
-    fn finished_status_includes_success_and_error_kind() {
-        assert_eq!(
-            format_finished_status(Some(grpc_gen::ResultKind {
-                value: Some(grpc_gen::result_kind::Value::Ok(
-                    grpc_gen::result_kind::Ok {},
-                )),
-            })),
-            "Finished: OK"
-        );
-        assert_eq!(
-            format_finished_status(Some(grpc_gen::ResultKind {
-                value: Some(grpc_gen::result_kind::Value::Error(
-                    grpc_gen::result_kind::Error {},
-                )),
-            })),
-            "Finished: Error"
-        );
-    }
-
-    #[test]
-    fn finished_status_includes_execution_failure_kind() {
-        assert_eq!(
-            format_finished_result_kind(grpc_gen::ResultKind {
-                value: Some(grpc_gen::result_kind::Value::ExecutionFailureKind(
-                    grpc_gen::ExecutionFailureKind::TimedOut.into(),
-                )),
-            }),
-            Some("Execution failure (TimedOut)".to_string())
-        );
-    }
-
-    #[test]
-    fn finished_status_falls_back_to_plain_finished_for_missing_or_unknown_result_kind() {
-        assert_eq!(format_finished_status(None), "Finished");
-        assert_eq!(
-            format_finished_status(Some(grpc_gen::ResultKind { value: None })),
-            "Finished"
-        );
-        assert_eq!(
-            format_finished_status(Some(grpc_gen::ResultKind {
-                value: Some(grpc_gen::result_kind::Value::ExecutionFailureKind(999)),
-            })),
-            "Finished"
-        );
-    }
 
     #[test]
     fn pause_submitted_marks_only_new_child_requests_as_paused() {
@@ -1331,14 +956,9 @@ async fn execution_list(
     json: bool,
 ) -> anyhow::Result<()> {
     let client = client_startup.web_api_client()?;
-    let accept = if json {
-        "application/json"
-    } else {
-        "text/plain"
-    };
     let mut req = client
         .get(format!("{api_url}/v1/executions"))
-        .header(ACCEPT, accept)
+        .header(ACCEPT, "application/json")
         .query(&[("length", limit.to_string())]);
     if let Some(ffqn) = ffqn {
         req = req.query(&[("ffqn_prefix", ffqn)]);
@@ -1352,7 +972,21 @@ async fn execution_list(
     if hide_finished {
         req = req.query(&[("hide_finished", "true")]);
     }
-    send_and_print(req).await
+    let executions: Vec<ExecutionWithStateSer> = send_json(req).await?;
+    if json {
+        print_json(&executions)
+    } else {
+        for execution in executions {
+            println!(
+                "{} `{}` {} `{}`",
+                execution.execution_id,
+                execution.pending_state,
+                execution.ffqn,
+                execution.first_scheduled_at,
+            );
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1446,18 +1080,16 @@ impl LogsOpts {
 /// Parse a JSON log response into items, print them (as JSONL when `json` is true,
 /// as human-readable text otherwise), and return the cursor of the last item.
 fn print_log_items(
-    body: &str,
+    items: &[LogEntryRowSer],
     json: bool,
     show_run_id: bool,
     show_derived: bool,
 ) -> anyhow::Result<Option<String>> {
-    let items: Vec<serde_json::Value> =
-        serde_json::from_str(body).context("failed to parse logs JSON")?;
     if items.is_empty() {
         return Ok(None);
     }
     if json {
-        for item in &items {
+        for item in items {
             println!(
                 "{}",
                 serde_json::to_string(item).context("failed to serialize log item")?
@@ -1465,53 +1097,43 @@ fn print_log_items(
         }
     } else {
         let mut output = String::new();
-        for item in &items {
-            let created_at = item["created_at"]
-                .as_str()
-                .context("missing created_at in log item")?;
-            let run_id = item["run_id"].as_str().unwrap_or_default();
-            let execution_id = item["execution_id"].as_str().unwrap_or_default();
+        for item in items {
             let mut prefix = String::new();
             if show_run_id {
-                write!(&mut prefix, "{run_id} ").expect("writing to string");
+                write!(&mut prefix, "{} ", item.run_id).expect("writing to string");
             }
             if show_derived {
-                write!(&mut prefix, "{execution_id} ").expect("writing to string");
+                write!(&mut prefix, "{} ", item.execution_id).expect("writing to string");
             }
-            match item["type"].as_str() {
-                Some("log") => {
-                    let level = item["level"].as_str().unwrap_or("INFO");
-                    let message = item["message"].as_str().unwrap_or_default();
-                    writeln!(
-                        &mut output,
-                        "{created_at} [{level:<6}] {prefix}{message}",
-                        level = level.to_uppercase(),
-                    )
-                    .expect("writing to string");
+            match &item.info {
+                LogEntrySer::Log {
+                    created_at,
+                    level,
+                    message,
+                } => {
+                    writeln!(&mut output, "{created_at} [{level:<6}] {prefix}{message}")
+                        .expect("writing to string");
                 }
-                Some("stream") => {
-                    let stream_type = item["stream_type"].as_str().unwrap_or("STDOUT");
-                    let payload_b64 = item["payload"].as_str().unwrap_or_default();
+                LogEntrySer::Stream {
+                    created_at,
+                    payload,
+                    stream_type,
+                } => {
                     let payload_bytes = base64::engine::general_purpose::STANDARD
-                        .decode(payload_b64)
+                        .decode(payload)
                         .unwrap_or_default();
                     let payload_utf8 = String::from_utf8_lossy(&payload_bytes);
                     writeln!(
                         &mut output,
                         "{created_at} [{stream_type:<6}] {prefix}{payload_utf8}",
-                        stream_type = stream_type.to_uppercase(),
                     )
                     .expect("writing to string");
                 }
-                _ => {}
             }
         }
         print!("{output}");
     }
-    let cursor = items
-        .last()
-        .and_then(|v| v["cursor"].as_str())
-        .map(str::to_string);
+    let cursor = items.last().map(|item| item.cursor.clone());
     Ok(cursor)
 }
 
@@ -1522,7 +1144,7 @@ async fn fetch_logs(
     cursor: Option<&str>,
     after: Option<&str>,
     direction: &str,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<Vec<LogEntryRowSer>> {
     let mut req = client
         .get(logs_url)
         .header(ACCEPT, "application/json")
@@ -1539,13 +1161,7 @@ async fn fetch_logs(
     if let Some(after) = after {
         req = req.query(&[("after", after)]);
     }
-    let resp = req.send().await.context("failed to send logs request")?;
-    let resp_status = resp.status();
-    if !resp_status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(anyhow::anyhow!("server returned {resp_status}: {body}"));
-    }
-    resp.text().await.context("failed to read logs response")
+    send_json(req).await
 }
 
 async fn execution_logs_cmd(
@@ -1558,8 +1174,8 @@ async fn execution_logs_cmd(
 ) -> anyhow::Result<()> {
     let client = client_startup.web_api_client()?;
     let logs_url = format!("{api_url}/v1/executions/{execution_id}/logs");
-    let body = fetch_logs(&client, &logs_url, opts, None, after.as_deref(), "newer").await?;
-    print_log_items(&body, json, opts.show_run_id, opts.show_derived)?;
+    let items = fetch_logs(&client, &logs_url, opts, None, after.as_deref(), "newer").await?;
+    print_log_items(&items, json, opts.show_run_id, opts.show_derived)?;
     Ok(())
 }
 
@@ -1577,7 +1193,7 @@ async fn follow_logs(
     let mut cursor: Option<String> = None;
 
     loop {
-        let body = fetch_logs(
+        let items = fetch_logs(
             &client,
             &logs_url,
             opts,
@@ -1586,7 +1202,7 @@ async fn follow_logs(
             "newer",
         )
         .await?;
-        let new_cursor = print_log_items(&body, json, opts.show_run_id, opts.show_derived)?;
+        let new_cursor = print_log_items(&items, json, opts.show_run_id, opts.show_derived)?;
         let has_items = new_cursor.is_some();
         if let Some(c) = new_cursor {
             cursor = Some(c);
@@ -1594,22 +1210,9 @@ async fn follow_logs(
 
         // Check if the execution has finished.
         let finished = {
-            let resp = client
-                .get(&status_url)
-                .header(ACCEPT, "application/json")
-                .send()
-                .await
-                .context("failed to get execution status")?;
-            let st = resp.status();
-            if !st.is_success() {
-                let body = resp.text().await.unwrap_or_default();
-                return Err(anyhow::anyhow!("status check returned {st}: {body}"));
-            }
-            let status_json: serde_json::Value = resp
-                .json()
-                .await
-                .context("failed to parse status response")?;
-            status_json["pending_state"]["status"].as_str() == Some("finished")
+            let status: ExecutionWithStateSer =
+                send_json(client.get(&status_url).header(ACCEPT, "application/json")).await?;
+            execution_status_is_finished(&status)
         };
 
         if finished && !has_items {
@@ -1633,14 +1236,9 @@ async fn execution_events_cmd(
     json: bool,
 ) -> anyhow::Result<()> {
     let client = client_startup.web_api_client()?;
-    let accept = if json {
-        "application/json"
-    } else {
-        "text/plain"
-    };
     let mut req = client
         .get(format!("{api_url}/v1/executions/{execution_id}/events"))
-        .header(ACCEPT, accept)
+        .header(ACCEPT, "application/json")
         .query(&[("length", limit.to_string())]);
     if let Some(from) = from {
         req = req
@@ -1650,7 +1248,15 @@ async fn execution_events_cmd(
         // Without an explicit cursor, fetch the newest events from the latest version.
         req = req.query(&[("direction", "older")]);
     }
-    send_and_print(req).await
+    let response: ExecutionEventsResponse = send_json(req).await?;
+    if json {
+        print_json(&response)
+    } else {
+        for event in response.events {
+            println!("{} `{}` {}", event.version, event.created_at, event.event);
+        }
+        Ok(())
+    }
 }
 
 async fn execution_responses_cmd(
@@ -1662,14 +1268,9 @@ async fn execution_responses_cmd(
     json: bool,
 ) -> anyhow::Result<()> {
     let client = client_startup.web_api_client()?;
-    let accept = if json {
-        "application/json"
-    } else {
-        "text/plain"
-    };
     let mut req = client
         .get(format!("{api_url}/v1/executions/{execution_id}/responses"))
-        .header(ACCEPT, accept)
+        .header(ACCEPT, "application/json")
         .query(&[("length", limit.to_string())]);
     if let Some(from) = from {
         req = req
@@ -1679,55 +1280,78 @@ async fn execution_responses_cmd(
         // Without an explicit cursor, fetch the newest responses from the latest cursor.
         req = req.query(&[("direction", "older")]);
     }
-    send_and_print(req).await
+    let response: ExecutionResponsesResponse = send_json(req).await?;
+    if json {
+        print_json(&response)
+    } else {
+        for response in response.responses {
+            println!(
+                "{} `{}` {} {}",
+                response.cursor,
+                response.event.created_at,
+                response.event.event.join_set_id,
+                response.event.event.event,
+            );
+        }
+        Ok(())
+    }
 }
 
 impl CancelCommand {
     #[instrument(skip_all)]
     pub(crate) async fn execute(self, client_startup: &ClientStartup) -> anyhow::Result<()> {
-        let channel = to_channel(&self.api_url).await?;
-        let mut client = client_startup.execution_repository_client(channel)?;
-        match self.id {
-            args::ExecutionIdOrDelayId::Execution(execution_id) => {
-                let resp = client
-                    .cancel_execution(tonic::Request::new(CancelExecutionRequest {
-                        execution_id: Some(grpc_gen::ExecutionId::from(execution_id)),
-                    }))
-                    .await?
-                    .into_inner();
-                match resp.outcome() {
-                    CancelExecutionOutcome::Unspecified => panic!("unspecified"),
-                    CancelExecutionOutcome::CancellationRequested => {
-                        println!("Cancellation requested");
-                    }
-                    CancelExecutionOutcome::AlreadyFinished => {
-                        println!("Already successfully finished");
-                    }
-                    CancelExecutionOutcome::AlreadyCancelling => {
-                        println!("Already cancelling");
-                    }
-                }
+        let client = client_startup.web_api_client()?;
+        let url = match self.id {
+            args::ExecutionIdOrDelayId::Execution(id) => {
+                format!("{}/v1/executions/{id}/cancel", self.api_url)
             }
-            args::ExecutionIdOrDelayId::Delay(delay_id) => {
-                let resp = client
-                    .cancel_delay(tonic::Request::new(CancelDelayRequest {
-                        delay_id: Some(grpc_gen::DelayId {
-                            id: delay_id.to_string(),
-                        }),
-                    }))
-                    .await?
-                    .into_inner();
-                match resp.outcome() {
-                    CancelDelayOutcome::Unspecified => panic!("unspecified"),
-                    CancelDelayOutcome::Cancelled => println!("Cancelled"),
-                    CancelDelayOutcome::AlreadyFinished => {
-                        println!("Already successfully finished");
-                    }
-                }
+            args::ExecutionIdOrDelayId::Delay(id) => {
+                format!("{}/v1/delays/{id}/cancel", self.api_url)
             }
+        };
+        let response = client
+            .put(url)
+            .header(ACCEPT, "application/json")
+            .send()
+            .await?;
+        let status = response.status();
+        if status.is_success() {
+            let body: ApiOk = response.json().await?;
+            println!("{}", capitalize(&body.ok));
+            return Ok(());
         }
-        Ok(())
+        let body: ApiError = response.json().await?;
+        if status == reqwest::StatusCode::CONFLICT {
+            println!("{}", capitalize(&body.err));
+            return Ok(());
+        }
+        bail!("server returned {status}: {}", body.err)
     }
+}
+
+async fn execution_pause_change(
+    client_startup: &ClientStartup,
+    api_url: &str,
+    id: args::ExecutionIdOrDelayId,
+    action: &str,
+) -> anyhow::Result<()> {
+    let client = client_startup.web_api_client()?;
+    let url = match id {
+        args::ExecutionIdOrDelayId::Execution(id) => {
+            format!("{api_url}/v1/executions/{id}/{action}")
+        }
+        args::ExecutionIdOrDelayId::Delay(id) => {
+            format!("{api_url}/v1/delays/{id}/{action}")
+        }
+    };
+    send_empty(client.put(url).header(ACCEPT, "application/json")).await
+}
+
+fn capitalize(value: &str) -> String {
+    let mut chars = value.chars();
+    chars.next().map_or_else(String::new, |first| {
+        first.to_uppercase().collect::<String>() + chars.as_str()
+    })
 }
 
 async fn upgrade(
@@ -1736,72 +1360,29 @@ async fn upgrade(
     execution_id: ExecutionId,
     skip_determinism_check: bool,
 ) -> anyhow::Result<()> {
-    let channel = to_channel(api_url).await?;
-
-    // Step 1: fetch the execution summary to get current component digest and ffqn.
-    let mut exec_client = client_startup.execution_repository_client(channel.clone())?;
-    let summary = exec_client
-        .get_status(tonic::Request::new(grpc_gen::GetStatusRequest {
-            execution_id: Some(grpc_gen::ExecutionId::from(execution_id.clone())),
-            follow: false,
-            send_finished_status: false,
-        }))
-        .await
-        .context("failed to get execution status")?
-        .into_inner()
-        .message()
-        .await
-        .context("failed to read status stream")?
-        .context("empty status stream")?;
-
-    let summary = match summary
-        .message
-        .context("missing message in status response")?
-    {
-        grpc::grpc_gen::get_status_response::Message::Summary(s) => s,
-        other => bail!("expected ExecutionSummary, got {other:?}"),
-    };
-
-    let ffqn = FunctionFqn::try_from(
-        summary
-            .function_name
-            .context("missing function_name in summary")?,
-    )
-    .map_err(|e| anyhow::anyhow!("failed to parse ffqn: {e}"))?;
-
-    let old_digest = summary
-        .component_digest
-        .context("missing component_digest in summary")?
-        .digest;
+    let client = client_startup.web_api_client()?;
+    let summary = fetch_execution_status_json(&client, api_url, &execution_id).await?;
+    let ffqn = summary.ffqn;
+    let old_digest = summary.component_digest;
 
     // Step 2: find the component that currently exports this ffqn.
-    let mut fn_client = client_startup.fn_repository_client(channel.clone())?;
-    let components = fn_client
-        .list_components(tonic::Request::new(grpc_gen::ListComponentsRequest {
-            function_name: Some(grpc_gen::FunctionName::from(&ffqn)),
-            component_digest: None,
-            extensions: false,
-            deployment_id: None,
-        }))
-        .await
-        .context("failed to list components")?
-        .into_inner()
-        .components;
+    let components: Vec<ComponentConfig> = send_json(
+        client
+            .get(format!("{api_url}/v1/components"))
+            .header(ACCEPT, "application/json")
+            .query(&[("ffqn", ffqn.to_string())]),
+    )
+    .await
+    .context("failed to list components")?;
 
     let new_digest = match components.as_slice() {
         [] => bail!("no component in the active deployment exports `{ffqn}`"),
-        [component] => component
-            .component_id
-            .as_ref()
-            .and_then(|id| id.digest.as_ref())
-            .map(|d| d.digest.clone())
-            .context("component is missing digest")?,
+        [component] => component.component_id.component_digest.clone(),
         _ => bail!(
             "multiple components export `{ffqn}`: {:?}",
             components
                 .iter()
-                .filter_map(|c| c.component_id.as_ref())
-                .map(|id| &id.name)
+                .map(|c| &c.component_id.name)
                 .collect::<Vec<_>>()
         ),
     };
@@ -1813,18 +1394,18 @@ async fn upgrade(
 
     println!("Upgrading from {old_digest} to {new_digest}");
 
-    // Step 3: perform the upgrade.
-    exec_client
-        .upgrade_execution_component(tonic::Request::new(
-            grpc_gen::UpgradeExecutionComponentRequest {
-                execution_id: Some(grpc_gen::ExecutionId::from(execution_id)),
-                expected_component_digest: Some(grpc_gen::ContentDigest { digest: old_digest }),
-                new_component_digest: Some(grpc_gen::ContentDigest { digest: new_digest }),
+    send_empty(
+        client
+            .put(format!("{api_url}/v1/executions/{execution_id}/upgrade"))
+            .header(ACCEPT, "application/json")
+            .json(&ExecutionUpgradePayload {
+                old: old_digest,
+                new: new_digest,
                 skip_determinism_check,
-            },
-        ))
-        .await
-        .context("upgrade failed")?;
+            }),
+    )
+    .await
+    .context("upgrade failed")?;
 
     println!("Upgraded");
     Ok(())

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -698,22 +698,42 @@ impl TestServer {
     async fn start(ip: String) -> Self {
         let (tmp_dir, server_path, deployment_path) = write_test_configs(&ip, "");
         let deployment = LocalDeployment::from_path(&deployment_path).await.unwrap();
-        Self::launch(ip, tmp_dir, server_path, deployment, true).await
+        Self::launch(ip, tmp_dir, server_path, deployment, true, None).await
     }
 
     /// Start a server with an empty deployment (no components, no CAS blobs), so a later
     /// `deployment apply` exercises the upload-then-submit path from a clean store.
     async fn start_empty(ip: String) -> Self {
         let (tmp_dir, server_path, _deployment_path) = write_test_configs(&ip, "");
-        Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty(), true).await
+        Self::launch(
+            ip,
+            tmp_dir,
+            server_path,
+            LocalDeployment::empty(),
+            true,
+            None,
+        )
+        .await
     }
 
     /// Start an empty server with API auth enabled (`no_auth = false`), accepting the
-    /// given extra top-level `server.toml` lines (e.g. `api.token = "..."`).
-    async fn start_empty_with_auth(ip: String, server_toml_api_lines: &str) -> Self {
+    /// given extra top-level `server.toml` lines (e.g. `api.token_hashes = [...]`).
+    async fn start_empty_with_auth(
+        ip: String,
+        server_toml_api_lines: &str,
+        legacy_api_token: Option<&str>,
+    ) -> Self {
         let (tmp_dir, server_path, _deployment_path) =
             write_test_configs(&ip, server_toml_api_lines);
-        Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty(), false).await
+        Self::launch(
+            ip,
+            tmp_dir,
+            server_path,
+            LocalDeployment::empty(),
+            false,
+            legacy_api_token.map(secrecy::SecretString::from),
+        )
+        .await
     }
 
     async fn launch(
@@ -722,6 +742,7 @@ impl TestServer {
         server_path: PathBuf,
         deployment: LocalDeployment,
         no_auth: bool,
+        legacy_api_token: Option<secrecy::SecretString>,
     ) -> Self {
         test_utils::set_up();
 
@@ -740,6 +761,7 @@ impl TestServer {
             clean_sqlite_directory: false,
             suppress_type_checking_errors: false,
             no_auth,
+            legacy_api_token,
         };
 
         let prepared_dirs = prepare_dirs(
@@ -1251,7 +1273,6 @@ impl TestServer {
     }
 }
 
-/// api.token is not tested as it interferes with `OBELISK__API__TOKEN` that might be set.
 #[tokio::test]
 async fn api_auth_should_deny_unauthenticated_requests() {
     fn list_components_request() -> ListComponentsRequest {
@@ -1264,12 +1285,14 @@ async fn api_auth_should_deny_unauthenticated_requests() {
     }
 
     let hashed_token = "hashed-secret-token";
+    let legacy_token = "legacy-secret-token";
     let server = TestServer::start_empty_with_auth(
         test_addr!(89),
         &format!(
             "api.token_hashes = [\"{hash}\"]",
             hash = crate::api::token_hash(hashed_token)
         ),
+        Some(legacy_token),
     )
     .await;
 
@@ -1288,6 +1311,15 @@ async fn api_auth_should_deny_unauthenticated_requests() {
         .client
         .get(&url)
         .bearer_auth(hashed_token)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "status: {}", resp.status());
+
+    let resp = server
+        .client
+        .get(&url)
+        .bearer_auth(legacy_token)
         .send()
         .await
         .unwrap();

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -708,7 +708,7 @@ impl TestServer {
         Self::launch(ip, tmp_dir, server_path, LocalDeployment::empty(), true).await
     }
 
-    /// Start an empty server with API auth enabled (no `allow_unauthenticated_api`), accepting the
+    /// Start an empty server with API auth enabled (`no_auth = false`), accepting the
     /// given extra top-level `server.toml` lines (e.g. `api.token = "..."`).
     async fn start_empty_with_auth(ip: String, server_toml_api_lines: &str) -> Self {
         let (tmp_dir, server_path, _deployment_path) =
@@ -721,7 +721,7 @@ impl TestServer {
         tmp_dir: tempfile::TempDir,
         server_path: PathBuf,
         deployment: LocalDeployment,
-        allow_unauthenticated_api: bool,
+        no_auth: bool,
     ) -> Self {
         test_utils::set_up();
 
@@ -739,7 +739,7 @@ impl TestServer {
             },
             clean_sqlite_directory: false,
             suppress_type_checking_errors: false,
-            allow_unauthenticated_api,
+            no_auth,
         };
 
         let prepared_dirs = prepare_dirs(

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -3189,6 +3189,55 @@ ffqn = "testing:integration/a.run"
     server.shutdown().await;
 }
 
+#[tokio::test]
+async fn gc_orphan_files_webapi() {
+    let server = TestServer::start(test_addr!(123)).await;
+    let orphan_digest = {
+        let pool = SqlitePool::new(&server.sqlite_file, SqliteConfig::default())
+            .await
+            .unwrap();
+        let digest = pool
+            .cas_conn()
+            .await
+            .unwrap()
+            .write_blob(b"orphan blob for REST GC")
+            .await
+            .unwrap();
+        pool.close().await;
+        digest.to_string()
+    };
+
+    let response = server
+        .client
+        .delete(format!("{}/v1/files/orphans", server.base_url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.json::<Value>().await.unwrap()["deleted_count"], 1);
+
+    let response = server
+        .client
+        .get(format!("{}/v1/files/{orphan_digest}", server.base_url))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let response = server
+        .client
+        .delete(format!("{}/v1/files/orphans", server.base_url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.json::<Value>().await.unwrap()["deleted_count"], 0);
+
+    server.shutdown().await;
+}
+
 // ---- Activity: submit + result ----
 
 #[tokio::test]

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -570,8 +570,8 @@ pub(crate) struct RunParams {
     pub(crate) dir_params: PrepareDirsParams,
     pub(crate) clean_sqlite_directory: bool,
     pub(crate) suppress_type_checking_errors: bool,
-    /// Accept unauthenticated API requests (`--allow-unauthenticated-api`).
-    pub(crate) allow_unauthenticated_api: bool,
+    /// Accept unauthenticated API requests (`--no-auth`).
+    pub(crate) no_auth: bool,
 }
 
 pub(crate) async fn run(
@@ -1909,10 +1909,8 @@ pub(crate) async fn run_internal(
     });
     if let Some(api_listening_addr) = api_listening_addr {
         let app = app_router.fallback_service(grpc_service);
-        let app_svc = if params.allow_unauthenticated_api {
-            warn!(
-                "API authentication is disabled by --allow-unauthenticated-api: accepting all API requests"
-            );
+        let app_svc = if params.no_auth {
+            warn!("API authentication is disabled by --no-auth: accepting all API requests");
             app.into_make_service()
         } else {
             let api_auth = Arc::new(crate::server::auth::ApiAuth::new(&api_config));

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -572,6 +572,7 @@ pub(crate) struct RunParams {
     pub(crate) suppress_type_checking_errors: bool,
     /// Accept unauthenticated API requests (`--no-auth`).
     pub(crate) no_auth: bool,
+    pub(crate) legacy_api_token: Option<secrecy::SecretString>,
 }
 
 pub(crate) async fn run(
@@ -749,6 +750,7 @@ pub(crate) async fn verify(
             let ServerStartup {
                 config_holder,
                 config,
+                legacy_api_token: _,
                 secret_registry,
             } = prepare_server_startup(
                 config_holder.config_source,
@@ -1913,7 +1915,10 @@ pub(crate) async fn run_internal(
             warn!("API authentication is disabled by --no-auth: accepting all API requests");
             app.into_make_service()
         } else {
-            let api_auth = Arc::new(crate::server::auth::ApiAuth::new(&api_config));
+            let api_auth = Arc::new(crate::server::auth::ApiAuth::new(
+                &api_config,
+                params.legacy_api_token.clone(),
+            ));
             info!(
                 "API startup token: {}",
                 api_auth.startup_token().expose_secret()

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use wasm_workers::http_request_policy::SecretResolver;
 
 pub(crate) const API_TOKEN_CLIENT: &str = "OBELISK_API_TOKEN";
-pub(crate) const API_TOKEN_SERVER: &str = "OBELISK__API__TOKEN";
+pub(crate) const API_TOKEN_LEGACY: &str = "OBELISK__API__TOKEN";
 
 /// Source of a secret in the `[secrets]` table.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -91,7 +91,7 @@ impl SecretRegistry {
 
         // Always sensitive, even when the operator did not register them as secrets.
         let mut sensitive =
-            HashSet::from([API_TOKEN_SERVER.to_string(), API_TOKEN_CLIENT.to_string()]);
+            HashSet::from([API_TOKEN_LEGACY.to_string(), API_TOKEN_CLIENT.to_string()]);
 
         let mut missing_env_vars = BTreeSet::new();
         for (logical_name, source) in secrets {

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -14,7 +14,6 @@ use concepts::component_id::Digest;
 use db_postgres::postgres_dao::{self, PostgresConfig};
 use db_sqlite::sqlite_dao::SqliteConfig;
 use schemars::JsonSchema;
-use secrecy::SecretString;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
@@ -192,11 +191,6 @@ pub(crate) struct ApiConfig {
     /// Generate an entry with `obelisk generate token`.
     #[serde(default)]
     pub(crate) token_hashes: Vec<Digest>,
-    /// Plaintext accepted token, intended for env injection only
-    /// (`OBELISK__API__TOKEN`); do not write it into the config file.
-    #[serde(default, deserialize_with = "deserialize_opt_secret_string")]
-    #[schemars(with = "Option<String>")]
-    pub(crate) token: Option<SecretString>,
 }
 
 impl Default for ApiConfig {
@@ -205,15 +199,8 @@ impl Default for ApiConfig {
             enabled: true,
             listening_addr: default_api_listening_addr(),
             token_hashes: Vec::new(),
-            token: None,
         }
     }
-}
-
-fn deserialize_opt_secret_string<'de, D: serde::Deserializer<'de>>(
-    deserializer: D,
-) -> Result<Option<SecretString>, D::Error> {
-    Ok(Option::<String>::deserialize(deserializer)?.map(SecretString::from))
 }
 
 fn default_api_listening_addr() -> SocketAddr {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), anyhow::Error> {
             empty: deployment_empty,
             description,
             suppress_type_checking_errors,
-            allow_unauthenticated_api,
+            no_auth,
         }) => {
             let ServerStartup {
                 config_holder,
@@ -76,7 +76,7 @@ fn main() -> Result<(), anyhow::Error> {
                     },
                     clean_sqlite_directory,
                     suppress_type_checking_errors,
-                    allow_unauthenticated_api,
+                    no_auth,
                 },
                 secret_registry,
             ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod wit_printer;
 use crate::command::server::{
     PrepareDirsParams, RunParams, RuntimeConfigAvailability, VerifyParams, run, verify,
 };
-use crate::config::secret_registry::EnvVarCleanupStrategy;
+use crate::config::secret_registry::{API_TOKEN_LEGACY, EnvVarCleanupStrategy};
 use args::{
     Args, ComponentArgs, Deployment, DeploymentArgs, DeploymentVerifyArgs, ExecutionArgs, Server,
     Subcommand, VerifyArgs,
@@ -57,6 +57,7 @@ fn main() -> Result<(), anyhow::Error> {
             let ServerStartup {
                 config_holder,
                 config,
+                legacy_api_token,
                 secret_registry,
             } = prepare_server_startup(
                 server_config.clone(),
@@ -77,6 +78,7 @@ fn main() -> Result<(), anyhow::Error> {
                     clean_sqlite_directory,
                     suppress_type_checking_errors,
                     no_auth,
+                    legacy_api_token,
                 },
                 secret_registry,
             ))
@@ -100,6 +102,7 @@ fn main() -> Result<(), anyhow::Error> {
             let ServerStartup {
                 config_holder,
                 config,
+                legacy_api_token: _,
                 secret_registry,
             } = prepare_server_startup(
                 server_config.clone(),
@@ -148,6 +151,7 @@ fn main() -> Result<(), anyhow::Error> {
             let ServerStartup {
                 config_holder,
                 config,
+                legacy_api_token: _,
                 secret_registry,
             } = prepare_server_startup(
                 server_config.clone(),
@@ -211,6 +215,7 @@ fn main() -> Result<(), anyhow::Error> {
 struct ServerStartup {
     config_holder: ConfigHolder,
     config: ServerConfigToml,
+    legacy_api_token: Option<secrecy::SecretString>,
     secret_registry: Arc<SecretRegistry>,
 }
 
@@ -228,7 +233,19 @@ fn prepare_server_startup(
         );
     }
     let config_holder = ConfigHolder::new(project_dirs(), BaseDirs::new(), server_config)?;
+    // backcompat: 0.41 exposed OBELISK__API__TOKEN as api.token; remove after 0.43.
+    let legacy_env = std::env::var(API_TOKEN_LEGACY).ok();
+    if legacy_env.is_some() {
+        // SAFETY: server configuration is loaded before the runtime and its threads start.
+        unsafe { std::env::remove_var(API_TOKEN_LEGACY) };
+    }
     let config = config_holder.load_config()?;
+    let legacy_api_token = legacy_env.filter(|token| !token.is_empty()).map(|token| {
+        eprintln!(
+            "warning: {API_TOKEN_LEGACY} is deprecated; use api.token_hashes for server authentication"
+        );
+        secrecy::SecretString::from(token)
+    });
     let secret_registry = Arc::new(SecretRegistry::resolve(
         config.secrets.clone(),
         env_var_cleanup,
@@ -237,6 +254,7 @@ fn prepare_server_startup(
     Ok(ServerStartup {
         config_holder,
         config,
+        legacy_api_token,
         secret_registry,
     })
 }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -25,7 +25,7 @@ pub(crate) struct ApiAuth {
 }
 
 impl ApiAuth {
-    pub(crate) fn new(config: &ApiConfig) -> Self {
+    pub(crate) fn new(config: &ApiConfig, legacy_token: Option<SecretString>) -> Self {
         let startup_token = SecretString::from(crate::api::generate_token());
         let mut accepted = vec![(
             crate::api::token_digest(startup_token.expose_secret()),
@@ -34,7 +34,7 @@ impl ApiAuth {
         for digest in &config.token_hashes {
             accepted.push((digest.0, hash_prefix_label(digest)));
         }
-        if let Some(token) = &config.token {
+        if let Some(token) = legacy_token {
             let digest = crate::api::token_digest(token.expose_secret());
             accepted.push((
                 digest,

--- a/src/server/deployment_summary.rs
+++ b/src/server/deployment_summary.rs
@@ -1,4 +1,6 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, utoipa::ToSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum DeploymentComponentType {
     WorkflowWasm,
@@ -13,13 +15,13 @@ pub(crate) enum DeploymentComponentType {
     Cron,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub(crate) struct DeploymentComponentCount {
     pub(crate) component_type: DeploymentComponentType,
     pub(crate) count: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 pub(crate) struct DeploymentComponentSummary {
     pub(crate) components: Vec<DeploymentComponentCount>,
 }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -4,7 +4,7 @@ use crate::{
         backtrace::{execution_backtrace, execution_backtrace_source},
         components::{component_wit, components_list},
         deployment::{
-            get_current_deployment_id, get_deployment, get_file, list_deployments,
+            gc_orphan_files, get_current_deployment_id, get_deployment, get_file, list_deployments,
             submit_deployment, switch_deployment,
         },
         functions::{function_wit, functions_list},
@@ -114,6 +114,7 @@ pub(crate) struct WebApiState {
         deployment::submit_deployment,
         deployment::switch_deployment,
         deployment::get_file,
+        deployment::gc_orphan_files,
     ),
     components(schemas(
         PaginationDirectionSortedFromLatest,
@@ -141,6 +142,7 @@ pub(crate) struct WebApiState {
         functions::FunctionOutput,
         deployment::DeploymentStateSer,
         deployment::DeploymentSubmitResponse,
+        deployment::GcOrphanFilesResponseSer,
         deployment::SubmitPackageErrorBody,
         deployment::FileIssue,
         deployment::DigestMismatch,
@@ -249,6 +251,7 @@ fn v1_router() -> Router<Arc<WebApiState>> {
         .route("/deployments", routing::get(list_deployments))
         .route("/deployments", routing::post(submit_deployment))
         .route("/deployments/{deployment-id}", routing::get(get_deployment))
+        .route("/files/orphans", routing::delete(gc_orphan_files))
         .route("/files/{digest}", routing::get(get_file))
         .route(
             "/deployments/{deployment-id}/switch",
@@ -449,7 +452,7 @@ enum ExecutionListCursorDeser {
     ExecutionId(ExecutionId),
 }
 /// Execution with current state information
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub struct ExecutionWithStateSer {
     /// Unique execution identifier
     #[schema(value_type = String, example = "E_01JKXYZ123456789ABCDEFGHIJ")]
@@ -783,14 +786,14 @@ struct ExecutionEventsParams {
 }
 
 /// Response containing execution events
-#[derive(Serialize, ToSchema)]
-struct ExecutionEventsResponse {
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(crate) struct ExecutionEventsResponse {
     /// List of execution events
     #[schema(value_type = Vec<Object>)]
-    events: Vec<ExecutionEvent>,
+    pub(crate) events: Vec<ExecutionEvent>,
     /// Maximum version in the response
     #[schema(value_type = u32)]
-    max_version: Version,
+    pub(crate) max_version: Version,
 }
 /// Get execution events (history)
 #[utoipa::path(
@@ -860,7 +863,7 @@ async fn execution_events(
     })
 }
 
-mod logs {
+pub(crate) mod logs {
     use super::*;
     use base64::{Engine as _, prelude::BASE64_STANDARD};
     use chrono::{DateTime, Utc};
@@ -953,7 +956,7 @@ mod logs {
     }
 
     /// Log entry row with cursor
-    #[derive(Serialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     pub(crate) struct LogEntryRowSer {
         /// Opaque cursor position
         pub cursor: String,
@@ -968,7 +971,7 @@ mod logs {
     }
 
     /// Log entry content
-    #[derive(Serialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     #[serde(tag = "type", rename_all = "snake_case")]
     pub(crate) enum LogEntrySer {
         /// Structured log message
@@ -1017,7 +1020,7 @@ mod logs {
         }
     }
 
-    #[derive(serde::Serialize, ToSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, ToSchema)]
     #[serde(rename_all = "snake_case")]
     pub(crate) enum LogLevelSer {
         Trace,
@@ -1051,7 +1054,7 @@ mod logs {
         }
     }
 
-    #[derive(serde::Serialize, ToSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, ToSchema)]
     #[serde(rename_all = "snake_case")]
     pub(crate) enum LogStreamTypeSer {
         Stdout,
@@ -1248,17 +1251,17 @@ struct ExecutionResponsesParams {
 }
 
 /// Response containing execution responses
-#[derive(Serialize, ToSchema)]
-struct ExecutionResponsesResponse {
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(crate) struct ExecutionResponsesResponse {
     /// List of responses with cursors
     #[schema(value_type = Vec<Object>)]
-    responses: Vec<ResponseWithCursor>,
+    pub(crate) responses: Vec<ResponseWithCursor>,
     /// Maximum cursor in the response
     #[schema(value_type = u32)]
-    max_cursor: ResponseCursor,
+    pub(crate) max_cursor: ResponseCursor,
     /// Execution-wide cursor reached in the requested direction
     #[schema(value_type = u32)]
-    scan_cursor: ResponseCursor,
+    pub(crate) scan_cursor: ResponseCursor,
 }
 /// Get execution responses (join set responses)
 #[utoipa::path(
@@ -1373,7 +1376,7 @@ async fn execution_status_get(
     })
 }
 
-fn format_execution_status_text(pending_state: &PendingState) -> String {
+pub(crate) fn format_execution_status_text(pending_state: &PendingState) -> String {
     match pending_state {
         PendingState::Locked(_) => "Locked".to_string(),
         PendingState::PendingAt(pending) => format!("Pending at {}", pending.scheduled_at),
@@ -2045,7 +2048,7 @@ enum AdvanceErrorSer {
     Transient(String),
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub(crate) struct PersistBacktracesResponseSer {
     /// Number of newly persisted backtraces (already-persisted ones are skipped).
     pub(crate) persisted_backtrace_count: u32,
@@ -2622,17 +2625,17 @@ async fn replay_execution_internal(
 }
 
 /// Payload for upgrading an execution to a new component version
-#[derive(Deserialize, ToSchema)]
-struct ExecutionUpgradePayload {
+#[derive(Serialize, Deserialize, ToSchema)]
+pub(crate) struct ExecutionUpgradePayload {
     /// Old component digest to upgrade from
     #[schema(value_type = String)]
-    pub old: ComponentDigest,
+    pub(crate) old: ComponentDigest,
     /// New component digest to upgrade to
     #[schema(value_type = String)]
-    pub new: ComponentDigest,
+    pub(crate) new: ComponentDigest,
     /// Skip determinism check during upgrade
     #[serde(default)]
-    pub skip_determinism_check: bool,
+    pub(crate) skip_determinism_check: bool,
 }
 
 /// Upgrade an execution to a new component version
@@ -2951,33 +2954,33 @@ pub(crate) mod components {
     }
 
     /// Component configuration with optional imports/exports
-    #[derive(Serialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     pub(crate) struct ComponentConfig {
         /// Component identifier
         #[schema(value_type = Object)]
-        component_id: ComponentId,
+        pub(crate) component_id: ComponentId,
         /// Deployment-owned files used by this component.
-        files: Vec<ComponentFileRef>,
+        pub(crate) files: Vec<ComponentFileRef>,
         /// Imported functions
         #[serde(skip_serializing_if = "Option::is_none")]
-        imports: Option<Vec<FunctionMetadataLite>>,
+        pub(crate) imports: Option<Vec<FunctionMetadataLite>>,
         /// Exported functions
         #[serde(skip_serializing_if = "Option::is_none")]
-        exports: Option<Vec<FunctionMetadataLite>>,
+        pub(crate) exports: Option<Vec<FunctionMetadataLite>>,
     }
 
-    #[derive(Serialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     pub(crate) struct ComponentFileRef {
-        file: ComponentFile,
+        pub(crate) file: ComponentFile,
         #[schema(value_type = String)]
-        role: ComponentFileRole,
+        pub(crate) role: ComponentFileRole,
     }
 
-    #[derive(Serialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     pub(crate) struct ComponentFile {
-        path: String,
-        digest: String,
-        size: u64,
+        pub(crate) path: String,
+        pub(crate) digest: String,
+        pub(crate) size: u64,
     }
 
     impl From<DeploymentComponentFileDetail> for ComponentFileRef {
@@ -2994,22 +2997,22 @@ pub(crate) mod components {
     }
 
     /// Lightweight function metadata
-    #[derive(serde::Serialize, derive_more::Display, ToSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, derive_more::Display, ToSchema)]
     #[display("{ffqn}: func({}) -> {return_type}", parameter_types.iter().join(", "))]
     pub(crate) struct FunctionMetadataLite {
         /// Fully qualified function name
         #[schema(value_type = String)]
-        ffqn: FunctionFqn,
+        pub(crate) ffqn: FunctionFqn,
         /// Parameter types
-        parameter_types: Vec<ParameterTypeLite>,
+        pub(crate) parameter_types: Vec<ParameterTypeLite>,
         /// Return type as WIT string
-        return_type: String,
+        pub(crate) return_type: String,
         /// Function extension type if any
         #[serde(skip_serializing_if = "Option::is_none")]
         #[schema(value_type = Option<String>)]
-        extension: Option<FunctionExtension>,
+        pub(crate) extension: Option<FunctionExtension>,
         /// Externally submittable: primary functions + `-schedule` extended, but no activity stubs
-        submittable: bool,
+        pub(crate) submittable: bool,
     }
     impl From<FunctionMetadata> for FunctionMetadataLite {
         fn from(value: FunctionMetadata) -> Self {
@@ -3044,13 +3047,13 @@ pub(crate) mod components {
     }
 
     /// Parameter type information
-    #[derive(serde::Serialize, derive_more::Display, ToSchema)]
+    #[derive(serde::Serialize, serde::Deserialize, derive_more::Display, ToSchema)]
     #[display("{name}: {wit_type}")]
     pub(crate) struct ParameterTypeLite {
         /// Parameter name
-        name: String,
+        pub(crate) name: String,
         /// WIT type representation
-        wit_type: String,
+        pub(crate) wit_type: String,
     }
 
     impl From<ParameterType> for ParameterTypeLite {
@@ -3213,7 +3216,7 @@ mod functions {
     }
 }
 
-mod deployment {
+pub(crate) mod deployment {
     use crate::{
         command::server::{self, RuntimeConfigAvailability, SwitchDeploymentAction},
         config::deployment::strip_generated_deployment_metadata,
@@ -3254,7 +3257,7 @@ mod deployment {
     use tracing::{info, instrument};
     use utoipa::{IntoParams, ToSchema};
 
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     #[serde(rename_all = "snake_case")]
     pub enum DeploymentStatusSer {
         Inactive,
@@ -3272,7 +3275,7 @@ mod deployment {
         }
     }
     /// Deployment state with execution counts
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct DeploymentStateSer {
         /// Deployment identifier
         #[schema(value_type = String, example = "Dep_01JKXYZ123456789ABCDEFGHIJ")]
@@ -3453,7 +3456,7 @@ mod deployment {
     }
 
     /// A deployment-owned file the manifest references.
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct FileRefSer {
         /// Deployment-relative path.
         pub path: String,
@@ -3474,7 +3477,7 @@ mod deployment {
     }
 
     /// Deployment details with config
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct DeploymentRecordSer {
         #[schema(value_type = String)]
         pub deployment_id: DeploymentId,
@@ -3488,6 +3491,11 @@ mod deployment {
         pub deployment_toml: String,
         /// Files the manifest references.
         pub files: Vec<FileRefSer>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
+    pub(crate) struct GcOrphanFilesResponseSer {
+        pub(crate) deleted_count: u64,
     }
 
     impl From<&DeploymentRecord> for DeploymentRecordSer {
@@ -3589,7 +3597,7 @@ mod deployment {
     }
 
     /// Request payload for submitting a new deployment
-    #[derive(Deserialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     pub struct DeploymentSubmitPayload {
         /// Verbatim deployment manifest (`deployment.toml`). Referenced file blobs must
         /// be uploaded separately after the server returns `missing_digests`.
@@ -3606,13 +3614,13 @@ mod deployment {
         pub deployment_id: Option<String>,
     }
 
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct DeploymentSubmitResponse {
         pub deployment_id: String,
     }
 
     /// A single file-set problem found while validating a submit package.
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct FileIssue {
         pub section: String,
         pub component_name: Option<String>,
@@ -3622,7 +3630,7 @@ mod deployment {
         pub message: String,
     }
 
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct DigestMismatch {
         pub file: FileIssue,
         pub supplied_digest: String,
@@ -3632,7 +3640,7 @@ mod deployment {
     /// Structured `409` body describing why a submit package was rejected. No
     /// deployment is stored when this is returned. A client retries the same submit
     /// with the `missing_files` blobs attached.
-    #[derive(Debug, Serialize, ToSchema)]
+    #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct SubmitPackageErrorBody {
         pub missing_digest_fields: Vec<FileIssue>,
         pub missing_files: Vec<FileIssue>,
@@ -3935,8 +3943,35 @@ mod deployment {
         Ok(content.into_response())
     }
 
+    /// Delete file blobs that are not referenced by a deployment.
+    #[utoipa::path(
+        delete,
+        path = "/v1/files/orphans",
+        tag = "deployments",
+        responses(
+            (status = 200, description = "Orphan files deleted", body = GcOrphanFilesResponseSer)
+        )
+    )]
+    pub(crate) async fn gc_orphan_files(
+        state: State<Arc<WebApiState>>,
+    ) -> Result<Response, HttpResponse> {
+        let accept = AcceptHeader::Json;
+        let deleted_count = state
+            .db_pool
+            .external_api_conn()
+            .await
+            .map_err(|e| ErrorWrapper(e, accept))?
+            .gc_orphan_files()
+            .await
+            .map_err(|e| ErrorWrapper(e, accept))?;
+        Ok(pretty_json_response(
+            StatusCode::OK,
+            &GcOrphanFilesResponseSer { deleted_count },
+        ))
+    }
+
     /// Request payload for switching deployment
-    #[derive(Deserialize, ToSchema)]
+    #[derive(Serialize, Deserialize, ToSchema)]
     pub struct DeploymentSwitchPayload {
         /// Tolerate runtime requirements unavailable on this server while verifying.
         /// Rejected when applying the deployment without restart.


### PR DESCRIPTION
## Summary

- migrate all remote CLI operations from native gRPC to the versioned REST API
- retain native gRPC for programmatic clients and gRPC-Web for the Web UI
- add `OBELISK_API_URL` as an alternative to `--api-url`
- make `--no-auth` the canonical server flag while retaining `--allow-unauthenticated-api` as a compatibility alias
- use Clap for the canonical `OBELISK_API_TOKEN` fallback
- deprecate `OBELISK__API__TOKEN` with a warning
- remove plaintext `api.token` from server configuration and use `api.token_hashes` for persistent tokens
- add the missing REST endpoint for orphan-file garbage collection

## Rationale

CLI traffic should work through ordinary HTTP gateways and `HTTPRoute` configurations without requiring native gRPC routing or HTTP/2 backend support. 

## Compatibility

- native gRPC remains available as a public server API
- Web UI gRPC-Web behavior is unchanged
- `--allow-unauthenticated-api` remains a visible alias for `--no-auth`
- `OBELISK__API__TOKEN` remains temporarily supported for client and server authentication, but emits a deprecation warning
- REST failures are returned directly, with no automatic gRPC fallback
