### PR TITLE
feat(config): make the API transport message size limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** *(config)* `max_deployment_file_bytes` moved from the top level of `server.toml`
+  to `limits.max_deployment_file_bytes`.
 - **Breaking:** *(config)* Deployments can only read process environment variables listed in the
   server's `[public_env].allowed` allowlist. This prevents platform-provided variables, including
   sensitive Kubernetes values, from being exposed through `deployment.toml`.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ Each top-level execution snapshots the effective limit. Child and scheduled
 executions inherit it, so a configuration change applies only to new execution
 trees and cannot change replay behavior. Existing databases require no schema
 migration: executions created by older releases retain their legacy unlimited
-contract. `MAX_GRPC_MESSAGE_SIZE` is a separate, larger transport safeguard and
-does not relax the persisted-value limit.
+contract. `max_transport_message_size_bytes` (also under `[limits]`, defaulting to
+512 MiB) is a separate, larger transport safeguard bounding a single gRPC message
+or REST request body, and does not relax the persisted-value limit.
 
 ## Getting Started
 

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -33,10 +33,6 @@
       "description": "Operator-owned allowlist for component-originated HTTP requests.\nAn empty allowlist denies every outbound request.",
       "$ref": "#/$defs/OutboundHttpToml"
     },
-    "max_deployment_file_bytes": {
-      "description": "Per-file size limit for deployment-owned blobs attached to a submit request.",
-      "$ref": "#/$defs/MaxDeploymentFileBytes"
-    },
     "limits": {
       "$ref": "#/$defs/LimitsToml"
     },
@@ -227,12 +223,6 @@
         "params"
       ]
     },
-    "MaxDeploymentFileBytes": {
-      "description": "Per-file size limit (in bytes) for deployment-owned blobs, defaulting to 20 MiB.",
-      "type": "integer",
-      "format": "uint32",
-      "minimum": 0
-    },
     "LimitsToml": {
       "type": "object",
       "properties": {
@@ -242,9 +232,19 @@
           "format": "uint64",
           "minimum": 0,
           "default": 1048576
+        },
+        "max_deployment_file_bytes": {
+          "description": "Per-file size limit for deployment-owned blobs attached to a submit request.",
+          "$ref": "#/$defs/MaxDeploymentFileBytes"
         }
       },
       "additionalProperties": false
+    },
+    "MaxDeploymentFileBytes": {
+      "description": "Per-file size limit (in bytes) for deployment-owned blobs, defaulting to 20 MiB.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
     },
     "ApiConfig": {
       "type": "object",

--- a/assets/schemas/toml/server.json
+++ b/assets/schemas/toml/server.json
@@ -236,6 +236,13 @@
         "max_deployment_file_bytes": {
           "description": "Per-file size limit for deployment-owned blobs attached to a submit request.",
           "$ref": "#/$defs/MaxDeploymentFileBytes"
+        },
+        "max_transport_message_size_bytes": {
+          "description": "Maximum size of a single API transport message: the gRPC encoded message\nsize and the equivalent REST request body limit. Must be positive; the\ndefault is 512 MiB. This is a transport bound and is distinct from\n`max_persisted_value_size_bytes`.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 536870912
         }
       },
       "additionalProperties": false

--- a/server-help.toml
+++ b/server-help.toml
@@ -42,10 +42,6 @@
 # [public_env]
 # allowed = ["OBELISK_PUBLIC_REGION"]
 
-## Per-file size limit (in bytes) for deployment-owned blobs attached to a submit request.
-## Defaults to 20 MiB.
-# max_deployment_file_bytes = 20971520
-
 ## Exec activities run host processes outside the WASM sandbox and are disabled by default.
 ## Allow any exec activity (logs a warning):
 # allow_exec_activities = true
@@ -193,3 +189,6 @@
 # bound. Increasing the transport bound does not relax this persisted-value limit.
 [limits]
 max_persisted_value_size_bytes = 1048576
+# Per-file size limit (in bytes) for deployment-owned blobs attached to a submit
+# request. Defaults to 20 MiB.
+# max_deployment_file_bytes = 20971520

--- a/server-help.toml
+++ b/server-help.toml
@@ -185,10 +185,14 @@
 # this setting affects only new execution trees and does not change replay.
 # Existing database events need no schema migration. Created events written by
 # older releases have no stored limit and retain their legacy unlimited contract.
-# This is separate from MAX_GRPC_MESSAGE_SIZE, which remains a larger transport
-# bound. Increasing the transport bound does not relax this persisted-value limit.
+# This is separate from `max_transport_message_size_bytes`, which is a larger
+# transport bound. Increasing the transport bound does not relax this
+# persisted-value limit.
 [limits]
 max_persisted_value_size_bytes = 1048576
 # Per-file size limit (in bytes) for deployment-owned blobs attached to a submit
 # request. Defaults to 20 MiB.
 # max_deployment_file_bytes = 20971520
