### PR TITLE
chore: Bump Rust dependencies

### DIFF
--- a/.config/deny.toml
+++ b/.config/deny.toml
@@ -60,25 +60,25 @@ skip = [
     { name = "hashbrown", version = "0.15" },
     { name = "hashbrown", version = "0.16.1" },
     { name = "foldhash", version = "0.1" },
-    # boa_engine requires itertools 0.15 while the workspace and wasmtime use 0.14
-    { name = "itertools", version = "0.15" },
+    # workspace and boa_engine use itertools 0.15 while prost-build and wasmtime use 0.14
+    { name = "itertools", version = "0.14" },
     # boa_interner requires phf 0.14 while tokio-postgres uses 0.13
     { name = "phf", version = "0.14" },
     { name = "phf_shared", version = "0.14" },
-    # reqwest 0.13.5 and oci-client 0.16.1 require base64 0.23; everything else uses 0.22
-    { name = "base64", version = "0.22" },
-    # obelisk uses sha2 0.10 RustCrypto suite; postgres-protocol requires sha2 0.11
+    # reqwest 0.13 and oci-client 0.17 require base64 0.23; everything else uses 0.22
+    { name = "base64", version = "0.23" },
+    # wasmtime's cranelift-codegen and boa_engine pin the sha2 0.10 suite; postgres-protocol requires sha2 0.11
     { name = "sha2", version = "0.10" },
     { name = "digest", version = "0.10" },
     { name = "block-buffer", version = "0.10" },
     { name = "crypto-common", version = "0.1" },
     { name = "cpufeatures", version = "0.2" },
-    # oci-wasm uses wit-component 0.244 (older wasm-tools suite)
-    { name = "wasmparser", version = "0.244" },
-    { name = "wasm-encoder", version = "0.244" },
-    { name = "wasm-metadata", version = "0.244" },
-    { name = "wit-component", version = "0.244" },
-    { name = "wit-parser", version = "0.244" },
+    # oci-wasm uses wit-component 0.253 (older wasm-tools suite)
+    { name = "wasmparser", version = "0.253" },
+    { name = "wasm-encoder", version = "0.253" },
+    { name = "wasm-metadata", version = "0.253" },
+    { name = "wit-component", version = "0.253" },
+    { name = "wit-parser", version = "0.253" },
     # wasm-compose 0.254 (wasmtime dep) uses wasm-tools 0.254, but its `wat` dep
     # pulls in wasm-tools 0.259 (canonical is 0.254, 0.259 is skipped)
     { name = "wasm-encoder", version = "0.259" },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
  "obeli-sk-boa-runtime",
  "serde_json",
  "tracing",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
  "wstd",
 ]
