### PR TITLE
feat(api): paginate responses within join-set filters

### DIFF
--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -1291,7 +1291,7 @@
           {
             "name": "join_set",
             "in": "query",
-            "description": "Filter by an exact named join-set name",
+            "description": "Filter by an exact join-set ID (bare names select named join sets)",
             "required": false,
             "schema": {
               "type": "string"
@@ -1311,7 +1311,7 @@
           {
             "name": "length",
             "in": "query",
-            "description": "Maximum number of execution-wide responses to scan",
+            "description": "Maximum number of responses to return",
             "required": false,
             "schema": {
               "type": "integer",
@@ -2499,7 +2499,7 @@
           "scan_cursor": {
             "type": "integer",
             "format": "int32",
-            "description": "Execution-wide cursor reached in the requested direction",
+            "description": "Cursor reached in the requested direction",
             "minimum": 0
           }
         }

--- a/assets/schemas/openapi.json
+++ b/assets/schemas/openapi.json
@@ -1316,7 +1316,7 @@
             "schema": {
               "type": "integer",
               "format": "int32",
-              "minimum": 0
+              "minimum": 1
             }
           },
           {

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -324,19 +324,15 @@ impl ListResponsesResponse {
         max_cursor: ResponseCursor,
         pagination: Pagination<u32>,
     ) -> Self {
-        let scan_cursor = if pagination.length() == 0 {
-            ResponseCursor(*pagination.cursor())
-        } else {
-            match pagination {
-                Pagination::NewerThan { length, .. } => match responses.last() {
-                    Some(response) if responses.len() >= usize::from(length) => response.cursor,
-                    _ => max_cursor,
-                },
-                Pagination::OlderThan { .. } => responses
-                    .first()
-                    .map(|response| response.cursor)
-                    .unwrap_or(ResponseCursor(0)),
-            }
+        let scan_cursor = match pagination {
+            Pagination::NewerThan { length, .. } => match responses.last() {
+                Some(response) if responses.len() >= usize::from(length) => response.cursor,
+                _ => max_cursor,
+            },
+            Pagination::OlderThan { .. } => responses
+                .first()
+                .map(|response| response.cursor)
+                .unwrap_or(ResponseCursor(0)),
         };
         Self {
             responses,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -317,6 +317,35 @@ pub struct ListResponsesResponse {
     pub scan_cursor: ResponseCursor,
 }
 
+impl ListResponsesResponse {
+    #[must_use]
+    pub fn from_page(
+        responses: Vec<ResponseWithCursor>,
+        max_cursor: ResponseCursor,
+        pagination: Pagination<u32>,
+    ) -> Self {
+        let scan_cursor = if pagination.length() == 0 {
+            ResponseCursor(*pagination.cursor())
+        } else {
+            match pagination {
+                Pagination::NewerThan { cursor, .. } => responses
+                    .last()
+                    .map(|response| response.cursor)
+                    .unwrap_or(ResponseCursor(cursor.max(max_cursor.0))),
+                Pagination::OlderThan { .. } => responses
+                    .first()
+                    .map(|response| response.cursor)
+                    .unwrap_or(ResponseCursor(0)),
+            }
+        };
+        Self {
+            responses,
+            max_cursor,
+            scan_cursor,
+        }
+    }
+}
+
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize /* webapi */, Deserialize, schemars::JsonSchema,
 )]

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -328,10 +328,10 @@ impl ListResponsesResponse {
             ResponseCursor(*pagination.cursor())
         } else {
             match pagination {
-                Pagination::NewerThan { cursor, .. } => responses
-                    .last()
-                    .map(|response| response.cursor)
-                    .unwrap_or(ResponseCursor(cursor.max(max_cursor.0))),
+                Pagination::NewerThan { length, .. } => match responses.last() {
+                    Some(response) if responses.len() >= usize::from(length) => response.cursor,
+                    _ => max_cursor,
+                },
                 Pagination::OlderThan { .. } => responses
                     .first()
                     .map(|response| response.cursor)

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1680,6 +1680,11 @@ async fn list_responses(
         None => None,
     };
 
+    if let Some(join_set) = join_set {
+        let p_join_set = add_param(Box::new(join_set.to_string()));
+        write!(sql, " AND r.join_set_id = {p_join_set}").unwrap();
+    }
+
     // 3. Ordering
     sql.push_str(" ORDER BY r.seq");
     let is_desc = pagination.as_ref().is_some_and(Pagination::is_desc);
@@ -1697,12 +1702,6 @@ async fn list_responses(
     // Re-order to ascending for consistent oldest-to-newest results
     if is_desc {
         sql = format!("SELECT * FROM ({sql}) AS sub ORDER BY seq ASC");
-    }
-
-    if let Some(join_set) = join_set {
-        let p_join_set = add_param(Box::new(join_set.to_string()));
-        sql =
-            format!("SELECT * FROM ({sql}) AS page WHERE join_set_id = {p_join_set} ORDER BY seq");
     }
 
     let params_refs: Vec<&(dyn ToSql + Sync)> = params
@@ -1728,32 +1727,36 @@ async fn get_response_scan_cursor(
     execution_id: &ExecutionId,
     pagination: Pagination<u32>,
     max_cursor: ResponseCursor,
+    join_set: Option<&JoinSetId>,
 ) -> Result<ResponseCursor, DbErrorRead> {
     if pagination.length() == 0 {
         return Ok(ResponseCursor(*pagination.cursor()));
     }
     let aggregate = if pagination.is_desc() { "MIN" } else { "MAX" };
     let order = if pagination.is_desc() { "DESC" } else { "ASC" };
+    let join_set_clause = join_set
+        .map(|_| " AND r.join_set_id = $4")
+        .unwrap_or_default();
     let sql = format!(
         "SELECT {aggregate}(seq) AS scan_cursor FROM (\
             SELECT r.seq FROM t_join_set_response r \
             LEFT OUTER JOIN t_execution_log l ON r.child_execution_id = l.execution_id \
             WHERE r.execution_id = $1 \
             AND (r.finished_version = l.version OR r.child_execution_id IS NULL) \
+            {join_set_clause} \
             AND r.seq {rel} $2 ORDER BY r.seq {order} LIMIT $3\
         ) AS scanned",
         rel = pagination.rel(),
     );
-    let row = tx
-        .query_one(
-            &sql,
-            &[
-                &execution_id.to_string(),
-                &i64::from(*pagination.cursor()),
-                &i64::from(pagination.length()),
-            ],
-        )
-        .await?;
+    let execution_id = execution_id.to_string();
+    let cursor = i64::from(*pagination.cursor());
+    let length = i64::from(pagination.length());
+    let join_set = join_set.map(ToString::to_string);
+    let mut params: Vec<&(dyn ToSql + Sync)> = vec![&execution_id, &cursor, &length];
+    if let Some(join_set) = &join_set {
+        params.push(join_set);
+    }
+    let row = tx.query_one(&sql, &params).await?;
     let scanned = get::<Option<i64>, _>(&row, "scan_cursor")?
         .map(|cursor| {
             u32::try_from(cursor).map_err(|_| consistency_db_err("seq must fit into u32"))
@@ -5112,7 +5115,7 @@ impl DbExternalApi for PostgresConnection {
 
         let max_cursor = get_max_response_cursor(&tx, execution_id).await?;
         let scan_cursor =
-            get_response_scan_cursor(&tx, execution_id, pagination, max_cursor).await?;
+            get_response_scan_cursor(&tx, execution_id, pagination, max_cursor, join_set).await?;
         let responses = list_responses(&tx, execution_id, Some(pagination), join_set).await?;
 
         tx.commit().await?;

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -1722,54 +1722,6 @@ async fn list_responses(
     Ok(results)
 }
 
-async fn get_response_scan_cursor(
-    tx: &Transaction<'_>,
-    execution_id: &ExecutionId,
-    pagination: Pagination<u32>,
-    max_cursor: ResponseCursor,
-    join_set: Option<&JoinSetId>,
-) -> Result<ResponseCursor, DbErrorRead> {
-    if pagination.length() == 0 {
-        return Ok(ResponseCursor(*pagination.cursor()));
-    }
-    let aggregate = if pagination.is_desc() { "MIN" } else { "MAX" };
-    let order = if pagination.is_desc() { "DESC" } else { "ASC" };
-    let join_set_clause = join_set
-        .map(|_| " AND r.join_set_id = $4")
-        .unwrap_or_default();
-    let sql = format!(
-        "SELECT {aggregate}(seq) AS scan_cursor FROM (\
-            SELECT r.seq FROM t_join_set_response r \
-            LEFT OUTER JOIN t_execution_log l ON r.child_execution_id = l.execution_id \
-            WHERE r.execution_id = $1 \
-            AND (r.finished_version = l.version OR r.child_execution_id IS NULL) \
-            {join_set_clause} \
-            AND r.seq {rel} $2 ORDER BY r.seq {order} LIMIT $3\
-        ) AS scanned",
-        rel = pagination.rel(),
-    );
-    let execution_id = execution_id.to_string();
-    let cursor = i64::from(*pagination.cursor());
-    let length = i64::from(pagination.length());
-    let join_set = join_set.map(ToString::to_string);
-    let mut params: Vec<&(dyn ToSql + Sync)> = vec![&execution_id, &cursor, &length];
-    if let Some(join_set) = &join_set {
-        params.push(join_set);
-    }
-    let row = tx.query_one(&sql, &params).await?;
-    let scanned = get::<Option<i64>, _>(&row, "scan_cursor")?
-        .map(|cursor| {
-            u32::try_from(cursor).map_err(|_| consistency_db_err("seq must fit into u32"))
-        })
-        .transpose()?;
-    Ok(ResponseCursor(scanned.unwrap_or_else(
-        || match pagination {
-            Pagination::NewerThan { cursor, .. } => cursor.max(max_cursor.0),
-            Pagination::OlderThan { .. } => 0,
-        },
-    )))
-}
-
 async fn list_logs_tx(
     tx: &Transaction<'_>,
     execution_id: &ExecutionId,
@@ -5114,16 +5066,12 @@ impl DbExternalApi for PostgresConnection {
         let tx = client_guard.transaction().await?;
 
         let max_cursor = get_max_response_cursor(&tx, execution_id).await?;
-        let scan_cursor =
-            get_response_scan_cursor(&tx, execution_id, pagination, max_cursor, join_set).await?;
         let responses = list_responses(&tx, execution_id, Some(pagination), join_set).await?;
 
         tx.commit().await?;
-        Ok(ListResponsesResponse {
-            responses,
-            max_cursor,
-            scan_cursor,
-        })
+        Ok(ListResponsesResponse::from_page(
+            responses, max_cursor, pagination,
+        ))
     }
 
     #[instrument(skip(self))]

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -1860,53 +1860,6 @@ impl SqlitePool {
             .map_err(DbErrorRead::from)
     }
 
-    fn get_response_scan_cursor(
-        tx: &Transaction,
-        execution_id: &ExecutionId,
-        pagination: Pagination<u32>,
-        max_cursor: ResponseCursor,
-        join_set: Option<&JoinSetId>,
-    ) -> Result<ResponseCursor, DbErrorRead> {
-        if pagination.length() == 0 {
-            return Ok(ResponseCursor(*pagination.cursor()));
-        }
-        let aggregate = if pagination.is_desc() { "MIN" } else { "MAX" };
-        let order = if pagination.is_desc() { "DESC" } else { "ASC" };
-        let join_set_clause = join_set
-            .map(|_| " AND r.join_set_id = :join_set_id")
-            .unwrap_or_default();
-        let sql = format!(
-            "SELECT {aggregate}(seq) FROM (\
-                SELECT r.seq FROM t_join_set_response r \
-                LEFT OUTER JOIN t_execution_log l ON r.child_execution_id = l.execution_id \
-                WHERE r.execution_id = :execution_id \
-                AND (r.finished_version = l.version OR r.child_execution_id IS NULL) \
-                {join_set_clause} \
-                AND r.seq {rel} :cursor ORDER BY r.seq {order} LIMIT :length\
-            )",
-            rel = pagination.rel(),
-        );
-        let mut params: Vec<(&str, Box<dyn ToSql>)> = vec![
-            (":execution_id", Box::new(execution_id.to_string())),
-            (":cursor", Box::new(*pagination.cursor())),
-            (":length", Box::new(pagination.length())),
-        ];
-        if let Some(join_set) = join_set {
-            params.push((":join_set_id", Box::new(join_set.to_string())));
-        }
-        let params = params
-            .iter()
-            .map(|(key, value)| (*key, value.as_ref()))
-            .collect::<Vec<_>>();
-        let scanned: Option<u32> = tx.query_row(&sql, params.as_slice(), |row| row.get(0))?;
-        Ok(ResponseCursor(scanned.unwrap_or_else(
-            || match pagination {
-                Pagination::NewerThan { cursor, .. } => cursor.max(max_cursor.0),
-                Pagination::OlderThan { .. } => 0,
-            },
-        )))
-    }
-
     fn parse_response_with_cursor(
         row: &rusqlite::Row<'_>,
     ) -> Result<ResponseWithCursor, rusqlite::Error> {
@@ -4983,20 +4936,11 @@ impl DbExternalApi for SqlitePool {
         self.transaction(
             move |tx| {
                 let max_cursor = Self::get_max_response_cursor(tx, &execution_id)?;
-                let scan_cursor = Self::get_response_scan_cursor(
-                    tx,
-                    &execution_id,
-                    pagination,
-                    max_cursor,
-                    join_set.as_ref(),
-                )?;
                 let responses =
                     Self::list_responses(tx, &execution_id, Some(pagination), join_set.as_ref())?;
-                Ok(ListResponsesResponse {
-                    responses,
-                    max_cursor,
-                    scan_cursor,
-                })
+                Ok(ListResponsesResponse::from_page(
+                    responses, max_cursor, pagination,
+                ))
             },
             TxType::Other, // read only
             "list_responses",

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -1830,6 +1830,10 @@ impl SqlitePool {
             }
             None => None,
         };
+        if let Some(join_set) = join_set {
+            sql.push_str(" AND r.join_set_id = :join_set_id");
+            params.push((":join_set_id", Box::new(join_set.to_string())));
+        }
         sql.push_str(" ORDER BY seq");
         let is_desc = pagination.as_ref().is_some_and(Pagination::is_desc);
         if is_desc {
@@ -1841,10 +1845,6 @@ impl SqlitePool {
         // Re-order to ascending for consistent oldest-to-newest results
         if is_desc {
             sql = format!("SELECT * FROM ({sql}) ORDER BY seq ASC");
-        }
-        if let Some(join_set) = join_set {
-            sql = format!("SELECT * FROM ({sql}) WHERE join_set_id = :join_set_id ORDER BY seq");
-            params.push((":join_set_id", Box::new(join_set.to_string())));
         }
         params.push((":execution_id", Box::new(execution_id.to_string())));
         tx.prepare(&sql)?
@@ -1865,31 +1865,40 @@ impl SqlitePool {
         execution_id: &ExecutionId,
         pagination: Pagination<u32>,
         max_cursor: ResponseCursor,
+        join_set: Option<&JoinSetId>,
     ) -> Result<ResponseCursor, DbErrorRead> {
         if pagination.length() == 0 {
             return Ok(ResponseCursor(*pagination.cursor()));
         }
         let aggregate = if pagination.is_desc() { "MIN" } else { "MAX" };
         let order = if pagination.is_desc() { "DESC" } else { "ASC" };
+        let join_set_clause = join_set
+            .map(|_| " AND r.join_set_id = :join_set_id")
+            .unwrap_or_default();
         let sql = format!(
             "SELECT {aggregate}(seq) FROM (\
                 SELECT r.seq FROM t_join_set_response r \
                 LEFT OUTER JOIN t_execution_log l ON r.child_execution_id = l.execution_id \
                 WHERE r.execution_id = :execution_id \
                 AND (r.finished_version = l.version OR r.child_execution_id IS NULL) \
+                {join_set_clause} \
                 AND r.seq {rel} :cursor ORDER BY r.seq {order} LIMIT :length\
             )",
             rel = pagination.rel(),
         );
-        let scanned: Option<u32> = tx.query_row(
-            &sql,
-            rusqlite::named_params! {
-                ":execution_id": execution_id.to_string(),
-                ":cursor": pagination.cursor(),
-                ":length": pagination.length(),
-            },
-            |row| row.get(0),
-        )?;
+        let mut params: Vec<(&str, Box<dyn ToSql>)> = vec![
+            (":execution_id", Box::new(execution_id.to_string())),
+            (":cursor", Box::new(*pagination.cursor())),
+            (":length", Box::new(pagination.length())),
+        ];
+        if let Some(join_set) = join_set {
+            params.push((":join_set_id", Box::new(join_set.to_string())));
+        }
+        let params = params
+            .iter()
+            .map(|(key, value)| (*key, value.as_ref()))
+            .collect::<Vec<_>>();
+        let scanned: Option<u32> = tx.query_row(&sql, params.as_slice(), |row| row.get(0))?;
         Ok(ResponseCursor(scanned.unwrap_or_else(
             || match pagination {
                 Pagination::NewerThan { cursor, .. } => cursor.max(max_cursor.0),
@@ -4974,8 +4983,13 @@ impl DbExternalApi for SqlitePool {
         self.transaction(
             move |tx| {
                 let max_cursor = Self::get_max_response_cursor(tx, &execution_id)?;
-                let scan_cursor =
-                    Self::get_response_scan_cursor(tx, &execution_id, pagination, max_cursor)?;
+                let scan_cursor = Self::get_response_scan_cursor(
+                    tx,
+                    &execution_id,
+                    pagination,
+                    max_cursor,
+                    join_set.as_ref(),
+                )?;
                 let responses =
                     Self::list_responses(tx, &execution_id, Some(pagination), join_set.as_ref())?;
                 Ok(ListResponsesResponse {

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -4452,6 +4452,23 @@ async fn test_list_responses_filters_exact_named_join_set_in_database(database: 
         .await;
     }
 
+    let full_page = api_conn
+        .list_responses_filtered(
+            &execution_id,
+            Pagination::NewerThan {
+                length: 1,
+                cursor: 0,
+                including_cursor: false,
+            },
+            Some(&target),
+        )
+        .await
+        .unwrap();
+    assert_eq!(1, full_page.responses.len());
+    assert_eq!(ResponseCursor(3), full_page.responses[0].cursor);
+    assert_eq!(ResponseCursor(3), full_page.scan_cursor);
+    assert_eq!(ResponseCursor(4), full_page.max_cursor);
+
     let first_page = api_conn
         .list_responses_filtered(
             &execution_id,
@@ -4466,7 +4483,7 @@ async fn test_list_responses_filters_exact_named_join_set_in_database(database: 
         .unwrap();
     assert_eq!(1, first_page.responses.len());
     assert_eq!(ResponseCursor(3), first_page.responses[0].cursor);
-    assert_eq!(ResponseCursor(3), first_page.scan_cursor);
+    assert_eq!(ResponseCursor(4), first_page.scan_cursor);
     assert_eq!(ResponseCursor(4), first_page.max_cursor);
 
     let second_page = api_conn

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -4432,9 +4432,14 @@ async fn test_list_responses_filters_exact_named_join_set_in_database(database: 
         )
         .await;
     }
-    for (index, join_set_id) in [same_name_one_off, unrelated, target.clone()]
-        .iter()
-        .enumerate()
+    for (index, join_set_id) in [
+        same_name_one_off,
+        unrelated.clone(),
+        target.clone(),
+        unrelated,
+    ]
+    .iter()
+    .enumerate()
     {
         append_delay_response(
             db_connection.as_ref(),
@@ -4459,9 +4464,10 @@ async fn test_list_responses_filters_exact_named_join_set_in_database(database: 
         )
         .await
         .unwrap();
-    assert!(first_page.responses.is_empty());
-    assert_eq!(ResponseCursor(2), first_page.scan_cursor);
-    assert_eq!(ResponseCursor(3), first_page.max_cursor);
+    assert_eq!(1, first_page.responses.len());
+    assert_eq!(ResponseCursor(3), first_page.responses[0].cursor);
+    assert_eq!(ResponseCursor(3), first_page.scan_cursor);
+    assert_eq!(ResponseCursor(4), first_page.max_cursor);
 
     let second_page = api_conn
         .list_responses_filtered(
@@ -4475,9 +4481,24 @@ async fn test_list_responses_filters_exact_named_join_set_in_database(database: 
         )
         .await
         .unwrap();
-    assert_eq!(1, second_page.responses.len());
-    assert_eq!(ResponseCursor(3), second_page.responses[0].cursor);
-    assert_eq!(ResponseCursor(3), second_page.scan_cursor);
+    assert!(second_page.responses.is_empty());
+    assert_eq!(ResponseCursor(4), second_page.scan_cursor);
+
+    let latest = api_conn
+        .list_responses_filtered(
+            &execution_id,
+            Pagination::OlderThan {
+                length: 1,
+                cursor: u32::MAX,
+                including_cursor: false,
+            },
+            Some(&target),
+        )
+        .await
+        .unwrap();
+    assert_eq!(1, latest.responses.len());
+    assert_eq!(ResponseCursor(3), latest.responses[0].cursor);
+    assert_eq!(ResponseCursor(3), latest.scan_cursor);
 
     let exhausted = api_conn
         .list_responses_filtered(
@@ -4492,7 +4513,7 @@ async fn test_list_responses_filters_exact_named_join_set_in_database(database: 
         .await
         .unwrap();
     assert!(exhausted.responses.is_empty());
-    assert_eq!(ResponseCursor(3), exhausted.scan_cursor);
+    assert_eq!(ResponseCursor(4), exhausted.scan_cursor);
 
     drop(api_conn);
     drop(db_connection);

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -182,6 +182,17 @@ fn convert_deployment_pagination(
     }
 }
 
+fn convert_response_length(length: u32) -> Result<u16, tonic::Status> {
+    let length = convert_length(length)?;
+    if length == 0 {
+        Err(tonic::Status::invalid_argument(
+            "`length` must be greater than zero",
+        ))
+    } else {
+        Ok(length)
+    }
+}
+
 #[tonic::async_trait]
 impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
     async fn generate_execution_id(
@@ -593,6 +604,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             .argument_must_exist("execution_id")?
             .try_into()?;
         tracing::Span::current().record("execution_id", tracing::field::display(&execution_id));
+        let length = convert_response_length(request.length)?;
         let conn = self
             .db_pool
             .external_api_conn()
@@ -602,7 +614,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
             .list_responses(
                 &execution_id,
                 concepts::storage::Pagination::NewerThan {
-                    length: convert_length(request.length)?,
+                    length,
                     cursor: request.cursor_from,
                     including_cursor: request.including_cursor,
                 },
@@ -631,6 +643,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
         tonic::Status,
     > {
         let request = request.into_inner();
+        let responses_length = convert_response_length(request.responses_length)?;
         let execution_id: ExecutionId = request
             .execution_id
             .argument_must_exist("execution_id")?
@@ -652,7 +665,7 @@ impl grpc_gen::execution_repository_server::ExecutionRepository for GrpcServer {
                 })?,
                 request.include_backtrace_id,
                 concepts::storage::Pagination::NewerThan {
-                    length: convert_length(request.responses_length)?,
+                    length: responses_length,
                     cursor: request.responses_cursor_from,
                     including_cursor: request.responses_including_cursor,
                 },
@@ -2183,6 +2196,21 @@ fn deployment_summary_to_grpc(
 mod tests {
     use super::*;
     use grpc_gen::list_deployments_request::{NewerThan, OlderThan};
+
+    #[test]
+    fn response_length_must_be_nonzero_u16() {
+        assert_eq!(1, convert_response_length(1).unwrap());
+        assert_eq!(
+            tonic::Code::InvalidArgument,
+            convert_response_length(0).unwrap_err().code()
+        );
+        assert_eq!(
+            tonic::Code::InvalidArgument,
+            convert_response_length(u32::from(u16::MAX) + 1)
+                .unwrap_err()
+                .code()
+        );
+    }
 
     #[test]
     fn test_convert_deployment_pagination_newer_than() {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1249,11 +1249,11 @@ pub(crate) mod logs {
 #[derive(Debug, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
 struct ExecutionResponsesParams {
-    /// Filter by an exact named join-set name
+    /// Filter by an exact join-set ID (bare names select named join sets)
     join_set: Option<String>,
     /// Cursor for pagination
     cursor: Option<u32>,
-    /// Maximum number of execution-wide responses to scan
+    /// Maximum number of responses to return
     length: Option<u16>,
     /// Include the cursor item in results
     #[serde(default)]
@@ -1261,6 +1261,18 @@ struct ExecutionResponsesParams {
     /// Pagination direction
     #[serde(default)]
     direction: PaginationDirectionSortedFromOldest,
+}
+
+fn parse_join_set_filter(join_set: String) -> Result<JoinSetId, String> {
+    if join_set.contains(':') {
+        join_set
+            .parse()
+            .map_err(|err: concepts::JoinSetIdParseError| err.to_string())
+    } else {
+        // backcompat: 0.41.4 accepted bare names as named join-set IDs.
+        JoinSetId::new(JoinSetKind::Named, StrVariant::from(join_set))
+            .map_err(|err| err.to_string())
+    }
 }
 
 /// Response containing execution responses
@@ -1272,7 +1284,7 @@ pub(crate) struct ExecutionResponsesResponse {
     /// Maximum cursor in the response
     #[schema(value_type = u32)]
     pub(crate) max_cursor: ResponseCursor,
-    /// Execution-wide cursor reached in the requested direction
+    /// Cursor reached in the requested direction
     #[schema(value_type = u32)]
     pub(crate) scan_cursor: ResponseCursor,
 }
@@ -1305,9 +1317,9 @@ async fn execution_responses(
     let length = params.length.unwrap_or(DEFAULT_LENGTH);
     let join_set = params
         .join_set
-        .map(|name| JoinSetId::new(JoinSetKind::Named, StrVariant::from(name)))
+        .map(parse_join_set_filter)
         .transpose()
-        .map_err(|err| HttpResponse::bad_request(accept, err.to_string()))?;
+        .map_err(|err| HttpResponse::bad_request(accept, err))?;
     let pagination = match params.direction {
         PaginationDirectionSortedFromOldest::Older => Pagination::OlderThan {
             length,
@@ -4523,7 +4535,7 @@ impl From<ErrorWrapper<SubmitError>> for HttpResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{RetVal, format_execution_status_text};
+    use super::{RetVal, format_execution_status_text, parse_join_set_filter};
     use chrono::{DateTime, Utc};
     use concepts::{
         ExecutionFailureKind, SupportedFunctionReturnValue,
@@ -4611,6 +4623,14 @@ mod tests {
             }
             .to_string(),
             "Finished: Execution failure (Uncategorized)"
+        );
+    }
+
+    #[test]
+    fn response_join_set_filter_accepts_canonical_id_and_bare_named_id() {
+        assert_eq!(
+            parse_join_set_filter("n:session-name".to_string()).unwrap(),
+            parse_join_set_filter("session-name".to_string()).unwrap(),
         );
     }
 

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -1254,6 +1254,7 @@ struct ExecutionResponsesParams {
     /// Cursor for pagination
     cursor: Option<u32>,
     /// Maximum number of responses to return
+    #[param(minimum = 1)]
     length: Option<u16>,
     /// Include the cursor item in results
     #[serde(default)]
@@ -1309,12 +1310,18 @@ async fn execution_responses(
     accept: AcceptHeader,
 ) -> Result<Response, HttpResponse> {
     const DEFAULT_LENGTH: u16 = 20;
+    let length = params.length.unwrap_or(DEFAULT_LENGTH);
+    if length == 0 {
+        return Err(HttpResponse::bad_request(
+            accept,
+            "`length` must be greater than zero".to_string(),
+        ));
+    }
     let conn = state
         .db_pool
         .external_api_conn()
         .await
         .map_err(|e| ErrorWrapper(e, accept))?;
-    let length = params.length.unwrap_or(DEFAULT_LENGTH);
     let join_set = params
         .join_set
         .map(parse_join_set_filter)


### PR DESCRIPTION
## Summary

- apply the join-set predicate before pagination so `direction=older&length=1` returns the latest matching response
- accept canonical join-set IDs such as `n:session-name`, while preserving bare named IDs such as `session-name`
- keep `scan_cursor` aligned with the filtered page in SQLite and Postgres
- update the generated OpenAPI schema

## Tests

- `scripts/test.sh test_list_responses_filters_exact_named_join_set_in_database`
- `scripts/test.sh response_join_set_filter_accepts_canonical_id_and_bare_named_id`
- `scripts/update-schemas.sh`
- `scripts/clippy.sh`