### PR TITLE
Cancel stubs synchronously in join set close, fix replay cancelling child workflows

### DIFF
--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -1343,11 +1343,11 @@ pub trait DbExecutor: Send + Sync {
         }
     }
 
-    /// Request cancellation of a cancellable workflow. In one version-guarded
-    /// transaction, appends [`ExecutionRequest::CancellationRequested`]; rejects a non-cancellable
-    /// target and returns `AlreadyFinished`/`AlreadyCancelling` without appending.
-    /// The `Finished(Cancelled)` outcome is driven later by the cancellation driver.
-    async fn cancel_workflow(
+    /// Request cancellation of a cancellable workflow.
+    /// Non-cancellable target is rejected with [`DbErrorWriteNonRetriable::IllegalState`].
+    /// Appends [`ExecutionRequest::CancellationRequested`]
+    /// or returns `AlreadyFinished`/`AlreadyCancelling` without appending.
+    async fn append_cancel_workflow_requested(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
@@ -1355,14 +1355,17 @@ pub trait DbExecutor: Send + Sync {
 
     /// Request cancellation of a cancellable workflow, retrying the version-guarded
     /// transaction on the live-worker race.
-    async fn cancel_workflow_with_retries(
+    async fn append_cancel_workflow_requested_with_retries(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
     ) -> Result<CancelOutcome, DbErrorWrite> {
         let mut retries = 5;
         loop {
-            match self.cancel_workflow(execution_id, cancelled_at).await {
+            match self
+                .append_cancel_workflow_requested(execution_id, cancelled_at)
+                .await
+            {
                 Err(DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::VersionConflict {
                     ..
                 })) if retries > 0 => retries -= 1,

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -2290,15 +2290,14 @@ pub enum DelayCancelOutcome {
     AlreadyFinished,
 }
 
-#[instrument(skip(db_connection))]
-pub async fn stub_execution(
+async fn upsert_stub_finished(
     db_connection: &dyn DbConnection,
     execution_id: ExecutionIdDerived,
     parent_execution_id: ExecutionId,
     join_set_id: JoinSetId,
     created_at: DateTime<Utc>,
     return_value: SupportedFunctionReturnValue,
-) -> Result<(), DbErrorWrite> {
+) -> Result<(), DbErrorStubResponse> {
     let stub_finished_version = Version::new(1); // Stub activities have no execution log except Created event.
     let finished_req = AppendRequest {
         created_at,
@@ -2323,15 +2322,35 @@ pub async fn stub_execution(
             created_at,
         )
         .await
-        .map_err(|err| match err {
-            DbErrorStubResponse::StubConflict => {
-                DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::Conflict)
-            }
-            DbErrorStubResponse::Write(db_err) => db_err,
-        })
 }
 
-pub async fn cancel_stub_execution(
+#[instrument(skip(db_connection))]
+pub async fn stub_execution(
+    db_connection: &dyn DbConnection,
+    execution_id: ExecutionIdDerived,
+    parent_execution_id: ExecutionId,
+    join_set_id: JoinSetId,
+    created_at: DateTime<Utc>,
+    return_value: SupportedFunctionReturnValue,
+) -> Result<(), DbErrorWrite> {
+    upsert_stub_finished(
+        db_connection,
+        execution_id,
+        parent_execution_id,
+        join_set_id,
+        created_at,
+        return_value,
+    )
+    .await
+    .map_err(|err| match err {
+        DbErrorStubResponse::StubConflict => {
+            DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::Conflict)
+        }
+        DbErrorStubResponse::Write(db_err) => db_err,
+    })
+}
+
+pub async fn cancel_stub_execution_ignoring_conflict(
     db_connection: &dyn DbConnection,
     execution_id: ExecutionIdDerived,
     cancelled_at: DateTime<Utc>,
@@ -2342,7 +2361,7 @@ pub async fn cancel_stub_execution(
         kind: ExecutionFailureKind::Cancelled,
         detail: None,
     });
-    stub_execution(
+    match upsert_stub_finished(
         db_connection,
         execution_id,
         parent_execution_id,
@@ -2351,6 +2370,10 @@ pub async fn cancel_stub_execution(
         retval,
     )
     .await
+    {
+        Ok(()) | Err(DbErrorStubResponse::StubConflict) => Ok(()),
+        Err(DbErrorStubResponse::Write(err)) => Err(err),
+    }
 }
 
 pub async fn cancel_delay(

--- a/crates/concepts/src/storage.rs
+++ b/crates/concepts/src/storage.rs
@@ -5,6 +5,7 @@ use crate::ContentDigest;
 use crate::ExecutionFailureKind;
 use crate::ExecutionId;
 use crate::ExecutionMetadata;
+use crate::FinishedExecutionFailure;
 use crate::FunctionExtension;
 use crate::FunctionFqn;
 use crate::FunctionMetadata;
@@ -1323,7 +1324,7 @@ pub trait DbExecutor: Send + Sync {
     );
 
     /// See [`Self::append_activity_cancellation_requested`].
-    async fn cancel_activity_with_retries(
+    async fn append_activity_cancellation_requested_with_retries(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,
@@ -2328,6 +2329,28 @@ pub async fn stub_execution(
             }
             DbErrorStubResponse::Write(db_err) => db_err,
         })
+}
+
+pub async fn cancel_stub_execution(
+    db_connection: &dyn DbConnection,
+    execution_id: ExecutionIdDerived,
+    cancelled_at: DateTime<Utc>,
+) -> Result<(), DbErrorWrite> {
+    let (parent_execution_id, join_set_id) = execution_id.split_to_parts();
+    let retval = SupportedFunctionReturnValue::ExecutionFailure(FinishedExecutionFailure {
+        reason: None,
+        kind: ExecutionFailureKind::Cancelled,
+        detail: None,
+    });
+    stub_execution(
+        db_connection,
+        execution_id,
+        parent_execution_id,
+        join_set_id,
+        cancelled_at,
+        retval,
+    )
+    .await
 }
 
 pub async fn cancel_delay(

--- a/crates/db-common/src/join_set_open_tracker.rs
+++ b/crates/db-common/src/join_set_open_tracker.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use concepts::prefixed_ulid::{DelayId, ExecutionIdDerived};
 use concepts::storage::{HistoryEvent, JoinNextTryOutcome, JoinSetRequest, JoinSetResponse};
 use concepts::{ComponentType, FunctionFqn, JoinSetId};
@@ -43,6 +44,18 @@ impl JoinSetMember {
         )
     }
 
+    /// Check before `is_activity`, which a stub also satisfies.
+    #[must_use]
+    pub fn is_stub(&self) -> bool {
+        matches!(
+            self,
+            Self::Child {
+                component_type: ComponentType::ActivityStub,
+                target_ffqn: _
+            }
+        )
+    }
+
     #[must_use]
     pub fn is_cancellable_workflow(&self) -> bool {
         matches!(
@@ -52,6 +65,84 @@ impl JoinSetMember {
                 target_ffqn
             } if target_ffqn.is_cancellable()
         )
+    }
+}
+
+/// One still-open join-set member that needs a signal to stop, in creation order.
+#[derive(Debug, Clone)]
+pub enum JoinSetCancellable {
+    Delay(DelayId),
+    /// Something is running it, so cancelling it is asynchronous.
+    Activity(ExecutionIdDerived),
+    /// Nothing is running it, so the caller finishes it inline instead.
+    Stub(ExecutionIdDerived),
+}
+
+impl JoinSetCancellable {
+    #[must_use]
+    pub fn response_id(&self) -> JoinSetResponseId {
+        match self {
+            Self::Delay(delay_id) => JoinSetResponseId::DelayId(delay_id.clone()),
+            Self::Activity(execution_id) | Self::Stub(execution_id) => {
+                JoinSetResponseId::ChildExecutionId(execution_id.clone())
+            }
+        }
+    }
+}
+
+/// Shared by a workflow's own `join-set-close` and the cancellation driver's whole-workflow close.
+/// The struct is guaranteed not to be empty.
+#[derive(Debug, Clone)]
+pub struct JoinSetCloseCancellations {
+    /// In creation order, acted on in reverse by the caller.
+    cancellables: Vec<JoinSetCancellable>,
+    /// Signalled, not finished: the cancellation driver closes these.
+    cancellable_child_workflow_ids: Vec<ExecutionIdDerived>,
+    pub cancelled_at: DateTime<Utc>,
+}
+
+impl JoinSetCloseCancellations {
+    #[must_use]
+    pub fn classify(
+        members: impl Iterator<Item = (JoinSetResponseId, JoinSetMember)>,
+        cancelled_at: DateTime<Utc>,
+    ) -> Option<JoinSetCloseCancellations> {
+        let mut cancellables = Vec::new();
+        let mut cancellable_child_workflow_ids = Vec::new();
+        for (response_id, member) in members {
+            match response_id {
+                JoinSetResponseId::DelayId(delay_id) => {
+                    cancellables.push(JoinSetCancellable::Delay(delay_id));
+                }
+                JoinSetResponseId::ChildExecutionId(child_id) => {
+                    if member.is_stub() {
+                        cancellables.push(JoinSetCancellable::Stub(child_id));
+                    } else if member.is_activity() {
+                        cancellables.push(JoinSetCancellable::Activity(child_id));
+                    } else if member.is_cancellable_workflow() {
+                        cancellable_child_workflow_ids.push(child_id);
+                    }
+                }
+            }
+        }
+        if cancellables.is_empty() && cancellable_child_workflow_ids.is_empty() {
+            None
+        } else {
+            Some(JoinSetCloseCancellations {
+                cancellables,
+                cancellable_child_workflow_ids,
+                cancelled_at,
+            })
+        }
+    }
+
+    pub fn iterate_in_cancellation_order(&self) -> impl Iterator<Item = &JoinSetCancellable> {
+        self.cancellables.iter().rev()
+    }
+
+    #[must_use]
+    pub fn cancellable_child_workflow_ids(&self) -> &[ExecutionIdDerived] {
+        &self.cancellable_child_workflow_ids
     }
 }
 

--- a/crates/db-common/src/lib.rs
+++ b/crates/db-common/src/lib.rs
@@ -8,7 +8,8 @@ mod subscribers;
 
 pub use combined_state::{CombinedState, CombinedStateDTO};
 pub use join_set_open_tracker::{
-    JoinSetMember, JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId,
+    JoinSetCancellable, JoinSetCloseCancellations, JoinSetMember, JoinSetOpenTracker,
+    JoinSetOpenTrackerError, JoinSetResponseId,
 };
 pub use notifiers::{AppendNotifier, NotifierExecutionFinished, NotifierPendingAt};
 pub use state_filter::{state_filter_to_sql, state_filters_now};

--- a/crates/db-postgres/src/postgres_dao.rs
+++ b/crates/db-postgres/src/postgres_dao.rs
@@ -4128,7 +4128,7 @@ impl DbExecutor for PostgresConnection {
     }
 
     #[instrument(skip(self))]
-    async fn cancel_workflow(
+    async fn append_cancel_workflow_requested(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,

--- a/crates/db-sqlite/src/sqlite_dao.rs
+++ b/crates/db-sqlite/src/sqlite_dao.rs
@@ -4616,7 +4616,7 @@ impl DbExecutor for SqlitePool {
     }
 
     #[instrument(skip(self))]
-    async fn cancel_workflow(
+    async fn append_cancel_workflow_requested(
         &self,
         execution_id: &ExecutionId,
         cancelled_at: DateTime<Utc>,

--- a/crates/testing/db-tests/tests/lifecycle.rs
+++ b/crates/testing/db-tests/tests/lifecycle.rs
@@ -2998,7 +2998,7 @@ async fn cancel_workflow_from_pending_at(database: Database) {
     .await;
 
     let outcome = db_connection
-        .cancel_workflow(&execution_id, sim_clock.now())
+        .append_cancel_workflow_requested(&execution_id, sim_clock.now())
         .await
         .unwrap();
     assert_eq!(CancelOutcome::CancelRequested, outcome);
@@ -3050,7 +3050,7 @@ async fn cancel_workflow_from_locked_should_keep_underlying_state(database: Data
         .unwrap();
 
     let outcome = db_connection
-        .cancel_workflow(&execution_id, sim_clock.now())
+        .append_cancel_workflow_requested(&execution_id, sim_clock.now())
         .await
         .unwrap();
     assert_eq!(CancelOutcome::CancelRequested, outcome);
@@ -3098,7 +3098,7 @@ async fn cancel_workflow_from_paused_should_keep_underlying_state(database: Data
         .unwrap();
 
     let outcome = db_connection
-        .cancel_workflow(&execution_id, sim_clock.now())
+        .append_cancel_workflow_requested(&execution_id, sim_clock.now())
         .await
         .unwrap();
     assert_eq!(CancelOutcome::CancelRequested, outcome);
@@ -3143,7 +3143,7 @@ async fn cancel_workflow_rejects_non_cancellable(database: Database) {
     .await;
 
     let err = db_connection
-        .cancel_workflow(&execution_id, sim_clock.now())
+        .append_cancel_workflow_requested(&execution_id, sim_clock.now())
         .await
         .unwrap_err();
     let reason = assert_matches!(err, DbErrorWrite::NonRetriable(DbErrorWriteNonRetriable::IllegalState { reason, .. }) => reason);
@@ -3175,12 +3175,12 @@ async fn cancel_workflow_second_call_is_already_cancelling(database: Database) {
     .await;
 
     let first = db_connection
-        .cancel_workflow(&execution_id, sim_clock.now())
+        .append_cancel_workflow_requested(&execution_id, sim_clock.now())
         .await
         .unwrap();
     assert_eq!(CancelOutcome::CancelRequested, first);
     let second = db_connection
-        .cancel_workflow(&execution_id, sim_clock.now())
+        .append_cancel_workflow_requested(&execution_id, sim_clock.now())
         .await
         .unwrap();
     assert_eq!(CancelOutcome::AlreadyCancelling, second);
@@ -3209,7 +3209,7 @@ async fn get_cancelling_returns_only_cancelling_rows(database: Database) {
     )
     .await;
     db_connection
-        .cancel_workflow(&cancelling, sim_clock.now())
+        .append_cancel_workflow_requested(&cancelling, sim_clock.now())
         .await
         .unwrap();
 

--- a/crates/wasm-workers/src/activity/cancel_registry.rs
+++ b/crates/wasm-workers/src/activity/cancel_registry.rs
@@ -112,8 +112,9 @@ impl CancelRegistry {
         }
     }
 
+    /// Move the activity to lifecycle state `cancelling`.
     /// It is the responsibility of the caller to check that the execution belongs to an activity!
-    pub async fn cancel_activity(
+    pub async fn request_activity_cancellation(
         &self,
         db_connection: &dyn DbConnection,
         execution_id: &ExecutionId,
@@ -121,7 +122,7 @@ impl CancelRegistry {
     ) -> Result<CancelOutcome, DbErrorWrite> {
         info!(%execution_id, "Cancelling activity");
         let outcome = db_connection
-            .cancel_activity_with_retries(execution_id, cancelled_at)
+            .append_activity_cancellation_requested_with_retries(execution_id, cancelled_at)
             .await?;
         if outcome == CancelOutcome::CancelRequested {
             // Sending the signal is best effort, the activity might not be registered yet.

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -213,11 +213,11 @@ async fn close_workflow_step(
                 now,
                 cancellation_requested_inflight,
             )
-            .await;
+            .await?;
         }
         for child_id in cancellations.cancellable_child_workflow_ids() {
             signal_cancellable_child_workflow(conn, child_id, now, cancellation_requested_inflight)
-                .await;
+                .await?;
         }
         Ok(())
     } else {
@@ -283,43 +283,38 @@ async fn resolve_child_component_types(
     Ok(types)
 }
 
-/// Best-effort, at most once per process; idempotent, so redoing it after a restart (empty `cancellation_requested_inflight`) is harmless.
+/// At most once per process; idempotent, so redoing it after a restart (empty
+/// `cancellation_requested_inflight`) is harmless. Any real error fails the whole
+/// close-step, retried next tick, rather than silently leaving this member uncancelled.
 async fn cancel_or_finish_delays_and_activities(
     conn: &dyn DbConnection,
     cancel_registry: &CancelRegistry,
     cancellable: &JoinSetCancellable,
     now: DateTime<Utc>,
     cancellation_requested_inflight: &mut HashSet<JoinSetResponseId>,
-) {
+) -> Result<(), DbErrorWrite> {
     let response_id = cancellable.response_id();
     if cancellation_requested_inflight.contains(&response_id) {
         // Waiting for activity finish.
-        return;
+        return Ok(());
     }
-    let outcome = match cancellable {
-        JoinSetCancellable::Delay(delay_id) => storage::cancel_delay(conn, delay_id.clone(), now)
-            .await
-            .map(|_| ())
-            .map_err(|err| debug!("Ignoring failure to cancel delay {delay_id} - {err:?}")),
+    match cancellable {
+        JoinSetCancellable::Delay(delay_id) => {
+            storage::cancel_delay(conn, delay_id.clone(), now).await?;
+        }
         JoinSetCancellable::Activity(child_id) => {
             let child = ExecutionId::Derived(child_id.clone());
             cancel_registry
                 .request_activity_cancellation(conn, &child, now)
-                .await
-                .map(|_| ())
-                .map_err(|err| debug!("Ignoring failure to cancel activity {child_id} - {err:?}"))
+                .await?;
         }
         JoinSetCancellable::Stub(execution_id) => {
-            storage::cancel_stub_execution(conn, execution_id.clone(), now)
-                .await
-                .map_err(|err| {
-                    debug!("Ignoring failure to finish cancelled stub {execution_id} - {err:?}");
-                })
+            storage::cancel_stub_execution_ignoring_conflict(conn, execution_id.clone(), now)
+                .await?;
         }
-    };
-    if outcome.is_ok() {
-        cancellation_requested_inflight.insert(response_id);
     }
+    cancellation_requested_inflight.insert(response_id);
+    Ok(())
 }
 
 /// Signal one cancellable workflow child. It is not finished here; its own
@@ -329,18 +324,15 @@ async fn signal_cancellable_child_workflow(
     child_id: &ExecutionIdDerived,
     now: DateTime<Utc>,
     cancellation_requested: &mut HashSet<JoinSetResponseId>,
-) {
+) -> Result<(), DbErrorWrite> {
     let response_id = JoinSetResponseId::ChildExecutionId(child_id.clone());
     if cancellation_requested.contains(&response_id) {
-        return;
+        return Ok(());
     }
     let child = ExecutionId::Derived(child_id.clone());
-    match conn.cancel_workflow_with_retries(&child, now).await {
-        Ok(_) => {
-            cancellation_requested.insert(response_id);
-        }
-        Err(err) => debug!("Ignoring failure to signal cancellable child {child_id} - {err:?}"),
-    }
+    conn.cancel_workflow_with_retries(&child, now).await?;
+    cancellation_requested.insert(response_id);
+    Ok(())
 }
 
 /// Append the synthetic closing `JoinNext`s followed by `Finished(Cancelled)` in a

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -60,11 +60,11 @@ impl CancellationDriver {
                 "cancellation_driver",
                 async move {
                     debug!("Spawned the cancellation driver");
-                    // Child executions and delays whose cancellation was already
-                    // requested/signalled this process. Pruned as responses land;
-                    // empty on restart (re-request is idempotent), so no durable state
-                    // is needed.
-                    let mut cancellation_requested: HashSet<JoinSetResponseId> = HashSet::new();
+                    // Child executions (activities/workflows) whose cancellation was
+                    // already requested by this process. Avoids needless DB interactions as further cancellation
+                    // requests are skipped.
+                    let mut cancellation_requested_inflight: HashSet<ExecutionIdDerived> =
+                        HashSet::new();
                     loop {
                         match db_pool.connection().await {
                             Ok(conn) => {
@@ -73,7 +73,7 @@ impl CancellationDriver {
                                     &cancel_registry,
                                     clock_fn.now(),
                                     batch_size,
-                                    &mut cancellation_requested,
+                                    &mut cancellation_requested_inflight,
                                 )
                                 .await;
                             }
@@ -94,7 +94,7 @@ async fn tick(
     cancel_registry: &CancelRegistry,
     now: DateTime<Utc>,
     batch_size: u32,
-    cancellation_requested: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested_inflight: &mut HashSet<ExecutionIdDerived>,
 ) {
     let ids = match conn.get_cancelling(batch_size).await {
         Ok(ids) => ids,
@@ -109,7 +109,7 @@ async fn tick(
             cancel_registry,
             &execution_id,
             now,
-            cancellation_requested,
+            cancellation_requested_inflight,
         )
         .await
         {
@@ -134,13 +134,20 @@ async fn close_step(
     cancel_registry: &CancelRegistry,
     execution_id: &ExecutionId,
     now: DateTime<Utc>,
-    cancellation_requested: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested_inflight: &mut HashSet<ExecutionIdDerived>,
 ) -> Result<(), CloseStepError> {
     let log = conn.get(execution_id).await?;
     if log.component_type.is_activity() {
         activity_finish_if_expired(conn, &log, now).await
     } else {
-        close_workflow_step(conn, cancel_registry, &log, now, cancellation_requested).await
+        close_workflow_step(
+            conn,
+            cancel_registry,
+            &log,
+            now,
+            cancellation_requested_inflight,
+        )
+        .await
     }
 }
 
@@ -163,7 +170,7 @@ async fn close_workflow_step(
     cancel_registry: &CancelRegistry,
     log: &ExecutionLog,
     now: DateTime<Utc>,
-    cancellation_requested_inflight: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested_inflight: &mut HashSet<ExecutionIdDerived>,
 ) -> Result<(), CloseStepError> {
     // Responses in cursor order, plus the set of children/delays that have one.
     let mut responses = Vec::with_capacity(log.responses.len());
@@ -193,7 +200,9 @@ async fn close_workflow_step(
         for (response_id, member) in members {
             if responded.contains(response_id) {
                 // Response landed.
-                cancellation_requested_inflight.remove(response_id);
+                if let JoinSetResponseId::ChildExecutionId(child_id) = response_id {
+                    cancellation_requested_inflight.remove(child_id);
+                }
             } else {
                 unresponded.push((response_id.clone(), member.clone()));
             }
@@ -283,37 +292,34 @@ async fn resolve_child_component_types(
     Ok(types)
 }
 
-/// At most once per process; idempotent, so redoing it after a restart (empty
-/// `cancellation_requested_inflight`) is harmless. Any real error fails the whole
-/// close-step, retried next tick, rather than silently leaving this member uncancelled.
+/// Only `Activity` is asynchronous (the locked worker owns the finish), so only it
+/// is deduped via `cancellation_requested_inflight`; delay/stub cancellation
+/// resolves inline in this same call.
 async fn cancel_or_finish_delays_and_activities(
     conn: &dyn DbConnection,
     cancel_registry: &CancelRegistry,
     cancellable: &JoinSetCancellable,
     now: DateTime<Utc>,
-    cancellation_requested_inflight: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested_inflight: &mut HashSet<ExecutionIdDerived>,
 ) -> Result<(), DbErrorWrite> {
-    let response_id = cancellable.response_id();
-    if cancellation_requested_inflight.contains(&response_id) {
-        // Waiting for activity finish.
-        return Ok(());
-    }
     match cancellable {
         JoinSetCancellable::Delay(delay_id) => {
             storage::cancel_delay(conn, delay_id.clone(), now).await?;
         }
         JoinSetCancellable::Activity(child_id) => {
-            let child = ExecutionId::Derived(child_id.clone());
-            cancel_registry
-                .request_activity_cancellation(conn, &child, now)
-                .await?;
+            if !cancellation_requested_inflight.contains(child_id) {
+                let child = ExecutionId::Derived(child_id.clone());
+                cancel_registry
+                    .request_activity_cancellation(conn, &child, now)
+                    .await?;
+                cancellation_requested_inflight.insert(child_id.clone());
+            } // avoid needless db interaction if cancellation was already requested.
         }
         JoinSetCancellable::Stub(execution_id) => {
             storage::cancel_stub_execution_ignoring_conflict(conn, execution_id.clone(), now)
                 .await?;
         }
     }
-    cancellation_requested_inflight.insert(response_id);
     Ok(())
 }
 
@@ -323,16 +329,15 @@ async fn signal_cancellable_child_workflow(
     conn: &dyn DbConnection,
     child_id: &ExecutionIdDerived,
     now: DateTime<Utc>,
-    cancellation_requested: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested: &mut HashSet<ExecutionIdDerived>,
 ) -> Result<(), DbErrorWrite> {
-    let response_id = JoinSetResponseId::ChildExecutionId(child_id.clone());
-    if cancellation_requested.contains(&response_id) {
+    if cancellation_requested.contains(child_id) {
         return Ok(());
     }
     let child = ExecutionId::Derived(child_id.clone());
     conn.append_cancel_workflow_requested_with_retries(&child, now)
         .await?;
-    cancellation_requested.insert(response_id);
+    cancellation_requested.insert(child_id.clone());
     Ok(())
 }
 

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -330,7 +330,8 @@ async fn signal_cancellable_child_workflow(
         return Ok(());
     }
     let child = ExecutionId::Derived(child_id.clone());
-    conn.cancel_workflow_with_retries(&child, now).await?;
+    conn.append_cancel_workflow_requested_with_retries(&child, now)
+        .await?;
     cancellation_requested.insert(response_id);
     Ok(())
 }
@@ -487,7 +488,9 @@ mod tests {
         )
         .await
         .unwrap();
-        conn.cancel_workflow(&parent_id, now).await.unwrap();
+        conn.append_cancel_workflow_requested(&parent_id, now)
+            .await
+            .unwrap();
 
         // A handful of ticks drives: parent signals child, child finishes and responds,
         // parent then finishes.
@@ -619,7 +622,9 @@ mod tests {
         )
         .await
         .unwrap();
-        conn.cancel_workflow(&parent_id, now).await.unwrap();
+        conn.append_cancel_workflow_requested(&parent_id, now)
+            .await
+            .unwrap();
 
         let mut cancellation_requested = HashSet::new();
         for _ in 0..10 {

--- a/crates/wasm-workers/src/cancellation_driver.rs
+++ b/crates/wasm-workers/src/cancellation_driver.rs
@@ -25,7 +25,10 @@ use concepts::{
     },
     time::{ClockFn, Sleep},
 };
-use db_common::{JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId};
+use db_common::{
+    JoinSetCancellable, JoinSetCloseCancellations, JoinSetOpenTracker, JoinSetOpenTrackerError,
+    JoinSetResponseId,
+};
 use executor::AbortOnDropHandle;
 use std::{collections::HashMap, collections::HashSet, sync::Arc, time::Duration};
 use tracing::{Instrument, debug, info_span, warn};
@@ -160,7 +163,7 @@ async fn close_workflow_step(
     cancel_registry: &CancelRegistry,
     log: &ExecutionLog,
     now: DateTime<Utc>,
-    cancellation_requested: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested_inflight: &mut HashSet<JoinSetResponseId>,
 ) -> Result<(), CloseStepError> {
     // Responses in cursor order, plus the set of children/delays that have one.
     let mut responses = Vec::with_capacity(log.responses.len());
@@ -173,9 +176,6 @@ async fn close_workflow_step(
     }
 
     // Resolve each child's component type (activity vs workflow) from its Created event.
-    // A resolution failure fails the whole step (retried next tick) rather than guessing
-    // a type: mis-classifying an activity as an uncancellable workflow would silently
-    // strand it as a permanent await barrier.
     let child_component_types = resolve_child_component_types(conn, log).await?;
 
     let tracker = JoinSetOpenTracker::reconstruct(
@@ -188,59 +188,45 @@ async fn close_workflow_step(
         },
     )?;
 
-    // Classify every still-running child or delay. Activities and delays are
-    // cancelled in reverse creation order below, matching normal join-set close;
-    // cancellable workflow children are signalled; uncancellable workflow children
-    // are only awaited.
-    let mut all_responded = true;
-    let mut activity_and_delay_ids = Vec::new();
-    let mut cancellable_child_ids = Vec::new();
+    let mut unresponded = Vec::new();
     for members in tracker.open_join_sets().values() {
         for (response_id, member) in members {
             if responded.contains(response_id) {
-                // Response landed: this child/delay is done, drop it from the
-                // process-local set to keep it bounded to in-flight children/delays.
-                cancellation_requested.remove(response_id);
-                continue;
-            }
-            all_responded = false;
-            match response_id {
-                JoinSetResponseId::DelayId(_) => activity_and_delay_ids.push(response_id.clone()),
-                JoinSetResponseId::ChildExecutionId(child_id) => {
-                    if member.is_activity() {
-                        activity_and_delay_ids.push(response_id.clone());
-                    } else if member.is_cancellable_workflow() {
-                        cancellable_child_ids.push(child_id.clone());
-                    }
-                }
+                // Response landed.
+                cancellation_requested_inflight.remove(response_id);
+            } else {
+                unresponded.push((response_id.clone(), member.clone()));
             }
         }
     }
 
-    for response_id in activity_and_delay_ids.iter().rev() {
-        cancel_activity_or_delay(
-            conn,
-            cancel_registry,
-            response_id,
-            now,
-            cancellation_requested,
-        )
-        .await;
-    }
-    for child_id in cancellable_child_ids {
-        signal_cancellable_child_workflow(conn, &child_id, now, cancellation_requested).await;
-    }
-
-    if all_responded {
-        // Pair each response driven during cancellation with a synthetic closing
-        // `JoinNext` (one per still-open member), mirroring a worker-run close so the
-        // UI/API can zip responses to `JoinNext`s positionally. `reconstruct` already
-        // consumed responses matched by pre-existing awaits, so the members left open
-        // are exactly the unpaired ones.
+    if !unresponded.is_empty() {
+        let cancellations = JoinSetCloseCancellations::classify(unresponded.into_iter(), now);
+        let Some(cancellations) = &cancellations else {
+            unreachable!("checked that unresponded is not empty")
+        };
+        for cancellable in cancellations.iterate_in_cancellation_order() {
+            cancel_or_finish_delays_and_activities(
+                conn,
+                cancel_registry,
+                cancellable,
+                now,
+                cancellation_requested_inflight,
+            )
+            .await;
+        }
+        for child_id in cancellations.cancellable_child_workflow_ids() {
+            signal_cancellable_child_workflow(conn, child_id, now, cancellation_requested_inflight)
+                .await;
+        }
+        Ok(())
+    } else {
+        // Done. Pair each response driven during cancellation with a synthetic closing `JoinNext`.
         let closing_join_nexts = build_closing_join_nexts(&tracker, now);
-        append_finish_cancelled(conn, log, closing_join_nexts, now).await?;
+        append_finish_cancelled(conn, log, closing_join_nexts, now)
+            .await
+            .map_err(CloseStepError::from)
     }
-    Ok(())
 }
 
 /// One closing `JoinNext` per still-open join-set member, matching the per-member
@@ -297,35 +283,42 @@ async fn resolve_child_component_types(
     Ok(types)
 }
 
-/// Best-effort teardown of one running activity or delay. Each child/delay has
-/// cancellation requested at most once per process; the action is idempotent, so
-/// re-doing it after a restart (empty set) is harmless.
-async fn cancel_activity_or_delay(
+/// Best-effort, at most once per process; idempotent, so redoing it after a restart (empty `cancellation_requested_inflight`) is harmless.
+async fn cancel_or_finish_delays_and_activities(
     conn: &dyn DbConnection,
     cancel_registry: &CancelRegistry,
-    response_id: &JoinSetResponseId,
+    cancellable: &JoinSetCancellable,
     now: DateTime<Utc>,
-    cancellation_requested: &mut HashSet<JoinSetResponseId>,
+    cancellation_requested_inflight: &mut HashSet<JoinSetResponseId>,
 ) {
-    if cancellation_requested.contains(response_id) {
+    let response_id = cancellable.response_id();
+    if cancellation_requested_inflight.contains(&response_id) {
+        // Waiting for activity finish.
         return;
     }
-    let outcome = match response_id {
-        JoinSetResponseId::DelayId(delay_id) => storage::cancel_delay(conn, delay_id.clone(), now)
+    let outcome = match cancellable {
+        JoinSetCancellable::Delay(delay_id) => storage::cancel_delay(conn, delay_id.clone(), now)
             .await
             .map(|_| ())
             .map_err(|err| debug!("Ignoring failure to cancel delay {delay_id} - {err:?}")),
-        JoinSetResponseId::ChildExecutionId(child_id) => {
+        JoinSetCancellable::Activity(child_id) => {
             let child = ExecutionId::Derived(child_id.clone());
             cancel_registry
-                .cancel_activity(conn, &child, now)
+                .request_activity_cancellation(conn, &child, now)
                 .await
                 .map(|_| ())
                 .map_err(|err| debug!("Ignoring failure to cancel activity {child_id} - {err:?}"))
         }
+        JoinSetCancellable::Stub(execution_id) => {
+            storage::cancel_stub_execution(conn, execution_id.clone(), now)
+                .await
+                .map_err(|err| {
+                    debug!("Ignoring failure to finish cancelled stub {execution_id} - {err:?}");
+                })
+        }
     };
     if outcome.is_ok() {
-        cancellation_requested.insert(response_id.clone());
+        cancellation_requested_inflight.insert(response_id);
     }
 }
 

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -1,10 +1,7 @@
 use super::workflow_worker::JoinNextBlockingStrategy;
 use crate::{
     activity::cancel_registry::CancelRegistry,
-    workflow::{
-        event_history::UpsertStubOrReplayInterrupt,
-        replay_advance::{JoinSetCloseCancellations, is_closing_join_next},
-    },
+    workflow::{event_history::UpsertStubOrReplayInterrupt, replay_advance::is_closing_join_next},
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -17,7 +14,7 @@ use concepts::{
         ResponseWithCursor, SubscribeToResponsesError, Version,
     },
 };
-use db_common::JoinSetResponseId;
+use db_common::{JoinSetCancellable, JoinSetCloseCancellations};
 use std::pin::Pin;
 use std::{any::Any, future::Future};
 use tracing::{debug, instrument, warn};
@@ -425,13 +422,12 @@ impl WorkflowDbConnection for CachingDbConnection {
         );
         self.flush_non_blocking_event_cache(req.created_at).await?;
 
-        // Activities and delays are cancelled in reverse order of creation.
         if let Some(cancellations) = cancellations {
-            for response_id in cancellations.iterate_in_cancellation_order() {
-                match response_id {
-                    JoinSetResponseId::ChildExecutionId(child_execution_id_derived) => {
+            for cancellable in cancellations.iterate_in_cancellation_order() {
+                match cancellable {
+                    JoinSetCancellable::Activity(child_execution_id_derived) => {
                         let res = cancel_registry
-                            .cancel_activity(
+                            .request_activity_cancellation(
                                 self.db_connection.as_ref(),
                                 &ExecutionId::Derived(child_execution_id_derived.clone()),
                                 cancellations.cancelled_at,
@@ -443,7 +439,20 @@ impl WorkflowDbConnection for CachingDbConnection {
                             );
                         }
                     }
-                    JoinSetResponseId::DelayId(delay_id) => {
+                    JoinSetCancellable::Stub(stub_execution_id) => {
+                        let res = storage::cancel_stub_execution(
+                            self.db_connection.as_ref(),
+                            stub_execution_id.clone(),
+                            cancellations.cancelled_at,
+                        )
+                        .await;
+                        if let Err(err) = res {
+                            debug!(
+                                "Ignoring failure to finish cancelled stub {stub_execution_id} - {err:?}"
+                            );
+                        }
+                    }
+                    JoinSetCancellable::Delay(delay_id) => {
                         let res = storage::cancel_delay(
                             self.db_connection.as_ref(),
                             delay_id.clone(),
@@ -458,7 +467,7 @@ impl WorkflowDbConnection for CachingDbConnection {
             }
             // Signal cancellable children; the driver drives their close and the
             // `Cancelled` response wakes our await.
-            for child_id in cancellations.cancellable_child_ids() {
+            for child_id in cancellations.cancellable_child_workflow_ids() {
                 let res = self
                     .db_connection
                     .cancel_workflow_with_retries(

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -410,79 +410,69 @@ impl WorkflowDbConnection for CachingDbConnection {
         version: Version,
         cancel_registry: &CancelRegistry,
         execution_id: ExecutionId,
-        req: AppendRequest,
+        join_next_req: AppendRequest,
         cancellations: Option<JoinSetCloseCancellations>,
         wasm_backtrace: Option<storage::WasmBacktrace>,
         component_id: &ComponentId,
     ) -> Result<(), DbErrorWrite> {
         assert_eq!(self.execution_id, execution_id);
         assert!(
-            is_closing_join_next(&req),
+            is_closing_join_next(&join_next_req),
             "append_join_set_close must append JoinNext(closing=true)"
         );
-        self.flush_non_blocking_event_cache(req.created_at).await?;
+        self.flush_non_blocking_event_cache(join_next_req.created_at)
+            .await?;
 
         if let Some(cancellations) = cancellations {
             for cancellable in cancellations.iterate_in_cancellation_order() {
                 match cancellable {
                     JoinSetCancellable::Activity(child_execution_id_derived) => {
-                        let res = cancel_registry
+                        cancel_registry
                             .request_activity_cancellation(
                                 self.db_connection.as_ref(),
                                 &ExecutionId::Derived(child_execution_id_derived.clone()),
                                 cancellations.cancelled_at,
                             )
-                            .await;
-                        if let Err(err) = res {
-                            debug!(
-                                "Ignoring failure to cancel activity {child_execution_id_derived} - {err:?}"
-                            );
-                        }
+                            .await?;
                     }
                     JoinSetCancellable::Stub(stub_execution_id) => {
-                        let res = storage::cancel_stub_execution(
+                        storage::cancel_stub_execution_ignoring_conflict(
                             self.db_connection.as_ref(),
                             stub_execution_id.clone(),
                             cancellations.cancelled_at,
                         )
-                        .await;
-                        if let Err(err) = res {
-                            debug!(
-                                "Ignoring failure to finish cancelled stub {stub_execution_id} - {err:?}"
-                            );
-                        }
+                        .await?;
                     }
                     JoinSetCancellable::Delay(delay_id) => {
-                        let res = storage::cancel_delay(
+                        storage::cancel_delay(
                             self.db_connection.as_ref(),
                             delay_id.clone(),
                             cancellations.cancelled_at,
                         )
-                        .await;
-                        if let Err(err) = res {
-                            debug!("Ignoring failure to cancel delay {delay_id} - {err:?}");
-                        }
+                        .await?;
                     }
                 }
             }
             // Signal cancellable children; the driver drives their close and the
             // `Cancelled` response wakes our await.
             for child_id in cancellations.cancellable_child_workflow_ids() {
-                let res = self
-                    .db_connection
+                self.db_connection
                     .cancel_workflow_with_retries(
                         &ExecutionId::Derived(child_id.clone()),
                         cancellations.cancelled_at,
                     )
-                    .await;
-                if let Err(err) = res {
-                    debug!("Ignoring failure to signal cancellable child {child_id} - {err:?}");
-                }
+                    .await?;
             }
         }
 
-        self.append_blocking(version, execution_id, req, wasm_backtrace, component_id)
-            .await
+        self.append_blocking(
+            version,
+            execution_id,
+            join_next_req,
+            wasm_backtrace,
+            component_id,
+        )
+        .await
     }
 
     async fn append_batch_create_new_execution(

--- a/crates/wasm-workers/src/workflow/caching_db_connection.rs
+++ b/crates/wasm-workers/src/workflow/caching_db_connection.rs
@@ -457,7 +457,7 @@ impl WorkflowDbConnection for CachingDbConnection {
             // `Cancelled` response wakes our await.
             for child_id in cancellations.cancellable_child_workflow_ids() {
                 self.db_connection
-                    .cancel_workflow_with_retries(
+                    .append_cancel_workflow_requested_with_retries(
                         &ExecutionId::Derived(child_id.clone()),
                         cancellations.cancelled_at,
                     )

--- a/crates/wasm-workers/src/workflow/event_history.rs
+++ b/crates/wasm-workers/src/workflow/event_history.rs
@@ -13,7 +13,6 @@ use crate::workflow::host_exports::latest;
 use crate::workflow::host_exports::latest::obelisk::types::execution as types_execution;
 use crate::workflow::host_exports::latest::obelisk::workflow::workflow_support::JoinNextError;
 use crate::workflow::host_exports::latest::obelisk::workflow::workflow_support::JoinNextTryError;
-use crate::workflow::replay_advance::JoinSetCloseCancellations;
 use assert_matches::assert_matches;
 use chrono::{DateTime, Utc};
 use concepts::ComponentId;
@@ -45,7 +44,9 @@ use concepts::storage::{HistoryEvent, JoinNextTryOutcome, JoinSetRequest};
 use concepts::storage::{ResponseSubscriptionEnd, SubscribeToResponsesError};
 use concepts::{ExecutionId, StrVariant};
 use concepts::{FunctionFqn, Params};
-use db_common::{JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId};
+use db_common::{
+    JoinSetCloseCancellations, JoinSetOpenTracker, JoinSetOpenTrackerError, JoinSetResponseId,
+};
 use hashbrown::HashMap;
 use indexmap::IndexMap;
 use indexmap::indexmap;
@@ -789,37 +790,13 @@ impl EventHistory {
         debug!("Closing `{join_set_id}` with unawaited {response_ids:?}");
 
         let join_next_count = response_ids.len();
-        // Activities+delays are cancelled, cancellable children are signalled, other
-        // children are merely awaited. Order retained (cancelled in reverse later).
-        let mut activity_and_delay_ids = Vec::new();
-        let mut cancellable_child_ids = Vec::new();
-        for (response_id, member) in response_ids {
-            match &response_id {
-                JoinSetResponseId::DelayId(_) => activity_and_delay_ids.push(response_id),
-                JoinSetResponseId::ChildExecutionId(child_id) => {
-                    if member.is_activity() {
-                        activity_and_delay_ids.push(response_id);
-                    } else if member.is_cancellable_workflow() {
-                        cancellable_child_ids.push(child_id.clone());
-                    }
-                }
-            }
-        }
         let mut cancellations =
-            if activity_and_delay_ids.is_empty() && cancellable_child_ids.is_empty() {
-                None
-            } else {
-                Some(JoinSetCloseCancellations::new(
-                    activity_and_delay_ids,
-                    cancellable_child_ids,
-                    called_at,
-                ))
-            };
+            JoinSetCloseCancellations::classify(response_ids.into_iter(), called_at);
         for _ in 0..join_next_count {
             let event_call =
                 EventCallKind::Blocking(EventCallBlocking::JoinSetClose(JoinSetClose {
                     join_set_id: join_set_id.clone(),
-                    cancellations: std::mem::take(&mut cancellations), // First iterations takes all cancellations, so that the activities get the signal ASAP.
+                    cancellations: std::mem::take(&mut cancellations), // First iteration takes all cancellations, so that the activities get the signal ASAP.
                     wasm_backtrace: wasm_backtrace.clone(),
                 }));
             self.apply_event_call(event_call, event_call_cursor, db_connection, called_at)
@@ -3104,6 +3081,7 @@ impl JoinNext {
 #[derive(derive_more::Debug, Clone)]
 pub(crate) struct JoinSetClose {
     pub(crate) join_set_id: JoinSetId,
+    // Only the first iteration contains `cancellations` so that the activities get the signal ASAP.
     pub(crate) cancellations: Option<JoinSetCloseCancellations>,
     #[debug(skip)]
     pub(crate) wasm_backtrace: Option<storage::WasmBacktrace>,

--- a/crates/wasm-workers/src/workflow/replay_advance.rs
+++ b/crates/wasm-workers/src/workflow/replay_advance.rs
@@ -1,15 +1,13 @@
 use crate::workflow::replay_db_proxy::InternalCapturedWrite;
-use chrono::{DateTime, Utc};
+use chrono::DateTime;
 use concepts::{
     SupportedFunctionReturnValue,
-    prefixed_ulid::ExecutionIdDerived,
     storage::{
         AppendEventsToExecution, AppendRequest, AppendResponseToExecution, CapturedDbWrite,
         CreateRequest, DbErrorWrite, ExecutionRequest, HistoryEvent, HistoryEventScheduleAt,
         JoinSetRequest, Version,
     },
 };
-use db_common::JoinSetResponseId;
 use executor::worker::FatalError;
 
 /// Replay outcome for a workflow execution.
@@ -232,36 +230,6 @@ pub(crate) fn is_closing_join_next(req: &AppendRequest) -> bool {
             event: HistoryEvent::JoinNext { closing: true, .. },
         }
     )
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct JoinSetCloseCancellations {
-    /// Order based on creation. Must be cancelled in the reverse order.
-    activity_and_delay_ids: Vec<JoinSetResponseId>,
-    /// Signalled (`CancellationRequested`), not finished-cancelled; the driver closes them.
-    cancellable_child_ids: Vec<ExecutionIdDerived>,
-    pub(crate) cancelled_at: DateTime<Utc>,
-}
-impl JoinSetCloseCancellations {
-    pub(crate) fn new(
-        activity_and_delay_ids: Vec<JoinSetResponseId>,
-        cancellable_child_ids: Vec<ExecutionIdDerived>,
-        cancelled_at: DateTime<Utc>,
-    ) -> JoinSetCloseCancellations {
-        JoinSetCloseCancellations {
-            activity_and_delay_ids,
-            cancellable_child_ids,
-            cancelled_at,
-        }
-    }
-
-    pub(crate) fn iterate_in_cancellation_order(&self) -> impl Iterator<Item = &JoinSetResponseId> {
-        self.activity_and_delay_ids.iter().rev()
-    }
-
-    pub(crate) fn cancellable_child_ids(&self) -> &[ExecutionIdDerived] {
-        &self.cancellable_child_ids
-    }
 }
 
 pub(crate) fn requested_write_matches_fresh_replay(

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -205,6 +205,15 @@ async fn apply_captured_write(
                 }
             }
         }
+        // Append lifecycle change requesting `cancelled` for cancellable child workflows.
+        // The `CancellationDriver` drives their close and their response wakes our JoinNext wait.
+        for child_id in cancellations.cancellable_child_workflow_ids() {
+            conn.append_cancel_workflow_requested_with_retries(
+                &ExecutionId::Derived(child_id.clone()),
+                cancellations.cancelled_at,
+            )
+            .await?;
+        }
     }
 
     match write.write.clone() {
@@ -802,7 +811,8 @@ mod tests {
     use super::*;
     use crate::workflow::caching_db_connection::{CachingBuffer, CachingDbConnection};
     use crate::workflow::workflow_worker::JoinNextBlockingStrategy;
-    use concepts::{FunctionFqn, Params};
+    use concepts::{ComponentType, FunctionFqn, Params};
+    use db_common::{JoinSetMember, JoinSetResponseId};
     use rstest::rstest;
 
     enum ConnectionMode {
@@ -901,5 +911,140 @@ mod tests {
             .unwrap();
 
         assert_eq!(found, create_request);
+    }
+
+    /// `append_join_set_close` must signal a cancellable child workflow the same way
+    /// whether the write lands directly (`CachingDbConnection`) or is captured during
+    /// replay and applied afterwards (`ReplayWorkflowDbConnection`). Regression test for
+    /// a bug where the replay path silently dropped the signal.
+    #[rstest]
+    #[case::caching(ConnectionMode::Caching)]
+    #[case::replay(ConnectionMode::Replay)]
+    #[tokio::test]
+    async fn join_set_close_signals_cancellable_child_workflow_in_both_modes(
+        #[case] mode: ConnectionMode,
+    ) {
+        let (_guard, db_pool, _db_close) = db_tests::Database::Sqlite.set_up().await;
+        let query_conn = db_pool.connection().await.unwrap();
+        let created_at = DateTime::UNIX_EPOCH;
+        let cancel_registry = CancelRegistry::new();
+
+        let parent_execution_id = ExecutionId::from_parts(0, 0);
+        let join_set_id = concepts::JoinSetId::new(
+            concepts::JoinSetKind::Named,
+            concepts::StrVariant::from("js"),
+        )
+        .unwrap();
+        let child_execution_id = parent_execution_id.next_level(&join_set_id);
+        let cancellable_ffqn =
+            FunctionFqn::new_static("testing:integration/workflow", "child-cancellable");
+
+        let parent_version = query_conn
+            .create(CreateRequest {
+                created_at,
+                execution_id: parent_execution_id.clone(),
+                ffqn: FunctionFqn::new_static("testing:integration/workflow", "parent"),
+                params: Params::empty(),
+                parent: None,
+                metadata: concepts::ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: ComponentId::dummy_workflow(),
+                deployment_id: concepts::prefixed_ulid::DeploymentId::generate(),
+                scheduled_by: None,
+                paused: true,
+            })
+            .await
+            .unwrap();
+        query_conn
+            .create(CreateRequest {
+                created_at,
+                execution_id: ExecutionId::Derived(child_execution_id.clone()),
+                ffqn: cancellable_ffqn.clone(),
+                params: Params::empty(),
+                parent: Some((parent_execution_id.clone(), join_set_id.clone())),
+                metadata: concepts::ExecutionMetadata::empty(),
+                scheduled_at: created_at,
+                component_id: ComponentId::dummy_workflow(),
+                deployment_id: concepts::prefixed_ulid::DeploymentId::generate(),
+                scheduled_by: None,
+                paused: false,
+            })
+            .await
+            .unwrap();
+
+        let cancellations = JoinSetCloseCancellations::classify(
+            std::iter::once((
+                JoinSetResponseId::ChildExecutionId(child_execution_id.clone()),
+                JoinSetMember::Child {
+                    component_type: ComponentType::Workflow,
+                    target_ffqn: cancellable_ffqn,
+                },
+            )),
+            created_at,
+        )
+        .expect("one cancellable child makes this non-empty");
+        let closing_join_next = AppendRequest {
+            created_at,
+            event: ExecutionRequest::HistoryEvent {
+                event: concepts::storage::HistoryEvent::JoinNext {
+                    join_set_id: join_set_id.clone(),
+                    run_expires_at: created_at,
+                    requested_ffqn: None,
+                    closing: true,
+                },
+            },
+        };
+
+        let op_conn = db_pool.connection().await.unwrap();
+        let mut connection: Box<dyn WorkflowDbConnection> = match mode {
+            ConnectionMode::Caching => Box::new(CachingDbConnection::new(
+                op_conn,
+                parent_execution_id.clone(),
+                None,
+            )),
+            ConnectionMode::Replay => Box::new(ReplayWorkflowDbConnection::new(
+                parent_execution_id.clone(),
+                op_conn,
+                None,
+            )),
+        };
+        connection
+            .append_join_set_close(
+                parent_version.clone(),
+                &cancel_registry,
+                parent_execution_id.clone(),
+                closing_join_next,
+                Some(cancellations),
+                None,
+                &ComponentId::dummy_workflow(),
+            )
+            .await
+            .unwrap();
+        if matches!(mode, ConnectionMode::Replay) {
+            let connection = connection
+                .as_any()
+                .downcast::<ReplayWorkflowDbConnection>()
+                .unwrap();
+            let (writes, _backtraces, real_connection) = connection.into_parts();
+            apply_writes(
+                real_connection.as_ref(),
+                &cancel_registry,
+                None,
+                writes,
+                parent_version,
+            )
+            .await
+            .unwrap();
+        }
+
+        let child_log = query_conn
+            .get(&ExecutionId::Derived(child_execution_id))
+            .await
+            .unwrap();
+        assert_matches::assert_matches!(
+            child_log.events.last().unwrap().event,
+            ExecutionRequest::CancellationRequested,
+            "join-set close must signal the cancellable child the same way in both modes"
+        );
     }
 }

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -3,7 +3,6 @@
 //! that the workflow would produce next.
 
 use super::caching_db_connection::{CacheableDbEvent, WorkflowDbConnection};
-use crate::workflow::replay_advance::JoinSetCloseCancellations;
 use crate::{
     activity::cancel_registry::CancelRegistry,
     workflow::{event_history::UpsertStubOrReplayInterrupt, replay_advance::is_closing_join_next},
@@ -21,7 +20,7 @@ use concepts::{
         ResponseSubscriptionEnd, ResponseWithCursor, SubscribeToResponsesError, Version,
     },
 };
-use db_common::JoinSetResponseId;
+use db_common::{JoinSetCancellable, JoinSetCloseCancellations};
 use std::pin::Pin;
 use std::{any::Any, future::Future};
 use tokio::sync::mpsc;
@@ -181,11 +180,11 @@ async fn apply_captured_write(
     cancel_registry: &CancelRegistry,
 ) -> Result<Option<Version>, DbErrorWrite> {
     if let Some(cancellations) = &write.cancellations {
-        for response_id in cancellations.iterate_in_cancellation_order() {
-            match response_id {
-                JoinSetResponseId::ChildExecutionId(execution_id) => {
+        for cancellable in cancellations.iterate_in_cancellation_order() {
+            match cancellable {
+                JoinSetCancellable::Activity(execution_id) => {
                     let res = cancel_registry
-                        .cancel_activity(
+                        .request_activity_cancellation(
                             conn,
                             &ExecutionId::Derived(execution_id.clone()),
                             cancellations.cancelled_at,
@@ -195,7 +194,20 @@ async fn apply_captured_write(
                         debug!("Ignoring failure to cancel activity {execution_id} - {err:?}");
                     }
                 }
-                JoinSetResponseId::DelayId(delay_id) => {
+                JoinSetCancellable::Stub(stub_execution_id) => {
+                    let res = storage::cancel_stub_execution(
+                        conn,
+                        stub_execution_id.clone(),
+                        cancellations.cancelled_at,
+                    )
+                    .await;
+                    if let Err(err) = res {
+                        debug!(
+                            "Ignoring failure to finish cancelled stub {stub_execution_id} - {err:?}"
+                        );
+                    }
+                }
+                JoinSetCancellable::Delay(delay_id) => {
                     let res =
                         storage::cancel_delay(conn, delay_id.clone(), cancellations.cancelled_at)
                             .await;

--- a/crates/wasm-workers/src/workflow/replay_db_proxy.rs
+++ b/crates/wasm-workers/src/workflow/replay_db_proxy.rs
@@ -24,7 +24,7 @@ use db_common::{JoinSetCancellable, JoinSetCloseCancellations};
 use std::pin::Pin;
 use std::{any::Any, future::Future};
 use tokio::sync::mpsc;
-use tracing::{debug, trace, warn};
+use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub(crate) struct InternalCapturedWrite {
@@ -183,38 +183,25 @@ async fn apply_captured_write(
         for cancellable in cancellations.iterate_in_cancellation_order() {
             match cancellable {
                 JoinSetCancellable::Activity(execution_id) => {
-                    let res = cancel_registry
+                    cancel_registry
                         .request_activity_cancellation(
                             conn,
                             &ExecutionId::Derived(execution_id.clone()),
                             cancellations.cancelled_at,
                         )
-                        .await;
-                    if let Err(err) = res {
-                        debug!("Ignoring failure to cancel activity {execution_id} - {err:?}");
-                    }
+                        .await?;
                 }
                 JoinSetCancellable::Stub(stub_execution_id) => {
-                    let res = storage::cancel_stub_execution(
+                    storage::cancel_stub_execution_ignoring_conflict(
                         conn,
                         stub_execution_id.clone(),
                         cancellations.cancelled_at,
                     )
-                    .await;
-                    if let Err(err) = res {
-                        debug!(
-                            "Ignoring failure to finish cancelled stub {stub_execution_id} - {err:?}"
-                        );
-                    }
+                    .await?;
                 }
                 JoinSetCancellable::Delay(delay_id) => {
-                    let res =
-                        storage::cancel_delay(conn, delay_id.clone(), cancellations.cancelled_at)
-                            .await;
-                    if let Err(err) = res {
-                        // This means that the watcher expired the delay in the mean time.
-                        trace!("Ignoring failure to cancel {delay_id} - {err:?}");
-                    }
+                    storage::cancel_delay(conn, delay_id.clone(), cancellations.cancelled_at)
+                        .await?;
                 }
             }
         }

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@execute_workflow_fn_with_single_delay-testing_stub-workflow__workflow.join-next-in-scope.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@execute_workflow_fn_with_single_delay-testing_stub-workflow__workflow.join-next-in-scope.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/wasm-workers/src/workflow/workflow_worker.rs
+assertion_line: 4101
 expression: "ExecutionLogSanitized::from(execution_log.clone())"
 ---
 {
@@ -487,7 +488,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.n:a_1",
-          "finished_version": 2,
+          "finished_version": 1,
           "result": {
             "execution_failure": {
               "kind": "cancelled"
@@ -503,7 +504,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.n:c_1",
-          "finished_version": 2,
+          "finished_version": 1,
           "result": {
             "execution_failure": {
               "kind": "cancelled"
@@ -532,7 +533,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.n:f_1",
-          "finished_version": 2,
+          "finished_version": 1,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_delay-testing_stub-workflow__workflow.submit-race-join-next-delay.snap
+++ b/crates/wasm-workers/src/workflow/snapshots/execute_workflow_fn_with_delays@stub_submit_race_join_next_delay-testing_stub-workflow__workflow.submit-race-join-next-delay.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/wasm-workers/src/workflow/workflow_worker.rs
+assertion_line: 4101
 expression: "ExecutionLogSanitized::from(execution_log.clone())"
 ---
 {
@@ -220,7 +221,7 @@ expression: "ExecutionLogSanitized::from(execution_log.clone())"
         "event": {
           "type": "child_execution_finished",
           "child_execution_id": "E_00000000000000000000000000.g:1_1",
-          "finished_version": 2,
+          "finished_version": 1,
           "result": {
             "execution_failure": {
               "kind": "cancelled"

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -4214,7 +4214,7 @@ async fn webhook_js_get_status_cancelling() {
         conn.create(create(ExecutionId::Derived(child_id), CHILD_FFQN))
             .await
             .unwrap();
-        conn.cancel_workflow_with_retries(&parent_id, now)
+        conn.append_cancel_workflow_requested_with_retries(&parent_id, now)
             .await
             .unwrap();
         pool.close().await;

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -132,7 +132,7 @@ impl GrpcServer {
                 .to_status(),
             ComponentType::Workflow => {
                 let outcome = conn
-                    .cancel_workflow_with_retries(execution_id, executed_at)
+                    .append_cancel_workflow_requested_with_retries(execution_id, executed_at)
                     .await
                     .to_status()?;
                 // Best-effort CPU saver: the write above already cancels it; a locally-running

--- a/src/server/grpc_server.rs
+++ b/src/server/grpc_server.rs
@@ -127,7 +127,7 @@ impl GrpcServer {
         match create_req.component_id.component_type {
             component_type if component_type.is_activity() => self
                 .cancel_registry
-                .cancel_activity(conn.as_ref(), execution_id, executed_at)
+                .request_activity_cancellation(conn.as_ref(), execution_id, executed_at)
                 .await
                 .to_status(),
             ComponentType::Workflow => {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -682,7 +682,7 @@ async fn execution_cancel(
         component_type if component_type.is_activity() => {
             state
                 .cancel_registry
-                .cancel_activity(conn.as_ref(), &execution_id, executed_at)
+                .request_activity_cancellation(conn.as_ref(), &execution_id, executed_at)
                 .await
         }
         ComponentType::Workflow => {

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -687,7 +687,7 @@ async fn execution_cancel(
         }
         ComponentType::Workflow => {
             let outcome = conn
-                .cancel_workflow_with_retries(&execution_id, executed_at)
+                .append_cancel_workflow_requested_with_retries(&execution_id, executed_at)
                 .await;
             if outcome.is_ok() {
                 // Best-effort CPU saver: the write above already cancels it; a locally-running


### PR DESCRIPTION
- **refactor: Cancel stubs in-line, without waiting for next cancel tick**
- **refactor: Fail on db error when cancelling delays or child execs**
- **refactor: Rename `cancel_workflow` to `append_cancel_workflow_requested`**
- **fix: Append cancel request to child workflows in replay**
- **refactor: Tighten `cancellation_requested_inflight`**