+# Maximum size of a single API transport message: the gRPC encoded message size and
+# the equivalent REST request body limit. Must be positive. Defaults to 512 MiB.
+# max_transport_message_size_bytes = 536870912

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,8 +3,9 @@ use rand::Rng as _;
 use sha2::{Digest as _, Sha256};
 use std::fmt::Write as _;
 
-/// Maximum encoded gRPC message size for deployment repository requests and responses.
-pub(crate) const MAX_GRPC_MESSAGE_SIZE: usize = 512 * 1024 * 1024;
+/// Default cap on a single API transport message: gRPC encoded message size and the
+/// equivalent REST request body limit. Overridable via `[limits] max_transport_message_size_bytes`.
+pub(crate) const DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES: usize = 512 * 1024 * 1024;
 pub(crate) const MIN_API_TOKEN_CHAR_LENGTH: usize = 32;
 const GENERATED_API_TOKEN_BYTES: usize = 32;
 

--- a/src/command/integration_tests.rs
+++ b/src/command/integration_tests.rs
@@ -1238,8 +1238,8 @@ impl TestServer {
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
                 .unwrap()
-                .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-                .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+                .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+                .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
 
         let deployment_id = DeploymentId::generate();
         let submit = async |files| {
@@ -1294,8 +1294,8 @@ impl TestServer {
             DeploymentRepositoryClient::connect(format!("http://{}", self.api_addr()))
                 .await
                 .unwrap()
-                .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-                .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+                .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+                .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
         let resp = grpc_client
             .switch_deployment(SwitchDeploymentRequest {
                 deployment_id: Some(GrpcDeploymentId {
@@ -1473,8 +1473,12 @@ impl TestDeployClient {
                     DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
                         .await
                         .unwrap()
-                        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-                        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+                        .max_encoding_message_size(
+                            crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES,
+                        )
+                        .max_decoding_message_size(
+                            crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES,
+                        );
                 let deployment_id = DeploymentId::generate();
                 grpc_client
                     .submit_deployment(SubmitDeploymentRequest {
@@ -2420,8 +2424,8 @@ ffqn = "testing:integration/deferred.run"
         DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
             .await
             .unwrap()
-            .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-            .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+            .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+            .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
     let submit = |files, id| {
         let mut client = grpc_client.clone();
         let toml = prepared.deployment_toml.clone();
@@ -2561,8 +2565,8 @@ routes = [{ methods = ["GET"], route = "/broken-import" }]
     let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+        .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
 
     let submit = |check: RuntimeConfigCheck, id: GrpcDeploymentId| {
         let mut client = grpc_client.clone();
@@ -2679,8 +2683,8 @@ routes = [{ methods = ["GET"], route = "/" }]
     let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+        .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
 
     let submit = |check: RuntimeConfigCheck, id: GrpcDeploymentId| {
         let mut client = grpc_client.clone();
@@ -2817,8 +2821,8 @@ routes = [{ methods = ["GET"], route = "/" }]
     let status = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+        .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
         .submit_deployment(SubmitDeploymentRequest {
             deployment_toml: broken_toml,
             created_by: Some("test".to_string()),
@@ -2898,8 +2902,8 @@ routes = [{ methods = ["GET"], route = "/" }]
         DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
             .await
             .unwrap()
-            .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-            .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+            .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+            .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
     grpc_client
         .submit_deployment(SubmitDeploymentRequest {
             deployment_toml: prepared.deployment_toml.clone(),
@@ -2950,8 +2954,8 @@ env_vars = ["OBELISK_PHASE5_DEFINITELY_MISSING_VAR"]
     let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+        .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
 
     let deployment_id = DeploymentId::generate();
 
@@ -3175,8 +3179,8 @@ async fn gc_orphan_files_grpc() {
     let grpc_client = DeploymentRepositoryClient::connect(format!("http://{}", server.api_addr()))
         .await
         .unwrap()
-        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES)
+        .max_decoding_message_size(crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES);
 
     // A valid deployment: its blob is referenced and must survive GC.
     let good_dir = tempfile::tempdir().unwrap();

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -1894,6 +1894,10 @@ pub(crate) async fn run_internal(
         deployment_switch_manager.clone(),
     ));
 
+    let max_transport_message_size_bytes = server_init
+        .server_verified
+        .max_transport_message_size_bytes();
+
     let mut grpc = RoutesBuilder::default();
 
     grpc.add_service(
@@ -1903,7 +1907,9 @@ pub(crate) async fn run_internal(
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)
         .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip),
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_decoding_message_size(max_transport_message_size_bytes)
+        .max_encoding_message_size(max_transport_message_size_bytes),
     )
     .add_service(
         grpc_gen::execution_repository_server::ExecutionRepositoryServer::from_arc(
@@ -1912,7 +1918,9 @@ pub(crate) async fn run_internal(
         .send_compressed(CompressionEncoding::Zstd)
         .accept_compressed(CompressionEncoding::Zstd)
         .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip),
+        .accept_compressed(CompressionEncoding::Gzip)
+        .max_decoding_message_size(max_transport_message_size_bytes)
+        .max_encoding_message_size(max_transport_message_size_bytes),
     )
     .add_service(
         grpc_gen::deployment_repository_server::DeploymentRepositoryServer::from_arc(
@@ -1924,13 +1932,15 @@ pub(crate) async fn run_internal(
         .accept_compressed(CompressionEncoding::Gzip)
         // Submit requests inline deployment-owned blobs; raise the decode limit
         // well above tonic's 4 MiB default. `GetFile` responses are likewise large.
-        .max_decoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(crate::api::MAX_GRPC_MESSAGE_SIZE),
+        .max_decoding_message_size(max_transport_message_size_bytes)
+        .max_encoding_message_size(max_transport_message_size_bytes),
     )
     .add_service(
         tonic_reflection::server::Builder::configure()
             .register_encoded_file_descriptor_set(grpc_gen::FILE_DESCRIPTOR_SET)
-            .build_v1()?,
+            .build_v1()?
+            .max_decoding_message_size(max_transport_message_size_bytes)
+            .max_encoding_message_size(max_transport_message_size_bytes),
     );
 
     let trace_layer = TraceLayer::new_for_grpc()
@@ -2025,6 +2035,7 @@ pub(crate) struct ServerVerified {
     api_addr_if_webui_enabled: Option<String>,
     max_deployment_file_bytes: u32,
     max_persisted_value_size_bytes: u64,
+    max_transport_message_size_bytes: u64,
     global_http_config: GlobalHttpConfig,
     /// The server's own `[[outbound_http.allowed_host]]` entries, verbatim. Kept so the
     /// `config_prepass::preflight` can report unregistered secret names before they are
@@ -2055,6 +2066,11 @@ struct ServerVerifiedLaunch {
 impl ServerVerified {
     pub(crate) const fn max_persisted_value_size_bytes(&self) -> u64 {
         self.max_persisted_value_size_bytes
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    pub(crate) const fn max_transport_message_size_bytes(&self) -> usize {
+        self.max_transport_message_size_bytes as usize
     }
 
     #[instrument(name = "ServerVerified::new", skip_all)]
@@ -2106,6 +2122,9 @@ impl ServerVerified {
         }
         if config.limits.max_persisted_value_size_bytes == 0 {
             bail!("`limits.max_persisted_value_size_bytes` must be greater than zero");
+        }
+        if config.limits.max_transport_message_size_bytes == 0 {
+            bail!("`limits.max_transport_message_size_bytes` must be greater than zero");
         }
         let workflows_response_refresh_interval =
             config.workflows_global_config.response_refresh_interval;
@@ -2163,6 +2182,7 @@ impl ServerVerified {
             },
             max_deployment_file_bytes: config.limits.max_deployment_file_bytes.0,
             max_persisted_value_size_bytes: config.limits.max_persisted_value_size_bytes,
+            max_transport_message_size_bytes: config.limits.max_transport_message_size_bytes,
             global_http_config,
             server_outbound_allowed_hosts,
             source_path,

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -2161,7 +2161,7 @@ impl ServerVerified {
             } else {
                 None
             },
-            max_deployment_file_bytes: config.max_deployment_file_bytes.0,
+            max_deployment_file_bytes: config.limits.max_deployment_file_bytes.0,
             max_persisted_value_size_bytes: config.limits.max_persisted_value_size_bytes,
             global_http_config,
             server_outbound_allowed_hosts,

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -77,6 +77,7 @@ pub(crate) struct ServerConfigToml {
 
 #[derive(Debug, Deserialize, JsonSchema, Clone, Copy)]
 #[serde(deny_unknown_fields)]
+#[expect(clippy::struct_field_names)]
 pub(crate) struct LimitsToml {
     /// Maximum compact JSON-encoded size of one newly persisted execution
     /// value. Each execution snapshots the effective positive value so config
@@ -87,6 +88,12 @@ pub(crate) struct LimitsToml {
     /// Per-file size limit for deployment-owned blobs attached to a submit request.
     #[serde(default)]
     pub(crate) max_deployment_file_bytes: MaxDeploymentFileBytes,
+    /// Maximum size of a single API transport message: the gRPC encoded message
+    /// size and the equivalent REST request body limit. Must be positive; the
+    /// default is 512 MiB. This is a transport bound and is distinct from
+    /// `max_persisted_value_size_bytes`.
+    #[serde(default = "default_max_transport_message_size_bytes")]
+    pub(crate) max_transport_message_size_bytes: u64,
 }
 
 impl Default for LimitsToml {
@@ -94,12 +101,17 @@ impl Default for LimitsToml {
         Self {
             max_persisted_value_size_bytes: DEFAULT_MAX_PERSISTED_VALUE_SIZE_BYTES,
             max_deployment_file_bytes: MaxDeploymentFileBytes::default(),
+            max_transport_message_size_bytes: default_max_transport_message_size_bytes(),
         }
     }
 }
 
 const fn default_max_persisted_value_size_bytes() -> u64 {
     DEFAULT_MAX_PERSISTED_VALUE_SIZE_BYTES
+}
+
+const fn default_max_transport_message_size_bytes() -> u64 {
+    crate::api::DEFAULT_MAX_TRANSPORT_MESSAGE_SIZE_BYTES as u64
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema, Clone)]

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -48,9 +48,6 @@ pub(crate) struct ServerConfigToml {
     /// An empty allowlist denies every outbound request.
     #[serde(default)]
     pub(crate) outbound_http: OutboundHttpToml,
-    /// Per-file size limit for deployment-owned blobs attached to a submit request.
-    #[serde(default)]
-    pub(crate) max_deployment_file_bytes: MaxDeploymentFileBytes,
     #[serde(default)]
     pub(crate) limits: LimitsToml,
     #[serde(default)]
@@ -87,12 +84,16 @@ pub(crate) struct LimitsToml {
     /// setting was persisted retain their legacy unlimited contract.
     #[serde(default = "default_max_persisted_value_size_bytes")]
     pub(crate) max_persisted_value_size_bytes: u64,
+    /// Per-file size limit for deployment-owned blobs attached to a submit request.
+    #[serde(default)]
+    pub(crate) max_deployment_file_bytes: MaxDeploymentFileBytes,
 }
 
 impl Default for LimitsToml {
     fn default() -> Self {
         Self {
             max_persisted_value_size_bytes: DEFAULT_MAX_PERSISTED_VALUE_SIZE_BYTES,
+            max_deployment_file_bytes: MaxDeploymentFileBytes::default(),
         }
     }
 }

--- a/src/server/web_api_server.rs
+++ b/src/server/web_api_server.rs
@@ -188,13 +188,14 @@ fn deprecated_text_response(response: impl IntoResponse) -> Response {
 }
 
 pub(crate) fn app_router(state: WebApiState) -> Router {
+    let max_transport_message_size_bytes = state.server_verified.max_transport_message_size_bytes();
     Router::new()
         .route("/openapi.json", routing::get(openapi_json))
-        .nest("/v1", v1_router())
+        .nest("/v1", v1_router(max_transport_message_size_bytes))
         .with_state(Arc::new(state))
 }
 
-fn v1_router() -> Router<Arc<WebApiState>> {
+fn v1_router(max_transport_message_size_bytes: usize) -> Router<Arc<WebApiState>> {
     Router::new()
         .route("/components", routing::get(components_list))
         .route("/components/{digest}/wit", routing::get(component_wit))
@@ -263,16 +264,10 @@ fn v1_router() -> Router<Arc<WebApiState>> {
             routing::put(execution_upgrade),
         )
         .route("/deployments", routing::get(deployment::list))
-        .route(
-            "/deployments",
-            routing::post(deployment::submit_post)
-                .layer(DefaultBodyLimit::max(crate::api::MAX_GRPC_MESSAGE_SIZE)),
-        )
+        .route("/deployments", routing::post(deployment::submit_post))
         .route(
             "/deployments/{deployment-id}",
-            routing::get(deployment::get)
-                .put(deployment::submit_put)
-                .layer(DefaultBodyLimit::max(crate::api::MAX_GRPC_MESSAGE_SIZE)),
+            routing::get(deployment::get).put(deployment::submit_put),
         )
         .route(
             "/files/orphans",
@@ -292,6 +287,7 @@ fn v1_router() -> Router<Arc<WebApiState>> {
             "/executions/{execution-id}/backtrace/source",
             routing::get(execution_backtrace_source),
         )
+        .layer(DefaultBodyLimit::max(max_transport_message_size_bytes))
 }
 
 /// Generate a new execution ID


### PR DESCRIPTION
- **refactor(config): move max_deployment_file_bytes into [limits]**
- **feat(config): make the API transport message size limit configurable**
