### PR TITLE
Add `--auth-token` to `server run`, fix legacy token handling in `[[secrets]]`

### DIFF
--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -60,6 +60,9 @@
             {
               "name": "--no-auth",
               "help": "Accept unauthenticated requests on the API port. Dev/recovery override"
+            },
+            {
+              "name": "--api-token"
             }
           ]
         },

--- a/assets/schemas/cli.json
+++ b/assets/schemas/cli.json
@@ -62,7 +62,8 @@
               "help": "Accept unauthenticated requests on the API port. Dev/recovery override"
             },
             {
-              "name": "--api-token"
+              "name": "--api-token",
+              "help": "API token required to access the API server as `Authorization: Bearer <token>`. Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated"
             }
           ]
         },

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -221,7 +221,7 @@
           "default": "127.0.0.1:5005"
         },
         "token_hashes": {
-          "description": "Accepted API bearer tokens as `sha256:<hex>` digests of the token text.\nHashes are not secrets, so this file stays safe to commit.\nGenerate an entry with `obelisk generate token`.",
+          "description": "Accepted API bearer tokens as `sha256:<hex>` digests of the token text.\nOnly hashes of high-entropy random tokens are safe to commit: SHA-256 is fast and unsalted,\nso hashes of passwords or other guessable tokens are vulnerable to offline guessing.\nTokens should contain at least 32 characters. Always generate an entry with\n`obelisk generate token`.",
           "type": "array",
           "items": {
             "type": "string"

--- a/server-help.toml
+++ b/server-help.toml
@@ -11,8 +11,11 @@
 
 ## API authentication. The API port denies requests without a valid `Authorization: Bearer <token>` header.
 ## An ephemeral startup token is always generated and printed to the console.
-## Persistent tokens are configured as sha256 hashes of the token text; hashes are not secrets,
-## so this file stays safe to commit. Add an entry with
+## Persistent tokens are configured as sha256 hashes of the token text. Only hashes of high-entropy
+## random tokens are safe to commit: SHA-256 is fast and unsalted, so passwords and other guessable
+## tokens are vulnerable to offline guessing. Tokens should contain at least 32 characters; shorter
+## tokens currently produce a compatibility warning and will be rejected in a future release.
+## Always create tokens with
 ## `obelisk generate token --server-config <this file>`, which prints the token to stdout.
 # api.token_hashes = [
 #   "sha256:...",   # agent

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,8 @@ use std::fmt::Write as _;
 
 /// Maximum encoded gRPC message size for deployment repository requests and responses.
 pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
-pub(crate) const MIN_API_TOKEN_LENGTH: usize = 32;
+pub(crate) const MIN_API_TOKEN_CHAR_LENGTH: usize = 32;
+const GENERATED_API_TOKEN_BYTES: usize = 32;
 
 pub(crate) fn token_digest(token: &str) -> [u8; 32] {
     Sha256::digest(token.as_bytes()).into()
@@ -18,10 +19,13 @@ pub(crate) fn token_hash(token: &str) -> Digest {
 
 /// Generate a high-entropy random token (64 hex chars).
 pub(crate) fn generate_token() -> String {
-    let bytes = rand::rng().random::<[u8; MIN_API_TOKEN_LENGTH]>();
+    let bytes = rand::rng().random::<[u8; GENERATED_API_TOKEN_BYTES]>();
     let mut out = String::with_capacity(bytes.len() * 2);
     for b in bytes {
         write!(&mut out, "{b:02x}").expect("writing to string");
+    }
+    const {
+        assert!(GENERATED_API_TOKEN_BYTES * 2 >= MIN_API_TOKEN_CHAR_LENGTH);
     }
     out
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,6 +5,7 @@ use std::fmt::Write as _;
 
 /// Maximum encoded gRPC message size for deployment repository requests and responses.
 pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
+pub(crate) const MIN_API_TOKEN_LENGTH: usize = 32;
 
 pub(crate) fn token_digest(token: &str) -> [u8; 32] {
     Sha256::digest(token.as_bytes()).into()
@@ -17,7 +18,7 @@ pub(crate) fn token_hash(token: &str) -> Digest {
 
 /// Generate a high-entropy random token (64 hex chars).
 pub(crate) fn generate_token() -> String {
-    let bytes = rand::rng().random::<[u8; 32]>();
+    let bytes = rand::rng().random::<[u8; MIN_API_TOKEN_LENGTH]>();
     let mut out = String::with_capacity(bytes.len() * 2);
     for b in bytes {
         write!(&mut out, "{b:02x}").expect("writing to string");

--- a/src/args.rs
+++ b/src/args.rs
@@ -41,6 +41,14 @@ fn parse_secret_string(value: &str) -> Result<SecretString, std::convert::Infall
     Ok(SecretString::from(value.to_owned()))
 }
 
+fn parse_non_empty_secret_string(value: &str) -> Result<SecretString, &'static str> {
+    if value.is_empty() {
+        Err("API token must not be empty")
+    } else {
+        Ok(SecretString::from(value.to_owned()))
+    }
+}
+
 /// A deployment source: either a path to a TOML file or an existing deployment ID.
 #[derive(Debug, Clone)]
 pub(crate) enum DeploymentSource {
@@ -490,13 +498,13 @@ pub(crate) enum Server {
         )]
         no_auth: bool,
 
-        // API token required to access the API server as `Authorization: Bearer <token>`.
-        // Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated.
+        /// API token required to access the API server as `Authorization: Bearer <token>`.
+        /// Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated.
         #[arg(long,
             env = API_TOKEN,
             hide_env_values = true,
             value_name = "TOKEN",
-            value_parser = parse_secret_string,
+            value_parser = parse_non_empty_secret_string,
             conflicts_with = "no_auth",
         )]
         api_token: Option<SecretString>,
@@ -1127,4 +1135,18 @@ pub(crate) struct CancelCommand {
     /// Execution id of an activity (E_01...) or a delay request (Delay_01...)
     #[arg(value_name = "ID")]
     pub(crate) id: ExecutionIdOrDelayId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_api_token_must_not_be_empty() {
+        let err =
+            Args::try_parse_from(["obelisk", "server", "run", "--api-token", ""]).unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(err.to_string().contains("API token must not be empty"));
+    }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -483,8 +483,23 @@ pub(crate) enum Server {
         suppress_type_checking_errors: bool,
         /// Accept unauthenticated requests on the API port. Dev/recovery override.
         // backcompat: remove the `allow-unauthenticated-api` alias after 0.43.
-        #[arg(long, visible_alias = "allow-unauthenticated-api")]
+        #[arg(
+            long,
+            visible_alias = "allow-unauthenticated-api",
+            conflicts_with = "api_token"
+        )]
         no_auth: bool,
+
+        // API token required to access the API server as `Authorization: Bearer <token>`.
+        // Falls back to `$OBELISK_API_TOKEN`; `$OBELISK__API__TOKEN` is deprecated.
+        #[arg(long,
+            env = API_TOKEN,
+            hide_env_values = true,
+            value_name = "TOKEN",
+            value_parser = parse_secret_string,
+            conflicts_with = "no_auth",
+        )]
+        api_token: Option<SecretString>,
     },
     /// Read the configuration, compile the components, verify their imports and exit without starting the server.
     Verify(VerifyArgs),

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use crate::config::secret_registry::API_TOKEN_CLIENT;
+use crate::config::secret_registry::API_TOKEN;
 use clap::Parser;
 use concepts::{
     ComponentType, ExecutionId, FunctionFqn, FunctionFqnParseError,
@@ -88,7 +88,7 @@ pub(crate) struct ClientToken {
     #[arg(
         long,
         global = true,
-        env = API_TOKEN_CLIENT,
+        env = API_TOKEN,
         hide_env_values = true,
         value_name = "TOKEN",
         value_parser = parse_secret_string

--- a/src/args.rs
+++ b/src/args.rs
@@ -33,15 +33,7 @@ fn parse_oci_reference(s: &str) -> Result<oci_client::Reference, String> {
     oci_client::Reference::from_str(s).map_err(|e| e.to_string())
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "clap function value parsers must return Result"
-)]
-fn parse_secret_string(value: &str) -> Result<SecretString, std::convert::Infallible> {
-    Ok(SecretString::from(value.to_owned()))
-}
-
-fn parse_non_empty_secret_string(value: &str) -> Result<SecretString, &'static str> {
+fn parse_secret_string(value: &str) -> Result<SecretString, &'static str> {
     if value.is_empty() {
         Err("API token must not be empty")
     } else {
@@ -504,7 +496,7 @@ pub(crate) enum Server {
             env = API_TOKEN,
             hide_env_values = true,
             value_name = "TOKEN",
-            value_parser = parse_non_empty_secret_string,
+            value_parser = parse_secret_string,
             conflicts_with = "no_auth",
         )]
         api_token: Option<SecretString>,

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -7,6 +7,7 @@
 //! fixed ports, allowing parallel test execution without conflicts.
 //! The `test_addr!` macro ensures unique addresses at link time.
 
+use crate::command::server::ServerAuth;
 use crate::server::web_api_server::ReplayResponseSer;
 use crate::{
     command::server::{LocalDeployment, PrepareDirsParams, RunParams, prepare_dirs, run_internal},
@@ -742,7 +743,7 @@ impl TestServer {
         server_path: PathBuf,
         deployment: LocalDeployment,
         no_auth: bool,
-        legacy_api_token: Option<secrecy::SecretString>,
+        api_token: Option<secrecy::SecretString>,
     ) -> Self {
         test_utils::set_up();
 
@@ -760,8 +761,11 @@ impl TestServer {
             },
             clean_sqlite_directory: false,
             suppress_type_checking_errors: false,
-            no_auth,
-            legacy_api_token,
+            auth: if no_auth {
+                ServerAuth::NoAuth
+            } else {
+                ServerAuth::Auth { api_token }
+            },
         };
 
         let prepared_dirs = prepare_dirs(

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -121,6 +121,7 @@ use grpc::grpc_gen;
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use secrecy::ExposeSecret as _;
+use secrecy::SecretString;
 use serde_json::json;
 use sha2::{Digest as _, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -570,9 +571,12 @@ pub(crate) struct RunParams {
     pub(crate) dir_params: PrepareDirsParams,
     pub(crate) clean_sqlite_directory: bool,
     pub(crate) suppress_type_checking_errors: bool,
-    /// Accept unauthenticated API requests (`--no-auth`).
-    pub(crate) no_auth: bool,
-    pub(crate) legacy_api_token: Option<secrecy::SecretString>,
+    pub(crate) auth: ServerAuth,
+}
+
+pub(crate) enum ServerAuth {
+    NoAuth,
+    Auth { api_token: Option<SecretString> },
 }
 
 pub(crate) async fn run(
@@ -1911,23 +1915,23 @@ pub(crate) async fn run_internal(
     });
     if let Some(api_listening_addr) = api_listening_addr {
         let app = app_router.fallback_service(grpc_service);
-        let app_svc = if params.no_auth {
-            warn!("API authentication is disabled by --no-auth: accepting all API requests");
-            app.into_make_service()
-        } else {
-            let api_auth = Arc::new(crate::server::auth::ApiAuth::new(
-                &api_config,
-                params.legacy_api_token.clone(),
-            ));
-            info!(
-                "API startup token: {}",
-                api_auth.startup_token().expose_secret()
-            );
-            app.layer(axum::middleware::from_fn_with_state(
-                api_auth,
-                crate::server::auth::auth_middleware,
-            ))
-            .into_make_service()
+        let app_svc = match params.auth {
+            ServerAuth::NoAuth => {
+                warn!("API authentication is disabled by --no-auth: accepting all API requests");
+                app.into_make_service()
+            }
+            ServerAuth::Auth { api_token } => {
+                let api_auth = Arc::new(crate::server::auth::ApiAuth::new(&api_config, api_token));
+                info!(
+                    "API startup token: {}",
+                    api_auth.startup_token().expose_secret()
+                );
+                app.layer(axum::middleware::from_fn_with_state(
+                    api_auth,
+                    crate::server::auth::auth_middleware,
+                ))
+                .into_make_service()
+            }
         };
         let listener = TcpListener::bind(api_listening_addr)
             .await

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use wasm_workers::http_request_policy::SecretResolver;
 
-pub(crate) const API_TOKEN_CLIENT: &str = "OBELISK_API_TOKEN";
+pub(crate) const API_TOKEN: &str = "OBELISK_API_TOKEN";
 pub(crate) const API_TOKEN_LEGACY: &str = "OBELISK__API__TOKEN";
 
 /// Source of a secret in the `[secrets]` table.
@@ -91,8 +91,7 @@ impl SecretRegistry {
         let mut values = HashMap::new();
 
         // Always sensitive, even when the operator did not register them as secrets.
-        let mut sensitive =
-            HashSet::from([API_TOKEN_LEGACY.to_string(), API_TOKEN_CLIENT.to_string()]);
+        let mut sensitive = HashSet::from([API_TOKEN_LEGACY.to_string(), API_TOKEN.to_string()]);
 
         let mut missing_env_vars = BTreeSet::new();
         for (logical_name, source) in secrets {

--- a/src/config/secret_registry.rs
+++ b/src/config/secret_registry.rs
@@ -86,6 +86,7 @@ impl SecretRegistry {
         secrets: SecretsToml,
         env_var_cleanup: EnvVarCleanupStrategy,
         runtime_config_availability: RuntimeConfigAvailability,
+        was_legacy_token_wiped: Option<&SecretString>,
     ) -> anyhow::Result<Self> {
         let mut values = HashMap::new();
 
@@ -98,12 +99,17 @@ impl SecretRegistry {
             match source {
                 SecretSourceToml::Env { env } => {
                     let value = if let Ok(value) = std::env::var(&env) {
-                        value
+                        SecretString::from(value)
+                    } else if let Some(value) = was_legacy_token_wiped
+                        && env == API_TOKEN_LEGACY
+                    {
+                        // backcompat: avoid failing here if [[secrets]] contains the token and it was wiped already.
+                        value.clone()
                     } else {
                         missing_env_vars.insert(env.clone());
-                        String::new()
+                        SecretString::from(String::new())
                     };
-                    values.insert(logical_name.clone(), SecretString::from(value));
+                    values.insert(logical_name.clone(), value);
                     sensitive.insert(env);
                     sensitive.insert(logical_name);
                 }
@@ -186,6 +192,7 @@ mod tests {
             secrets,
             EnvVarCleanupStrategy::Wipe,
             RuntimeConfigAvailability::Strict,
+            None,
         )
         .unwrap();
 
@@ -224,6 +231,7 @@ mod tests {
             secrets,
             EnvVarCleanupStrategy::Noop,
             RuntimeConfigAvailability::Strict,
+            None,
         )
         .unwrap_err()
         .to_string();

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -187,8 +187,10 @@ pub(crate) struct ApiConfig {
     #[serde(default = "default_api_listening_addr")]
     pub(crate) listening_addr: SocketAddr,
     /// Accepted API bearer tokens as `sha256:<hex>` digests of the token text.
-    /// Hashes are not secrets, so this file stays safe to commit.
-    /// Generate an entry with `obelisk generate token`.
+    /// Only hashes of high-entropy random tokens are safe to commit: SHA-256 is fast and unsalted,
+    /// so hashes of passwords or other guessable tokens are vulnerable to offline guessing.
+    /// Tokens should contain at least 32 characters. Always generate an entry with
+    /// `obelisk generate token`.
     #[serde(default)]
     pub(crate) token_hashes: Vec<Digest>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,10 @@ mod server;
 mod wit_printer;
 
 use crate::command::server::{
-    PrepareDirsParams, RunParams, RuntimeConfigAvailability, VerifyParams, run, verify,
+    PrepareDirsParams, RunParams, RuntimeConfigAvailability, ServerAuth, VerifyParams, run, verify,
 };
-use crate::config::secret_registry::{API_TOKEN_LEGACY, EnvVarCleanupStrategy};
+use crate::config::secret_registry::{API_TOKEN, API_TOKEN_LEGACY, EnvVarCleanupStrategy};
+use anyhow::ensure;
 use args::{
     Args, ComponentArgs, Deployment, DeploymentArgs, DeploymentVerifyArgs, ExecutionArgs, Server,
     Subcommand, VerifyArgs,
@@ -53,6 +54,7 @@ fn main() -> Result<(), anyhow::Error> {
             description,
             suppress_type_checking_errors,
             no_auth,
+            api_token,
         }) => {
             let ServerStartup {
                 config_holder,
@@ -64,6 +66,19 @@ fn main() -> Result<(), anyhow::Error> {
                 EnvVarCleanupStrategy::Wipe,
                 RuntimeConfigAvailability::Strict,
             )?;
+            let auth = if no_auth {
+                assert!(api_token.is_none(), "{API_TOKEN} conflicts with --no-auth");
+                // Remove ambiguity
+                ensure!(
+                    legacy_api_token.is_none(),
+                    "unset {API_TOKEN_LEGACY} when using --no-auth"
+                );
+                ServerAuth::NoAuth
+            } else {
+                ensure!(!no_auth, "guarded by conflicts_with");
+                let api_token = api_token.or(legacy_api_token);
+                ServerAuth::Auth { api_token }
+            };
             Box::pin(run(
                 config_holder,
                 config,
@@ -77,8 +92,7 @@ fn main() -> Result<(), anyhow::Error> {
                     },
                     clean_sqlite_directory,
                     suppress_type_checking_errors,
-                    no_auth,
-                    legacy_api_token,
+                    auth,
                 },
                 secret_registry,
             ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,7 @@ fn main() -> Result<(), anyhow::Error> {
                 SecretsToml::new(),
                 EnvVarCleanupStrategy::Noop,
                 RuntimeConfigAvailability::AllowUnavailable,
+                None,
             )?);
             Box::pin(generate.run(secret_registry))
         }
@@ -196,6 +197,7 @@ fn main() -> Result<(), anyhow::Error> {
                 SecretsToml::new(),
                 EnvVarCleanupStrategy::Noop,
                 RuntimeConfigAvailability::AllowUnavailable,
+                None,
             )?);
             Box::pin(command.run(client_startup, secret_registry))
         }
@@ -237,9 +239,11 @@ fn prepare_server_startup(
     let legacy_env = std::env::var(API_TOKEN_LEGACY).ok();
     if legacy_env.is_some() {
         // SAFETY: server configuration is loaded before the runtime and its threads start.
+        // Wipe it so that server config can be loaded.
         unsafe { std::env::remove_var(API_TOKEN_LEGACY) };
     }
     let config = config_holder.load_config()?;
+
     let legacy_api_token = legacy_env.filter(|token| !token.is_empty()).map(|token| {
         eprintln!(
             "warning: {API_TOKEN_LEGACY} is deprecated; use api.token_hashes for server authentication"
@@ -250,6 +254,7 @@ fn prepare_server_startup(
         config.secrets.clone(),
         env_var_cleanup,
         runtime_config_availability,
+        legacy_api_token.as_ref(),
     )?);
     Ok(ServerStartup {
         config_holder,

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -37,7 +37,7 @@ impl ApiAuth {
         let mut accepted = vec![(
             crate::api::token_digest(startup_token.expose_secret()),
             "startup-token".to_string(),
-            AtomicBool::default(), // startup token will never warn, generate_token uses `MIN_API_TOKEN_LENGTH`.
+            AtomicBool::default(),
         )];
         for digest in &config.token_hashes {
             accepted.push((digest.0, hash_prefix_label(digest), AtomicBool::default()));
@@ -82,13 +82,13 @@ impl ApiAuth {
             .find(|(accepted, _, _)| accepted.ct_eq(&digest).into())
             .ok_or("unknown token")?;
         // backcompat: 0.41 accepts tokens shorter than 32 characters; reject after 0.43.
-        if token.len() < crate::api::MIN_API_TOKEN_LENGTH
+        if token.len() < crate::api::MIN_API_TOKEN_CHAR_LENGTH
             && !warned_short.swap(true, Ordering::Relaxed)
         {
             warn!(
                 identity,
                 length = token.len(),
-                minimum = crate::api::MIN_API_TOKEN_LENGTH,
+                minimum = crate::api::MIN_API_TOKEN_CHAR_LENGTH,
                 "Accepted a short API token for compatibility; replace it with `obelisk generate token`"
             );
         }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -13,13 +13,20 @@ use axum::{
     response::Response,
 };
 use secrecy::{ExposeSecret as _, SecretString};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use subtle::ConstantTimeEq as _;
 use tracing::{debug, warn};
 
 pub(crate) struct ApiAuth {
     /// Accepted token digests with the identity label used in audit logs.
-    accepted: Vec<([u8; 32], String)>,
+    accepted: Vec<(
+        [u8; 32],
+        String,
+        AtomicBool, // true means do not emit low length warnings (anymore).
+    )>,
     /// Recovery token, printed to the console, valid until shutdown.
     startup_token: SecretString,
 }
@@ -30,15 +37,17 @@ impl ApiAuth {
         let mut accepted = vec![(
             crate::api::token_digest(startup_token.expose_secret()),
             "startup-token".to_string(),
+            AtomicBool::default(), // startup token will never warn, generate_token uses `MIN_API_TOKEN_LENGTH`.
         )];
         for digest in &config.token_hashes {
-            accepted.push((digest.0, hash_prefix_label(digest)));
+            accepted.push((digest.0, hash_prefix_label(digest), AtomicBool::default()));
         }
         if let Some(token) = api_token {
             let digest = crate::api::token_digest(token.expose_secret());
             accepted.push((
                 digest,
                 hash_prefix_label(&concepts::component_id::Digest(digest)),
+                AtomicBool::default(), // Short explicit tokens will remain accepted.
             ));
         }
         Self {
@@ -65,12 +74,25 @@ impl ApiAuth {
         }
         // Hash-then-compare: digests of the secret are matched, so the comparison
         // cannot leak anything useful about accepted tokens.
-        let digest = crate::api::token_digest(token.trim());
-        self.accepted
+        let token = token.trim();
+        let digest = crate::api::token_digest(token);
+        let (_, identity, warned_short) = self
+            .accepted
             .iter()
-            .find(|(accepted, _)| accepted.ct_eq(&digest).into())
-            .map(|(_, identity)| identity.as_str())
-            .ok_or("unknown token")
+            .find(|(accepted, _, _)| accepted.ct_eq(&digest).into())
+            .ok_or("unknown token")?;
+        // backcompat: 0.41 accepts tokens shorter than 32 characters; reject after 0.43.
+        if token.len() < crate::api::MIN_API_TOKEN_LENGTH
+            && !warned_short.swap(true, Ordering::Relaxed)
+        {
+            warn!(
+                identity,
+                length = token.len(),
+                minimum = crate::api::MIN_API_TOKEN_LENGTH,
+                "Accepted a short API token for compatibility; replace it with `obelisk generate token`"
+            );
+        }
+        Ok(identity)
     }
 }
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -25,7 +25,7 @@ pub(crate) struct ApiAuth {
 }
 
 impl ApiAuth {
-    pub(crate) fn new(config: &ApiConfig, legacy_token: Option<SecretString>) -> Self {
+    pub(crate) fn new(config: &ApiConfig, api_token: Option<SecretString>) -> Self {
         let startup_token = SecretString::from(crate::api::generate_token());
         let mut accepted = vec![(
             crate::api::token_digest(startup_token.expose_secret()),
@@ -34,7 +34,7 @@ impl ApiAuth {
         for digest in &config.token_hashes {
             accepted.push((digest.0, hash_prefix_label(digest)));
         }
-        if let Some(token) = legacy_token {
+        if let Some(token) = api_token {
             let digest = crate::api::token_digest(token.expose_secret());
             accepted.push((
                 digest,


### PR DESCRIPTION
- **refactor(auth): Do not fail if legacy token is in `[[secrets]]`**
- **style: Rename `API_TOKEN_CLIENT` to `API_TOKEN`**
- **feat(server): Add `--api-token` to server run with env fallback**