@@ -1055,11 +1055,13 @@ dependencies = [
 
 [[package]]
 name = "croner"
-version = "2.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+checksum = "a59ed87528b2ee2b6d2b14d6767f6dbe41867dfc581433fc23a7c0fae847467a"
 dependencies = [
  "chrono",
+ "derive_builder",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -2045,11 +2047,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2783,13 +2781,13 @@ checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro-string"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+checksum = "6e7b3a5bbb2f63aaa223a671ea1bd0e7bc16bd30ce387324cf63995deaddbbd2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3252,7 +3250,7 @@ dependencies = [
  "deadpool-postgres",
  "derive-where",
  "derive_more",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "insta",
  "obeli-sk-val-json",
@@ -3282,7 +3280,7 @@ name = "obeli-sk-db-common"
 version = "0.42.0-rc.1"
 dependencies = [
  "chrono",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "obeli-sk-concepts",
  "thiserror 2.0.20",
@@ -3301,7 +3299,7 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "derive_more",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "obeli-sk-concepts",
  "obeli-sk-db-common",
  "obeli-sk-refinery",
@@ -3326,9 +3324,9 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_more",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hdrhistogram",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "obeli-sk-concepts",
  "obeli-sk-db-common",
  "obeli-sk-refinery",
@@ -3369,7 +3367,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "derive_more",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "obeli-db-tests",
  "obeli-sk-concepts",
@@ -3481,7 +3479,7 @@ dependencies = [
  "chrono",
  "const_format",
  "derive_more",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hyper",
  "id-arena",
  "indexmap 2.14.2",
@@ -3519,10 +3517,10 @@ version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "insta",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "schemars 1.2.2",
  "serde",
  "serde_json",
@@ -3547,13 +3545,13 @@ dependencies = [
  "croner",
  "derive_more",
  "futures-util",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "http-body-util",
  "hyper",
  "hyper-util",
  "indexmap 2.14.2",
  "insta",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "obeli-db-tests",
  "obeli-sk-boa-engine",
@@ -3630,12 +3628,12 @@ dependencies = [
  "directories",
  "docker_credential",
  "futures-util",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "hmac 0.12.1",
  "http",
  "indexmap 2.14.2",
  "insta",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jsonwebtoken",
  "obeli-sk-boa-engine",
  "obeli-sk-concepts",
@@ -3742,13 +3740,14 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "hex",
  "http",
  "http-auth",
  "jsonwebtoken",
@@ -3759,7 +3758,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3785,19 +3784,19 @@ dependencies = [
 
 [[package]]
 name = "oci-wasm"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841cceed413ad8a4c8b4a833ccfa333eebe55dfb12af7c3899687258934ca2a4"
+checksum = "87689298bd74f0f2675fcac99956a34c31098ca3bdced3d7635e71dc03c5ca21"
 dependencies = [
  "anyhow",
  "chrono",
  "oci-client",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tokio",
- "wit-component 0.244.0",
- "wit-parser 0.244.0",
+ "wit-component 0.253.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -4182,6 +4181,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.5",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,7 +4229,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph 0.8.3",
- "prettyplease",
+ "prettyplease 0.2.37",
  "prost",
  "prost-types",
  "pulldown-cmark",
@@ -4641,9 +4650,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+checksum = "948203e6d13b83e51a90d7cf236dd58a0065f23f4b902f00f306e7eb2bd09b9c"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -4652,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+checksum = "a8d92eaf7b6e51e12471d71ddc72608e7151573de44099aacfbb1128177c0da4"
 dependencies = [
  "cfg-if",
  "glob",
@@ -5246,6 +5255,9 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
 
 [[package]]
 name = "strum"
@@ -5364,7 +5376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.5.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5394,7 +5406,7 @@ name = "test-db-macro"
 version = "0.42.0-rc.1"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5402,7 +5414,7 @@ name = "test-programs-fibo-activity"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5418,7 +5430,7 @@ name = "test-programs-fibo-webhook"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
  "wstd",
 ]
@@ -5437,7 +5449,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "serde_json",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5453,7 +5465,7 @@ name = "test-programs-fibo-workflow-outer"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5469,7 +5481,7 @@ name = "test-programs-http-get-activity"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
  "wstd",
 ]
@@ -5486,7 +5498,7 @@ name = "test-programs-http-get-webhook"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
  "wstd",
 ]
@@ -5503,7 +5515,7 @@ name = "test-programs-http-get-workflow"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5519,7 +5531,7 @@ name = "test-programs-serde-activity"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5535,7 +5547,7 @@ name = "test-programs-serde-workflow"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5551,7 +5563,7 @@ name = "test-programs-sleep-activity"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5567,7 +5579,7 @@ name = "test-programs-sleep-webhook"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
  "wstd",
 ]
@@ -5585,7 +5597,7 @@ version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5601,7 +5613,7 @@ name = "test-programs-stub-activity"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -5617,7 +5629,7 @@ name = "test-programs-stub-workflow"
 version = "0.42.0-rc.1"
 dependencies = [
  "anyhow",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 
@@ -6018,7 +6030,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6041,7 +6053,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "prost-build",
  "prost-types",
@@ -6302,11 +6314,11 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "1.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+checksum = "947dde63b6d514cc5e044edad4e0ca7261afd1099d16c83d942cb2b2f348689c"
 dependencies = [
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
  "web-time",
 ]
@@ -6594,12 +6606,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.244.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -6614,16 +6626,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.258.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.258.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d0246511d901aacf25d2dc9111f0054947de5e093fe662099e709ff7530dc3"
@@ -6634,14 +6636,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.244.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+checksum = "b3f45816ef616806f48498bcd831377de578c4fa51db0c83ab8ceb78cc13523b"
 dependencies = [
  "anyhow",
  "indexmap 2.14.2",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -6658,14 +6660,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.258.0"
+version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a11585adb92fe9b55ad1d760e8d8fb5d87e0d2e303cb8eed57f078d54293a2"
+checksum = "4e7bf119eb01f4a246864c10bd87c8f26c566350abb25aa4d5273c415bbab338"
 dependencies = [
  "anyhow",
  "indexmap 2.14.2",
- "wasm-encoder 0.258.0",
- "wasmparser 0.258.0",
+ "wasm-encoder 0.259.0",
+ "wasmparser 0.259.0",
 ]
 
 [[package]]
@@ -6683,12 +6685,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags 2.13.2",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "semver",
 ]
@@ -6708,23 +6710,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.258.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
-dependencies = [
- "bitflags 2.13.2",
- "hashbrown 0.17.1",
- "indexmap 2.14.2",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7c12eac7bb587801590f6a67ff0bc84d0748513864b71108e4b311cc3df694"
 dependencies = [
  "bitflags 2.13.2",
+ "hashbrown 0.17.1",
  "indexmap 2.14.2",
  "semver",
 ]
@@ -7113,7 +7104,7 @@ dependencies = [
  "obeli-sk-boa-runtime",
  "serde",
  "serde_json",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
  "wstd",
 ]
@@ -7510,9 +7501,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e473fd0095479f9689ac7d2a52c427cc96bb2b973ace50238dfcc1ab1cd52d93"
+checksum = "53cb4b5556c3a791e86838ea287782bdafa704d55b0e68b5b81a3a16b9ea5f4b"
 dependencies = [
  "bitflags 2.13.2",
  "wit-bindgen-rust-macro",
@@ -7520,52 +7511,52 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87445680dfe6d6b5369e884bd63c03a3335268e855365b2fc3f7bcdce96a630e"
+checksum = "72ad22a37ecbc0e1fdca34d2b670ba41368cb0920735643e00fdf39a16ee5431"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.258.0",
+ "wit-parser 0.259.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f2fe494de0d898216caf0fd0ae76af75753fcb3ff4f465b46131537cf24cf8"
+checksum = "84ba5213d4332c260a0d4e69e34b0f7e4b85ddae10b6ebfbac00d9c185ba628a"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.14.2",
- "prettyplease",
- "syn 2.0.119",
- "wasm-metadata 0.258.0",
+ "prettyplease 0.3.0",
+ "syn 3.0.5",
+ "wasm-metadata 0.259.0",
  "wit-bindgen-core",
- "wit-component 0.258.0",
+ "wit-component 0.259.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.61.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59283a01aec94f60f92ada22ffe182a5cea8acfce43be3be688de8d52df55312"
+checksum = "8f19d63da8e478a370ef8192d90ccb517965b7747d6b46cd2d831dd0ef4d2541"
 dependencies = [
  "anyhow",
  "macro-string",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
 
 [[package]]
 name = "wit-component"
-version = "0.244.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+checksum = "dbbd2500ac3488489ee8c6e59b79d7e47e6da5bfb019efd35d5dca57b78af624"
 dependencies = [
  "anyhow",
  "bitflags 2.13.2",
@@ -7574,10 +7565,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata 0.244.0",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "wasm-encoder 0.253.0",
+ "wasm-metadata 0.253.0",
+ "wasmparser 0.253.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -7601,9 +7592,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.258.0"
+version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481b5c47b2ecce0389b5e08a05557d6a190c9cd761773b8880a8017ee04dc7ef"
+checksum = "092f783dee3253265fcde131475055f8c275ac0176a9c0396db1dc7b5544bfb4"
 dependencies = [
  "anyhow",
  "bitflags 2.13.2",
@@ -7612,19 +7603,20 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.258.0",
- "wasm-metadata 0.258.0",
- "wasmparser 0.258.0",
- "wit-parser 0.258.0",
+ "wasm-encoder 0.259.0",
+ "wasm-metadata 0.259.0",
+ "wasmparser 0.259.0",
+ "wit-parser 0.259.0",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.244.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+checksum = "4d997b8e5920fcbeec742b58e583325d6419a6aca617ae8075c406a61c65ba8a"
 dependencies = [
  "anyhow",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap 2.14.2",
  "log",
@@ -7632,8 +7624,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
+ "unicode-ident",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -7657,9 +7649,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.258.0"
+version = "0.259.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4daaa3cd97ae49ecd0a99dc009d453f93e0f083dd3be38c0f24a83a93e37ac"
+checksum = "6390f4f02493ce678d509c859cf1698e38929fb75c8012a6ee2f7d6b6cb66cd7"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -7671,7 +7663,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.258.0",
+ "wasmparser 0.259.0",
 ]
 
 [[package]]
@@ -7696,7 +7688,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "obeli-sk-boa-engine",
  "serde_json",
- "wit-bindgen 0.61.1",
+ "wit-bindgen 0.62.0",
  "wit-bindgen-rust",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ async-trait = "0.1"
 axum = { version = "0.8.9", features = ["http2", "multipart"] }
 axum-accept = "0.0.7"
 axum-extra = { version = "0.12.6", features = ["query"] }
-base64 = "0.22.1"
+base64 = "0.22.1" # keep on 0.22 to match axum/tonic/hyper-util; only reqwest/oci pull 0.23
 bytes = "1.12.1"
 cargo_metadata = "0.23"
 cfg-if = "1.0.4"
@@ -258,7 +258,7 @@ config = { version = "0.15.25", default-features = false, features = [
 ] }
 console-subscriber = "0.5.0"
 const_format = "0.2.36"
-croner = "2"
+croner = "4"
 criterion = "0.8"
 crossterm = "0.29.0"
 deadpool-postgres = "0.14.2"
@@ -280,7 +280,7 @@ futures-concurrency = "7.7.1"
 futures-lite = "2.6.1"
 futures-util = "0.3.34"
 getrandom = "0.4"
-hashbrown = { version = "0.16.1", features = ["serde"] }
+hashbrown = { version = "0.17.1", features = ["serde"] }
 hdrhistogram = { version = "7.6.0", default-features = false }
 http = "1.5.0"
 http-body-util = "0.1"
@@ -289,17 +289,17 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 id-arena = "2.3.0"
 indexmap = { version = "2.14", features = ["serde"] }
 insta = { version = "1.48.0", features = ["json"] }
-itertools = "0.14"
-jsonwebtoken = { version = "10", default-features = false }
+itertools = "0.15"
+jsonwebtoken = { version = "10", default-features = false } # keep in sync with oci-client's jsonwebtoken
 lazy_static = "1.5"
 libc = "0.2.189"
-oci-client = { version = "0.16.1", default-features = false }
-oci-wasm = { version = "0.4.0", default-features = false } # Dependent on matching oci-client
+oci-client = { version = "0.17.0", default-features = false }
+oci-wasm = { version = "0.6.0", default-features = false } # Dependent on matching oci-client
 paste = "1.0"
 prost = "0.14.4"
 prost-wkt-types = "0.7"
 quote = "1"
-rand = "0.9"
+rand = "0.9" # postgres-protocol pulls rand 0.10; obelisk stays on 0.9 (0.10 reorganized the Rng traits)
 regex = "1.13"
 refinery = { package = "obeli-sk-refinery", version = "0.9.2-obeli-sk.1", default-features = false, features = ["rusqlite", "tokio-postgres-rustls"] }
 reqwest = { version = "0.13", default-features = false, features = [
@@ -314,7 +314,7 @@ rustls = { version = "0.23", default-features = false, features = [
     "tls12",
 ] }
 route-recognizer = "0.3.1"
-rstest = "0.26"
+rstest = "0.27"
 rusqlite = { version = "0.40.2", features = [
     "bundled",
     "chrono",
@@ -326,11 +326,11 @@ semver = "1.0.28"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = { version = "1.0.151", features = ["preserve_order"] }
 serde_with = "3.23.0"
-hmac = "0.12.1"
-sha2 = "0.10.9"
+hmac = "0.12.1" # keep on the 0.10 digest suite; postgres-protocol pulls sha2/hmac 0.11
+sha2 = "0.10.9" # 0.11 switched output to hybrid-array::Array which breaks {:x} hashing
 subtle = "2.6.1"
 strum = { version = "0.28.0", features = ["derive"] }
-syn = { version = "2", features = ["full"] }
+syn = { version = "3", features = ["full"] }
 tempfile = "3.27"
 thiserror = "2.0"
 tokio-postgres = { version = "0.7.18", features = ["with-chrono-0_4", "with-serde_json-1"] }
@@ -355,12 +355,12 @@ tonic-prost-build = "0.14.6"
 tonic-reflection = "0.14.6"
 tonic-web = "0.14.6"
 tower = "0.5.3"
-tower-http = { version = "0.6.11", features = ["trace", "cors"] }
+tower-http = { version = "0.6.11", features = ["trace", "cors"] } # keep in sync with reqwest's tower-http
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = "0.2.5"
 tracing-error = "0.2.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
-ulid = { version = "1.2", features = ["serde"] }
+ulid = { version = "3.0", features = ["serde"] }
 url = "2.5.8"
 utoipa = { version = "5.5.0", features = ["chrono"] }
 utoipa-axum = "0.2.0"
@@ -372,7 +372,7 @@ wasmtime-wasi = "48.0.2"
 wasmtime-wasi-io = "48.0.2"
 wasmtime-wasi-http = "48.0.2"
 wasmtime-environ = "48.0.2"
-# wasm-tools
+# wasm-tools (keep in sync with wasmtime's pinned wasm-tools suite)
 wast = "254.0.0"
 wit-parser = "0.254.0"
 wasmparser = "0.254.0"
@@ -392,9 +392,9 @@ boa_runtime = { package="obeli-sk-boa-runtime" , version="1.0.0-obeli-sk.12", de
 # boa_runtime = { git = "https://github.com/obeli-sk/boa", package = "boa_runtime", rev = "9b145317", default-features = false, features = ["fetch"] }
 
 # testing components
-wasip2 = "1.0.4"
-wit-bindgen = "0.61.1"
-wit-bindgen-rust = "0.61.1"
+wasip2 = "2.0.0"
+wit-bindgen = "0.62.0"
+wit-bindgen-rust = "0.62.0"
 wstd = "0.6.8"
 
 # otlp

--- a/crates/concepts/src/lib.rs
+++ b/crates/concepts/src/lib.rs
@@ -856,7 +856,7 @@ pub mod prefixed_ulid {
     impl<T> PrefixedUlid<T> {
         #[must_use]
         pub fn generate() -> Self {
-            Self::new(Ulid::new())
+            Self::new(Ulid::generate())
         }
 
         #[must_use]

--- a/crates/val-json/src/wast_val_ser.rs
+++ b/crates/val-json/src/wast_val_ser.rs
@@ -737,7 +737,7 @@ impl<'de> DeserializeSeed<'de> for WastValDeserialize<'_> {
 pub mod params {
     use crate::{type_wrapper::TypeWrapper, wast_val::WastVal, wast_val_ser::WastValDeserialize};
     use core::fmt;
-    use itertools::{Itertools as _, Position};
+    use itertools::Itertools as _;
     use serde::{
         Deserializer,
         de::{Expected, SeqAccess, Visitor},
@@ -828,10 +828,10 @@ pub mod params {
             .with_position()
             .fold("[".to_string(), |mut acc, (pos, item)| {
                 acc.push_str(&item.clone());
-                if pos != Position::Last && pos != Position::Only {
-                    acc.push(',');
-                } else {
+                if pos.is_last {
                     acc.push(']');
+                } else {
+                    acc.push(',');
                 }
                 acc
             });

--- a/crates/wasm-workers/src/cron/cron_worker.rs
+++ b/crates/wasm-workers/src/cron/cron_worker.rs
@@ -220,7 +220,7 @@ mod tests {
     }
 
     fn parse_cron(expr: &str) -> CronOrOnce {
-        CronOrOnce::Cron(Box::new(croner::Cron::new(expr).parse().unwrap()))
+        CronOrOnce::Cron(Box::new(expr.parse::<croner::Cron>().unwrap()))
     }
 
     fn make_locked_event(now: DateTime<Utc>) -> Locked {

--- a/src/config/deployment/resolved.rs
+++ b/src/config/deployment/resolved.rs
@@ -1956,9 +1956,10 @@ impl CronComponentConfigTomlExt for CronComponentConfigToml {
             CronOrOnce::Once
         } else {
             CronOrOnce::Cron(Box::new(
-                croner::Cron::new(&self.schedule)
-                    .with_seconds_optional()
-                    .parse()
+                croner::parser::CronParser::builder()
+                    .seconds(croner::parser::Seconds::Optional)
+                    .build()
+                    .parse(&self.schedule)
                     .with_context(|| {
                         format!(
                             "invalid cron expression `{}` for schedule `{name}`",


### PR DESCRIPTION
Ran `cargo upgrade --incompatible`, then migrated code and reverted the
bumps that were not worth their cost.

Migrated to the new majors:
- ulid 3.0: `Ulid::new()` -> `Ulid::generate()`.
- itertools 0.15: `Position` is now a struct, use `pos.is_last`.
- croner 4: `Cron::new(..).parse()` builder removed, use
  `CronParser::builder().seconds(Seconds::Optional).build().parse(..)`
  and `str::parse::<Cron>()`; `find_next_occurrence` is unchanged.

Reverted (kept older) where the bump only added churn or a duplicate:
- rand 0.10 -> 0.9: 0.10 reorganized the Rng traits; postgres pulls 0.10
  transitively (skipped).
- sha2 0.11 -> 0.10.9, hmac 0.13 -> 0.12.1: 0.11 moved the digest output
  to hybrid-array::Array, dropping LowerHex; wasmtime's cranelift and boa
  pin 0.10 anyway so the split (and skip) stays regardless.
- base64 0.23 -> 0.22.1: 0.22 matches axum/tonic/hyper-util; only
  reqwest/oci-client need 0.23 (skipped).
- jsonwebtoken 11 -> 10, tower-http 0.7 -> 0.6.11: match oci-client and
  reqwest to avoid duplicates.
- wasm-tools suite (wast/wit-parser/wasmparser/wit-component) 0.259 ->
  0.254: keep in sync with wasmtime 48's pinned suite.

Updated deny.toml skips accordingly (base64 0.23, itertools 0.14,
oci-wasm's wasm-tools 0.253).
